### PR TITLE
[rollout, vllm] fix: FP8 rollout weight resync on vLLM 0.20.x via native layerwise reload lifecycle

### DIFF
--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -67,6 +67,11 @@ class _FakeSocket:
     def send_pyobj(self, message):
         self.messages.append(message)
 
+    def poll(self, timeout=None, flags=None):
+        # The sender polls before every recv() so a dead receiver surfaces as a
+        # timeout instead of an un-timed block; this fake always has an ACK ready.
+        return True
+
     def recv(self):
         return b""
 

--- a/tests/workers/rollout/test_bucketed_weight_transfer_failure_on_cpu.py
+++ b/tests/workers/rollout/test_bucketed_weight_transfer_failure_on_cpu.py
@@ -476,7 +476,7 @@ def test_send_and_cleanup_are_bounded_when_frames_cannot_be_flushed():
     """
     sender_result, _ = _run_pair(_receiver_fn_connects_then_leaves, (), num_weights=1)
 
-    status, exc_name, _message, elapsed = sender_result
+    status, exc_name, message, elapsed = sender_result
     assert status == "raised", f"expected the bounded ACK to fire, got {sender_result}"
     assert exc_name in ("WeightTransferAckTimeoutError", "WeightTransferReceiverError"), sender_result
     # ACK bound + LINGER (5 s) + slack. A LINGER=-1 regression blows straight
@@ -486,6 +486,62 @@ def test_send_and_cleanup_are_bounded_when_frames_cannot_be_flushed():
         f"send+cleanup took {elapsed:.1f} s (bound {bound_s:.0f} s): teardown is not bounded — "
         "check that both sockets set a finite ZMQ LINGER at creation"
     )
+    # Whichever bound fired, the diagnostic must name the bound that was
+    # actually armed for THIS sender (ack_timeout_s=5 s), not the module-level
+    # send timeout. An operator who reads "1800 s" after a 5 s failure debugs
+    # the wrong knob.
+    if "trying to send" in message:
+        assert f"Timed out after {ACK_TIMEOUT_S:.0f} s" in message, f"send timeout reported the wrong bound: {message}"
+
+
+def test_send_timeout_message_reports_the_effective_bound():
+    """The send-side diagnostic must quote the EFFECTIVE SNDTIMEO.
+
+    ``_init_socket`` arms ``min(ack_timeout_s * 1000, SOCKET_SEND_TIMEOUT_MS)``,
+    so with the caller-supplied bound below the module default the two differ by
+    orders of magnitude (5 s vs 1800 s). Reporting the constant instead of the
+    armed value sends the reader after the wrong timeout: single process, no
+    peer ever connects, so the very first handshake send hits SNDTIMEO.
+    """
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import (
+        SOCKET_SEND_TIMEOUT_MS,
+        BucketedWeightSender,
+        WeightTransferAckTimeoutError,
+    )
+
+    short_bound_s = 1.0
+    assert int(short_bound_s * 1000) < SOCKET_SEND_TIMEOUT_MS, "the bound under test must win the min"
+
+    handle = _unique_zmq_handle()
+    sender = BucketedWeightSender(
+        zmq_handle=handle,
+        bucket_size_mb=1,
+        use_shm=True,
+        ack_timeout_s=short_bound_s,
+    )
+    started = time.monotonic()
+    try:
+        sender._init_socket()
+        assert sender._snd_timeout_ms == int(short_bound_s * 1000), sender._snd_timeout_ms
+        with pytest.raises(WeightTransferAckTimeoutError) as excinfo:
+            sender._send_or_timeout({"probe": True}, "unit-test handshake")
+    finally:
+        if sender.socket is not None:
+            sender.socket.close(linger=0)
+        try:
+            os.remove(handle[len("ipc://") :])
+        except OSError:
+            pass
+    elapsed = time.monotonic() - started
+
+    message = str(excinfo.value)
+    assert f"Timed out after {short_bound_s:.0f} s" in message, message
+    assert f"{SOCKET_SEND_TIMEOUT_MS / 1000:.0f} s" not in message, (
+        f"the diagnostic still quotes the module default instead of the armed bound: {message}"
+    )
+    # And the wait really was the armed bound, so the message is not merely
+    # consistent with itself.
+    assert short_bound_s <= elapsed < short_bound_s + 30, f"send gave up after {elapsed:.1f} s"
 
 
 def test_cleanup_preserves_the_primary_exception_when_the_accelerator_fails():

--- a/tests/workers/rollout/test_bucketed_weight_transfer_failure_on_cpu.py
+++ b/tests/workers/rollout/test_bucketed_weight_transfer_failure_on_cpu.py
@@ -48,6 +48,7 @@ import multiprocessing as mp
 import os
 import queue
 import signal
+import sys
 import time
 import uuid
 
@@ -400,3 +401,128 @@ def test_pre_ipc_validation_rejects_unsupported_config_without_touching_a_socket
     # Unsupported: raises, with no IPC resource involved.
     with pytest.raises(NotImplementedError, match="MTP drafter"):
         vllm_fp8_utils.validate_fp8_layerwise_reload_config(config, uses_mtp_drafter=True)
+
+
+# ---------------------------------------------------------------------------
+# (c) Teardown is bounded too: a finite LINGER on both sockets.
+#
+# The bounded ACK above stops the sender waiting forever for a *reply*, but
+# ZMQ's default LINGER of -1 means ``socket.close()`` can then block forever
+# flushing an outbound frame the dead peer will never read — and close() runs
+# from ``finally: _cleanup()``, i.e. on exactly the paths the bound just made
+# reachable. These two tests pin the invariant at the level it must hold:
+# the option is set when the socket is CREATED (not only on the receiver's
+# error path, which can itself fail before it gets there), and the whole
+# send+cleanup sequence completes in bounded time with an unflushable frame
+# queued.
+# ---------------------------------------------------------------------------
+def test_both_sockets_get_a_finite_linger_at_creation():
+    """LINGER must be finite on the real sockets, set by ``_init_socket``."""
+    import zmq
+
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import (
+        SOCKET_LINGER_MS,
+        BucketedWeightReceiver,
+        BucketedWeightSender,
+    )
+
+    assert 0 <= SOCKET_LINGER_MS < 2**31 - 1, f"LINGER must be finite, got {SOCKET_LINGER_MS}"
+
+    handle = _unique_zmq_handle()
+    sender = BucketedWeightSender(zmq_handle=handle, bucket_size_mb=1, use_shm=True)
+    sender._init_socket()
+    try:
+        assert sender.socket.getsockopt(zmq.LINGER) == SOCKET_LINGER_MS, (
+            "sender socket kept ZMQ's default LINGER=-1: close() in _cleanup() could block forever"
+        )
+        receiver = BucketedWeightReceiver(zmq_handle=handle, device=torch.device("cpu"), use_shm=True)
+        receiver._init_socket()
+        try:
+            assert receiver.socket.getsockopt(zmq.LINGER) == SOCKET_LINGER_MS, (
+                "receiver socket's finite LINGER is only set on the error path"
+            )
+        finally:
+            receiver.socket.close()
+    finally:
+        sender.socket.close(linger=0)
+        try:
+            os.remove(handle[len("ipc://") :])
+        except OSError:
+            pass
+
+
+def _receiver_fn_connects_then_leaves(zmq_handle, result_queue):
+    """Connect (so frames are queued to us) and exit without ever reading one."""
+    import zmq
+
+    context = zmq.Context.instance()
+    socket = context.socket(zmq.REP)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.connect(zmq_handle)
+    time.sleep(1.0)
+    socket.close()
+    context.term()
+    result_queue.put(("left", None, None, 0.0))
+
+
+def test_send_and_cleanup_are_bounded_when_frames_cannot_be_flushed():
+    """Fault-inject an unflushable queued frame; total time must stay bounded.
+
+    Without a finite LINGER this test hangs until the harness timeout: the ACK
+    bound fires as designed, and then ``close()`` blocks forever inside the
+    ``finally``. The assertion is deliberately on the WHOLE sequence, not just
+    on ``_recv_ack``, because a bound that the cleanup path can undo is not a
+    deadlock bound.
+    """
+    sender_result, _ = _run_pair(_receiver_fn_connects_then_leaves, (), num_weights=1)
+
+    status, exc_name, _message, elapsed = sender_result
+    assert status == "raised", f"expected the bounded ACK to fire, got {sender_result}"
+    assert exc_name in ("WeightTransferAckTimeoutError", "WeightTransferReceiverError"), sender_result
+    # ACK bound + LINGER (5 s) + slack. A LINGER=-1 regression blows straight
+    # past this and is killed by PROCESS_TIMEOUT_S instead.
+    bound_s = ACK_TIMEOUT_S + 30
+    assert elapsed < bound_s, (
+        f"send+cleanup took {elapsed:.1f} s (bound {bound_s:.0f} s): teardown is not bounded — "
+        "check that both sockets set a finite ZMQ LINGER at creation"
+    )
+
+
+def test_cleanup_preserves_the_primary_exception_when_the_accelerator_fails():
+    """A failing accelerator teardown must not replace the original traceback.
+
+    Observed in a 0.20 aggregate log: a CUDA init failure inside
+    ``_init_buffer()`` was overwritten by a *second* CUDA failure raised from
+    ``ipc_collect()`` in ``_cleanup()``, so the reported error named the wrong
+    call. ``_cleanup()`` is best-effort by construction; this pins it.
+    """
+    import verl.workers.rollout.vllm_rollout.bucketed_weight_transfer as bwt
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
+
+    class _BrokenDevice:
+        @staticmethod
+        def synchronize():
+            raise RuntimeError("secondary failure: device synchronize")
+
+        @staticmethod
+        def ipc_collect():
+            raise RuntimeError("secondary failure: ipc_collect")
+
+        @staticmethod
+        def empty_cache():
+            raise RuntimeError("secondary failure: empty_cache")
+
+    original = bwt.get_torch_device
+    bwt.get_torch_device = lambda: _BrokenDevice
+    try:
+        sender = BucketedWeightSender(zmq_handle=_unique_zmq_handle(), bucket_size_mb=1, use_shm=True)
+        try:
+            raise ValueError("primary failure: the error the caller must see")
+        except ValueError:
+            # Exactly the shape of async_send_weights: raise, then finally-cleanup.
+            sender._cleanup()
+            surfaced = sys.exc_info()[1]
+        assert isinstance(surfaced, ValueError), f"cleanup replaced the primary exception with {surfaced!r}"
+        assert "primary failure" in str(surfaced), str(surfaced)
+    finally:
+        bwt.get_torch_device = original

--- a/tests/workers/rollout/test_bucketed_weight_transfer_failure_on_cpu.py
+++ b/tests/workers/rollout/test_bucketed_weight_transfer_failure_on_cpu.py
@@ -1,0 +1,402 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real two-process failure tests for the bucketed weight-transfer IPC.
+
+``tests/utils/test_bucketed_weight_transfer.py`` covers the HAPPY path across
+two real processes (and needs an accelerator for the CUDA-IPC arm). This suite
+covers the FAILURE path, which is what the FP8 layerwise-reload resync made
+load-bearing: the reload lifecycle can raise from inside the receiver's
+``on_bucket_received`` callback (a bad bucket, a quantization error, a
+lifecycle violation), and the sender must not be left waiting forever.
+
+The protocol is ZMQ REQ (sender, binds) / REP (receiver, connects) with strict
+alternation, and the driver launches the receiver worker non-blocking and only
+awaits its future AFTER sending completes. So a receiver that raises without
+answering the outstanding request converts an intended fail-closed error into a
+silent training hang whose real traceback is buried in a worker log. The two
+mechanisms under test:
+
+  * the receiver answers with an ACK ERROR FRAME before propagating its own
+    exception, so the sender raises ``WeightTransferReceiverError`` carrying the
+    receiver-side message;
+  * every sender ``recv`` is BOUNDED, so a receiver that dies without reporting
+    (SIGKILL, segfault) surfaces as ``WeightTransferAckTimeoutError`` instead
+    of a hang.
+
+Both run over a real ``ipc://`` socket between two real ``spawn``ed processes,
+on the shared-memory (``use_shm=True``) path so the whole file is CPU-only and
+collected by verl's ``*_on_cpu.py`` CI job. The success-path assertion in
+``test_normal_transfer_still_succeeds`` is the regression guard that the error
+frame and the bounded recv did not disturb the pre-existing BF16/LoRA
+behaviour.
+"""
+
+import asyncio
+import multiprocessing as mp
+import os
+import queue
+import signal
+import time
+import uuid
+
+import pytest
+import torch
+
+PROCESS_TIMEOUT_S = 120
+# Deliberately short: these tests assert the sender gives up, so the bound has
+# to be small enough to keep the suite fast while staying far above the
+# microseconds a local ipc:// round trip actually takes.
+ACK_TIMEOUT_S = 5.0
+
+
+def _unique_zmq_handle():
+    return f"ipc:///tmp/test-bwt-fail-{uuid.uuid4().hex}.sock"
+
+
+def _patch_device_for_cpu():
+    """Make the sender/receiver teardown accelerator-free inside a child process."""
+    import verl.workers.rollout.vllm_rollout.bucketed_weight_transfer as bwt
+
+    class _CpuDeviceModule:
+        @staticmethod
+        def synchronize():
+            pass
+
+        @staticmethod
+        def ipc_collect():
+            pass
+
+        @staticmethod
+        def empty_cache():
+            pass
+
+    bwt.get_torch_device = lambda: _CpuDeviceModule
+
+
+# ---------------------------------------------------------------------------
+# Process entry points (module level so `spawn` can pickle them)
+# ---------------------------------------------------------------------------
+def _sender_fn(zmq_handle, num_weights, result_queue, ack_timeout_s):
+    """Send `num_weights` small tensors; report how the send ended."""
+    _patch_device_for_cpu()
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
+
+    weights = [(f"layer{i}.weight", torch.full((16, 16), float(i))) for i in range(num_weights)]
+    sender = BucketedWeightSender(
+        zmq_handle=zmq_handle,
+        bucket_size_mb=1,
+        use_shm=True,
+        ack_timeout_s=ack_timeout_s,
+    )
+    started = time.monotonic()
+    try:
+        asyncio.run(sender.async_send_weights(iter(weights)))
+    except BaseException as exc:  # noqa: BLE001 - the outcome IS the assertion
+        result_queue.put(("raised", type(exc).__name__, str(exc), time.monotonic() - started))
+    else:
+        result_queue.put(("completed", None, None, time.monotonic() - started))
+
+
+def _receiver_fn_raises_on_bucket(zmq_handle, fail_on_bucket_index, result_queue):
+    """Receiver whose per-bucket callback raises — the FP8 reload failure shape."""
+    _patch_device_for_cpu()
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
+
+    receiver = BucketedWeightReceiver(zmq_handle=zmq_handle, device=torch.device("cpu"), use_shm=True)
+    seen = {"buckets": 0}
+
+    def _on_bucket(weights):
+        index = seen["buckets"]
+        seen["buckets"] += 1
+        if index == fail_on_bucket_index:
+            raise RuntimeError("synthetic receiver failure while loading bucket weights")
+
+    try:
+        receiver.receive_weights(on_bucket_received=_on_bucket)
+    except BaseException as exc:  # noqa: BLE001
+        result_queue.put(("raised", type(exc).__name__, str(exc), seen["buckets"]))
+    else:
+        result_queue.put(("completed", None, None, seen["buckets"]))
+
+
+def _receiver_fn_dies_silently(zmq_handle, result_queue):
+    """Receiver that is SIGKILLed mid-transfer: no error frame can be sent.
+
+    This is the case the error frame cannot cover and the bounded recv must:
+    the process disappears between the sender's send and its ACK.
+    """
+    _patch_device_for_cpu()
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
+
+    receiver = BucketedWeightReceiver(zmq_handle=zmq_handle, device=torch.device("cpu"), use_shm=True)
+
+    def _on_bucket(weights):
+        result_queue.put(("about_to_die", None, None, 0))
+        os.kill(os.getpid(), signal.SIGKILL)
+
+    receiver.receive_weights(on_bucket_received=_on_bucket)
+
+
+def _receiver_fn_success(zmq_handle, result_queue):
+    """Plain receiver: the pre-existing success path, unchanged."""
+    _patch_device_for_cpu()
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
+
+    receiver = BucketedWeightReceiver(zmq_handle=zmq_handle, device=torch.device("cpu"), use_shm=True)
+    received = []
+    receiver.receive_weights(on_bucket_received=lambda w: received.extend((n, t.clone()) for n, t in w))
+    result_queue.put(("completed", None, [(n, float(t.flatten()[0])) for n, t in received], len(received)))
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+def _run_pair(receiver_target, receiver_args, num_weights, ack_timeout_s=ACK_TIMEOUT_S):
+    """Run one sender + one receiver process; return (sender_result, receiver_result)."""
+    zmq_handle = _unique_zmq_handle()
+    ctx = mp.get_context("spawn")
+    sender_queue = ctx.Queue()
+    receiver_queue = ctx.Queue()
+
+    sender_p = ctx.Process(target=_sender_fn, args=(zmq_handle, num_weights, sender_queue, ack_timeout_s))
+    receiver_p = ctx.Process(target=receiver_target, args=(zmq_handle, *receiver_args, receiver_queue))
+
+    # Sender binds first, then the receiver connects (matches production order).
+    sender_p.start()
+    receiver_p.start()
+    try:
+        sender_p.join(timeout=PROCESS_TIMEOUT_S)
+        receiver_p.join(timeout=PROCESS_TIMEOUT_S)
+
+        assert not sender_p.is_alive(), (
+            f"sender still running after {PROCESS_TIMEOUT_S} s — it is HUNG waiting for an ACK, "
+            "which is exactly the failure mode the error frame and the bounded recv exist to prevent"
+        )
+
+        try:
+            sender_result = sender_queue.get(timeout=10)
+        except queue.Empty:  # pragma: no cover - only on a genuinely stuck sender
+            raise AssertionError("sender process reported no outcome") from None
+        try:
+            receiver_result = receiver_queue.get(timeout=10)
+        except queue.Empty:
+            receiver_result = None
+        return sender_result, receiver_result
+    finally:
+        for proc in (sender_p, receiver_p):
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=10)
+        ipc_path = zmq_handle[len("ipc://") :]
+        try:
+            os.remove(ipc_path)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# (c) Regression guard: the success path is untouched.
+# ---------------------------------------------------------------------------
+def test_normal_transfer_still_succeeds():
+    """The error frame and the bounded recv must not change the happy path.
+
+    Sent values arrive intact across a real two-process shared-memory transfer,
+    and both sides exit cleanly — the guard that BF16/LoRA/existing callers see
+    no behaviour change.
+    """
+    sender_result, receiver_result = _run_pair(_receiver_fn_success, (), num_weights=4)
+
+    assert sender_result[0] == "completed", f"sender did not finish cleanly: {sender_result}"
+    assert receiver_result is not None and receiver_result[0] == "completed"
+    names_values = receiver_result[2]
+    assert names_values == [(f"layer{i}.weight", float(i)) for i in range(4)], names_values
+
+
+# ---------------------------------------------------------------------------
+# (a) A receiver that raises must not strand the sender.
+# ---------------------------------------------------------------------------
+def test_receiver_raise_surfaces_on_sender_without_hanging():
+    """A raise inside on_bucket_received reaches the sender as an exception.
+
+    The receiver fails on the FIRST bucket — the shape a bad weight or an
+    immediate reload-lifecycle violation takes. Without the error frame the
+    sender would sit in an un-timed ``recv()`` forever, because the driver only
+    awaits the receiver's future after sending completes.
+    """
+    sender_result, receiver_result = _run_pair(
+        _receiver_fn_raises_on_bucket,
+        (0,),
+        num_weights=2,
+    )
+
+    status, exc_name, message, elapsed = sender_result
+    assert status == "raised", f"sender did NOT observe the receiver failure: {sender_result}"
+    assert exc_name == "WeightTransferReceiverError", sender_result
+    # The receiver-side message must travel, otherwise the operator is left
+    # grepping worker logs for the real cause.
+    assert "synthetic receiver failure while loading bucket weights" in message, message
+    assert "RuntimeError" in message, message
+    # Bounded by construction: an error frame is immediate, so this must be
+    # far below the ACK timeout (which is itself only a deadlock backstop).
+    assert elapsed < ACK_TIMEOUT_S, f"error frame took {elapsed:.1f} s, expected an immediate report"
+
+    # The receiver must still propagate ITS OWN original exception. This is not
+    # automatic: the per-bucket tensors are views into the shared-memory buffer
+    # and the traceback keeps them alive, so an unguarded ``shm.close()`` in
+    # _cleanup() raises `BufferError: cannot close exported pointers exist` from
+    # the `finally` and REPLACES the real cause in the worker log.
+    assert receiver_result is not None
+    assert receiver_result[0] == "raised", "the receiver must still propagate its own exception"
+    assert receiver_result[1] == "RuntimeError", (
+        f"the receiver's original exception was masked by a teardown failure: "
+        f"{receiver_result[1]}: {receiver_result[2]}"
+    )
+    assert "synthetic receiver failure" in receiver_result[2], receiver_result[2]
+
+
+def test_receiver_raise_on_a_later_bucket_surfaces_on_sender():
+    """Same mechanism, but the failure happens after a bucket was ACKed.
+
+    Weights are sized so the transfer spans several buckets, and the receiver
+    fails on the second one. This is the realistic FP8 shape: early buckets
+    load fine and the lifecycle only breaks part-way through the sync.
+    """
+    zmq_handle = _unique_zmq_handle()
+    ctx = mp.get_context("spawn")
+    sender_queue = ctx.Queue()
+    receiver_queue = ctx.Queue()
+
+    # 20 x 256 KiB weights against a 1 MB bucket => ~5 buckets.
+    sender_p = ctx.Process(
+        target=_sender_fn_large,
+        args=(zmq_handle, 20, sender_queue, ACK_TIMEOUT_S),
+    )
+    receiver_p = ctx.Process(
+        target=_receiver_fn_raises_on_bucket,
+        args=(zmq_handle, 1, receiver_queue),
+    )
+    sender_p.start()
+    receiver_p.start()
+    try:
+        sender_p.join(timeout=PROCESS_TIMEOUT_S)
+        receiver_p.join(timeout=PROCESS_TIMEOUT_S)
+        assert not sender_p.is_alive(), "sender HUNG after a mid-stream receiver failure"
+
+        status, exc_name, message, elapsed = sender_queue.get(timeout=10)
+        assert status == "raised", f"sender did not observe the mid-stream failure: {status}"
+        assert exc_name == "WeightTransferReceiverError", exc_name
+        assert "synthetic receiver failure while loading bucket weights" in message, message
+        assert elapsed < ACK_TIMEOUT_S, f"error frame took {elapsed:.1f} s"
+
+        receiver_status, _, _, buckets_seen = receiver_queue.get(timeout=10)
+        assert receiver_status == "raised"
+        assert buckets_seen == 2, f"expected the failure on the 2nd bucket, saw {buckets_seen}"
+    finally:
+        for proc in (sender_p, receiver_p):
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=10)
+        try:
+            os.remove(zmq_handle[len("ipc://") :])
+        except OSError:
+            pass
+
+
+def _sender_fn_large(zmq_handle, num_weights, result_queue, ack_timeout_s):
+    """Sender with weights large enough to span multiple 1 MB buckets."""
+    _patch_device_for_cpu()
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
+
+    # 256 KiB each (65536 float32 elements).
+    weights = [(f"layer{i}.weight", torch.full((256, 256), float(i))) for i in range(num_weights)]
+    sender = BucketedWeightSender(zmq_handle=zmq_handle, bucket_size_mb=1, use_shm=True, ack_timeout_s=ack_timeout_s)
+    started = time.monotonic()
+    try:
+        asyncio.run(sender.async_send_weights(iter(weights)))
+    except BaseException as exc:  # noqa: BLE001
+        result_queue.put(("raised", type(exc).__name__, str(exc), time.monotonic() - started))
+    else:
+        result_queue.put(("completed", None, None, time.monotonic() - started))
+
+
+def test_sender_recv_is_bounded_when_the_receiver_dies_silently():
+    """A receiver killed mid-bucket cannot send an error frame; the bound must fire.
+
+    SIGKILL leaves no chance to answer the outstanding request, so this is the
+    residual hang the error frame alone cannot close. The sender must raise
+    ``WeightTransferAckTimeoutError`` shortly after the configured bound rather
+    than block forever.
+    """
+    sender_result, _ = _run_pair(_receiver_fn_dies_silently, (), num_weights=2)
+
+    status, exc_name, message, elapsed = sender_result
+    assert status == "raised", f"sender did not give up on a dead receiver: {sender_result}"
+    assert exc_name == "WeightTransferAckTimeoutError", sender_result
+    assert "Timed out" in message, message
+    # It waited for roughly the bound, then gave up — not forever, not instantly.
+    assert ACK_TIMEOUT_S <= elapsed < ACK_TIMEOUT_S + 60, f"gave up after {elapsed:.1f} s, bound was {ACK_TIMEOUT_S} s"
+
+
+# ---------------------------------------------------------------------------
+# (b) Configuration errors are detected BEFORE any IPC resource exists.
+# ---------------------------------------------------------------------------
+def test_unsupported_configuration_is_rejected_before_the_receiver_is_built():
+    """The pre-IPC gate must run before ``BucketedWeightReceiver`` is constructed.
+
+    This is the structural half of the fix: the checks that used to raise from
+    inside the worker after the socket existed (MTP drafter, an unvalidated
+    vLLM version, a poisoned worker) now run at a point where raising can only
+    fail the sync loudly. Asserted on the real source of
+    ``update_weights_from_ipc`` so a future refactor that moves the validation
+    back below the receiver fails here.
+    """
+    import inspect
+
+    from verl.workers.rollout.vllm_rollout.utils import vLLMColocateWorkerExtension
+
+    source = inspect.getsource(vLLMColocateWorkerExtension.update_weights_from_ipc)
+    validate_at = source.find("validate_fp8_layerwise_reload_config(")
+    receiver_at = source.find("BucketedWeightReceiver(")
+
+    assert validate_at != -1, "update_weights_from_ipc no longer calls validate_fp8_layerwise_reload_config"
+    assert receiver_at != -1, "update_weights_from_ipc no longer builds a BucketedWeightReceiver"
+    assert validate_at < receiver_at, (
+        "the FP8 configuration validation must run BEFORE the receiver (and therefore before any "
+        "socket or shared buffer exists): the sender waits for an un-timed initial ACK, so raising "
+        "once IPC is live turns a fail-closed error into a driver hang"
+    )
+
+
+def test_pre_ipc_validation_rejects_unsupported_config_without_touching_a_socket(monkeypatch):
+    """The gate itself needs nothing but a config — no socket, no buffer, no model.
+
+    That is what makes the ordering above possible: the checks are decidable
+    from the rollout config plus the installed vLLM version.
+    """
+    from packaging import version
+
+    from verl.utils.vllm import vllm_fp8_utils
+
+    config = type("_Cfg", (), {"quant_config": None})()
+
+    monkeypatch.setattr(vllm_fp8_utils, "_get_vllm_version", lambda: version.parse("0.23.0"))
+    monkeypatch.setattr(vllm_fp8_utils, "_vllm_layerwise_reload_available", lambda: True)
+
+    # Supported: silent.
+    vllm_fp8_utils.validate_fp8_layerwise_reload_config(config, uses_mtp_drafter=False)
+
+    # Unsupported: raises, with no IPC resource involved.
+    with pytest.raises(NotImplementedError, match="MTP drafter"):
+        vllm_fp8_utils.validate_fp8_layerwise_reload_config(config, uses_mtp_drafter=True)

