### PR TITLE
[rollout, vllm] fix: skip non-local experts before reload cloning

### DIFF
--- a/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
+++ b/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
@@ -56,6 +56,23 @@ class _FakeModel:
         return iter(())
 
 
+class _FakeExperts:
+    def __init__(self, expert_map):
+        self._expert_map = torch.tensor(expert_map, dtype=torch.int32)
+
+
+class _FakeExpertModel(_FakeModel):
+    def __init__(self, expert_map, mapper=None):
+        super().__init__()
+        if mapper is not None:
+            self.hf_to_vllm_mapper = mapper
+        self.experts = _FakeExperts(expert_map)
+
+    def named_modules(self):
+        yield "", self
+        yield "model.layers.0.mlp.experts", self.experts
+
+
 def _make_worker(model):
     worker = object.__new__(vLLMColocateWorkerExtension)
     worker.model_runner = SimpleNamespace(model=model)
@@ -100,6 +117,77 @@ def test_normalize_base_sync_weight_names_handles_bridge_inserted_base_layer_on_
         "model.language_model.layers.0.mlp.experts.gate_up_proj",
         "model.language_model.layers.0.mlp.experts.down_proj",
     ]
+
+
+def test_layerwise_reload_skips_nonlocal_expert_weights_before_clone():
+    mapper = _FakeMapper(
+        {
+            "model.language_model.layers.0.mlp.experts.1.down_proj.weight": (
+                "model.layers.0.mlp.experts.1.down_proj.weight"
+            )
+        }
+    )
+    worker = _make_worker(_FakeExpertModel([0, -1], mapper=mapper))
+    local_expert = torch.tensor([1.0])
+    nonlocal_expert = torch.tensor([2.0])
+    dense_weight = torch.tensor([3.0])
+
+    normalized_weights = list(
+        worker._iter_normalized_base_sync_weights(
+            [
+                ("model.layers.0.mlp.experts.0.gate_proj.weight", local_expert),
+                ("model.layers.0.mlp.experts.1.gate_proj.weight", nonlocal_expert),
+                ("model.language_model.layers.0.mlp.experts.1.down_proj.weight", nonlocal_expert),
+                ("model.layers.0.self_attn.q_proj.weight", dense_weight),
+            ],
+            clone_tensors=True,
+        )
+    )
+
+    assert [name for name, _ in normalized_weights] == [
+        "model.layers.0.mlp.experts.0.gate_proj.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+    ]
+    assert normalized_weights[0][1].data_ptr() != local_expert.data_ptr()
+    assert normalized_weights[1][1].data_ptr() != dense_weight.data_ptr()
+
+
+def test_layerwise_reload_expert_filter_fails_open_for_unknown_weights():
+    worker = _make_worker(_FakeExpertModel([0, -1]))
+    unknown_expert = torch.tensor([1.0])
+    expert_scale = torch.tensor([2.0])
+
+    normalized_weights = list(
+        worker._iter_normalized_base_sync_weights(
+            [
+                ("model.layers.1.mlp.experts.1.gate_proj.weight", unknown_expert),
+                ("model.layers.0.mlp.experts.1.gate_proj.weight_scale", expert_scale),
+            ],
+            clone_tensors=True,
+        )
+    )
+
+    assert [name for name, _ in normalized_weights] == [
+        "model.layers.1.mlp.experts.1.gate_proj.weight",
+        "model.layers.0.mlp.experts.1.gate_proj.weight_scale",
+    ]
+    assert normalized_weights[0][1].data_ptr() != unknown_expert.data_ptr()
+    assert normalized_weights[1][1].data_ptr() != expert_scale.data_ptr()
+
+
+def test_nonlocal_expert_filter_only_applies_to_layerwise_clone_path():
+    worker = _make_worker(_FakeExpertModel([0, -1]))
+    nonlocal_expert = torch.tensor([1.0])
+
+    normalized_weights = list(
+        worker._iter_normalized_base_sync_weights(
+            [("model.layers.0.mlp.experts.1.gate_proj.weight", nonlocal_expert)],
+            clone_tensors=False,
+        )
+    )
+
+    assert len(normalized_weights) == 1
+    assert normalized_weights[0][1] is nonlocal_expert
 
 
 def test_update_weights_from_ipc_accumulates_lora_tensors_across_buckets(monkeypatch):

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import platform
+import re
 import signal
 import threading
 from collections.abc import Mapping
@@ -42,6 +43,8 @@ VLLM_LORA_NAME = "123"
 VLLM_LORA_PATH = "simon_lora_path"
 
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
+
+_PER_EXPERT_WEIGHT_PATTERN = re.compile(r"^(?P<module>.+\.experts)\.(?P<expert_id>\d+)\..+\.weight$")
 
 
 def _resolve_vllm_weight_sync_local_rank(worker_local_rank: int, parallel_config: Any) -> int:
@@ -346,10 +349,60 @@ class vLLMColocateWorkerExtension:
 
         return weight_name
 
+    @staticmethod
+    def _collect_expert_maps(model) -> dict[str, tuple[int, ...]]:
+        """Snapshot vLLM's global-to-local expert maps for this reload."""
+        named_modules = getattr(model, "named_modules", None)
+        if not callable(named_modules):
+            return {}
+
+        expert_maps = {}
+        for module_name, module in named_modules():
+            expert_map = getattr(module, "_expert_map", None)
+            if not isinstance(expert_map, torch.Tensor) or expert_map.ndim != 1:
+                continue
+            expert_maps[module_name] = tuple(int(local_id) for local_id in expert_map.detach().cpu().tolist())
+        return expert_maps
+
+    @classmethod
+    def _is_nonlocal_expert_weight(
+        cls,
+        model,
+        weight_name: str,
+        expert_maps: dict[str, tuple[int, ...]],
+    ) -> bool:
+        """Return whether vLLM's live expert map rejects this expert weight."""
+        # Some quantization backends need scale metadata from every expert.
+        # Only filter the large checkpoint weight tensors.
+        if not expert_maps or not weight_name.endswith(".weight"):
+            return False
+
+        candidate_names = [weight_name]
+        mapped_name = cls._map_weight_name_for_vllm(model, weight_name)
+        if mapped_name is not None and mapped_name != weight_name:
+            candidate_names.append(mapped_name)
+
+        for candidate_name in candidate_names:
+            match = _PER_EXPERT_WEIGHT_PATTERN.match(candidate_name)
+            if match is None:
+                continue
+
+            expert_map = expert_maps.get(match.group("module"))
+            if expert_map is None:
+                continue
+
+            expert_id = int(match.group("expert_id"))
+            if expert_id < len(expert_map):
+                return expert_map[expert_id] < 0
+
+        return False
+
     def _iter_normalized_base_sync_weights(self, weights, clone_tensors: bool = False):
         model = self.model_runner.model
         model_weight_names = {name for name, _ in model.named_parameters(remove_duplicate=False)}
         model_weight_names.update(name for name, _ in model.named_buffers())
+        expert_maps = self._collect_expert_maps(model) if clone_tensors else {}
+        skipped_nonlocal_expert_weights = 0
 
         for name, tensor in weights:
             normalized_name = self._resolve_weight_name_for_vllm(
@@ -358,6 +411,15 @@ class vLLMColocateWorkerExtension:
                 model_weight_names=model_weight_names,
             )
 
+            if self._is_nonlocal_expert_weight(model, normalized_name, expert_maps):
+                if skipped_nonlocal_expert_weights == 0:
+                    logger.info(
+                        "Filtering non-local expert weights using %d live expert maps",
+                        len(expert_maps),
+                    )
+                skipped_nonlocal_expert_weights += 1
+                continue
+
             if clone_tensors:
                 # vLLM layerwise reload may retain references to incoming tensors
                 # until an entire layer has been reconstructed. Clone here so
@@ -365,6 +427,12 @@ class vLLMColocateWorkerExtension:
                 tensor = tensor.clone()
 
             yield normalized_name, tensor
+
+        if skipped_nonlocal_expert_weights:
+            logger.info(
+                "Skipped %d non-local expert weights before vLLM layerwise reload",
+                skipped_nonlocal_expert_weights,
+            )
 
     def _maybe_reload_standard_weights_from_ipc(self, receiver) -> bool:
         from vllm.config import set_current_vllm_config


### PR DESCRIPTION
### What does this PR do?

This PR reduces GPU memory used by vLLM layerwise MoE weight reloads by filtering expert weights that are not local to the current EP worker before Verl clones the reused CUDA-IPC buffer view.

Both Megatron and FSDP reconstruct logical Hugging Face tensors before sending them through the shared vLLM rollout update path. Previously, every vLLM worker cloned every expert tensor even when its live FusedMoE `_expert_map` marked that expert as non-local. With Qwen3.5-35B-A3B using TP8/EP8, each worker unnecessarily cloned 26,880 non-local expert weights per reload. 

Before this change, the avoidable per-worker clone volume scaled with the global expert payload rather than the local EP shard. Increasing TP/EP reduced resident model weights but did not eliminate this global clone amplification, making it a blocker for large MoE reloads. This PR removes that non-local amplification.

The filter snapshots vLLM's live global-to-local expert maps, applies vLLM name mapping, and skips only explicit non-local `.weight` tensors. It fails open for unknown modules, packed tensors, scale metadata, and non-layerwise paths. Local expert and dense tensors continue to be cloned to preserve IPC-buffer ownership.

This is backend-independent because the filtering happens in `vLLMColocateWorkerExtension` after the Megatron/FSDP producer paths converge. End-to-end GPU validation was performed with Megatron; FSDP follows the same receiver path but has not yet been GPU-tested.


Related work:
- #5599 introduced the layerwise clone path used by standard weight reloads, which directly related to this problem.
- #7136 addresses FP8 layerwise-reload lifecycle correctness and does not filter non-local EP weights.
> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is:pr+is:open+layerwise+reload+expert+memory+moe
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)


### Test
- Additional unit tests.
- Qwen3.6-35B-A3B, TP8/EP8, vLLM 0.18.0.1, 8×H200, `gpu_memory_utilization=0.7`: each worker skipped 26,880 non-local weights, KV-cache wake succeeded, and rollout generation started.
- E2e training with Qwen3.6-35B-A3B on gsm8k to show no regression in terms of speed and quality.

### API and Usage Example
N/A

### Design & Code Changes

- Snapshot each live FusedMoE module's `_expert_map` once per layerwise reload.
- Resolve incoming names against vLLM's model namespace before matching expert ownership.
- Skip only expert `.weight` tensors whose global expert ID maps to `-1`.
- Preserve existing behavior for local experts, dense weights, scales, packed tensors, unknown mappings, and non-layerwise loading.
- Add CPU regression coverage for direct and mapped names, fail-open behavior, clone ownership, and fallback-path isolation.
> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
