### PR TITLE
[megatron] feat: add megatron_adaptor+te-npu backend for Ascend NPU

### DIFF
--- a/docs/ascend_tutorial/feature_support/megatron_adaptor_backend.md
+++ b/docs/ascend_tutorial/feature_support/megatron_adaptor_backend.md
@@ -1,0 +1,51 @@
+# MegatronAdaptor + TransformerEngine-NPU Backend
+
+Last updated: 07/24/2026.
+
+`megatron_adaptor` is a Megatron training-engine backend for Ascend NPU, provided as an
+alternative to the MindSpeed path. It runs the lightweight **MegatronAdaptor** patch layer
+together with **TransformerEngine-NPU (TE-NPU)**, which lets verl track newer `megatron-core`
+releases and unlocks **mxfp8** (MXFP8 block scaling) low-precision training on NPU.
+
+It reuses the generic Megatron engine (`MegatronEngineWithLMHead` / `MegatronEngineWithValueHead`);
+all NPU patches are applied once at `import megatron_adaptor`. It coexists with the `megatron`
+and `mindspeed` backends and does not change their behavior.
+
+## Requirements
+
+Install the following on your Ascend environment (they are not pulled in automatically):
+
+| Component | Note |
+| --- | --- |
+| `megatron_adaptor` | Ascend MegatronAdaptor patch layer |
+| `transformer_engine` | TransformerEngine-NPU (drop-in replacement) |
+| `megatron-core` | the version supported by your MegatronAdaptor release |
+
+## Usage
+
+Select the backend through the engine config group (or by overriding the strategy directly):
+
+```bash
+python3 -m verl.trainer.main_ppo \
+    engine=megatron_adaptor \
+    actor_rollout_ref.actor.strategy=megatron_adaptor \
+    ...
+```
+
+To enable mxfp8 low-precision training, pass the fp8 recipe through
+`override_transformer_config`:
+
+```bash
+    +actor_rollout_ref.actor.megatron.override_transformer_config.fp8=hybrid \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.fp8_recipe=mxfp8
+```
+
+All other Megatron parallel/offload options
+(`tensor_model_parallel_size`, `expert_model_parallel_size`, `param_offload`, ...) behave the
+same as the `megatron` backend; see `verl/trainer/config/engine/megatron_adaptor.yaml`.
+
+## Notes
+
+- `strategy=megatron_adaptor` is accepted by `McoreEngineConfig` alongside `megatron`.
+- fp8 is forwarded only when explicitly set via `override_transformer_config`; otherwise the
+  historical behavior (fp8 disabled) is preserved, so existing users are unaffected.

--- a/docs/ascend_tutorial/index.rst
+++ b/docs/ascend_tutorial/index.rst
@@ -1,7 +1,7 @@
 Ascend (NPU) Tutorial
 =====================
 
-Last updated: 06/05/2026.
+Last updated: 07/24/2026.
 
 .. toctree::
    :maxdepth: 1
@@ -19,6 +19,7 @@ Last updated: 06/05/2026.
 
    feature_support/ascend_backend_features
    feature_support/npu_advance_features
+   feature_support/megatron_adaptor_backend
 
 .. toctree::
    :maxdepth: 1