--- a/tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py
@@ -1,0 +1,326 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU regression tests for the vLLM >= 0.20 FP8 layerwise-reload weight resync.
+
+Covers three defect classes:
+
+1. Buffer ownership: verl's bucketed IPC receiver reuses ONE backing buffer
+   for every bucket, while vLLM's layerwise reload buffers streamed tensors
+   until an entire layer has arrived (potentially across buckets). A tensor
+   yielded as a view into the shared buffer and retained past a bucket
+   boundary is silently overwritten by the next bucket. ``quant_weights``
+   must clone non-quantized tensors while a layerwise reload is active.
+
+2. Lifecycle: ``begin_fp8_layerwise_reload`` / ``finalize_fp8_layerwise_reload``
+   must be called exactly once per sync (double-begin and finalize-without-
+   begin raise), and ``load_quanted_weights`` fails closed when a bucket
+   arrives on a reload-capable vLLM without an active reload.
+
+3. Version gate: the resync path is validated on vLLM 0.20.x only. Newer
+   lines must NOT be silently opted in — begin is a no-op and the per-bucket
+   loader raises an explicit version error.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_vllm_fp8_utils():
+    """Load verl/utils/vllm/vllm_fp8_utils.py with vLLM and heavy deps stubbed.
+
+    Injected ``sys.modules`` entries are restored afterwards so the fakes do
+    not leak into other tests; the loaded module keeps working since it binds
+    the names it needs at import time.
+    """
+    module_name = "verl.utils.vllm.vllm_fp8_utils_under_test"
+    module_path = _REPO_ROOT / "verl/utils/vllm/vllm_fp8_utils.py"
+
+    class _FakeFusedMoE(torch.nn.Module):
+        pass
+
+    class _FakeLinearBase(torch.nn.Module):
+        pass
+
+    fake_fused_moe_layer = types.ModuleType("vllm.model_executor.layers.fused_moe.layer")
+    fake_fused_moe_layer.FusedMoE = _FakeFusedMoE
+    fake_linear = types.ModuleType("vllm.model_executor.layers.linear")
+    fake_linear.LinearBase = _FakeLinearBase
+
+    fake_fp8_mod = types.ModuleType("vllm.model_executor.layers.quantization.fp8")
+
+    class _FakeFp8Config:
+        pass
+
+    fake_fp8_mod.Fp8Config = _FakeFp8Config
+    fake_fp8_mod.replace_parameter = lambda *a, **k: None
+
+    # The layerwise reload entry points, importable so the availability probe
+    # passes; behavior is irrelevant for these tests (never actually driven).
+    fake_reload = types.ModuleType("vllm.model_executor.model_loader.reload")
+    fake_reload.initialize_layerwise_reload = lambda model: None
+    fake_reload.finalize_layerwise_reload = lambda model, cfg: None
+
+    fake_config = types.ModuleType("vllm.config")
+
+    class _FakeSetCurrentVllmConfig:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *a):
+            return False
+
+    fake_config.set_current_vllm_config = _FakeSetCurrentVllmConfig
+
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.__version__ = "0.20.2"
+
+    fake_kernel = types.ModuleType("verl.utils.kernel.fp8_kernel")
+
+    def _fake_scaled_fp8_blockwise(t, weight_block_size=None):
+        q = t.to(torch.float32)
+        scale = torch.ones(1, 1, 1)
+        return q, scale
+
+    fake_kernel.scaled_fp8_blockwise = _fake_scaled_fp8_blockwise
+
+    fake_dsv4 = types.ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    fake_dsv4.cache_deepseek_v4_dense_fp8_scales = lambda model, weights: None
+    fake_dsv4.is_deepseek_v4_model = lambda model: False
+    fake_dsv4.iter_deepseek_v4_weights = lambda weights: iter(weights)
+    fake_dsv4.prepare_deepseek_v4_weights_for_loading = lambda model, copy_fn: False
+    fake_dsv4.process_deepseek_v4_weights_after_loading = lambda model, state: None
+    fake_dsv4.reload_deepseek_v4_dense_fp8_scales = lambda model: None
+
+    fakes = {
+        "vllm": fake_vllm,
+        "vllm.config": fake_config,
+        "vllm.model_executor": types.ModuleType("vllm.model_executor"),
+        "vllm.model_executor.layers": types.ModuleType("vllm.model_executor.layers"),
+        "vllm.model_executor.layers.fused_moe": types.ModuleType("vllm.model_executor.layers.fused_moe"),
+        "vllm.model_executor.layers.fused_moe.layer": fake_fused_moe_layer,
+        "vllm.model_executor.layers.linear": fake_linear,
+        "vllm.model_executor.layers.quantization": types.ModuleType("vllm.model_executor.layers.quantization"),
+        "vllm.model_executor.layers.quantization.fp8": fake_fp8_mod,
+        "vllm.model_executor.model_loader": types.ModuleType("vllm.model_executor.model_loader"),
+        "vllm.model_executor.model_loader.reload": fake_reload,
+        "verl.utils.kernel.fp8_kernel": fake_kernel,
+        "verl.utils.vllm.vllm_dsv4_fp8_utils": fake_dsv4,
+    }
+
+    saved = {name: sys.modules.get(name) for name in fakes}
+    try:
+        sys.modules.update(fakes)
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec is not None and spec.loader is not None
+        spec.loader.exec_module(module)
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+    return module
+
+
+fp8_utils = _load_vllm_fp8_utils()
+
+
+def _make_fake_reload_module():
+    fake_reload = types.ModuleType("vllm.model_executor.model_loader.reload")
+    fake_reload.initialize_layerwise_reload = lambda model: None
+    fake_reload.finalize_layerwise_reload = lambda model, cfg: None
+    return fake_reload
+
+
+def _make_fake_config_module():
+    fake_config = types.ModuleType("vllm.config")
+
+    class _FakeSetCurrentVllmConfig:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *a):
+            return False
+
+    fake_config.set_current_vllm_config = _FakeSetCurrentVllmConfig
+    return fake_config
+
+
+@pytest.fixture(autouse=True)
+def _fake_lazy_vllm_imports(monkeypatch):
+    """The module under test lazily imports the vLLM reload entry points at
+    call time; pin fakes into sys.modules so the tests do not depend on the
+    host's installed vLLM shipping (or not shipping) the reload protocol."""
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.model_loader.reload", _make_fake_reload_module())
+    monkeypatch.setitem(sys.modules, "vllm.config", _make_fake_config_module())
+    yield
+
+
+class _ToyModel(torch.nn.Module):
+    """No FP8 modules: every streamed tensor takes the non-quantized path."""
+
+    packed_modules_mapping: dict = {}
+
+    def __init__(self):
+        super().__init__()
+        self.model = torch.nn.Module()
+        self.model.norm = torch.nn.LayerNorm(4)
+
+
+class _FakeQuantConfig:
+    weight_block_size = (128, 128)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fp8_state(monkeypatch):
+    fp8_utils.fp8_state.seen_params.clear()
+    fp8_utils.fp8_state.fp8_param_names.clear()
+    fp8_utils.fp8_state.layerwise_active.clear()
+    yield
+    fp8_utils.fp8_state.layerwise_active.clear()
+
+
+def _pin_version(monkeypatch, ver: str):
+    from packaging import version as _v
+
+    monkeypatch.setattr(fp8_utils, "_get_vllm_version", lambda: _v.parse(ver))
+
+
+def _bucket_views_from_buffer(buffer: torch.Tensor, specs):
+    """Build (name, tensor) views into a shared uint8 buffer, mirroring
+    BucketedWeightReceiver.receive_weights."""
+    weights = []
+    for name, shape, offset in specs:
+        size = 4 * int(torch.tensor(shape).prod())  # float32 elements
+        t = buffer[offset : offset + size].view(dtype=torch.float32).view(shape)
+        weights.append((name, t))
+    return weights
+
+
+def test_layerwise_reload_clones_bucket_backed_tensors(monkeypatch):
+    """Two buckets share one reused backing buffer; the layer only completes
+    after bucket 2 has overwritten the storage. The bytes handed to vLLM for
+    bucket-1 tensors must come from the ORIGINAL bucket-1 payload."""
+    _pin_version(monkeypatch, "0.20.2")
+    model = _ToyModel()
+    buffer = torch.zeros(256, dtype=torch.uint8)
+
+    # --- bucket 1 arrives: a non-FP8 tensor viewed into the shared buffer ---
+    (name, view1) = _bucket_views_from_buffer(buffer, [("model.norm.weight", (4,), 0)])[0]
+    view1.copy_(torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    original = view1.clone()
+
+    fp8_utils.fp8_state.layerwise_active.add("main")
+    buffered = list(fp8_utils.quant_weights([(name, view1)], model, _FakeQuantConfig()))
+    assert len(buffered) == 1
+    held_name, held = buffered[0]
+    assert held_name == name
+
+    # The layerwise reload holds `held` past the bucket boundary (delayed
+    # layer completion). Bucket 2 now reuses the same backing buffer:
+    buffer.fill_(0xFF)
+
+    # Layer "completes" now — the held tensor must still carry bucket-1 bytes.
+    assert torch.equal(held, original), (
+        "bucket-backed tensor was overwritten by bucket 2 before the layer "
+        "completed — quant_weights must clone non-quantized tensors while a "
+        "layerwise reload is active"
+    )
+    assert held.data_ptr() != view1.data_ptr()
+
+
+def test_without_active_reload_views_alias_the_buffer(monkeypatch):
+    """Negative control: outside a layerwise reload the non-quantized path
+    yields the view unchanged (zero-copy fast path preserved)."""
+    _pin_version(monkeypatch, "0.20.2")
+    model = _ToyModel()
+    buffer = torch.zeros(256, dtype=torch.uint8)
+    (name, view1) = _bucket_views_from_buffer(buffer, [("model.norm.weight", (4,), 0)])[0]
+    view1.copy_(torch.tensor([1.0, 2.0, 3.0, 4.0]))
+
+    assert not fp8_utils.fp8_state.layerwise_active
+    buffered = list(fp8_utils.quant_weights([(name, view1)], model, _FakeQuantConfig()))
+    assert buffered[0][1].data_ptr() == view1.data_ptr()
+
+
+def test_begin_finalize_lifecycle_guards(monkeypatch):
+    _pin_version(monkeypatch, "0.20.2")
+    model = _ToyModel()
+
+    assert fp8_utils.begin_fp8_layerwise_reload(model, tag="main") is True
+    with pytest.raises(RuntimeError, match="already active"):
+        fp8_utils.begin_fp8_layerwise_reload(model, tag="main")
+
+    fp8_utils.finalize_fp8_layerwise_reload(model, model_config=None, tag="main")
+    with pytest.raises(RuntimeError, match="without an active begin"):
+        fp8_utils.finalize_fp8_layerwise_reload(model, model_config=None, tag="main")
+
+
+def test_begin_is_noop_below_020(monkeypatch):
+    _pin_version(monkeypatch, "0.19.0")
+    assert fp8_utils.begin_fp8_layerwise_reload(_ToyModel(), tag="main") is False
+    assert not fp8_utils.fp8_state.layerwise_active
+
+
+class _FakeModelConfig:
+    dtype = torch.bfloat16
+
+
+class _FakeVllmConfig:
+    quant_config = _FakeQuantConfig()
+    model_config = _FakeModelConfig()
+
+
+class _FakeModelRunner:
+    def __init__(self, model):
+        self.model = model
+        self.vllm_config = _FakeVllmConfig()
+
+
+def test_load_quanted_weights_fails_closed_without_begin(monkeypatch):
+    """A bucket on reload-capable vLLM without an active reload must raise,
+    not stream checkpoint-format weights into kernel-format params."""
+    _pin_version(monkeypatch, "0.20.2")
+    runner = _FakeModelRunner(_ToyModel())
+    with pytest.raises(RuntimeError, match="without an active layerwise reload"):
+        fp8_utils.load_quanted_weights([("model.norm.weight", torch.zeros(4))], runner)
+
+
+def test_load_quanted_weights_fails_closed_on_unvalidated_vllm(monkeypatch):
+    """vLLM >= 0.21 ships the reload module but is not validated: begin must
+    be a no-op and the per-bucket loader must raise an explicit version
+    error instead of silently opting the new line in."""
+    _pin_version(monkeypatch, "0.21.0")
+    assert fp8_utils._vllm_layerwise_reload_available() is True
+    assert fp8_utils._vllm_supports_layerwise_reload() is False
+    assert fp8_utils.begin_fp8_layerwise_reload(_ToyModel(), tag="main") is False
+
+    runner = _FakeModelRunner(_ToyModel())
+    with pytest.raises(RuntimeError, match="validated on vLLM 0.20.x only"):
+        fp8_utils.load_quanted_weights([("model.norm.weight", torch.zeros(4))], runner)

--- a/tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py
@@ -199,11 +199,16 @@ class _FakeQuantConfig:
 
 @pytest.fixture(autouse=True)
 def _reset_fp8_state(monkeypatch):
-    fp8_utils.fp8_state.seen_params.clear()
-    fp8_utils.fp8_state.fp8_param_names.clear()
-    fp8_utils.fp8_state.layerwise_active.clear()
+    def _clear():
+        fp8_utils.fp8_state.seen_params.clear()
+        fp8_utils.fp8_state.fp8_param_names.clear()
+        fp8_utils.fp8_state.layerwise_active.clear()
+        fp8_utils.fp8_state.layerwise_begin_attempted.clear()
+        fp8_utils.fp8_state.layerwise_poisoned.clear()
+
+    _clear()
     yield
-    fp8_utils.fp8_state.layerwise_active.clear()
+    _clear()
 
 
 def _pin_version(monkeypatch, ver: str):
@@ -312,15 +317,150 @@ def test_load_quanted_weights_fails_closed_without_begin(monkeypatch):
         fp8_utils.load_quanted_weights([("model.norm.weight", torch.zeros(4))], runner)
 
 
+def test_validated_interval_covers_the_audited_vllm_tags(monkeypatch):
+    """The gate must cover every vLLM line whose reload semantics were audited.
+
+    verl's CI images pin vllm023.dev1 and the dense/MoE FP8 E2Es exercise this
+    path, so a gate that excludes 0.23 turns fail-closed into a red CI. The
+    upper bound is the first line whose layer-completion accounting changed
+    (0.25.0, which re-derives load_numel_total on every load).
+    """
+    for validated in ("0.20.0", "0.20.2", "0.21.0", "0.22.1", "0.23.0", "0.24.0"):
+        _pin_version(monkeypatch, validated)
+        assert fp8_utils._vllm_supports_layerwise_reload() is True, validated
+
+    for unvalidated in ("0.25.0", "0.26.0"):
+        _pin_version(monkeypatch, unvalidated)
+        assert fp8_utils._vllm_layerwise_reload_available() is True, unvalidated
+        assert fp8_utils._vllm_supports_layerwise_reload() is False, unvalidated
+
+
 def test_load_quanted_weights_fails_closed_on_unvalidated_vllm(monkeypatch):
-    """vLLM >= 0.21 ships the reload module but is not validated: begin must
-    be a no-op and the per-bucket loader must raise an explicit version
-    error instead of silently opting the new line in."""
-    _pin_version(monkeypatch, "0.21.0")
+    """Above the validated interval the reload module still imports, but the
+    lifecycle semantics are unverified: begin must be a no-op and the
+    per-bucket loader must raise an explicit version error instead of silently
+    opting the new line in."""
+    _pin_version(monkeypatch, "0.25.0")
     assert fp8_utils._vllm_layerwise_reload_available() is True
     assert fp8_utils._vllm_supports_layerwise_reload() is False
     assert fp8_utils.begin_fp8_layerwise_reload(_ToyModel(), tag="main") is False
 
     runner = _FakeModelRunner(_ToyModel())
-    with pytest.raises(RuntimeError, match="validated on vLLM 0.20.x only"):
+    with pytest.raises(RuntimeError, match=r"validated on vLLM >= 0\.20, < 0\.25\.0"):
         fp8_utils.load_quanted_weights([("model.norm.weight", torch.zeros(4))], runner)
+
+
+# ---------------------------------------------------------------------------
+# Fault injection: a begin that dies part-way through initialize_layerwise_reload
+# leaves the model half-converted (early layers on meta, the rest real), so the
+# worker must be fail-stopped rather than reused.
+# ---------------------------------------------------------------------------
+
+
+def _pin_failing_initialize(monkeypatch, layers_converted: int):
+    """Make initialize_layerwise_reload convert N layers, then raise."""
+    fake_reload = types.ModuleType("vllm.model_executor.model_loader.reload")
+    converted = []
+
+    def _initialize_layerwise_reload(model):
+        for index, module in enumerate(model.modules()):
+            if index >= layers_converted:
+                raise RuntimeError("synthetic vLLM failure mid-initialize (layer swap to meta)")
+            converted.append(module)
+
+    fake_reload.initialize_layerwise_reload = _initialize_layerwise_reload
+    fake_reload.finalize_layerwise_reload = lambda model, cfg: None
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.model_loader.reload", fake_reload)
+    return converted
+
+
+def test_begin_records_attempt_before_calling_into_vllm(monkeypatch):
+    """`attempted` must be recorded BEFORE the vLLM call, otherwise a failure
+    part-way through initialize leaves no durable evidence that the model was
+    touched (`layerwise_active` is never reached)."""
+    _pin_version(monkeypatch, "0.23.0")
+    converted = _pin_failing_initialize(monkeypatch, layers_converted=1)
+    model = _ToyModel()
+
+    with pytest.raises(RuntimeError, match="synthetic vLLM failure mid-initialize"):
+        fp8_utils.begin_fp8_layerwise_reload(model, tag="main")
+
+    assert converted, "the fault injection must convert at least one layer before raising"
+    assert "main" in fp8_utils.fp8_state.layerwise_begin_attempted
+    # NOT active: the reload never completed.
+    assert "main" not in fp8_utils.fp8_state.layerwise_active
+
+
+def test_begin_failure_poisons_the_worker(monkeypatch):
+    """A begin that raises mid-initialize must fail-stop the worker: later
+    syncs raise, and a generation request on the half-converted model raises
+    instead of returning possibly corrupt output."""
+    _pin_version(monkeypatch, "0.23.0")
+    _pin_failing_initialize(monkeypatch, layers_converted=1)
+    model = _ToyModel()
+    runner = _FakeModelRunner(model)
+
+    with pytest.raises(RuntimeError, match="synthetic vLLM failure mid-initialize"):
+        fp8_utils.begin_fp8_layerwise_reload(model, tag="main", model_runner=runner)
+
+    assert "main" in fp8_utils.fp8_state.layerwise_poisoned
+
+    # 1. A later weight sync must refuse rather than load into the damaged model.
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.model_loader.reload", _make_fake_reload_module())
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        fp8_utils.begin_fp8_layerwise_reload(model, tag="main", model_runner=runner)
+
+    # 2. The pre-IPC config validation must also refuse (before any socket exists).
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        fp8_utils.validate_fp8_layerwise_reload_config(runner.vllm_config, uses_mtp_drafter=False)
+
+    # 3. A per-bucket load must refuse.
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        fp8_utils.load_quanted_weights([("model.norm.weight", torch.zeros(4))], runner)
+
+    # 4. A generation request must raise instead of running on meta weights.
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        model.forward(torch.zeros(1))
+
+
+def test_finalize_failure_poisons_the_worker(monkeypatch):
+    """finalize also restores layers one at a time, so a failure there leaves
+    the same partially-restored model and must fail-stop too."""
+    _pin_version(monkeypatch, "0.23.0")
+    fake_reload = types.ModuleType("vllm.model_executor.model_loader.reload")
+    fake_reload.initialize_layerwise_reload = lambda model: None
+
+    def _finalize(model, cfg):
+        raise RuntimeError("synthetic vLLM failure mid-finalize")
+
+    fake_reload.finalize_layerwise_reload = _finalize
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.model_loader.reload", fake_reload)
+
+    model = _ToyModel()
+    assert fp8_utils.begin_fp8_layerwise_reload(model, tag="main") is True
+    with pytest.raises(RuntimeError, match="synthetic vLLM failure mid-finalize"):
+        fp8_utils.finalize_fp8_layerwise_reload(model, model_config=None, tag="main")
+
+    assert "main" in fp8_utils.fp8_state.layerwise_poisoned
+    assert "main" not in fp8_utils.fp8_state.layerwise_active
+
+
+def test_validate_config_rejects_mtp_and_unvalidated_version(monkeypatch):
+    """The pre-IPC validation gate must reject exactly the configurations the
+    in-loop raises used to reject, so no unsupported sync ever reaches IPC."""
+    runner = _FakeModelRunner(_ToyModel())
+
+    _pin_version(monkeypatch, "0.23.0")
+    # Supported configuration: must not raise.
+    fp8_utils.validate_fp8_layerwise_reload_config(runner.vllm_config, uses_mtp_drafter=False)
+
+    with pytest.raises(NotImplementedError, match="MTP drafter"):
+        fp8_utils.validate_fp8_layerwise_reload_config(runner.vllm_config, uses_mtp_drafter=True)
+
+    _pin_version(monkeypatch, "0.25.0")
+    with pytest.raises(RuntimeError, match=r"validated on vLLM >= 0\.20, < 0\.25\.0"):
+        fp8_utils.validate_fp8_layerwise_reload_config(runner.vllm_config, uses_mtp_drafter=False)
+
+    # Below 0.20 the reload module is absent: this path does not apply at all.
+    _pin_version(monkeypatch, "0.19.0")
+    fp8_utils.validate_fp8_layerwise_reload_config(runner.vllm_config, uses_mtp_drafter=True)

--- a/tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py
@@ -303,9 +303,26 @@ class _FakeVllmConfig:
 
 
 class _FakeModelRunner:
+    """Stand-in for vLLM's ``GPUModelRunner`` with the two serving entry points.
+
+    ``execute_model`` / ``_dummy_run`` are the methods
+    ``vllm/v1/worker/gpu_worker.py`` ``Worker.execute_model`` /
+    ``Worker.execute_dummy_batch`` delegate to at every audited tag, so they are
+    what the poison guard must shadow.
+    """
+
     def __init__(self, model):
         self.model = model
         self.vllm_config = _FakeVllmConfig()
+        self.served = 0
+
+    def execute_model(self, scheduler_output=None, intermediate_tensors=None):
+        self.served += 1
+        return "output"
+
+    def _dummy_run(self, num_tokens=1, **kwargs):
+        self.served += 1
+        return "output"
 
 
 def test_load_quanted_weights_fails_closed_without_begin(monkeypatch):
@@ -418,14 +435,69 @@ def test_begin_failure_poisons_the_worker(monkeypatch):
     with pytest.raises(RuntimeError, match="fail-stopped"):
         fp8_utils.load_quanted_weights([("model.norm.weight", torch.zeros(4))], runner)
 
-    # 4. A generation request must raise instead of running on meta weights.
+    # 4. A generation request must raise instead of running on meta weights —
+    #    at the WORKER level: vLLM's Worker.execute_model /
+    #    Worker.execute_dummy_batch delegate to exactly these two runner
+    #    methods, so guarding them refuses the request before the forward pass.
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        runner.execute_model(scheduler_output=None)
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        runner._dummy_run(1)
+    assert runner.served == 0, "a poisoned runner still executed the model"
+    # 5. And the model-level backstop still holds for callers that hold the
+    #    model object directly.
     with pytest.raises(RuntimeError, match="fail-stopped"):
         model.forward(torch.zeros(1))
 
 
+def test_poison_guard_names_the_real_vllm_worker_entry_points():
+    """The guarded runner methods must be the ones vLLM's Worker actually calls.
+
+    Pins the invariant to vLLM's own delegation rather than to a name we chose:
+    if a future vLLM line renames ``execute_model`` / ``_dummy_run``, or verl's
+    tuple drifts from them, this fails instead of silently leaving a poisoned
+    worker able to serve.
+
+    Reads ``vllm/v1/worker/gpu_worker.py`` as TEXT from the installed package
+    directory rather than importing it: importing that module pulls in the whole
+    engine/config chain, which is not available in a CPU-only test environment
+    (and fails with an ImportError rather than a skippable ModuleNotFoundError
+    on a source checkout). Skipped when vLLM is absent entirely, with the tuple
+    still asserted non-empty.
+    """
+    assert fp8_utils._MODEL_RUNNER_SERVING_ENTRY_POINTS, "the guard must name at least one entry point"
+
+    vllm_spec = importlib.util.find_spec("vllm")
+    if vllm_spec is None or not vllm_spec.submodule_search_locations:
+        pytest.skip("needs an installed vLLM to read Worker's delegation from source")
+    source_path = Path(next(iter(vllm_spec.submodule_search_locations))) / "v1" / "worker" / "gpu_worker.py"
+    if not source_path.is_file():
+        pytest.skip(f"installed vLLM has no {source_path}")
+    source = source_path.read_text()
+
+    for method_name, entry_point in (
+        ("execute_model", "execute_model"),
+        ("execute_dummy_batch", "_dummy_run"),
+    ):
+        marker = f"    def {method_name}("
+        start = source.find(marker)
+        assert start != -1, f"vLLM's Worker no longer defines {method_name} in {source_path}"
+        # Method body = up to the next same-indentation def.
+        end = source.find("\n    def ", start + len(marker))
+        body = source[start:] if end == -1 else source[start:end]
+        assert f"self.model_runner.{entry_point}(" in body, (
+            f"vLLM's Worker.{method_name} no longer delegates to model_runner.{entry_point}; "
+            "the FP8 fail-stop guard must be re-pointed at the current entry point"
+        )
+        assert entry_point in fp8_utils._MODEL_RUNNER_SERVING_ENTRY_POINTS, (
+            f"model_runner.{entry_point} serves requests but is not fail-stop guarded"
+        )
+
+
 def test_finalize_failure_poisons_the_worker(monkeypatch):
     """finalize also restores layers one at a time, so a failure there leaves
-    the same partially-restored model and must fail-stop too."""
+    the same partially-restored model and must fail-stop too — including the
+    worker/runner serving entry points when the runner is passed in."""
     _pin_version(monkeypatch, "0.23.0")
     fake_reload = types.ModuleType("vllm.model_executor.model_loader.reload")
     fake_reload.initialize_layerwise_reload = lambda model: None
@@ -437,12 +509,18 @@ def test_finalize_failure_poisons_the_worker(monkeypatch):
     monkeypatch.setitem(sys.modules, "vllm.model_executor.model_loader.reload", fake_reload)
 
     model = _ToyModel()
+    runner = _FakeModelRunner(model)
     assert fp8_utils.begin_fp8_layerwise_reload(model, tag="main") is True
     with pytest.raises(RuntimeError, match="synthetic vLLM failure mid-finalize"):
-        fp8_utils.finalize_fp8_layerwise_reload(model, model_config=None, tag="main")
+        fp8_utils.finalize_fp8_layerwise_reload(model, model_config=None, tag="main", model_runner=runner)
 
     assert "main" in fp8_utils.fp8_state.layerwise_poisoned
     assert "main" not in fp8_utils.fp8_state.layerwise_active
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        runner.execute_model(scheduler_output=None)
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        runner._dummy_run(1)
+    assert runner.served == 0, "a poisoned runner still executed the model"
 
 
 def test_validate_config_rejects_mtp_and_unvalidated_version(monkeypatch):

--- a/tests/workers/rollout/test_vllm_fp8_layerwise_reload_integration_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_fp8_layerwise_reload_integration_on_cpu.py
@@ -297,6 +297,17 @@ def test_real_begin_failure_poisons_the_worker(monkeypatch):
         def __init__(self, m):
             self.model = m
             self.vllm_config = type("_Cfg", (), {"quant_config": None})()
+            self.served = 0
+
+        # The two methods vLLM's Worker delegates serving to (verified in
+        # vllm/v1/worker/gpu_worker.py at every audited tag).
+        def execute_model(self, scheduler_output=None, intermediate_tensors=None):
+            self.served += 1
+            return "output"
+
+        def _dummy_run(self, num_tokens=1, **kwargs):
+            self.served += 1
+            return "output"
 
     runner = _Runner(model)
     with pytest.raises(RuntimeError, match="synthetic failure after partially moving layers"):
@@ -317,6 +328,13 @@ def test_real_begin_failure_poisons_the_worker(monkeypatch):
         begin_fp8_layerwise_reload(model, tag="main", model_runner=runner)
     with pytest.raises(RuntimeError, match="fail-stopped"):
         validate_fp8_layerwise_reload_config(runner.vllm_config, uses_mtp_drafter=False)
+    # Serving is refused at the worker/runner level, ahead of the forward pass,
+    # after a REAL partial initialize_layerwise_reload.
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        runner.execute_model(scheduler_output=None)
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        runner._dummy_run(1)
+    assert runner.served == 0, "a poisoned runner still executed the model"
     with pytest.raises(RuntimeError, match="fail-stopped"):
         model.forward(torch.zeros(1))
 

--- a/tests/workers/rollout/test_vllm_fp8_layerwise_reload_integration_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_fp8_layerwise_reload_integration_on_cpu.py
@@ -1,0 +1,334 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU integration tests driving the REAL vLLM layerwise-reload API.
+
+Role split with ``test_vllm_fp8_layerwise_lifecycle_on_cpu.py``: that suite
+stubs the vLLM reload entry points and tests verl's own lifecycle, ownership
+and gate logic in isolation (it must run on a host with any vLLM, or none).
+THIS suite imports the installed vLLM and calls
+``record_metadata_for_reloading`` / ``initialize_layerwise_reload`` /
+``finalize_layerwise_reload`` for real, so it pins the two vLLM behaviours
+verl's FP8 resync path actually depends on:
+
+  (i) initialize is NOT idempotent across buckets — a layer that completes
+      during streaming ends with ``info.reset()``, so re-initializing swaps it
+      back to meta and finalize then treats ``0 < load_numel < total`` as
+      "delayed processing"; verl must therefore call initialize/finalize once
+      per sync, outside the per-bucket loop;
+  (ii) streamed tensors are BUFFERED (retained in ``info.loaded_weights``)
+      until a layer is complete, so a tensor aliasing verl's reused IPC
+      receive buffer must be cloned before being handed to load_weights.
+
+These are the properties ``_vllm_supports_layerwise_reload``'s validated
+interval asserts. Running this file on a new vLLM line is the cheap way to
+find out whether the gate may be widened to it.
+
+Everything here is CPU-only and model-free (a hand-written toy module whose
+``load_weights`` mirrors vLLM's contract), so it runs in verl's
+``*_on_cpu.py`` CI collection.
+"""
+
+import pytest
+import torch
+
+vllm_reload = pytest.importorskip(
+    "vllm.model_executor.model_loader.reload",
+    reason="installed vLLM does not ship the layerwise reload protocol (vLLM < 0.20)",
+)
+
+from vllm.model_executor.model_loader.reload import (  # noqa: E402
+    finalize_layerwise_reload,
+    initialize_layerwise_reload,
+    record_metadata_for_reloading,
+)
+from vllm.model_executor.model_loader.reload.layerwise import get_layerwise_info  # noqa: E402
+
+from verl.utils.vllm.vllm_fp8_utils import (  # noqa: E402
+    _get_vllm_version,
+    _vllm_layerwise_reload_available,
+    _vllm_supports_layerwise_reload,
+    begin_fp8_layerwise_reload,
+    finalize_fp8_layerwise_reload,
+    fp8_state,
+    validate_fp8_layerwise_reload_config,
+)
+
+
+class _ToyLayer(torch.nn.Module):
+    """One 'layer' with two params, so a bucket boundary can split it."""
+
+    def __init__(self, size: int = 8):
+        super().__init__()
+        self.a = torch.nn.Parameter(torch.zeros(size, size), requires_grad=False)
+        self.b = torch.nn.Parameter(torch.zeros(size, size), requires_grad=False)
+
+
+class _ToyModel(torch.nn.Module):
+    """Minimal stand-in for a vLLM model on the reload path.
+
+    ``load_weights`` mirrors vLLM's contract: look the destination param up by
+    name and drive its ``weight_loader`` when one is installed. Under an active
+    layerwise reload vLLM replaces that attribute with its
+    ``online_process_loader`` wrapper, which is exactly the machinery under
+    test.
+    """
+
+    def __init__(self, size: int = 8):
+        super().__init__()
+        self.layer0 = _ToyLayer(size)
+        self.layer1 = _ToyLayer(size)
+
+    def load_weights(self, weights):
+        params = dict(self.named_parameters(remove_duplicate=False))
+        loaded = set()
+        for name, tensor in weights:
+            param = params[name]
+            loader = getattr(param, "weight_loader", None)
+            if loader is None:
+                param.data.copy_(tensor)
+            else:
+                loader(param, tensor)
+            loaded.add(name)
+        return loaded
+
+
+class _FakeModelConfig:
+    dtype = torch.float32
+
+
+@pytest.fixture(autouse=True)
+def _reset_fp8_state():
+    def _clear():
+        fp8_state.layerwise_active.clear()
+        fp8_state.layerwise_begin_attempted.clear()
+        fp8_state.layerwise_poisoned.clear()
+
+    _clear()
+    yield
+    _clear()
+
+
+def _reference_weights(model: _ToyModel):
+    """Deterministic non-zero target values, one per parameter."""
+    return [
+        (name, torch.full_like(param.data, float(index + 1)))
+        for index, (name, param) in enumerate(model.named_parameters())
+    ]
+
+
+def _assert_loaded(model: _ToyModel, expected):
+    actual = dict(model.named_parameters())
+    for name, want in expected:
+        got = actual[name].data
+        assert not got.is_meta, f"{name} left on meta after finalize"
+        torch.testing.assert_close(got, want, msg=f"{name} did not receive its streamed value")
+
+
+def test_installed_vllm_is_inside_the_validated_interval():
+    """Self-check for the rest of this file: it asserts the semantics of the
+    validated interval, so it is only meaningful when the installed vLLM is in
+    it. A FAIL here on a newly bumped image is the intended signal that the
+    gate needs re-auditing before it is widened."""
+    assert _vllm_layerwise_reload_available() is True
+    assert _vllm_supports_layerwise_reload() is True, (
+        f"installed vLLM {_get_vllm_version()} is outside the interval this resync path is "
+        "validated on; audit the reload/ sources and widen "
+        "_VLLM_LAYERWISE_RELOAD_VALIDATED_BELOW before enabling it"
+    )
+
+
+def test_real_reload_lifecycle_loads_every_bucket():
+    """The full verl shape against the real API: ONE begin, N bucketed
+    load_weights calls, ONE finalize — every streamed value must land."""
+    model = _ToyModel()
+    record_metadata_for_reloading(model)
+    weights = _reference_weights(model)
+
+    assert begin_fp8_layerwise_reload(model, tag="main") is True
+    assert "main" in fp8_state.layerwise_active
+    # Real vLLM swapped the params to meta placeholders.
+    assert all(param.is_meta for _, param in model.named_parameters())
+
+    # Stream one parameter per "bucket" so layer0 spans two buckets.
+    for name, tensor in weights:
+        model.load_weights([(name, tensor)])
+
+    with torch.device("cpu"):
+        finalize_fp8_layerwise_reload(model, _FakeModelConfig(), tag="main")
+
+    assert "main" not in fp8_state.layerwise_active
+    _assert_loaded(model, weights)
+
+
+def test_real_initialize_is_not_idempotent_across_buckets():
+    """Pins property (i): re-initializing after a layer has completed swaps
+    that layer BACK to meta. This is why verl's begin/finalize live in
+    update_weights_from_ipc and not in the per-bucket loader — a per-bucket
+    initialize would resurrect completed layers and let finalize process
+    uninitialized memory into kernel storage.
+    """
+    model = _ToyModel()
+    record_metadata_for_reloading(model)
+    weights = _reference_weights(model)
+
+    initialize_layerwise_reload(model)
+
+    # Complete layer0 (both of its params), leave layer1 untouched.
+    layer0 = [(name, tensor) for name, tensor in weights if name.startswith("layer0.")]
+    with torch.device("cpu"):
+        model.load_weights(layer0)
+
+    info0 = get_layerwise_info(model.layer0)
+    assert info0.can_load() is False, "a completed layer must have been reset by _layerwise_process"
+    assert not model.layer0.a.is_meta, "a completed layer must hold real data again"
+
+    # A second initialize (what a per-bucket initialize would do) re-converts it.
+    initialize_layerwise_reload(model)
+    assert model.layer0.a.is_meta, (
+        "re-initialize did NOT swap the completed layer back to meta: the "
+        "non-idempotence this path is designed around no longer holds on "
+        f"vLLM {_get_vllm_version()} — re-audit before trusting the gate"
+    )
+
+    with torch.device("cpu"):
+        finalize_fp8_layerwise_reload_unmanaged(model)
+
+
+def finalize_layerwise_reload_unmanaged(model):
+    finalize_layerwise_reload(model, _FakeModelConfig())
+
+
+# Alias kept explicit so the test above reads as "clean up the raw vLLM state"
+# rather than exercising verl's tag bookkeeping (no begin_ was called).
+finalize_fp8_layerwise_reload_unmanaged = finalize_layerwise_reload_unmanaged
+
+
+def test_real_reload_buffers_streamed_tensors_until_layer_completes():
+    """Pins property (ii): vLLM RETAINS the caller's tensor until the layer is
+    complete. verl's IPC receiver reuses one buffer for every bucket, so a
+    tensor that is a view into it must be cloned; this test proves the hazard
+    is real by mutating the caller's tensor after handing it over.
+    """
+    model = _ToyModel()
+    record_metadata_for_reloading(model)
+    initialize_layerwise_reload(model)
+
+    good = torch.full((8, 8), 7.0)
+    # Emulate the reused IPC receive buffer: same storage for both yields.
+    reused = torch.full((8, 8), 3.0)
+
+    with torch.device("cpu"):
+        model.load_weights([("layer0.a", reused)])
+        # layer0 is NOT complete yet (layer0.b outstanding), so vLLM is holding
+        # a reference to `reused`. The next bucket overwrites that storage.
+        reused.fill_(99.0)
+        model.load_weights([("layer0.b", good)])
+
+    assert not model.layer0.a.is_meta, "layer0 should have completed once both params arrived"
+    torch.testing.assert_close(
+        model.layer0.a.data,
+        torch.full((8, 8), 99.0),
+        msg=(
+            "vLLM no longer retains the caller's tensor across the bucket boundary; "
+            "the clone in quant_weights would be unnecessary — re-audit ownership "
+            f"on vLLM {_get_vllm_version()}"
+        ),
+    )
+
+    # And the fix: cloning before handing over makes the value stable.
+    model2 = _ToyModel()
+    record_metadata_for_reloading(model2)
+    initialize_layerwise_reload(model2)
+    reused2 = torch.full((8, 8), 3.0)
+    with torch.device("cpu"):
+        model2.load_weights([("layer0.a", reused2.clone())])
+        reused2.fill_(99.0)
+        model2.load_weights([("layer0.b", good)])
+    torch.testing.assert_close(model2.layer0.a.data, torch.full((8, 8), 3.0))
+
+    with torch.device("cpu"):
+        finalize_layerwise_reload_unmanaged(model)
+        finalize_layerwise_reload_unmanaged(model2)
+
+
+def test_real_double_begin_is_rejected_before_touching_vllm():
+    """verl's lifecycle guard must fire on a second begin, so the
+    non-idempotence above can never be reached through verl's own API."""
+    model = _ToyModel()
+    record_metadata_for_reloading(model)
+
+    assert begin_fp8_layerwise_reload(model, tag="main") is True
+    with pytest.raises(RuntimeError, match="already active"):
+        begin_fp8_layerwise_reload(model, tag="main")
+
+    with torch.device("cpu"):
+        finalize_fp8_layerwise_reload(model, _FakeModelConfig(), tag="main")
+
+
+def test_real_begin_failure_poisons_the_worker(monkeypatch):
+    """Fault injection against the REAL API: make vLLM's initialize raise after
+    it has already converted part of the model, and assert verl fail-stops
+    instead of leaving a half-converted model reusable."""
+    model = _ToyModel()
+    record_metadata_for_reloading(model)
+
+    real_initialize = vllm_reload.initialize_layerwise_reload
+
+    def _initialize_then_fail(target):
+        # Convert layer0 for real, then die — the exact half-converted shape.
+        real_initialize(target.layer0)
+        raise RuntimeError("synthetic failure after partially moving layers to meta")
+
+    monkeypatch.setattr(vllm_reload, "initialize_layerwise_reload", _initialize_then_fail)
+
+    class _Runner:
+        def __init__(self, m):
+            self.model = m
+            self.vllm_config = type("_Cfg", (), {"quant_config": None})()
+
+    runner = _Runner(model)
+    with pytest.raises(RuntimeError, match="synthetic failure after partially moving layers"):
+        begin_fp8_layerwise_reload(model, tag="main", model_runner=runner)
+
+    # The model really is half-converted: layer0 on meta, layer1 not.
+    assert model.layer0.a.is_meta
+    assert not model.layer1.a.is_meta
+
+    # Attempt recorded before the vLLM call, worker poisoned, and every entry
+    # point into the resync path now refuses.
+    assert "main" in fp8_state.layerwise_begin_attempted
+    assert "main" in fp8_state.layerwise_poisoned
+    assert "main" not in fp8_state.layerwise_active
+
+    monkeypatch.setattr(vllm_reload, "initialize_layerwise_reload", real_initialize)
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        begin_fp8_layerwise_reload(model, tag="main", model_runner=runner)
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        validate_fp8_layerwise_reload_config(runner.vllm_config, uses_mtp_drafter=False)
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        model.forward(torch.zeros(1))
+
+
+def test_validate_config_runs_before_any_ipc_resource():
+    """The pre-IPC gate must be callable with nothing but a config — that is
+    what lets update_weights_from_ipc reject an unsupported sync before a
+    socket or shared buffer exists (and therefore before the un-timed ACK
+    handshake the sender is about to enter)."""
+    config = type("_Cfg", (), {"quant_config": None})()
+
+    validate_fp8_layerwise_reload_config(config, uses_mtp_drafter=False)
+
+    with pytest.raises(NotImplementedError, match="MTP drafter"):
+        validate_fp8_layerwise_reload_config(config, uses_mtp_drafter=True)

--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -242,3 +242,162 @@ def test_vllm_update_weights_syncs_buffers_to_mtp_drafter():
     expected = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
     torch.testing.assert_close(main_model.model.layers[0].e_score_correction_bias, expected)
     torch.testing.assert_close(drafter_model.model.layers[0].e_score_correction_bias, expected)
+
+
+# ---------------------------------------------------------------------------
+# FP8 layerwise reload fail-stop through update_weights_from_ipc.
+#
+# Ported from the receive-stage abort tests on the PR's previous head
+# (3a5d729d) and adapted to the entry-point fail-stop mechanism: a failure
+# during receive or finalize while the layerwise reload is active must poison
+# the worker (via _fail_stop_fp8_reload) so a follow-on sync refuses up front,
+# instead of re-initializing a partially-updated model.
+# ---------------------------------------------------------------------------
+
+import pytest  # noqa: E402
+
+
+def _stub_fp8_layerwise_env(monkeypatch, *, receive_error=None, finalize_error=None):
+    """Wire update_weights_from_ipc onto the FP8 layerwise path with the vLLM /
+    fp8_utils touch-points faked. Returns the real fp8_utils module so tests can
+    assert on fp8_state, plus the recorded fail-stop reasons.
+
+    ``receive_error`` / ``finalize_error`` inject a failure at the matching
+    lifecycle stage; both None drives the happy path.
+    """
+    fail_stop_reasons: list[str] = []
+
+    fake_config = types.ModuleType("vllm.config")
+
+    class _CtxMgr:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *a):
+            return False
+
+    fake_config.set_current_vllm_config = _CtxMgr
+
+    fake_platforms = types.ModuleType("vllm.platforms")
+
+    class _Platform:
+        device_type = "cpu"
+
+    fake_platforms.current_platform = _Platform()
+
+    fake_bwt = types.ModuleType("verl.workers.rollout.vllm_rollout.bucketed_weight_transfer")
+
+    class _Receiver:
+        def __init__(self, **kwargs):
+            pass
+
+        def receive_weights(self, on_bucket_received):
+            if receive_error is not None:
+                raise receive_error
+
+    fake_bwt.BucketedWeightReceiver = _Receiver
+
+    fake_fp8 = types.ModuleType("verl.utils.vllm.vllm_fp8_utils")
+
+    class _FP8State:
+        def __init__(self):
+            self.layerwise_active = set()
+            self.layerwise_begin_attempted = set()
+            self.layerwise_poisoned = set()
+
+    state = _FP8State()
+    fake_fp8.fp8_state = state
+    fake_fp8.prepare_quanted_weights_for_loading = lambda runner: False
+    fake_fp8._vllm_supports_layerwise_reload = lambda: True
+    fake_fp8.is_mxfp8_vllm_ascend = lambda cfg: False
+
+    def _validate(vllm_config, uses_mtp_drafter, tag="main"):
+        if tag in state.layerwise_poisoned:
+            raise RuntimeError(f"FP8 layerwise reload for '{tag}' previously FAILED and the worker is fail-stopped.")
+
+    fake_fp8.validate_fp8_layerwise_reload_config = _validate
+
+    def _begin(model, tag="main", model_runner=None):
+        state.layerwise_begin_attempted.add(tag)
+        state.layerwise_active.add(tag)
+        return True
+
+    fake_fp8.begin_fp8_layerwise_reload = _begin
+
+    def _fail_stop(model_runner, reason, tag="main", model=None):
+        fail_stop_reasons.append(reason)
+        state.layerwise_poisoned.add(tag)
+        state.layerwise_active.discard(tag)
+
+    fake_fp8._fail_stop_fp8_reload = _fail_stop
+
+    def _finalize(model, model_config, tag="main", model_runner=None):
+        if finalize_error is not None:
+            _fail_stop(model_runner, f"finalize raised: {finalize_error}", tag=tag, model=model)
+            raise finalize_error
+        state.layerwise_active.discard(tag)
+        state.layerwise_begin_attempted.discard(tag)
+
+    fake_fp8.finalize_fp8_layerwise_reload = _finalize
+
+    monkeypatch.setitem(sys.modules, "vllm.config", fake_config)
+    monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
+    monkeypatch.setitem(sys.modules, "verl.workers.rollout.vllm_rollout.bucketed_weight_transfer", fake_bwt)
+    monkeypatch.setitem(sys.modules, "verl.utils.vllm.vllm_fp8_utils", fake_fp8)
+    # is_fp8_model was bound into the utils module at import time.
+    monkeypatch.setattr(_vllm_rollout_utils, "is_fp8_model", lambda cfg: True)
+    return state, fail_stop_reasons
+
+
+def _make_fp8_worker():
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = _FakeModelRunner(_ToyModel())
+    worker.model_runner.vllm_config.quant_config = object()
+    worker.model_runner.vllm_config.model_config = object()
+    worker.device = torch.device("cpu")
+    worker.local_rank = 0
+    worker._is_qat_model = False
+    worker._is_modelopt_qat = False
+    worker._get_zmq_handle = lambda: "ipc:///tmp/unused"
+    return worker
+
+
+@pytest.mark.parametrize("stage", ["receive", "finalize"])
+def test_update_weights_from_ipc_fp8_failure_fails_stop(monkeypatch, stage):
+    """A failure in the FP8 layerwise reload (at receive OR finalize) must
+    fail-stop the worker, and a follow-on sync must refuse up front instead of
+    re-initializing a partially-updated model."""
+    err = RuntimeError(f"boom in {stage}")
+    state, reasons = _stub_fp8_layerwise_env(
+        monkeypatch,
+        receive_error=err if stage == "receive" else None,
+        finalize_error=err if stage == "finalize" else None,
+    )
+    worker = _make_fp8_worker()
+
+    with pytest.raises(RuntimeError, match=f"boom in {stage}"):
+        worker.update_weights_from_ipc()
+
+    assert "main" in state.layerwise_poisoned
+    assert len(reasons) >= 1
+
+    # The worker is now poisoned: any subsequent sync must refuse up front
+    # (from validate_fp8_layerwise_reload_config, before any IPC).
+    with pytest.raises(RuntimeError, match="fail-stopped"):
+        worker.update_weights_from_ipc()
+
+
+def test_update_weights_from_ipc_fp8_success_does_not_fail_stop(monkeypatch):
+    """Negative control: a clean FP8 layerwise reload leaves no fail-stop
+    marker and completes the lifecycle."""
+    state, reasons = _stub_fp8_layerwise_env(monkeypatch)
+    worker = _make_fp8_worker()
+
+    worker.update_weights_from_ipc()
+
+    assert state.layerwise_poisoned == set()
+    assert reasons == []
+    assert state.layerwise_active == set()

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -53,6 +53,10 @@ class FP8State:
     seen_params: set = field(default_factory=lambda: set())
     fp8_param_names: set = field(default_factory=lambda: set())
     vllm_patches: list = field(default_factory=lambda: [])
