### PR TITLE
[sglang] fix: use _base guard in _compact_for_bucket to prevent NCCL buffer race

### DIFF
--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -83,7 +83,15 @@ def _compact_for_bucket(tensor: torch.Tensor) -> torch.Tensor:
     transiently doubles the tensor's footprint -- which OOMs on multi-GiB fused MoE weights
     (e.g. ``[num_experts, ...]`` ``gate_up_proj``/``qkv``) while the actor params and rollout
     weights are both already resident. Skip the clone when the tensor already owns its storage.
+
+    NOTE: A view tensor whose data fills the *entire* underlying storage would pass the
+    ``nbytes == numel * element_size`` test (false negative) -- e.g. a chunk view spanning a
+    full NCCL bucket.  Those are caught by the ``_base`` guard.
     """
+    # View tensors share storage with a parent buffer (e.g. NCCL recv bucket) that may
+    # be overwritten by double-buffering before the bucket is flushed.
+    if tensor._base is not None:
+        return tensor.clone()
     if tensor.is_contiguous() and tensor.untyped_storage().nbytes() == tensor.numel() * tensor.element_size():
         return tensor
     return tensor.clone()

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -83,18 +83,8 @@ def _compact_for_bucket(tensor: torch.Tensor) -> torch.Tensor:
     transiently doubles the tensor's footprint -- which OOMs on multi-GiB fused MoE weights
     (e.g. ``[num_experts, ...]`` ``gate_up_proj``/``qkv``) while the actor params and rollout
     weights are both already resident. Skip the clone when the tensor already owns its storage.
-
-    NOTE: A view tensor whose data fills the *entire* underlying storage would pass the
-    ``nbytes == numel * element_size`` test (false negative) -- e.g. a chunk view spanning a
-    full NCCL bucket.  Those are caught by the ``_base`` guard.
     """
-    # View tensors share storage with a parent buffer (e.g. NCCL recv bucket) that may
-    # be overwritten by double-buffering before the bucket is flushed.
-    if tensor._base is not None:
-        return tensor.clone()
-    if tensor.is_contiguous() and tensor.untyped_storage().nbytes() == tensor.numel() * tensor.element_size():
-        return tensor
-    return tensor.clone()
+    return tensor.clone() if tensor._base is not None else tensor
 
 
 async def get_named_tensor_buckets(


### PR DESCRIPTION
The original nbytes == numel*element_size heuristic fails to detect NCCL recv_buf view tensors when the bucket size (e.g. 1024 MB) exactly equals the tensor footprint.  Such tensors escape the clone, remain views into the recv_buf, and get silently overwritten by the next NCCL broadcast before the CUDA IPC handle is consumed on the SGLang side.  This causes params (e.g. gate_up_proj, down_proj) to shift by one or more layers.

Add tensor._base is not None as a reliable view-detection guard that catches all recv_buf views regardless of bucket/tensor size coincidence, while preserving the no-clone fast path for FSDP DTensor.full_tensor() and torch.stack() outputs.

related pr: https://github.com/verl-project/verl/pull/6738/

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