--- a/tests/workers/test_megatron_adaptor_registry_on_cpu.py
+++ b/tests/workers/test_megatron_adaptor_registry_on_cpu.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_registry_resolves_adaptor_engine_on_npu(monkeypatch):
+    monkeypatch.setenv("VERL_ENGINE_DEVICE", "npu")
+    from verl.workers.engine import EngineRegistry
+
+    lm_cls = EngineRegistry.get_engine_cls("language_model", "megatron_adaptor")
+    assert lm_cls.__name__ == "MegatronAdaptorEngineWithLMHead"
+    vm_cls = EngineRegistry.get_engine_cls("value_model", "megatron_adaptor")
+    assert vm_cls.__name__ == "MegatronAdaptorEngineWithValueHead"
+
+
+def test_adaptor_does_not_shadow_plain_megatron_backend(monkeypatch):
+    monkeypatch.setenv("VERL_ENGINE_DEVICE", "npu")
+    from verl.workers.engine import EngineRegistry
+
+    cls = EngineRegistry.get_engine_cls("language_model", "megatron")
+    assert cls.__name__ != "MegatronAdaptorEngineWithLMHead"
+
+
+def test_mcore_config_accepts_adaptor_strategy():
+    from verl.workers.config import McoreEngineConfig
+
+    cfg = McoreEngineConfig(strategy="megatron_adaptor", tensor_model_parallel_size=2)
+    assert cfg.strategy == "megatron_adaptor"
+
+
+def test_mcore_config_rejects_unknown_strategy():
+    import pytest
+
+    from verl.workers.config import McoreEngineConfig
+
+    with pytest.raises(AssertionError):
+        McoreEngineConfig(strategy="not_a_backend")

--- a/tests/workers/test_megatron_adaptor_registry_on_cpu.py
+++ b/tests/workers/test_megatron_adaptor_registry_on_cpu.py
@@ -12,23 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 
-def test_registry_resolves_adaptor_engine_on_npu(monkeypatch):
-    monkeypatch.setenv("VERL_ENGINE_DEVICE", "npu")
-    from verl.workers.engine import EngineRegistry
+try:
+    from verl.workers.engine import MegatronAdaptorEngineWithLMHead as _AdaptorLMEngine
+except Exception:
+    _AdaptorLMEngine = None
 
-    lm_cls = EngineRegistry.get_engine_cls("language_model", "megatron_adaptor")
-    assert lm_cls.__name__ == "MegatronAdaptorEngineWithLMHead"
-    vm_cls = EngineRegistry.get_engine_cls("value_model", "megatron_adaptor")
-    assert vm_cls.__name__ == "MegatronAdaptorEngineWithValueHead"
-
-
-def test_adaptor_does_not_shadow_plain_megatron_backend(monkeypatch):
-    monkeypatch.setenv("VERL_ENGINE_DEVICE", "npu")
-    from verl.workers.engine import EngineRegistry
-
-    cls = EngineRegistry.get_engine_cls("language_model", "megatron")
-    assert cls.__name__ != "MegatronAdaptorEngineWithLMHead"
+# The megatron_adaptor engine classes register at import of verl.workers.engine. Registration
+# only needs megatron-core (not torch_npu / the megatron_adaptor patch layer), so it succeeds on
+# the GPU-based CI image and the registry assertions below run there. When megatron-core itself is
+# absent the classes are not importable, so those assertions are skipped instead of failing.
+_ADAPTOR_UNAVAILABLE = _AdaptorLMEngine is None
+_ADAPTOR_SKIP_REASON = "megatron / megatron_adaptor engine not importable in this environment"
 
 
 def test_mcore_config_accepts_adaptor_strategy():
@@ -39,9 +35,29 @@ def test_mcore_config_accepts_adaptor_strategy():
 
 
 def test_mcore_config_rejects_unknown_strategy():
-    import pytest
-
     from verl.workers.config import McoreEngineConfig
 
     with pytest.raises(AssertionError):
         McoreEngineConfig(strategy="not_a_backend")
+
+
+@pytest.mark.skipif(_ADAPTOR_UNAVAILABLE, reason=_ADAPTOR_SKIP_REASON)
+def test_adaptor_engine_registered_under_npu_backend():
+    from verl.workers.engine.base import EngineRegistry
+
+    lm = EngineRegistry._engines["language_model"]
+    vm = EngineRegistry._engines["value_model"]
+
+    assert lm["megatron_adaptor"]["npu"].__name__ == "MegatronAdaptorEngineWithLMHead"
+    assert vm["megatron_adaptor"]["npu"].__name__ == "MegatronAdaptorEngineWithValueHead"
+
+
+@pytest.mark.skipif(_ADAPTOR_UNAVAILABLE, reason=_ADAPTOR_SKIP_REASON)
+def test_adaptor_does_not_shadow_plain_megatron_backend():
+    from verl.workers.engine.base import EngineRegistry
+
+    lm = EngineRegistry._engines["language_model"]
+    # megatron_adaptor must be a distinct backend entry, never overwriting the plain
+    # megatron backend's registrations.
+    for engine_cls in lm.get("megatron", {}).values():
+        assert engine_cls.__name__ != "MegatronAdaptorEngineWithLMHead"