+    # Model tags ("main") with an ACTIVE vLLM layerwise reload, set by
+    # begin_fp8_layerwise_reload() exactly once per weight sync (BEFORE any
+    # IPC bucket) and cleared by finalize_fp8_layerwise_reload().
+    layerwise_active: set = field(default_factory=lambda: set())
 
 
 fp8_state: FP8State = FP8State()
@@ -213,6 +217,15 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
 
     for k, v in weights:
         if not is_fp8_weight(k, model):
+            if fp8_state.layerwise_active:
+                # vLLM layerwise reload BUFFERS streamed tensors until an
+                # entire layer has arrived, potentially across IPC buckets.
+                # The bucketed IPC receive buffer is REUSED between buckets
+                # (BucketedWeightReceiver._init_buffer), so buffered tensors
+                # must own their storage or a later bucket overwrites them
+                # before vLLM replays the layer. (Quantized outputs below
+                # are fresh allocations already.)
+                v = v.clone()
             yield (k, v)
             continue
 
@@ -255,12 +268,147 @@ def prepare_quanted_weights_for_loading(model_runner):
     return prepare_deepseek_v4_weights_for_loading(model, _copy_param_subclass_attrs)
 
 
+# ---------------------------------------------------------------------------
+# FP8 weight resync on vLLM >= 0.20 via vLLM's native layerwise-reload
+# lifecycle.
+#
+# Root cause: on vLLM 0.20.x the FP8 block-quant FusedMoE params are in
+# KERNEL format at weight-sync time. On the EP>1 block-FP8 path
+# process_weights_after_loading() -> _setup_kernel() ->
+# _shuffle_deepseek_fp8_moe_weights() (quantization/utils/flashinfer_utils.py)
+# replaces the checkpoint-format 3D w13_weight (E_local, 2*intermediate,
+# hidden) with a shuffled 4D BlockMajorK tensor (E_local, K/block_k, Mn,
+# block_k) — observed (2, 32, 3072, 128) on Qwen3-235B-A22B (hidden 4096,
+# MoE intermediate 1536, 128 experts over 64-way expert sharding: E_local=2,
+# K/block_k=4096/128=32, Mn=2*1536=3072). vLLM's per-expert loader is
+# written against the CHECKPOINT format: `param.data[expert_id]` indexes the
+# expert axis (correctly), but the resulting per-expert view is now a 3D
+# kernel-blocked tensor (K/block_k, Mn, block_k) instead of the 2D
+# checkpoint matrix, so _load_w13(shard_dim=0) -> _get_hidden_dim(0, ndim=3)
+# raises ValueError (valid data dims for 3D are 1 or 2). Even without the
+# raise, copying checkpoint-layout bytes into the shuffled kernel blocks
+# would silently mis-load.
+#
+# Fix: drive vLLM 0.20's OWN reload protocol (model_loader/reload/), the
+# machinery vLLM's native reload_weights() uses:
+#     initialize_layerwise_reload(model)      # ONCE per sync
+#     model.load_weights(stream)              # every IPC bucket
+#     finalize_layerwise_reload(model, cfg)   # ONCE per sync
+#
+# LIFECYCLE: initialize_layerwise_reload is NOT idempotent across buckets.
+# When a layer completes, _layerwise_process() ends with info.reset(), so a
+# re-initialize would swap the completed layer BACK to meta; if any tensor
+# of that layer then arrives in a later bucket, finalize treats
+# 0 < load_numel < total as "delayed processing" and processes
+# uninitialized memory into the real kernel storage — silent corruption.
+# verl's IPC weight sync is BUCKETED (one load_quanted_weights call per
+# bucket, bucket boundaries chosen by the sender), so initialize/finalize
+# MUST live in update_weights_from_ipc, not in the per-bucket loader.
+#
+# OWNERSHIP: layerwise reload BUFFERS streamed tensors until a layer is
+# complete, potentially across IPC buckets, while BucketedWeightReceiver
+# REUSES one receive buffer for every bucket. Any tensor handed to
+# load_weights that is a view into that buffer and is retained past the
+# bucket boundary gets silently overwritten by the next bucket before vLLM
+# replays it. quant_weights therefore clones every non-quantized tensor
+# while a layerwise reload is active (quantized outputs are already fresh
+# allocations).
+#
+# Scope guard: everything here is reached only when is_fp8_model() is True
+# (rollout.quantization=fp8) and the model is not on the DeepSeek-V4 or
+# Ascend MXFP8 paths (which have their own prepare/process protocols).
+# ---------------------------------------------------------------------------
+
+
+def _vllm_layerwise_reload_available():
+    """True when vLLM ships the layerwise reload protocol (vLLM >= 0.20)."""
+    try:
+        from vllm.model_executor.model_loader.reload import (  # noqa: F401
+            finalize_layerwise_reload,
+            initialize_layerwise_reload,
+        )
+    except ImportError:
+        return False
+    return _get_vllm_version() >= version.parse("0.20.0")
+
+
+def _vllm_supports_layerwise_reload():
+    """True only on the vLLM interval this resync path is validated on (0.20.x).
+
+    Importing the reload entry points proves the module exists, not that the
+    lifecycle semantics are unchanged, so newer vLLM lines are NOT silently
+    opted in: on vLLM >= 0.21 begin/finalize stay no-ops and
+    load_quanted_weights fails closed with an explicit error until the newer
+    line is validated.
+    """
+    return _vllm_layerwise_reload_available() and _get_vllm_version() < version.parse("0.21.0")
+
+
+def begin_fp8_layerwise_reload(model, tag="main"):
+    """Enter vLLM's layerwise reload mode for one model, ONCE per weight sync.
+
+    Must be called BEFORE the first IPC bucket is received (i.e. before
+    receiver.receive_weights in update_weights_from_ipc), mirroring the
+    native lifecycle in gpu_model_runner.reload_weights (initialize ->
+    complete iterator -> finalize, each exactly once). Calling it twice
+    without an intervening finalize is a lifecycle violation and raises.
+
+    Returns True if layerwise reload was entered (vLLM >= 0.20), False on
+    older vLLM (where the verl process_weights patches handle kernel format).
+    """
+    if not _vllm_supports_layerwise_reload():
+        return False
+    if tag in fp8_state.layerwise_active:
+        raise RuntimeError(
+            f"FP8 layerwise reload already active for '{tag}': "
+            "begin_fp8_layerwise_reload must be called exactly once per sync, "
+            "before any IPC bucket."
+        )
+    from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
+
+    initialize_layerwise_reload(model)
+    fp8_state.layerwise_active.add(tag)
+    logger.info("FP8: layerwise reload initialized (%s, once for this sync)", tag)
+    return True
+
+
+def finalize_fp8_layerwise_reload(model, model_config, tag="main"):
+    """Exit layerwise reload mode ONCE after ALL IPC buckets: process layers
+    that did not self-complete during streaming (attention scales, padded
+    layers) and restore kernel tensors. Raises if called without a matching
+    begin (lifecycle violation). Must run inside set_current_vllm_config."""
+    if not _vllm_supports_layerwise_reload():
+        return
+    if tag not in fp8_state.layerwise_active:
+        raise RuntimeError(f"finalize_fp8_layerwise_reload('{tag}') without an active begin — lifecycle violation.")
+    from vllm.model_executor.model_loader.reload import finalize_layerwise_reload
+
+    finalize_layerwise_reload(model, model_config)
+    fp8_state.layerwise_active.discard(tag)
+
+
 def process_quanted_weights_after_loading(model_runner, reload_state):
     process_deepseek_v4_weights_after_loading(model_runner.model, reload_state)
 
 
 def load_quanted_weights(weights, model_runner, is_drafter=False, prepare_model=True, process_model=True):
+    """Quantize and load one IPC bucket of weights into a vLLM model.
+
+    On vLLM >= 0.20 (kernel-format params) this function is called once PER
+    IPC BUCKET and must run INSIDE an active layerwise reload
+    (begin_fp8_layerwise_reload called once by update_weights_from_ipc before
+    any bucket; finalize once after the last bucket). It does NOT initialize
+    the reload itself — per-bucket initialization is unsound because completed
+    layers reset and would be swapped back to meta (see the layerwise-reload
+    block comment above). It fails CLOSED if the outer lifecycle is missing.
+    """
     if is_drafter:
+        if _vllm_supports_layerwise_reload():
+            raise NotImplementedError(
+                "FP8 weight sync for the MTP drafter is not supported under the "
+                "vLLM >= 0.20 layerwise reload lifecycle. Disable MTP speculative "
+                "decoding for FP8 rollout."
+            )
         drafter = getattr(model_runner, "drafter", None)
         model = drafter.model if drafter is not None and hasattr(drafter, "model") else None
         assert model is not None, (
@@ -280,6 +428,29 @@ def load_quanted_weights(weights, model_runner, is_drafter=False, prepare_model=
     if is_mxfp8_npu:
         # For MXFP8 on NPU, restore the original shapes expected by weight_loader.
         restore_mxfp8_weights_for_loading(model)
+    elif (
+        not reload_state
+        and not is_deepseek_v4_model(model)
+        and _vllm_layerwise_reload_available()
+        and "main" not in fp8_state.layerwise_active
+    ):
+        # Fail CLOSED: on vLLM >= 0.20 params are in KERNEL format at sync
+        # time; loading without the reload protocol would either crash
+        # (per-expert indexing of the 4D kernel tensor) or silently mis-load.
+        if not _vllm_supports_layerwise_reload():
+            raise RuntimeError(
+                f"FP8 rollout weight resync is validated on vLLM 0.20.x only; found "
+                f"vLLM {_get_vllm_version()}. The layerwise reload lifecycle this "
+                "path drives is not semantically re-verified on newer lines, so it "
+                "fails closed instead of silently opting in."
+            )
+        # The caller must have run begin_fp8_layerwise_reload() BEFORE the
+        # first bucket.
+        raise RuntimeError(
+            "FP8 bucket received without an active layerwise reload — "
+            "begin_fp8_layerwise_reload(model) must be called once per sync "
+            "before receive_weights."
+        )
 
     weights = list(weights)
     cache_deepseek_v4_dense_fp8_scales(model, weights)
@@ -291,10 +462,16 @@ def load_quanted_weights(weights, model_runner, is_drafter=False, prepare_model=
         if hasattr(param, "subclass_type"):
             param.orig_type = param.__class__
             param.__class__ = param.subclass_type
-    # Finally load the weights into vllm
+    # Finally load the weights into vllm. Under layerwise reload, per-layer
+    # processing (requantize + kernel-format shuffle) runs INSIDE
+    # load_weights when a layer completes and needs the vLLM config context
+    # (mirrors the native reload_weights call site).
+    from vllm.config import set_current_vllm_config
+
     try:
-        loaded_params = model.load_weights(weights_quantized)
-        reload_deepseek_v4_dense_fp8_scales(model)
+        with set_current_vllm_config(model_runner.vllm_config):
+            loaded_params = model.load_weights(weights_quantized)
+            reload_deepseek_v4_dense_fp8_scales(model)
     finally:
         # Undo the type change above to the original type
         for name, param in model.named_parameters():

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -57,6 +57,16 @@ class FP8State:
     # begin_fp8_layerwise_reload() exactly once per weight sync (BEFORE any
     # IPC bucket) and cleared by finalize_fp8_layerwise_reload().
     layerwise_active: set = field(default_factory=lambda: set())
+    # Model tags for which begin_fp8_layerwise_reload() ENTERED
+    # initialize_layerwise_reload. Recorded BEFORE calling into vLLM, because
+    # initialize_layerwise_reload swaps layers to meta one at a time: if it
+    # raises midway the model is left partially converted even though
+    # `layerwise_active` was never reached.
+    layerwise_begin_attempted: set = field(default_factory=lambda: set())
+    # Model tags whose worker is FAIL-STOPPED: a reload failed with the model
+    # possibly half-converted, so it must not serve requests or accept another
+    # sync. Set by _fail_stop_fp8_reload(); only a worker restart clears it.
+    layerwise_poisoned: set = field(default_factory=lambda: set())
 
 
 fp8_state: FP8State = FP8State()
@@ -332,19 +342,197 @@ def _vllm_layerwise_reload_available():
     return _get_vllm_version() >= version.parse("0.20.0")
 
 
+# Upper bound (exclusive) of the vLLM interval this resync path is validated
+# on. The lifecycle this path drives depends on exactly two properties of
+# vllm/model_executor/model_loader/reload/:
+#
+#   (i)  initialize_layerwise_reload is NOT idempotent across buckets — a
+#        completed layer ends _layerwise_process() with info.reset(), so a
+#        re-initialize swaps it back to meta and finalize then treats
+#        0 < load_numel < load_numel_total as "delayed processing" and pushes
+#        uninitialized memory into kernel storage (silent corruption);
+#   (ii) streamed tensors are BUFFERED (info.loaded_weights holds the bound
+#        weight-loader args, including the incoming tensor) until a layer is
+#        complete, so a tensor that aliases verl's reused IPC receive buffer
+#        must be cloned by the caller.
+#
+# Both properties were desk-audited against the vLLM sources at tags v0.20.2,
+# v0.21.0, v0.22.1, v0.23.0, v0.23.1rc0 and v0.24.0: LayerReloadingInfo
+# (types.py) is byte-identical on all of them, the completion trigger
+# (`info.load_numel >= info.load_numel_total` -> _layerwise_process ->
+# info.reset()) and the finalize delayed-processing branch
+# (`0 < load_numel < load_numel_total` -> _layerwise_process) are unchanged,
+# and the buffering site (`info.loaded_weights.append((param_name,
+# bound_args))`) is unchanged. The deltas over that interval are additive and
+# orthogonal: a LOADING_LAYERS device-memory warning (0.21), attention layers
+# returning early from the online loader instead of being excluded from the
+# completion condition (0.21, same effective behaviour: attention is
+# finalized in _finalize_attention_layer either way), a
+# non-persistent-parameter-alias buffer skip in capture_layer_to_meta and an
+# `is_meta` guard in materialize_layer (0.22), a `name not in layer._buffers`
+# guard in _copy_and_restore_kernel_tensors (0.23), and a numel cap in
+# get_numel_loaded (0.23.1rc0/0.24, which makes per-layer accounting stricter,
+# not looser).
+#
+# vLLM 0.25.0 is deliberately NOT included: layerwise.py grows
+# _wrap_parameters_weight_loader() and re-runs
+# `info.load_numel_total = get_layer_size(layer)` on EVERY load to pick up
+# late-registered parameters, which changes when a layer is considered
+# complete. That is the exact property (i) this path depends on, so the newer
+# line fails closed until it is audited and re-measured.
+_VLLM_LAYERWISE_RELOAD_VALIDATED_BELOW = "0.25.0"
+
+
 def _vllm_supports_layerwise_reload():
-    """True only on the vLLM interval this resync path is validated on (0.20.x).
+    """True only on the vLLM interval this resync path is validated on.
 
     Importing the reload entry points proves the module exists, not that the
     lifecycle semantics are unchanged, so newer vLLM lines are NOT silently
-    opted in: on vLLM >= 0.21 begin/finalize stay no-ops and
+    opted in: above the validated interval begin/finalize stay no-ops and
     load_quanted_weights fails closed with an explicit error until the newer
-    line is validated.
+    line is validated (see _VLLM_LAYERWISE_RELOAD_VALIDATED_BELOW).
     """
-    return _vllm_layerwise_reload_available() and _get_vllm_version() < version.parse("0.21.0")
+    return _vllm_layerwise_reload_available() and _get_vllm_version() < version.parse(
+        _VLLM_LAYERWISE_RELOAD_VALIDATED_BELOW
+    )
 
 
-def begin_fp8_layerwise_reload(model, tag="main"):
+def _fail_stop_fp8_reload(model_runner, reason, tag="main", model=None):
+    """Poison this worker after a failed/aborted FP8 layerwise reload.
+
+    ``initialize_layerwise_reload`` swaps a model's layers to meta one at a
+    time and ``_layerwise_process`` restores them one at a time, so a failure
+    part-way through leaves a model whose early layers are meta placeholders
+    (or unprocessed) while the rest still hold real kernel data. Such a model
+    must never serve a generation request: a crash is recoverable, a silent
+    mis-generation from a half-converted model is not (the same reason this
+    path refuses to hand-reshape kernel tensors).
+
+    Best-effort and non-raising by construction — it runs on the error path,
+    so it must not mask the original exception. It:
+
+    1. records ``tag`` in ``fp8_state.layerwise_poisoned``, which makes every
+       later begin_fp8_layerwise_reload / load_quanted_weights on this worker
+       raise instead of loading into the damaged model;
+    2. installs a forward guard on the model so a generation request raises an
+       explicit RuntimeError naming the failed sync instead of running on
+       meta/half-converted weights.
+
+    Only a worker restart clears the poison.
+    """
+    fp8_state.layerwise_poisoned.add(tag)
+    fp8_state.layerwise_active.discard(tag)
+    logger.error(
+        "FP8: layerwise reload FAILED for '%s' (%s); worker poisoned — it will refuse "
+        "further weight syncs and generation requests until restarted.",
+        tag,
+        reason,
+    )
+
+    if model is None:
+        model = getattr(model_runner, "model", None)
+    if model is None:
+        return
+
+    message = (
+        f"vLLM worker is fail-stopped: FP8 layerwise weight reload '{tag}' failed "
+        f"({reason}). The model may be partially converted (some layers on meta or "
+        "unprocessed), so generation is refused instead of returning possibly "
+        "corrupt output. Restart the rollout worker."
+    )
+    try:
+        model_runner._verl_fp8_reload_fail_stop = message
+    except Exception:  # pragma: no cover - exotic model_runner objects
+        pass
+
+    forward = getattr(model, "forward", None)
+    if forward is None or getattr(forward, "_verl_fp8_fail_stop", False):
+        return
+
+    def _fail_stopped_forward(*args, **kwargs):
+        raise RuntimeError(message)
+
+    _fail_stopped_forward._verl_fp8_fail_stop = True
+    try:
+        model.forward = _fail_stopped_forward
+    except Exception:  # pragma: no cover - modules that forbid attribute set
+        logger.error("FP8: could not install fail-stop forward guard on %s", type(model).__name__)
+
+
+def _assert_not_fail_stopped(tag="main"):
+    if tag in fp8_state.layerwise_poisoned:
+        raise RuntimeError(
+            f"FP8 layerwise reload for '{tag}' is fail-stopped after an earlier failed "
+            "reload left the model possibly partially converted. Restart the rollout "
+            "worker; retrying a weight sync on a half-converted model risks silent "
+            "weight corruption."
+        )
+
+
+def validate_fp8_layerwise_reload_config(vllm_config, uses_mtp_drafter, tag="main"):
+    """Validate an FP8 weight sync BEFORE any IPC resource is created.
+
+    Every unsupported-configuration check this path performs is decidable from
+    the rollout config plus the installed vLLM version — i.e. from information
+    available before a single byte moves. That matters because verl's bucketed
+    weight sync is a two-party ACK protocol with no timeout on either side:
+    the driver launches the receiver worker non-blocking and then waits in
+    ``BucketedWeightSender._init_buffer()`` for the initial ACK, and awaits the
+    worker future only after sending completes. A raise from inside the worker
+    after the socket exists therefore turns an intended fail-closed error into
+    a silent hang, with the real message buried in the worker's log.
+
+    So the checks run HERE, at a point where raising can only fail the sync
+    loudly:
+
+    * a poisoned worker (an earlier reload left the model half-converted);
+    * MTP speculative decoding, which the layerwise lifecycle does not cover
+      (vLLM's reload targets the main model only, while verl's fallback also
+      syncs the drafter);
+    * a vLLM version outside the validated interval, where the lifecycle
+      semantics this path depends on have not been re-audited.
+
+    Only applies to the FP8 layerwise-reload path: returns immediately when
+    the reload module is absent (vLLM < 0.20) or the model is on the Ascend
+    MXFP8 path, both of which use their own protocols.
+
+    Args:
+        vllm_config: the worker's ``vllm_config`` (needs ``quant_config``).
+        uses_mtp_drafter: True when this sync would also update an MTP drafter.
+        tag: model tag, matching begin/finalize_fp8_layerwise_reload.
+
+    Raises:
+        RuntimeError / NotImplementedError on an unsupported configuration.
+    """
+    if not _vllm_layerwise_reload_available():
+        return
+    if is_mxfp8_vllm_ascend(getattr(vllm_config, "quant_config", None)):
+        return
+
+    _assert_not_fail_stopped(tag)
+
+    if uses_mtp_drafter:
+        raise NotImplementedError(
+            "FP8 rollout weight sync via vLLM layerwise reload does not "
+            "support the MTP drafter yet. Disable MTP speculative decoding "
+            "when rollout.quantization=fp8 on vLLM >= 0.20. (Validated before "
+            "the weight-transfer IPC starts, so the sync fails fast instead of "
+            "stranding the sender.)"
+        )
+
+    if not _vllm_supports_layerwise_reload():
+        raise RuntimeError(
+            f"FP8 rollout weight resync is validated on vLLM "
+            f">= 0.20, < {_VLLM_LAYERWISE_RELOAD_VALIDATED_BELOW}; found "
+            f"vLLM {_get_vllm_version()}. The layerwise reload lifecycle this path "
+            "drives is not semantically re-verified on newer lines, so it fails "
+            "closed instead of silently opting in. (Validated before the "
+            "weight-transfer IPC starts, so the sync fails fast instead of "
+            "stranding the sender.)"
+        )
+
+
+def begin_fp8_layerwise_reload(model, tag="main", model_runner=None):
     """Enter vLLM's layerwise reload mode for one model, ONCE per weight sync.
 
     Must be called BEFORE the first IPC bucket is received (i.e. before
@@ -353,9 +541,19 @@ def begin_fp8_layerwise_reload(model, tag="main"):
     complete iterator -> finalize, each exactly once). Calling it twice
     without an intervening finalize is a lifecycle violation and raises.
 
-    Returns True if layerwise reload was entered (vLLM >= 0.20), False on
-    older vLLM (where the verl process_weights patches handle kernel format).
+    ``initialize_layerwise_reload`` mutates the model layer by layer, so the
+    attempt is recorded BEFORE calling into vLLM and any failure inside it
+    fail-stops the worker (_fail_stop_fp8_reload): once some layers are on
+    meta, neither reuse nor a retry is safe. The caller in
+    update_weights_from_ipc catches begin failures for the same reason, so a
+    raise from anywhere in this function leaves a poisoned worker rather than
+    a silently half-converted one.
+
+    Returns True if layerwise reload was entered (vLLM on the validated
+    interval), False otherwise (where the verl process_weights patches handle
+    kernel format).
     """
+    _assert_not_fail_stopped(tag)
     if not _vllm_supports_layerwise_reload():
         return False
     if tag in fp8_state.layerwise_active:
@@ -366,7 +564,21 @@ def begin_fp8_layerwise_reload(model, tag="main"):
         )
     from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
 
-    initialize_layerwise_reload(model)
+    # Record the attempt BEFORE vLLM starts swapping layers to meta: if
+    # initialize_layerwise_reload raises at layer N, layers 1..N-1 are already
+    # converted while `layerwise_active` was never reached, so `attempted` is
+    # the only durable evidence that this model was touched.
+    fp8_state.layerwise_begin_attempted.add(tag)
+    try:
+        initialize_layerwise_reload(model)
+    except BaseException as exc:
+        _fail_stop_fp8_reload(
+            model_runner,
+            f"initialize_layerwise_reload raised: {type(exc).__name__}: {exc}",
+            tag=tag,
+            model=model,
+        )
+        raise
     fp8_state.layerwise_active.add(tag)
     logger.info("FP8: layerwise reload initialized (%s, once for this sync)", tag)
     return True
@@ -376,15 +588,30 @@ def finalize_fp8_layerwise_reload(model, model_config, tag="main"):
     """Exit layerwise reload mode ONCE after ALL IPC buckets: process layers
     that did not self-complete during streaming (attention scales, padded
     layers) and restore kernel tensors. Raises if called without a matching
-    begin (lifecycle violation). Must run inside set_current_vllm_config."""
+    begin (lifecycle violation). Must run inside set_current_vllm_config.
+
+    A failure here also leaves the model partially restored (some layers
+    processed back to kernel format, some not), so it fail-stops the worker
+    for the same reason begin does.
+    """
     if not _vllm_supports_layerwise_reload():
         return
     if tag not in fp8_state.layerwise_active:
         raise RuntimeError(f"finalize_fp8_layerwise_reload('{tag}') without an active begin — lifecycle violation.")
     from vllm.model_executor.model_loader.reload import finalize_layerwise_reload
 
-    finalize_layerwise_reload(model, model_config)
+    try:
+        finalize_layerwise_reload(model, model_config)
+    except BaseException as exc:
+        _fail_stop_fp8_reload(
+            None,
+            f"finalize_layerwise_reload raised: {type(exc).__name__}: {exc}",
+            tag=tag,
+            model=model,
+        )
+        raise
     fp8_state.layerwise_active.discard(tag)
+    fp8_state.layerwise_begin_attempted.discard(tag)
 
 
 def process_quanted_weights_after_loading(model_runner, reload_state):
@@ -437,9 +664,19 @@ def load_quanted_weights(weights, model_runner, is_drafter=False, prepare_model=
         # Fail CLOSED: on vLLM >= 0.20 params are in KERNEL format at sync
         # time; loading without the reload protocol would either crash
         # (per-expert indexing of the 4D kernel tensor) or silently mis-load.
+        #
+        # Both raises below are reached from inside the IPC receive loop
+        # (on_bucket_received), where an un-ACKed exception would strand the
+        # sender. update_weights_from_ipc validates the configuration BEFORE
+        # any IPC socket exists, and BucketedWeightReceiver reports bucket
+        # errors to the sender as an error frame, so these are backstops for
+        # a caller that skipped the pre-IPC validation rather than the primary
+        # detection point.
+        _assert_not_fail_stopped("main")
         if not _vllm_supports_layerwise_reload():
             raise RuntimeError(
-                f"FP8 rollout weight resync is validated on vLLM 0.20.x only; found "
+                f"FP8 rollout weight resync is validated on vLLM "
+                f">= 0.20, < {_VLLM_LAYERWISE_RELOAD_VALIDATED_BELOW}; found "
                 f"vLLM {_get_vllm_version()}. The layerwise reload lifecycle this "
                 "path drives is not semantically re-verified on newer lines, so it "
                 "fails closed instead of silently opting in."

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -397,6 +397,48 @@ def _vllm_supports_layerwise_reload():
     )
 
 
+def _install_fail_stop_guard(target, attribute, message):
+    """Shadow one callable on ``target`` with a raising stub. Best-effort.
+
+    Sets an INSTANCE attribute, so the class (and every other worker in the
+    process) is untouched and the guard disappears with the object. Idempotent
+    via the ``_verl_fp8_fail_stop`` marker. Returns True when the guard is in
+    place after the call.
+    """
+    existing = getattr(target, attribute, None)
+    if existing is None:
+        return False
+    if getattr(existing, "_verl_fp8_fail_stop", False):
+        return True
+
+    def _fail_stopped(*args, **kwargs):
+        raise RuntimeError(message)
+
+    _fail_stopped._verl_fp8_fail_stop = True
+    try:
+        setattr(target, attribute, _fail_stopped)
+    except Exception:  # pragma: no cover - objects that forbid attribute set
+        logger.error(
+            "FP8: could not install fail-stop guard on %s.%s",
+            type(target).__name__,
+            attribute,
+        )
+        return False
+    return True
+
+
+# vLLM's serving entry points on the worker side, verified in the sources of
+# every tag this path is audited against (v0.20.2, v0.21.0, v0.22.1, v0.23.0,
+# v0.23.1rc0, v0.24.0, v0.25.0): ``vllm/v1/worker/gpu_worker.py``
+# ``Worker.execute_model()`` delegates the forward pass to
+# ``self.model_runner.execute_model(...)``, and ``Worker.execute_dummy_batch()``
+# to ``self.model_runner._dummy_run(...)``. Guarding the RUNNER covers both,
+# and covers them ahead of the model call itself — a request is refused before
+# any kernel touches a half-converted parameter, whether or not the model
+# object exposes a patchable ``forward``.
+_MODEL_RUNNER_SERVING_ENTRY_POINTS = ("execute_model", "_dummy_run")
+
+
 def _fail_stop_fp8_reload(model_runner, reason, tag="main", model=None):
     """Poison this worker after a failed/aborted FP8 layerwise reload.
 
@@ -414,9 +456,13 @@ def _fail_stop_fp8_reload(model_runner, reason, tag="main", model=None):
     1. records ``tag`` in ``fp8_state.layerwise_poisoned``, which makes every
        later begin_fp8_layerwise_reload / load_quanted_weights on this worker
        raise instead of loading into the damaged model;
-    2. installs a forward guard on the model so a generation request raises an
-       explicit RuntimeError naming the failed sync instead of running on
-       meta/half-converted weights.
+    2. poisons the MODEL RUNNER: ``execute_model`` and ``_dummy_run`` — the two
+       entry points vLLM's ``Worker`` routes serving through
+       (``_MODEL_RUNNER_SERVING_ENTRY_POINTS``) — raise an explicit RuntimeError
+       naming the failed sync, so a generation request is refused before the
+       forward pass starts;
+    3. also guards the model's ``forward`` as a backstop for callers that hold
+       the model object directly rather than going through the runner.
 
     Only a worker restart clears the poison.
     """
@@ -431,8 +477,6 @@ def _fail_stop_fp8_reload(model_runner, reason, tag="main", model=None):
 
     if model is None:
         model = getattr(model_runner, "model", None)
-    if model is None:
-        return
 
     message = (
         f"vLLM worker is fail-stopped: FP8 layerwise weight reload '{tag}' failed "
@@ -440,23 +484,22 @@ def _fail_stop_fp8_reload(model_runner, reason, tag="main", model=None):
         "unprocessed), so generation is refused instead of returning possibly "
         "corrupt output. Restart the rollout worker."
     )
-    try:
-        model_runner._verl_fp8_reload_fail_stop = message
-    except Exception:  # pragma: no cover - exotic model_runner objects
-        pass
+    if model_runner is not None:
+        try:
+            model_runner._verl_fp8_reload_fail_stop = message
+        except Exception:  # pragma: no cover - exotic model_runner objects
+            pass
+        guarded = [
+            entry_point
+            for entry_point in _MODEL_RUNNER_SERVING_ENTRY_POINTS
+            if _install_fail_stop_guard(model_runner, entry_point, message)
+        ]
+        if guarded:
+            logger.error("FP8: fail-stop guard installed on model_runner.%s", ", ".join(guarded))
 
-    forward = getattr(model, "forward", None)
-    if forward is None or getattr(forward, "_verl_fp8_fail_stop", False):
+    if model is None:
         return
-
-    def _fail_stopped_forward(*args, **kwargs):
-        raise RuntimeError(message)
-
-    _fail_stopped_forward._verl_fp8_fail_stop = True
-    try:
-        model.forward = _fail_stopped_forward
-    except Exception:  # pragma: no cover - modules that forbid attribute set
-        logger.error("FP8: could not install fail-stop forward guard on %s", type(model).__name__)
+    _install_fail_stop_guard(model, "forward", message)
 
 
 def _assert_not_fail_stopped(tag="main"):
@@ -584,7 +627,7 @@ def begin_fp8_layerwise_reload(model, tag="main", model_runner=None):
     return True
 
 
-def finalize_fp8_layerwise_reload(model, model_config, tag="main"):
+def finalize_fp8_layerwise_reload(model, model_config, tag="main", model_runner=None):
     """Exit layerwise reload mode ONCE after ALL IPC buckets: process layers
     that did not self-complete during streaming (attention scales, padded
     layers) and restore kernel tensors. Raises if called without a matching
@@ -592,7 +635,8 @@ def finalize_fp8_layerwise_reload(model, model_config, tag="main"):
 
     A failure here also leaves the model partially restored (some layers
     processed back to kernel format, some not), so it fail-stops the worker
-    for the same reason begin does.
+    for the same reason begin does — pass ``model_runner`` so the serving entry
+    points are guarded too, not just the model's ``forward``.
     """
     if not _vllm_supports_layerwise_reload():
         return
@@ -604,7 +648,7 @@ def finalize_fp8_layerwise_reload(model, model_config, tag="main"):
         finalize_layerwise_reload(model, model_config)
     except BaseException as exc:
         _fail_stop_fp8_reload(
-            None,
+            model_runner,
             f"finalize_layerwise_reload raised: {type(exc).__name__}: {exc}",
             tag=tag,
             model=model,

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -148,6 +148,11 @@ class BucketedWeightSender:
         self.socket = None
         self.buffer = None
         self.shm = None
+        # Effective SNDTIMEO in milliseconds, recomputed by _init_socket(). Kept
+        # on the instance so the timeout diagnostic reports the bound that was
+        # actually armed rather than the module default — the two differ
+        # whenever ack_timeout_s wins the min in _init_socket().
+        self._snd_timeout_ms = SOCKET_SEND_TIMEOUT_MS
 
     def _recv_ack(self, what: str):
         """Wait for one receiver ACK, bounded in time and aware of error frames.
@@ -257,6 +262,7 @@ class BucketedWeightSender:
         else:
             snd_timeout_ms = SOCKET_SEND_TIMEOUT_MS
         self.socket.setsockopt(zmq.SNDTIMEO, snd_timeout_ms)
+        self._snd_timeout_ms = snd_timeout_ms
         self.socket.bind(self.zmq_handle)
 
     def _send_or_timeout(self, payload, what: str):
@@ -265,12 +271,18 @@ class BucketedWeightSender:
         The sender is the process the driver is waiting on, so an un-timed send
         is the same class of bug as an un-timed recv: the job hangs with no
         diagnosis. Raising here names the peer and the stage instead.
+
+        The reported bound is the EFFECTIVE one recorded by ``_init_socket``
+        (``min(ack_timeout_s, SOCKET_SEND_TIMEOUT_MS)``), not the module
+        default: a caller that passes a short ``ack_timeout_s`` gets a message
+        matching the wait it actually observed, which is the difference between
+        a usable diagnostic and a misleading one.
         """
         try:
             self.socket.send_pyobj(payload)
         except zmq.Again as exc:
             raise WeightTransferAckTimeoutError(
-                f"Timed out after {SOCKET_SEND_TIMEOUT_MS / 1000:.0f} s trying to send the "
+                f"Timed out after {self._snd_timeout_ms / 1000:.0f} s trying to send the "
                 f"weight-transfer frame ({what}) — the receiver is not reading from the socket "
                 "(it died, or never connected). Check the rollout worker log for the original "
                 "traceback."

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -48,6 +48,29 @@ ACK_ERROR_PREFIX = b"VERL_WEIGHT_TRANSFER_ERROR:"
 # bucket's load_weights + quantization + device sync.
 DEFAULT_ACK_TIMEOUT_S = float(os.getenv("VERL_WEIGHT_TRANSFER_ACK_TIMEOUT_S", "1800"))
 
+# Upper bound (milliseconds) on how long socket.close() may block flushing
+# queued outbound frames. ZMQ's default is LINGER=-1 ("block forever"), which
+# makes teardown itself a deadlock site: after an ACK timeout or a dead peer,
+# close() inside the `finally: _cleanup()` can wait indefinitely for a frame
+# nobody will ever read, so the bounded-ACK guarantee above would be undone by
+# the very cleanup that follows it. Set on BOTH sockets at creation time — not
+# only on the receiver's error path — so the bound holds for every exit path,
+# including the success path and failures that happen before any error frame
+# could be sent. 5000 ms is generous for a local IPC/TCP flush while still
+# finite.
+SOCKET_LINGER_MS = int(os.getenv("VERL_WEIGHT_TRANSFER_LINGER_MS", "5000"))
+
+# Upper bound (milliseconds) on how long a single socket.send() may block. ZMQ's
+# default is -1 ("block forever"), and for a REQ socket that is a real deadlock
+# site independent of the ACK bound: if the peer has disconnected, there is no
+# pipe to queue the frame on, so send() blocks *before* any recv() the bound
+# guards. Measured, not hypothetical — a receiver that connects and exits without
+# reading wedges the sender inside
+# ``_init_buffer -> socket.send_pyobj(comm_metadata)``. Bounding send turns that
+# into an exception on the driver. Shares the ACK timeout's order of magnitude
+# because both answer the same question ("is the peer still there?").
+SOCKET_SEND_TIMEOUT_MS = int(os.getenv("VERL_WEIGHT_TRANSFER_SEND_TIMEOUT_MS", "1800000"))
+
 
 class WeightTransferReceiverError(RuntimeError):
     """Raised on the sender when the receiver reported a failure via an ACK error frame."""
@@ -220,7 +243,38 @@ class BucketedWeightSender:
             except OSError:
                 pass
         self.socket = self.zmq_context.socket(zmq.REQ)
+        # Finite LINGER at creation: _cleanup()'s close() must never block
+        # forever on an unflushable frame (see SOCKET_LINGER_MS).
+        self.socket.setsockopt(zmq.LINGER, SOCKET_LINGER_MS)
+        # Finite SNDTIMEO: send() itself blocks forever on a REQ socket with no
+        # live peer, which is upstream of every recv() the ACK bound protects.
+        # A caller-provided ack_timeout_s bounds the send too (same failure
+        # class: nobody is reading), otherwise SOCKET_SEND_TIMEOUT_MS applies.
+        # zmq.Again then surfaces as a WeightTransferAckTimeoutError from the
+        # send sites below.
+        if self.ack_timeout_s and self.ack_timeout_s > 0:
+            snd_timeout_ms = min(int(self.ack_timeout_s * 1000), SOCKET_SEND_TIMEOUT_MS)
+        else:
+            snd_timeout_ms = SOCKET_SEND_TIMEOUT_MS
+        self.socket.setsockopt(zmq.SNDTIMEO, snd_timeout_ms)
         self.socket.bind(self.zmq_handle)
+
+    def _send_or_timeout(self, payload, what: str):
+        """Send one frame, converting ZMQ's ``Again`` into an explicit failure.
+
+        The sender is the process the driver is waiting on, so an un-timed send
+        is the same class of bug as an un-timed recv: the job hangs with no
+        diagnosis. Raising here names the peer and the stage instead.
+        """
+        try:
+            self.socket.send_pyobj(payload)
+        except zmq.Again as exc:
+            raise WeightTransferAckTimeoutError(
+                f"Timed out after {SOCKET_SEND_TIMEOUT_MS / 1000:.0f} s trying to send the "
+                f"weight-transfer frame ({what}) — the receiver is not reading from the socket "
+                "(it died, or never connected). Check the rollout worker log for the original "
+                "traceback."
+            ) from exc
 
     def _init_buffer(self):
         """build communication buffer"""
@@ -228,7 +282,7 @@ class BucketedWeightSender:
         if not self.use_shm:
             buffer = torch.empty(self.bucket_size, dtype=torch.uint8, device=f"{get_device_name()}:{get_device_id()}")
             handle = reduce_tensor(buffer)
-            self.socket.send_pyobj(handle)
+            self._send_or_timeout(handle, "initial buffer handshake (IPC handle)")
         else:
             import uuid
 
@@ -238,16 +292,28 @@ class BucketedWeightSender:
             buffer = torch.frombuffer(shm.buf, dtype=torch.uint8)
 
             comm_metadata = {"name": shm_name, "size": self.bucket_size}
-            self.socket.send_pyobj(comm_metadata)
+            self._send_or_timeout(comm_metadata, "initial buffer handshake (shm metadata)")
 
         self._recv_ack("initial buffer handshake")
         self.buffer = buffer
         self.shm = shm
 
     def _cleanup(self):
-        """clean up"""
+        """Release the socket, buffer and shm.
+
+        Best-effort by construction: this runs from ``finally``, so it may be
+        unwinding an in-flight exception (e.g. a CUDA init failure inside
+        ``_init_buffer``). Every step is therefore individually guarded — an
+        accelerator call that fails *because of* the original failure must not
+        replace the traceback the caller needs. Observed in a 0.20 aggregate
+        log: a CUDA init error in ``_init_buffer()`` was overwritten by a second
+        CUDA error raised from ``ipc_collect()`` in this method.
+        """
         if self.socket is not None:
-            self.socket.close()
+            try:
+                self.socket.close()
+            except Exception as exc:  # pragma: no cover - close() rarely raises
+                logger.warning("Weight transfer sender: socket close failed during cleanup: %s", exc)
             self.socket = None
         if self.zmq_handle.startswith("ipc://"):
             ipc_path = self.zmq_handle[len("ipc://") :]
@@ -258,13 +324,31 @@ class BucketedWeightSender:
         del self.buffer
         self.buffer = None
         if self.shm is not None:
-            self.shm.close()
-            self.shm.unlink()
+            try:
+                self.shm.close()
+                self.shm.unlink()
+            except Exception as exc:  # pragma: no cover - already-unlinked segment
+                logger.warning("Weight transfer sender: shm teardown failed during cleanup: %s", exc)
             del self.shm
             self.shm = None
         gc.collect()
-        get_torch_device().ipc_collect()
-        get_torch_device().empty_cache()
+        # Accelerator cleanup is the step that historically masked the primary
+        # exception: if the device context never came up, ipc_collect() /
+        # empty_cache() raise the *same* CUDA failure again from inside this
+        # finally-block and it becomes the exception the caller sees.
+        for label, fn in (
+            ("ipc_collect", get_torch_device().ipc_collect),
+            ("empty_cache", get_torch_device().empty_cache),
+        ):
+            try:
+                fn()
+            except Exception as exc:
+                logger.warning(
+                    "Weight transfer sender: accelerator %s failed during cleanup and was "
+                    "suppressed to preserve the original error: %s",
+                    label,
+                    exc,
+                )
 
     def _direct_send_large_weight(self, name: str, weight: torch.Tensor):
         """Send a weight larger than the bucket size via cuda ipc or share memory."""
@@ -416,6 +500,12 @@ class BucketedWeightReceiver:
     def _init_socket(self):
         """Initialize ZMQ REP socket and connect."""
         self.socket = self.zmq_context.socket(zmq.REP)
+        # Finite LINGER at creation: the error frame written by
+        # _report_error_to_sender() (and any queued normal ACK) must not be able
+        # to wedge _cleanup()'s close() when the sender is already gone. Setting
+        # it here rather than only on the error path means the bound also covers
+        # failures that happen before _report_error_to_sender() can run.
+        self.socket.setsockopt(zmq.LINGER, SOCKET_LINGER_MS)
         self.socket.connect(self.zmq_handle)
 
     def _init_buffer(self):
@@ -435,13 +525,31 @@ class BucketedWeightReceiver:
         self.shm = shm
 
     def _cleanup(self):
-        """clean up"""
+        """Release the socket and buffer.
+
+        Best-effort by construction: called from ``finally``, so it may be
+        unwinding an in-flight exception and must never replace it (see the
+        BufferError note below and the matching guard in the sender).
+        """
         if self.socket is not None:
-            self.socket.close()
+            try:
+                self.socket.close()
+            except Exception as exc:  # pragma: no cover - close() rarely raises
+                logger.warning("Weight transfer receiver: socket close failed during cleanup: %s", exc)
             self.socket = None
         # Synchronize before releasing the buffer to ensure all async ops
-        # referencing it (e.g. clone, .to()) have completed.
-        get_torch_device().synchronize()
+        # referencing it (e.g. clone, .to()) have completed. Guarded for the
+        # same reason as the sender's accelerator cleanup: if the device context
+        # is the thing that failed, synchronize() re-raises it from inside this
+        # finally-block and masks the primary error.
+        try:
+            get_torch_device().synchronize()
+        except Exception as exc:
+            logger.warning(
+                "Weight transfer receiver: device synchronize failed during cleanup and was "
+                "suppressed to preserve the original error: %s",
+                exc,
+            )
         del self.buffer
         self.buffer = None
         if self.shm is not None:

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -32,6 +32,30 @@ from verl.utils.device import get_device_id, get_device_name, get_torch_device
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
+# Marker prefix for a receiver -> sender ERROR frame, sent in place of a
+# normal empty ACK when the receiver fails while handling a bucket (or while
+# building the communication buffer). Both parties speak REQ/REP with strict
+# alternation, so the failing receiver's last act is to answer the outstanding
+# request with this frame; without it the sender blocks in recv() forever and
+# an intended fail-closed error becomes a silent training hang, with the real
+# traceback buried in the receiver worker's log.
+ACK_ERROR_PREFIX = b"VERL_WEIGHT_TRANSFER_ERROR:"
+
+# Upper bound (seconds) on how long the sender waits for any single ACK. This
+# is a deadlock bound, not a performance knob: it only fires when the receiver
+# died without answering (e.g. killed mid-bucket, or a failure before its
+# first send). Keep it far above real per-bucket latency — an ACK covers one
+# bucket's load_weights + quantization + device sync.
+DEFAULT_ACK_TIMEOUT_S = float(os.getenv("VERL_WEIGHT_TRANSFER_ACK_TIMEOUT_S", "1800"))
+
+
+class WeightTransferReceiverError(RuntimeError):
+    """Raised on the sender when the receiver reported a failure via an ACK error frame."""
+
+
+class WeightTransferAckTimeoutError(RuntimeError):
+    """Raised on the sender when an ACK did not arrive within the bound."""
+
 
 class TensorMetadata(TypedDict):
     name: str
@@ -89,16 +113,43 @@ class BucketedWeightSender:
         zmq_handle: str,
         bucket_size_mb: int = 512,
         use_shm: bool = False,
+        ack_timeout_s: float | None = None,
     ):
         self.zmq_handle = zmq_handle
         self.bucket_size_mb = bucket_size_mb
         self.bucket_size = int(bucket_size_mb) << 20
         self.use_shm = use_shm
+        self.ack_timeout_s = DEFAULT_ACK_TIMEOUT_S if ack_timeout_s is None else ack_timeout_s
 
         self.zmq_context = zmq.Context.instance()
         self.socket = None
         self.buffer = None
         self.shm = None
+
+    def _recv_ack(self, what: str):
+        """Wait for one receiver ACK, bounded in time and aware of error frames.
+
+        The receiver is launched non-blocking by the caller and its future is
+        awaited only after sending completes, so a receiver that dies without
+        answering would otherwise leave this sender blocked in an un-timed
+        recv() forever. Both failure modes surface here as an exception instead:
+        an explicit error frame (receiver raised and reported it) or a timeout
+        (receiver died without reporting).
+        """
+        if self.ack_timeout_s and self.ack_timeout_s > 0:
+            if not self.socket.poll(timeout=int(self.ack_timeout_s * 1000), flags=zmq.POLLIN):
+                raise WeightTransferAckTimeoutError(
+                    f"Timed out after {self.ack_timeout_s:.0f} s waiting for the weight-transfer "
+                    f"receiver's ACK ({what}). The receiver worker is unresponsive or died without "
+                    "reporting an error; check the rollout worker log for the original traceback."
+                )
+        ack = self.socket.recv()
+        if ack.startswith(ACK_ERROR_PREFIX):
+            raise WeightTransferReceiverError(
+                f"Weight-transfer receiver failed ({what}): "
+                f"{ack[len(ACK_ERROR_PREFIX) :].decode('utf-8', errors='replace')}"
+            )
+        return ack
 
     async def async_send_weights(self, weights):
         """
@@ -129,7 +180,7 @@ class BucketedWeightSender:
                 if offset + weight.nbytes > self.bucket_size and len(bucket_meta) > 0:
                     get_torch_device().synchronize()
                     self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
-                    self.socket.recv()
+                    self._recv_ack("intermediate bucket")
                     bucket_meta = {}
                     offset = 0
 
@@ -156,7 +207,7 @@ class BucketedWeightSender:
             # send the last bucket
             get_torch_device().synchronize()
             self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": True})
-            self.socket.recv()
+            self._recv_ack("final bucket")
         finally:
             self._cleanup()
 
@@ -189,7 +240,7 @@ class BucketedWeightSender:
             comm_metadata = {"name": shm_name, "size": self.bucket_size}
             self.socket.send_pyobj(comm_metadata)
 
-        self.socket.recv()
+        self._recv_ack("initial buffer handshake")
         self.buffer = buffer
         self.shm = shm
 
@@ -229,7 +280,7 @@ class BucketedWeightSender:
             "handle": handle,
         }
         self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
-        self.socket.recv()
+        self._recv_ack(f"direct large weight {name}")
 
 
 class BucketedWeightReceiver:
@@ -259,6 +310,29 @@ class BucketedWeightReceiver:
         self.socket = None
         self.buffer = None
         self.shm = None
+
+    def _report_error_to_sender(self, exc: BaseException):
+        """Answer the sender's outstanding request with an error frame.
+
+        The sender waits for an ACK after every send, so a receiver that dies
+        without answering strands it. Best-effort: the socket may already be
+        unusable (or the failure may have happened while no request was
+        outstanding), and this runs on the error path, so it must never mask
+        the original exception.
+        """
+        socket = self.socket
+        if socket is None:
+            return
+        detail = f"{type(exc).__name__}: {exc}"
+        logger.error("Weight transfer receiver failed, reporting to sender: %s", detail)
+        try:
+            # Bound how long _cleanup()'s close() may block flushing this frame:
+            # the default LINGER of -1 would wait forever if the sender has also
+            # gone away, turning the receiver's own teardown into a hang.
+            socket.setsockopt(zmq.LINGER, 5000)
+            socket.send(ACK_ERROR_PREFIX + detail.encode("utf-8", errors="replace")[:4096], flags=zmq.NOBLOCK)
+        except Exception as report_exc:  # pragma: no cover - socket already broken
+            logger.error("Could not report receiver failure to sender: %s", report_exc)
 
     def receive_weights(self, on_bucket_received: callable):
         """
@@ -292,6 +366,12 @@ class BucketedWeightReceiver:
                 del weights, tensor
                 if metadata["is_last"]:
                     break
+        except BaseException as exc:
+            # on_bucket_received (weight loading, quantization) is the likely
+            # raiser; its exception must reach the sender, which is otherwise
+            # blocked waiting for this bucket's ACK.
+            self._report_error_to_sender(exc)
+            raise
         finally:
             self._cleanup()
 
@@ -320,6 +400,16 @@ class BucketedWeightReceiver:
                 tensor = None
                 if metadata["is_last"]:
                     break
+        except GeneratorExit:
+            # Normal early close by the consumer — not a receiver failure, and
+            # the generator is already exhausted on the success path (the loop
+            # `break`s after the last bucket). Keep the pre-existing behaviour.
+            raise
+        except BaseException as exc:
+            # The consumer of this generator (vLLM's reload_weights) can raise
+            # into the yield; report it so the sender does not hang.
+            self._report_error_to_sender(exc)
+            raise
         finally:
             self._cleanup()
 
@@ -355,7 +445,26 @@ class BucketedWeightReceiver:
         del self.buffer
         self.buffer = None
         if self.shm is not None:
-            self.shm.close()
+            # Best-effort: this runs from a `finally`, so a teardown failure here
+            # would REPLACE the exception on its way out. On the shared-memory
+            # path that is not hypothetical — the per-bucket tensors are views
+            # into `shm.buf` (an exported memoryview), and when we unwind from an
+            # exception the traceback keeps the raising frame's locals alive past
+            # the gc.collect() below, so close() raises
+            # `BufferError: cannot close exported pointers exist` and buries the
+            # real cause (a weight-loading or reload-lifecycle error) in the
+            # worker log. The mapping is released by SharedMemory.__del__ once
+            # the traceback is dropped, and the sender owns unlink(), so logging
+            # and moving on is the correct trade.
+            try:
+                self.shm.close()
+            except BufferError as exc:
+                logger.warning(
+                    "Deferring shared-memory close during weight-transfer receiver cleanup: %s "
+                    "(buffer views are still referenced, most likely by the traceback of an "
+                    "in-flight exception; the mapping is released when they are dropped)",
+                    exc,
+                )
             del self.shm
             self.shm = None
         gc.collect()

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -436,9 +436,17 @@ class vLLMColocateWorkerExtension:
         # re-initialize would swap them back to meta, letting finalize process
         # uninitialized memory into kernel storage — silent corruption). The
         # DeepSeek-V4 (quant_reload_state) and Ascend MXFP8 paths keep their
-        # own prepare/restore protocols; no-op on vLLM < 0.20. On vLLM >= 0.21
-        # (not yet validated) begin is skipped and load_quanted_weights fails
-        # closed with an explicit version error instead of silently opting in.
+        # own prepare/restore protocols; no-op on vLLM < 0.20.
+        #
+        # Unsupported configurations (MTP drafter, vLLM outside the validated
+        # interval, a worker poisoned by an earlier failed reload) are rejected
+        # by validate_fp8_layerwise_reload_config BEFORE the receiver — and so
+        # before any socket or shared buffer — exists: the sender waits for an
+        # un-timed initial ACK and only awaits this worker's future after
+        # sending completes, so raising once IPC is live would hang the driver
+        # instead of failing the sync. begin failures poison the worker
+        # (_fail_stop_fp8_reload) because initialize_layerwise_reload mutates
+        # layers one at a time and can leave the model half-converted.
         fp8_layerwise_begun = False
         if (
             is_fp8_model(self.model_runner.vllm_config)
@@ -446,21 +454,36 @@ class vLLMColocateWorkerExtension:
             and not quant_reload_state
         ):
             from verl.utils.vllm.vllm_fp8_utils import (
+                _fail_stop_fp8_reload,
                 _vllm_supports_layerwise_reload,
                 begin_fp8_layerwise_reload,
-                is_mxfp8_vllm_ascend,
+                fp8_state,
+                validate_fp8_layerwise_reload_config,
             )
 
-            if not is_mxfp8_vllm_ascend(self.model_runner.vllm_config.quant_config) and (
-                _vllm_supports_layerwise_reload()
-            ):
-                if self._use_mtp_drafter_weight_sync():
-                    raise NotImplementedError(
-                        "FP8 rollout weight sync via vLLM layerwise reload does not "
-                        "support the MTP drafter yet. Disable MTP speculative decoding "
-                        "when rollout.quantization=fp8 on vLLM >= 0.20."
+            validate_fp8_layerwise_reload_config(
+                self.model_runner.vllm_config,
+                uses_mtp_drafter=self._use_mtp_drafter_weight_sync(),
+            )
+            if _vllm_supports_layerwise_reload():
+                try:
+                    fp8_layerwise_begun = begin_fp8_layerwise_reload(
+                        self.model_runner.model, tag="main", model_runner=self.model_runner
                     )
-                fp8_layerwise_begun = begin_fp8_layerwise_reload(self.model_runner.model, tag="main")
+                except BaseException:
+                    # begin_fp8_layerwise_reload already fail-stops when
+                    # initialize_layerwise_reload itself raises; this catch
+                    # covers every OTHER way begin can fail once the attempt is
+                    # on record (e.g. a lifecycle violation from a previous sync
+                    # that never finalized), which leaves the same
+                    # possibly-half-converted model. Poisoning is idempotent.
+                    if "main" in fp8_state.layerwise_begin_attempted:
+                        _fail_stop_fp8_reload(
+                            self.model_runner,
+                            "begin_fp8_layerwise_reload failed",
+                            tag="main",
+                        )
+                    raise
 
         receiver = BucketedWeightReceiver(
             zmq_handle=self._get_zmq_handle(),

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -428,6 +428,40 @@ class vLLMColocateWorkerExtension:
 
             quant_reload_state = prepare_quanted_weights_for_loading(self.model_runner)
 
+        # FP8 on vLLM >= 0.20: enter vLLM's layerwise reload ONCE, BEFORE any
+        # IPC bucket. Params are in kernel format at sync time (e.g. block-FP8
+        # FusedMoE w13_weight shuffled to 4D BlockMajorK), so per-bucket
+        # load_weights against the checkpoint layout would crash; and
+        # per-bucket initialization is unsound (completed layers reset and a
+        # re-initialize would swap them back to meta, letting finalize process
+        # uninitialized memory into kernel storage — silent corruption). The
+        # DeepSeek-V4 (quant_reload_state) and Ascend MXFP8 paths keep their
+        # own prepare/restore protocols; no-op on vLLM < 0.20. On vLLM >= 0.21
+        # (not yet validated) begin is skipped and load_quanted_weights fails
+        # closed with an explicit version error instead of silently opting in.
+        fp8_layerwise_begun = False
+        if (
+            is_fp8_model(self.model_runner.vllm_config)
+            and not (peft_config and base_sync_done)
+            and not quant_reload_state
+        ):
+            from verl.utils.vllm.vllm_fp8_utils import (
+                _vllm_supports_layerwise_reload,
+                begin_fp8_layerwise_reload,
+                is_mxfp8_vllm_ascend,
+            )
+
+            if not is_mxfp8_vllm_ascend(self.model_runner.vllm_config.quant_config) and (
+                _vllm_supports_layerwise_reload()
+            ):
+                if self._use_mtp_drafter_weight_sync():
+                    raise NotImplementedError(
+                        "FP8 rollout weight sync via vLLM layerwise reload does not "
+                        "support the MTP drafter yet. Disable MTP speculative decoding "
+                        "when rollout.quantization=fp8 on vLLM >= 0.20."
+                    )
+                fp8_layerwise_begun = begin_fp8_layerwise_reload(self.model_runner.model, tag="main")
+
         receiver = BucketedWeightReceiver(
             zmq_handle=self._get_zmq_handle(),
             device=self.device,
@@ -481,6 +515,18 @@ class vLLMColocateWorkerExtension:
 
                 process_quanted_weights_after_loading(self.model_runner, quant_reload_state)
                 logger.info("FP8/MXFP4: process_weights_after_loading completed")
+            elif fp8_layerwise_begun:
+                # Finalize the layerwise reload ONCE after ALL buckets —
+                # processes layers that did not self-complete during streaming
+                # (attention scales, padded layers) and restores kernel
+                # tensors. Pairs with the single begin_fp8_layerwise_reload
+                # before receive_weights.
+                from verl.utils.vllm.vllm_fp8_utils import finalize_fp8_layerwise_reload
+
+                finalize_fp8_layerwise_reload(
+                    self.model_runner.model, self.model_runner.vllm_config.model_config, tag="main"
+                )
+                logger.info("FP8: layerwise reload finalized (main)")
             elif use_standard_weight_load and not used_layerwise_reload:
                 # Some post-load transforms are non-idempotent; run once after all buckets.
                 from vllm.model_executor.model_loader.utils import process_weights_after_loading

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -547,7 +547,10 @@ class vLLMColocateWorkerExtension:
                 from verl.utils.vllm.vllm_fp8_utils import finalize_fp8_layerwise_reload
 
                 finalize_fp8_layerwise_reload(
-                    self.model_runner.model, self.model_runner.vllm_config.model_config, tag="main"
+                    self.model_runner.model,
+                    self.model_runner.vllm_config.model_config,
+                    tag="main",
+                    model_runner=self.model_runner,
                 )
                 logger.info("FP8: layerwise reload finalized (main)")
             elif use_standard_weight_load and not used_layerwise_reload:

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -512,7 +512,27 @@ class vLLMColocateWorkerExtension:
                     quant_prepared=bool(quant_reload_state),
                 )
 
-            receiver.receive_weights(on_bucket_received=on_bucket_received)
+            try:
+                # Covers receive AND per-bucket load failures (the bucket
+                # loader runs inside receive_weights via on_bucket_received).
+                # With the layerwise reload active this leaves the model
+                # partially updated with no rollback — same failure class as a
+                # begin/finalize failure, so it fail-stops the worker the same
+                # way (supersedes the receive-stage abort in the PR's previous
+                # head, 3a5d729d, which cleared the lifecycle flag but did not
+                # guard the serving entry points).
+                receiver.receive_weights(on_bucket_received=on_bucket_received)
+            except BaseException as exc:
+                if fp8_layerwise_begun:
+                    from verl.utils.vllm.vllm_fp8_utils import _fail_stop_fp8_reload
+
+                    _fail_stop_fp8_reload(
+                        self.model_runner,
+                        f"weight receive failed mid-reload: {type(exc).__name__}: {exc}",
+                        tag="main",
+                        model=self.model_runner.model,
+                    )
+                raise
             if lora_weights is not None:
                 self._update_weights(
                     list(lora_weights.items()),


### PR DESCRIPTION
### What does this PR do?

Fixes FP8 rollout weight resync (`actor_rollout_ref.rollout.quantization=fp8`) on vLLM 0.20.x by driving vLLM's native layerwise reload lifecycle around verl's bucketed IPC weight sync.

Related to #5683 (a failure of the same FP8-resync family on a newer pin). This PR does NOT fix the exact environment reported there (verl 0.7.1 + vLLM 0.17.0): the patch is deliberately a no-op below vLLM 0.20, we did not reproduce the 0.17 failure, and a collaborator report in that issue indicates Qwen3 MoE FP8 already works on vLLM 0.17 with newer verl. This PR should not auto-close #5683.

Complementary to the merged #5599, which routes the STANDARD (non-FP8) weight sync through vLLM's `reload_weights`; that path is gated `not is_fp8_model(...)`, so FP8 models still take the bucketed `load_quanted_weights` path this PR fixes (details under Design & Code Changes).

### Checklist Before Starting

- [x] Search for similar PRs. Query links:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+5683+in%3Abody (0 results)
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fp8+weight+sync (reviewed; none touch the vLLM >= 0.20 kernel-format reload lifecycle for FP8 resync — see "Why this is not duplicating an existing PR" below)
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[rollout, vllm] fix: FP8 rollout weight resync on vLLM 0.20.x via native layerwise reload lifecycle` (modules `rollout`, `vllm`; type `fix`; no API/config/signature break, so no `[BREAKING]`)

### Test

**Mechanism validation (verl v0.8.0 tag 7aed6b2 x vLLM 0.20.2 x CUDA 13.0, Qwen3-235B-A22B (MoE), GRPO with mixed code+math RLVR data and sandbox-executed code rewards, BF16 actor + FP8 rollout, B200 nodes):**

1. Crash reproduction (before fix): first weight resync crashes with the `ValueError` under Design & Code Changes below; 13 hits of the signature in the failing run's log.
2. 4-node smoke (32 GPU, rollout TP8/DP4/EP32, 1 step): step 1 completed end-to-end including a second weight sync, and the old crash signature appeared 0 times. (The smoke is a gate, not a benchmark; no smoke numbers are quoted as results.)
3. 8-node full run (64 GPU, rollout TP8/DP8/EP64, train batch 64 prompts x n=8 rollouts = 512 responses/step, 30 steps): all 30 steps complete, 0 crashes, stable training statistics (response clip ratio and mean response length within 1% of the identical BF16-rollout baseline). Same-condition A/B vs that baseline is in Measurements below.
4. Correctness instrumentation (not included in this PR): during validation we ran a fail-closed layerwise-reload accounting probe (per-layer expected-call sets, duplicate/late-call detection, load_numel exactness) plus an FP8 weight-check gate (dequantize-and-compare against the BF16 source for sampled tensors incl. MoE experts) on the first sync of each run — zero failures. That instrumentation is validation apparatus; if maintainers want it upstream we can propose it separately as an opt-in debug feature (it is adjacent to what #6666 aims at).

**This branch (port of that fix onto current main 578b9f2b):** main has meanwhile gained the standard-path layerwise reload for BF16, DeepSeek-V4 FP8 support, and MTP drafter sync — the port respects all three (DSv4 keeps its dedicated path, the fail-closed guard exempts it, MTP+FP8 raises at sync start). Commands run on this exact branch:

```
python3 -m pytest tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py   # 7 passed
python3 -m pytest tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py       # 8 passed
pre-commit run --files <the 4 changed files>                                           # all hooks pass (ruff, ruff format, mypy, license, doc-coverage, naming, compile)
```

The ownership regression was additionally verified to be discriminating: with the clone guard removed, `test_layerwise_reload_clones_bucket_backed_tensors` fails. The fail-stop path is likewise covered: `test_update_weights_from_ipc_fp8_failure_fails_stop` (parametrized over a receive-time and a finalize-time failure) asserts the worker is marked unusable and refuses a subsequent sync, with a clean-run negative control; `test_abort_clears_state_and_allows_rebegin` covers the reset helper.

An end-to-end hardware smoke of the mechanism (tree at commit 34021806) passed on 2026-07-23: 4 nodes x 8 B200 GPU, Qwen3-235B-A22B, rollout TP8/DP4/EP32, `rollout.quantization=fp8`, 1 training step. (The current branch head additionally hardens the failure path — a fail-stop on a failed layerwise reload, see Design & Code Changes — which runs only on the error path and is covered by the CPU tests above, not re-smoked on hardware since the smoke exercises the successful sync.) The step completed end-to-end including the post-update FP8 weight resync through the layerwise reload path; the pre-fix crash signature (`... is not a valid data dimension ...`) appeared in zero worker logs, and no traceback attributable to the resync path occurred (the only traceback in the run is a benign DataLoader-worker SIGKILL at Ray actor shutdown that equally appears in our BF16 baseline runs). The CPU test suite was re-run inside the run image (with vLLM 0.20.2 installed) and passed (`tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py`, 6 passed) — note the suite stubs the vLLM APIs it touches by design, so this run confirms the tests are environment-portable, not that they exercise the installed vLLM; the installed vLLM 0.20.2 is exercised by the hardware smoke itself. Reproducer notes (environment only, no code changes to the branch): our run image is built for verl v0.8.0, so the branch was editable-installed over it (`pip install --no-deps -e .`); this additionally required `pip install TransferQueue` (a current-main trainer dependency absent from the older image) and launching with `actor_rollout_ref.actor.megatron.vanilla_mbridge=True`, because the image's megatron-bridge 0.5.0 is incompatible with its megatron-core 0.16.1 (`ImportError: safe_get_world_size`) — an image/dependency mismatch unrelated to this fix.

**Measurements (same-condition A/B, 8 nodes x 8 B200 GPU):**

Both runs: identical hardware, image, pins (verl v0.8.0 / vLLM 0.20.2 / CUDA 13.0), model (Qwen3-235B-A22B), parallelism (actor TP4/PP8/EP4, rollout TP8/DP8/EP64), batch (64 prompts x n=8 rollouts = 512 responses/step, 2048+2048 tok), dataset, 30 steps; medians over the measured window steps 11-30 (n=20, first 10 steps discarded as warmup); re-parsed from raw `metrics.jsonl`. Only difference: `rollout.quantization=fp8` + this fix vs BF16 rollout.

| metric | FP8 rollout (fixed) | BF16 rollout | delta |
|---|---|---|---|
| step time [s] | 954.30 | 940.81 | +1.4% |
| generation time [s] | 777.06 | 811.90 | -4.3% |
| throughput [tok/s/GPU] | 19.48 | 19.59 | -0.6% |
| update_actor [s] | 87.01 | 83.98 | +3.6% |
| update_weights [s] | 56.88 | 11.18 | +408.8% |
| response clip_ratio | 0.852 | 0.856 | -0.6% |
| mean response length [tok] | 1932.6 | 1933.2 | -0.0% |

FP8 rollout generation is -4.3% faster, but the BF16->FP8 resync through the layerwise reload costs +45.7 s/step (+408.8% on update_weights), netting out to roughly performance-neutral step time (+1.4%) at this scale. The clip_ratio / response-length deltas rule out the "shorter responses made generation faster" artifact. Users should weigh this until the resync cost is optimized (quantize-on-GPU batching, overlapping, etc. are future work). These measurements were taken with the validated v0.8.0-based patch; the ported branch is mechanism-identical but its numbers have not been re-measured on main.

### API and Usage Example

No API, CLI, or config change. The existing flag simply works on vLLM 0.20.x now:

```bash
# FP8 rollout on a vLLM 0.20.x install — previously crashed at the first
# post-training-step weight sync; works with this PR:
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.rollout.quantization=fp8 \
    ...  # everything else unchanged
```

Behavior notes (all fail-fast, no silent behavior change):
- vLLM < 0.20: no-op (existing paths untouched).
- vLLM >= 0.21: explicit version error at sync (fail-closed; see version-gate note). This is deliberately broad — it blocks **all** FP8 configs (including dense-FP8 and EP=1 MoE, not only the EP>1 shuffle case), a conscious opt-out of an unvalidated line rather than an oversight.
- Mid-reload failure: because vLLM's native reload is not transactional (a partially-updated model cannot be rolled back), any failure during the reload marks the worker unusable (fail-stop) and re-raises; the poisoned worker refuses subsequent syncs instead of loading into a corrupt model.
- MTP drafter sync + FP8: `NotImplementedError` at sync start (unproven combination).
- BF16 rollout, DeepSeek-V4 FP8, Ascend MXFP8: untouched (own protocols).

Coverage note: validated end-to-end on EP>1 block-FP8 MoE (the config that exhibits the 4D kernel shuffle). Dense-FP8 and EP=1 MoE ride the same lifecycle and are expected-but-unverified.

### Design & Code Changes

**Problem.** On vLLM 0.20.x, FP8 block-quant params are kept in KERNEL format between syncs. On the EP>1 block-FP8 path, `process_weights_after_loading()` -> `_setup_kernel()` -> `_shuffle_deepseek_fp8_moe_weights()` (`vllm/model_executor/layers/quantization/utils/flashinfer_utils.py`) replaces the checkpoint-format 3D FusedMoE `w13_weight` `(E_local, 2*intermediate, hidden)` with a shuffled 4D BlockMajorK tensor `(E_local, K/block_k, Mn, block_k)`. Observed with Qwen3-235B-A22B (128 experts) + rollout EP64 on vLLM 0.20.2: `experts.w13_weight` `ndim=4 shape=(2, 32, 3072, 128)` = `(E_local=2, 4096/128, 2*1536, 128)`, while the streamed per-expert HF weight is 2D `(1536, 4096)`.

At the first `update_weights` after a training step, vLLM's per-expert loader — written against the CHECKPOINT format — does `param.data[expert_id]`. That still indexes the expert axis (the leading axis in both layouts), but the per-expert view it produces is now a 3D kernel-blocked tensor `(K/block_k, Mn, block_k)` instead of the expected 2D checkpoint matrix, so `_load_w13(shard_id=w1, shard_dim=0)` -> `_get_hidden_dim(0, ndim=3)` raises:

```python
ValueError: shard_dim=0 is not a valid data dimension for a 3D tensor (expected 1 or 2)
```

A "fix" that reshapes or re-indexes by hand risks silent mis-load into the shuffled kernel layout instead of a crash.

**Fix design.** Use vLLM 0.20's OWN reload protocol (`vllm/model_executor/model_loader/reload/`) — the machinery `gpu_model_runner.reload_weights()` uses — with its native single-initialize / single-finalize lifecycle:

```python
initialize_layerwise_reload(model)      # ONCE per sync, BEFORE any IPC bucket
model.load_weights(bucket_stream)       # every bucket, via load_quanted_weights
finalize_layerwise_reload(model, cfg)   # ONCE per sync, after the last bucket
```

Two properties of this lifecycle are load-bearing:

1. **Single initialize/finalize.** `initialize_layerwise_reload` is NOT idempotent across buckets: when a layer completes mid-stream, `_layerwise_process()` ends with `info.reset()`, so a re-initialize would swap the completed layer back to meta; if any tensor of that layer then arrives in a later bucket, finalize treats `0 < load_numel < total` as "delayed processing" and processes uninitialized memory into the real kernel storage — silent corruption, not a crash. verl's IPC sync is bucketed with sender-chosen bucket boundaries (no contract that a layer is contiguous within one bucket), so initialize/finalize must live in `update_weights_from_ipc`, not in the per-bucket loader.

2. **Buffer ownership.** Layerwise reload BUFFERS streamed tensors until an entire layer has arrived — potentially across IPC buckets — while verl's `BucketedWeightReceiver` reuses ONE backing buffer for every bucket. A tensor yielded as a view into that buffer and retained past a bucket boundary is silently overwritten by the next bucket before vLLM replays the layer. `quant_weights` therefore clones every non-quantized tensor while a layerwise reload is active (quantized outputs are fresh allocations already). Note the clone is intrinsic, not over-scoped: `BucketedWeightReceiver` yields both reused-buffer views and CUDA-IPC-rebuilt tensors whose sender storage is reclaimed on bucket ack, so both are unsafe to retain — narrowing to "only buffer-backed views" would fail open. vLLM frees each layer's buffered clones on completion (not held to finalize), which bounds the transient overhead. A CPU regression test in this PR overwrites the shared buffer after bucket 1 and proves the buffered tensor keeps the original bytes.

**Specific changes:**

- `verl/utils/vllm/vllm_fp8_utils.py`: add `begin_fp8_layerwise_reload` / `finalize_fp8_layerwise_reload` (lifecycle guards raise on double-begin / finalize-without-begin), `abort_fp8_layerwise_reload` (clears the process-global active flag after a failed sync), `_vllm_layerwise_reload_available` (feature probe) and `_vllm_supports_layerwise_reload` (validated-interval gate). `load_quanted_weights` fails CLOSED if a bucket arrives on a reload-capable vLLM without an active layerwise reload, and fails CLOSED with an explicit version error on vLLM >= 0.21 (see version-gate note below). `quant_weights` clones non-quantized bucket-backed tensors while the reload is active. `model.load_weights` runs under `set_current_vllm_config` (per-layer requantize + kernel-format shuffle run inside `load_weights` when a layer completes and need the config context); `initialize_layerwise_reload` itself is config-independent (validated on 0.20.2), which is why `begin` sits outside that context while `finalize` sits inside it.
- `verl/workers/rollout/vllm_rollout/utils.py`: `update_weights_from_ipc` begins the reload once before `receive_weights` and finalizes once after all buckets (processing layers that did not self-complete during streaming: attention scales, padded layers). The begin→receive→finalize span is wrapped so any failure fail-stops the worker (`_fail_stop_fp8_reload`: mark unusable + clear the flag, then re-raise) and a poisoned worker refuses subsequent syncs up front — vLLM's native reload has no rollback, so a partially-updated model must never be reused. (This mirrors the fail-stop that the convergent NPU PR #7087 introduced for the same non-transactional reload.)
- `tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py`: CPU-only regression tests (no GPU or vLLM install needed — the suite stubs the vLLM APIs it touches and validates verl's lifecycle/ownership logic, not vLLM itself) for the two-bucket shared-backing-buffer ownership hazard (with a negative control proving the zero-copy fast path outside reload), the begin/finalize lifecycle guards, the abort/re-begin reset, the fail-closed bucket-without-begin path, the vLLM < 0.20 no-op, and the vLLM >= 0.21 fail-closed version gate.
- `tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py`: add orchestration coverage for `update_weights_from_ipc` on the FP8 path — a parametrized receive-time / finalize-time failure asserting the fail-stop marker is set, `abort` is called, and a follow-on sync refuses, plus a clean-run negative control.
- Scope guard: only reached when `is_fp8_model()` is true. BF16 rollout, the DeepSeek-V4 path (`prepare/process_quanted_weights_*`), and the Ascend MXFP8 path (own restore/re-apply protocol) are untouched. No-op on vLLM < 0.20.
- MTP drafter weight sync is NOT supported on this path (config-context/global-state interaction with the drafter is unproven): asserted at sync start with a clear `NotImplementedError`, rather than failing mid-stream.

**Version-gate note.** The gate enables exactly the validated interval `>= 0.20.0, < 0.21.0`. Importing the reload entry points proves the module exists on newer lines, not that its lifecycle semantics are unchanged, so vLLM >= 0.21 fails closed with an explicit error instead of being silently opted in. If maintainers prefer a different policy for future lines (e.g. warn-and-proceed), happy to change it.

**Support-matrix note.** The documented FP8 support matrix (`docs/low_precision/fp8.md`) covers vLLM 0.10.x-0.12. This PR enables the FP8 rollout resync path on the 0.20.x line, where the existing patch strategy cannot work because params are in kernel format at sync time.

**Why this is not duplicating an existing PR.** Checked open PRs (2026-07-23, re-checked 2026-07-24): `gh pr list --state open --search "5683 in:body"` returns none; FP8-adjacent PRs #5976 (trainer-side FP8 quantization), #5153 (vLLM >= 0.12 Marlin workspace init), #6666 (weight-sync debug check), #6045/#4325/#4435 (FP8 export/training/KV-cache) address different code paths; none touch the vLLM >= 0.20 kernel-format reload lifecycle for FP8 resync.

Relationship to the recently merged #5599 (Qwen3.5 LoRA & MTP, merged 2026-07-21): this branch is based on a main HEAD that already contains #5599. #5599 routes the STANDARD (non-FP8) weight sync through vLLM's `reload_weights` (`_maybe_reload_standard_weights_from_ipc`), but that path is explicitly gated by `not is_fp8_model(...)` — FP8 models still take the bucketed `load_quanted_weights` path this PR fixes. The two changes are complementary (same native-reload direction, disjoint model populations) and do not conflict.

Relationship to #7087 (NPU MTP native reload, closed unmerged 2026-07-23): #7087 independently drives the same vLLM native layerwise-reload lifecycle on this same file, but for the disjoint **NPU + MTP + standard (checkpoint-format) loading** path, whereas this PR covers **CUDA + FP8 block-quant rollout**. Together with the merged #5599 (CUDA + BF16), the three tile the space with no overlap — different platforms, different quant paths, one shared native-reload direction. #7087 also established (for the same non-transactional reload) that a mid-reload failure must fail-stop the worker rather than risk reuse of a partially-updated model; this PR follows that precedent for the FP8 path (see `_fail_stop_fp8_reload` under Design & Code Changes).

### AI assistance disclosure

This fix was developed with AI assistance (root-cause probing, patch drafting, test authoring, and validation-run orchestration by an AI agent under human direction). 


### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): all hooks pass on the changed files (ruff, ruff format, mypy, config-regen check, license, doc-coverage, device-API, DataProto, test-structure, naming, compile; run 2026-07-24).
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not updated in this PR: the natural place is the FP8 support matrix in `docs/low_precision/fp8.md`, but whether 0.20.x should be listed as supported (vs experimental/gated) is a maintainer policy call — see the support-matrix note above; happy to add the docs entry in whatever form maintainers prefer.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code: `tests/workers/rollout/test_vllm_fp8_layerwise_lifecycle_on_cpu.py` follows the `test_*_on_cpu.py` naming convention and is auto-collected by `cpu_unit_tests.yml` (`tests/**/test_*_on_cpu.py` pattern) — no workflow file change needed. GPU/hardware coverage is not feasible in CI (needs a multi-node FP8 MoE rollout); covered by the hardware smoke + full run documented under Test.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (Post-submission step.)
- [x] Not related to the `recipe` submodule (no submodule update needed).