--- a/verl/trainer/config/engine/megatron_adaptor.yaml
+++ b/verl/trainer/config/engine/megatron_adaptor.yaml
@@ -1,0 +1,158 @@
+# Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+_target_: verl.workers.config.McoreEngineConfig
+
+# the strategy (backend): select the MegatronAdaptor + TransformerEngine-NPU engine on Ascend NPU
+strategy: megatron_adaptor
+
+# Whether to offload model parameters to CPU
+param_offload: False
+
+# Whether to offload gradients to CPU
+grad_offload: False
+
+# Whether to offload optimizer state to CPU
+optimizer_offload: False
+
+# tensor model parallel size
+tensor_model_parallel_size: 1
+
+# expert model parallel size
+expert_model_parallel_size: 1
+
+# expert tensor parallel size (null to be same as TP)
+expert_tensor_parallel_size: null
+
+# pipeline model parallel size
+pipeline_model_parallel_size: 1
+
+# virtual pipeline model parallel size
+virtual_pipeline_model_parallel_size: null
+
+# context parallel size
+context_parallel_size: 1
+
+# sequence parallel
+sequence_parallel: True
+
+# Whether to use distributed optimizer
+use_distributed_optimizer: True
+
+# Whether to use distributed checkpointing
+use_dist_checkpointing: False
+
+# distributed checkpointing path
+dist_checkpointing_path: null
+
+# Whether to use hybrid context parallelism
+dynamic_context_parallel: False
+
+# Maximum sequence length per DPxCP rank
+max_seqlen_per_dp_cp_rank: null
+
+# distributed checkpointing prefix, e.g. Nemo2 will append prefix 'module.' to the state dict keys
+dist_checkpointing_prefix: ''
+
+# Make optimizer distributed checkpoint fully reshardable (TP/PP/EP/DP) as opposed to plain DP reshardability
+dist_ckpt_optim_fully_reshardable: False
+
+# Use as little memory as possible during save and load by using Gloo.
+# Has effect only when `dist_ckpt_optim_fully_reshardable` is enabled
+distrib_optim_fully_reshardable_mem_efficient: False
+
+# Whether to use entropy from logits with chunking
+entropy_from_logits_with_chunking: False
+
+# Chunk size for entropy from logits with chunking
+entropy_from_logits_chunk_size: 2048
+
+# oc.select: default val for ref.megatron.seed
+seed: 42
+
+# Allow to override Distributed Data Parallel (DDP) config
+override_ddp_config: {}
+
+# additional transformer config like: num_layers_in_first(/last)_pipeline_stage
+# oc.select: default val for ref.megatron.override_transformer_config
+override_transformer_config:
+  # Recompute configuration, same as in megatron.training.arguments
+  # default use minimal performance-interference recompute methods
+  # Recompute granualarity, choices: ["full", "selective"]
+  recompute_granularity: null
+
+  # Recompute modules, multiple choices: ["core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe"]
+  # Please use correct module in matched model
+  recompute_modules: ["core_attn"]
+
+  # 'uniform', 'block'
+  # 'uniform' divides the total number of transformer layers and checkpoints the input activation of each chunk
+  # 'block' checkpoints the specified number of layers per pipeline stage at the specified granularity
+  recompute_method: null
+
+  # 'full' will checkpoint the entire transformer layer and 'selective' only checkpoints memory intensive part of attention
+  recompute_num_layers: null
+
+  # Attention backend to use (flash,fused,unfused,local,auto). Defaults to auto in mcore, flash in verl
+  attention_backend: flash
+
+override_mcore_model_config: {}
+
+# oc.select: default val for ref.megatron.use_mbridge
+use_mbridge: True
+
+# Whether to use the deprecated legacy mbridge backend instead of Megatron-Bridge
+# oc.select: default val for ref.megatron.vanilla_mbridge
+vanilla_mbridge: False
+
+# whether to use thd format (sequence packing), if not, use bshd format, padding the input_ids to the longest sequence length
+use_remove_padding: True
+
+# BSHD path only. Pad every micro-batch of a mini-batch to the mini-batch's global max sequence length instead of
+# each micro-batch's own max. Unifies padding across micro-batches to avoid repeated cuDNN compilation. Only takes
+# effect when use_remove_padding=False (BSHD); no-op on the THD path.
+pad_bshd_to_minibatch_max: True
+
+# Whether to use Megatron-FSDP (Zero-3 sharding)
+use_megatron_fsdp: False
+
+# whether to use forward only
+forward_only: False
+
+# Mixed precision training param dtype
+dtype: bfloat16 # ["bfloat16", "float16"]
+
+# Router replay configuration for MoE models
+router_replay:
+
+  # Target dataclass for this configuration
+  _target_: verl.workers.config.EngineRouterReplayConfig
+
+  # Router replay mode: disabled, R2, R3
+  # - R2: Use R2 routing strategy (record mode)
+  # - R3: Use R3 routing strategy (record mode)
+  mode: disabled
+
+  # File path to save recorded routing decisions
+  # Required when mode is 'record', 'R2', or 'R3'
+  record_file: null
+
+  # File path to load recorded routing decisions for replay
+  # Required when mode is 'replay'
+  replay_file: null
+
+# QAT (Quantization-Aware Training) configuration
+qat:
+  _target_: verl.workers.config.QATEngineConfig
+  # Whether to enable QAT
+  enable: false
+  # Quantization mode: "w4a16" (weight-only FP4) or "w4a4" (weight + activation FP4)
+  mode: "w4a16"
+  # Group size for blockwise quantization (NVFP4 requires 16)
+  group_size: 16
+  # Module name patterns to exclude from quantization (fnmatch style for Megatron)
+  ignore_patterns:
+    - "lm_head"
+    - "*mlp.gate"
+  # Activation observer strategy (W4A4 only): "static_minmax", "memoryless_minmax", "minmax"
+  activation_observer: null
+  # Path to quantization config JSON for vLLM weight export
+  quantization_config_path: null

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -140,7 +140,10 @@ def get_model(
 
     # Fp16 conversion.
     config: TransformerConfig = get_model_config(model[0])
-    config.fp8 = None
+    # fp8 is non-None here only when explicitly enabled via override_transformer_config;
+    # otherwise keep the historical behavior of forcing it off.
+    if not getattr(config, "fp8", None):
+        config.fp8 = None
     tfconfig: TransformerConfig = model[0].config
     if config.fp16 or config.bf16:  # the ModelParallelConfig in GPTModel
         model = [Float16Module(config, model_module) for model_module in model]

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -213,7 +213,7 @@ class McoreEngineConfig(EngineConfig):
     def __post_init__(self) -> None:
         super().__post_init__()
         """config validation logics go here"""
-        assert self.strategy == "megatron"
+        assert self.strategy in ["megatron", "megatron_adaptor"], f"strategy {self.strategy} not supported"
         assert self.dtype in ["bfloat16", "float16"], f"dtype {self.dtype} not supported"
         if self.vanilla_mbridge:
             warnings.warn(

--- a/verl/workers/engine/__init__.py
+++ b/verl/workers/engine/__init__.py
@@ -11,14 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-try:
-    # Apply Ascend NPU monkey patches before any megatron import below (.fsdp imports
-    # megatron transitively). Broad except: torch_npu raises non-ImportError when CANN
-    # env is missing, which must not break non-NPU backends.
-    import megatron_adaptor  # noqa: F401
-except Exception:
-    pass
-
 from .base import BaseEngine, EngineRegistry
 from .fsdp import FSDPEngine, FSDPEngineWithLMHead
 
@@ -53,8 +45,8 @@ except ImportError:
     AutomodelEngine = None
     AutomodelEngineWithLMHead = None
 
-# MegatronAdaptor (Ascend NPU) must be imported before Megatron so its monkey patches
-# are in effect when megatron modules are first imported
+# MegatronAdaptor (Ascend NPU) engine registration. Patches are applied lazily when the engine
+# is initialized (see megatron_adaptor.transformer_impl), so import order does not matter here.
 try:
     from .megatron_adaptor import MegatronAdaptorEngineWithLMHead, MegatronAdaptorEngineWithValueHead
 

--- a/verl/workers/engine/__init__.py
+++ b/verl/workers/engine/__init__.py
@@ -11,6 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+try:
+    # Apply Ascend NPU monkey patches before any megatron import below (.fsdp imports
+    # megatron transitively). Broad except: torch_npu raises non-ImportError when CANN
+    # env is missing, which must not break non-NPU backends.
+    import megatron_adaptor  # noqa: F401
+except Exception:
+    pass
+
 from .base import BaseEngine, EngineRegistry
 from .fsdp import FSDPEngine, FSDPEngineWithLMHead
 
@@ -44,6 +52,16 @@ try:
 except ImportError:
     AutomodelEngine = None
     AutomodelEngineWithLMHead = None
+
+# MegatronAdaptor (Ascend NPU) must be imported before Megatron so its monkey patches
+# are in effect when megatron modules are first imported
+try:
+    from .megatron_adaptor import MegatronAdaptorEngineWithLMHead, MegatronAdaptorEngineWithValueHead
+
+    __all__ += ["MegatronAdaptorEngineWithLMHead", "MegatronAdaptorEngineWithValueHead"]
+except ImportError:
+    MegatronAdaptorEngineWithLMHead = None
+    MegatronAdaptorEngineWithValueHead = None
 
 # Mindspeed must be imported before Megatron to ensure the related monkey patches take effect as expected
 try:

--- a/verl/workers/engine/megatron_adaptor/__init__.py
+++ b/verl/workers/engine/megatron_adaptor/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .transformer_impl import MegatronAdaptorEngineWithLMHead, MegatronAdaptorEngineWithValueHead
+
+__all__ = ["MegatronAdaptorEngineWithLMHead", "MegatronAdaptorEngineWithValueHead"]

--- a/verl/workers/engine/megatron_adaptor/transformer_impl.py
+++ b/verl/workers/engine/megatron_adaptor/transformer_impl.py
@@ -15,24 +15,6 @@
 import logging
 import os
 
-try:
-    # Importing megatron_adaptor applies the Ascend NPU monkey patches to megatron.core.
-    # It must run before any megatron module is imported so that from-imports elsewhere
-    # bind the patched attributes.
-    import megatron_adaptor  # noqa: F401
-
-    HAVE_MEGATRON_ADAPTOR = True
-except Exception:
-    # torch_npu raises non-ImportError (e.g. UnicodeDecodeError) when CANN env is missing
-    HAVE_MEGATRON_ADAPTOR = False
-
-from verl.trainer.config import CheckpointConfig
-from verl.workers.config import (
-    HFModelConfig,
-    McoreEngineConfig,
-    McoreOptimizerConfig,
-)
-
 from ..base import EngineRegistry
 from ..megatron import MegatronEngineWithLMHead, MegatronEngineWithValueHead
 
@@ -45,35 +27,36 @@ _ADAPTOR_REQUIRED_MSG = (
 )
 
 
+def _apply_megatron_adaptor_patch():
+    """Import megatron_adaptor to apply the Ascend NPU monkey patches to megatron.core.
+
+    Done lazily (mirroring the MindSpeed backend's ``repatch()``) so the patches are applied only
+    when a megatron_adaptor engine is actually initialized -- importing this module for engine
+    registration, or selecting another backend, never triggers them. This also avoids clashing
+    with the top-level ``megatron_adaptor`` module shipped by MindSpeed-LLM on Ascend images.
+    """
+    try:
+        import megatron_adaptor  # noqa: F401
+    except Exception as e:
+        # torch_npu raises non-ImportError (e.g. UnicodeDecodeError) when the CANN env is missing.
+        raise AssertionError(_ADAPTOR_REQUIRED_MSG) from e
+
+
 @EngineRegistry.register(model_type="language_model", backend="megatron_adaptor", device="npu")
 class MegatronAdaptorEngineWithLMHead(MegatronEngineWithLMHead):
-    """Megatron engine on Ascend NPU via the lightweight MegatronAdaptor patch layer.
+    """Megatron engine on Ascend NPU via the lightweight MegatronAdaptor patch layer."""
 
-    Unlike the MindSpeed backend, all patching happens once at import time of
-    megatron_adaptor; no per-engine repatch call is needed.
-    """
-
-    def __init__(
-        self,
-        model_config: HFModelConfig,
-        engine_config: McoreEngineConfig,
-        optimizer_config: McoreOptimizerConfig,
-        checkpoint_config: CheckpointConfig,
-    ):
-        assert HAVE_MEGATRON_ADAPTOR, _ADAPTOR_REQUIRED_MSG
-        super().__init__(model_config, engine_config, optimizer_config, checkpoint_config)
+    def _init_device_mesh(self):
+        # Apply the MegatronAdaptor patches before initialize_model_parallel, mirroring the
+        # MindSpeed backend, so the patched megatron.core APIs are in effect at model build time.
+        _apply_megatron_adaptor_patch()
+        super()._init_device_mesh()
 
 
 @EngineRegistry.register(model_type="value_model", backend="megatron_adaptor", device="npu")
 class MegatronAdaptorEngineWithValueHead(MegatronEngineWithValueHead):
     """Value-model variant of the MegatronAdaptor NPU engine."""
 
-    def __init__(
-        self,
-        model_config: HFModelConfig,
-        engine_config: McoreEngineConfig,
-        optimizer_config: McoreOptimizerConfig,
-        checkpoint_config: CheckpointConfig,
-    ):
-        assert HAVE_MEGATRON_ADAPTOR, _ADAPTOR_REQUIRED_MSG
-        super().__init__(model_config, engine_config, optimizer_config, checkpoint_config)
+    def _init_device_mesh(self):
+        _apply_megatron_adaptor_patch()
+        super()._init_device_mesh()

--- a/verl/workers/engine/megatron_adaptor/transformer_impl.py
+++ b/verl/workers/engine/megatron_adaptor/transformer_impl.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+
+try:
+    # Importing megatron_adaptor applies the Ascend NPU monkey patches to megatron.core.
+    # It must run before any megatron module is imported so that from-imports elsewhere
+    # bind the patched attributes.
+    import megatron_adaptor  # noqa: F401
+
+    HAVE_MEGATRON_ADAPTOR = True
+except Exception:
+    # torch_npu raises non-ImportError (e.g. UnicodeDecodeError) when CANN env is missing
+    HAVE_MEGATRON_ADAPTOR = False
+
+from verl.trainer.config import CheckpointConfig
+from verl.workers.config import (
+    HFModelConfig,
+    McoreEngineConfig,
+    McoreOptimizerConfig,
+)
+
+from ..base import EngineRegistry
+from ..megatron import MegatronEngineWithLMHead, MegatronEngineWithValueHead
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+_ADAPTOR_REQUIRED_MSG = (
+    "backend='megatron_adaptor' requires the megatron_adaptor package "
+    "(https://gitcode.com/Ascend/MegatronAdaptor) to be installed"
+)
+
+
+@EngineRegistry.register(model_type="language_model", backend="megatron_adaptor", device="npu")
+class MegatronAdaptorEngineWithLMHead(MegatronEngineWithLMHead):
+    """Megatron engine on Ascend NPU via the lightweight MegatronAdaptor patch layer.
+
+    Unlike the MindSpeed backend, all patching happens once at import time of
+    megatron_adaptor; no per-engine repatch call is needed.
+    """
+
+    def __init__(
+        self,
+        model_config: HFModelConfig,
+        engine_config: McoreEngineConfig,
+        optimizer_config: McoreOptimizerConfig,
+        checkpoint_config: CheckpointConfig,
+    ):
+        assert HAVE_MEGATRON_ADAPTOR, _ADAPTOR_REQUIRED_MSG
+        super().__init__(model_config, engine_config, optimizer_config, checkpoint_config)
+
+
+@EngineRegistry.register(model_type="value_model", backend="megatron_adaptor", device="npu")
+class MegatronAdaptorEngineWithValueHead(MegatronEngineWithValueHead):
+    """Value-model variant of the MegatronAdaptor NPU engine."""
+
+    def __init__(
+        self,
+        model_config: HFModelConfig,
+        engine_config: McoreEngineConfig,
+        optimizer_config: McoreOptimizerConfig,
+        checkpoint_config: CheckpointConfig,
+    ):
+        assert HAVE_MEGATRON_ADAPTOR, _ADAPTOR_REQUIRED_MSG
+        super().__init__(model_config, engine_config, optimizer_config, checkpoint_config)


### PR DESCRIPTION
### What does this PR do?

Adds a megatron_adaptor engine backend for Ascend NPU, as an alternative to the MindSpeed path. It registers under strategy="megatron_adaptor" and reuses the generic MegatronEngineWithLMHead/ValueHead (a thin ~80-line shell), applying the Ascend NPU patches once at import megatron_adaptor. This lets users run the lightweight MegatronAdaptor + TransformerEngine-NPU stack (tracking newer megatron-core) and unlocks mxfp8 low-precision training on NPU. It coexists with the megatron / mindspeed backends; no change to existing backends.


### Test

- CPU unit test: tests/workers/test_megatron_adaptor_registry_on_cpu.py (registry resolves the backend, does not shadow megatron, config accepts/rejects strategy).
- End-to-end on Ascend 950DT (MegatronAdaptor + TE-NPU + vLLM): mxfp8 Qwen3-30B-A3B (MoE) GRPO, 100-step run with checkpoint save/resume; reward, grad_norm, entropy, and train-infer pearson_corr all healthy throughout.
- 
<img width="1430" height="880" alt="mxfp8_100_curves_ema" src="https://github.com/user-attachments/assets/2cac7da9-ff82-4150-ba23-fa75a45f0896" />


### API and Usage Example

Select the backend via the engine config group (or override the strategy):

python3 -m verl.trainer.main_ppo \
    engine=megatron_adaptor \
    actor_rollout_ref.actor.strategy=megatron_adaptor \
    +actor_rollout_ref.actor.megatron.override_transformer_config.fp8=hybrid \
    +actor_rollout_ref.actor.megatron.override_transformer_config.fp8_recipe=mxfp8 \
    ...

Requires the megatron_adaptor and transformer_engine (TE-NPU) packages installed on Ascend.

### Design & Code Changes

- verl/workers/engine/megatron_adaptor/{__init__.py,transformer_impl.py}: new thin-shell backend; registers LM/Value engines at (backend="megatron_adaptor", device="npu").
- verl/workers/engine/__init__.py: import megatron_adaptor before megatron (patch ordering) + try/except-register the engines.
- verl/workers/config/engine.py: McoreEngineConfig accepts strategy in ["megatron", "megatron_adaptor"].
- verl/utils/megatron_utils.py: only force config.fp8 = None when fp8 is not explicitly set via override_transformer_config (unlocks fp8/mxfp8; zero change for existing users).
- verl/trainer/config/engine/megatron_adaptor.yaml: engine config group (= megatron.yaml with strategy: megatron_adaptor).