### PR TITLE
[ckpt, fsdp] feat: sharded delta block placements + backend-owned HF export (engine core + FSDP)

### DIFF
--- a/docs/advance/delta_weight_sync.md
+++ b/docs/advance/delta_weight_sync.md
@@ -21,11 +21,41 @@ pay off differently:
   tensors or a full-model snapshot, and the gather moves only changed elements. This removes the
   full-tensor all-gather and rank-0 staging costs that the plain ``nccl`` engine pays *regardless
   of network speed* — which is why ``delta_sharded`` beat the full broadcast at every size we
-  measured (0.5B through 72B, 1.3–3.1×), not just at the large end.
+  measured (0.5B through 235B, 1.3–21×), not just at the large end.
 
 This is why ``delta_sharded`` is the only delta backend we ship: an earlier full-gather variant
 (diff on a rank-0 full-model snapshot) was consistently slower than ``delta_sharded`` at every
 size we measured, so it was dropped in favor of the sharded design.
+
+## Wire contract: what a rank sends to rank 0
+
+Steady state has ONE canonical shape. Per parameter, each rank contributes a triple
+``(counts[K], idx_concat int32, val_concat)`` where:
+
+- **K is the parameter's slot count**, fixed by a static slot table identical on every
+  rank. Identity params (dense DTensor, explicit blocks, unsharded) have ``K=1`` -- the
+  slot is the parameter itself. Slot-enumerable converter params (``spec.hf_slots``)
+  have one slot per converter output (e.g. a fused ``gate_up`` stack: ``K = E x 2``).
+- The k-th slice of ``idx``/``val`` holds **final HF coordinates inside slot k**: the
+  sender has already done all conversion; coordinate semantics never change after this
+  point. Rank 0's whole job is slot-keyed assembly: concatenate ranks' (disjoint)
+  pieces per slot, bucket, broadcast. No conversion, no rebuild, no layout knowledge.
+
+Invariants: (1) *alignment* -- every rank enumerates the same K and slot order, with
+``counts[k]=0`` for untouched slots, so the batched gather stays in lockstep; (2)
+*disjointness* -- per slot, different ranks' coordinate sets never overlap (block
+geometry guarantees it), so union == concatenation; (3) *bounds* -- a slot has fewer
+than 2^31 elements (int32 positions), and the batched gather internally splits a
+round into deterministic sub-rounds (derived from the all-gathered counts matrix, so
+every rank derives the same split) whenever the largest per-rank blob would exceed
+``bucket_size``. Flush triggers are count-only: they must be identical on every rank,
+and byte totals are not.
+
+Two explicit exemptions: converter params without an enumerable slot table (custom
+``MOE_PARAM_HANDERS``, the Megatron shard-list contract) fall back to shard-local
+payloads plus a rank-0 segmented NaN rebuild; and the dense seed for identity params
+ships values only (no positions), since the first sync covers every element. The seed
+for slot params is just the steady shape at full coverage.
 
 ## Design
 
@@ -33,14 +63,21 @@ The ``delta_sharded`` backend plugs into the standard checkpoint-engine flow (``
 ``CheckpointEngineWorker``), so they work with any trainer that drives weight sync through the
 checkpoint engine (including the V1 ``separate_async`` trainer).
 
-- **Export contract**: the trainer's ``get_per_tensor_param_shard()`` yields
-  ``(name, local_shard, ShardSpec)`` per local parameter — the spec (see
-  :mod:`verl.workers.engine.spec`) describes the shard's placement declaratively (DeviceMesh +
-  Placements), and the engine derives the flat offset, gather group, and contributing rank itself.
-  All layout knowledge stays on the trainer side; the engine is trainer-agnostic.
-- **Diff**: each rank byte-diffs **its own shard** against a pinned-CPU snapshot of that shard from
-  the previous sync (no rank holds a full-model snapshot). The comparison is bit-exact (integer
-  view inequality), so the reconstruction is lossless by construction — no thresholds, no drift.
+- **Export contract**: the delta engine consumes FINAL HF-coordinate payloads; everything
+  backend-specific — the weight→HF naming, the to-HF conversion, the diff and its base — lives on
+  the backend side. The **seed** (first sync) streams the backend's existing full export
+  ``get_per_tensor_param()`` over the values-only wire: every backend already knows how to assemble
+  and convert its own full tensors (FSDP all-gather, veomni expert restack, Megatron TP/PP fusion),
+  so the seed inherits all of that for free and trainer resume works by construction. After the
+  seed the backend pins its shards (``prime_delta_snapshots``); every **steady** sync consumes
+  ``get_per_tensor_param_delta_shard()`` — per-parameter entries ``(slots, dtype_str, counts,
+  hf_idx, hf_val, gather_group)`` whose coordinates are already final HF coordinates. The engine
+  only batches, gathers, buckets and ships.
+- **Diff (backend-owned)**: the default strategy (``verl.workers.engine.utils.hf_delta_export``) byte-diffs each rank's **own shard** against its
+  pinned-CPU snapshot, refreshed on every export (no rank holds a full-model snapshot). The
+  comparison is bit-exact (integer view inequality), so the reconstruction is lossless by
+  construction — no thresholds, no drift. A backend that already keeps the previous step's weights
+  (e.g. Decoupled PPO) can diff against that checkpoint instead and skip the dedicated snapshot.
 - **Sparse gather + encoding**: only the changed ``(position, value)`` pairs are gathered to rank 0
   (batched, variable-length), translated to full-tensor coordinates, and packed as a shared
   ``(positions, values)`` payload plus a per-parameter manifest (``indices`` encoding: int32
@@ -98,18 +135,21 @@ Other shard dimensions than ``Shard(0)`` are not supported and raise.
 ## Measured results
 
 All numbers: H100 nodes, GSM8K GRPO, verl V1 ``separate_async`` (disaggregated trainer/rollout),
-FSDP2 + param/optimizer offload, SGLang rollout, per-step steady-state weight sync.
+SGLang rollout, per-step steady-state weight sync. The ``nccl`` baseline is current main
+(including the pinned-staging fix from #7005); param/optimizer offload is ON unless noted.
 
-| model (placement) | ``delta_sharded`` | ``nccl`` (full broadcast) | speedup | saved / step |
-|---|---|---|---|---|
-| Qwen2.5-7B (1+1 nodes, sustained over 200 steps) | **3.8 s** | 9.1 s | 2.4x | 5.2 s |
-| Qwen2.5-32B (2+2 nodes) | **12.5 s** | 23.2 s | 1.9x | 10.7 s |
-| Qwen2.5-72B (4+4 nodes, TP8) | **12.0 s** | 36.9 s | **3.1x** | **24.9 s** |
+| model (placement) | ``delta_sharded`` | ``nccl`` (full broadcast) | speedup |
+|---|---|---|---|
+| Qwen2.5-7B (1+1 nodes) | **3.9-4.9 s** | 5.5-6.0 s | ~1.3x |
+| Qwen2.5-32B (2+2 nodes) | **11.2-11.9 s** | 17.7-18.1 s | 1.55x |
+| Qwen2.5-32B (2+2 nodes, offload off) | **6.2 s** | 14.2 s | 2.3x |
+| Qwen2.5-72B (4+4 nodes, gen TP8, offload off) | **12.0-13.0 s** | 28.5-29.1 s | 2.3x |
 
-The delta sync time stays essentially flat from 32B to 72B -- the sharded sparse gather amortizes
-over the larger trainer world -- while the full broadcast grows linearly with parameter bytes, so
-the advantage widens with scale. The per-step changed ratio is stable at ~1-3% of parameter bytes
-across sizes and stays there over long runs.
+The delta sync time grows far slower than parameter bytes -- the sharded sparse gather
+amortizes over the larger trainer world -- while the full broadcast pays a full-model
+materialization that grows linearly with parameter bytes, so the advantage widens with scale.
+The per-step changed ratio is ~1-3% of parameter bytes for dense models and stays there over
+long runs.
 
 Correctness evidence (details in the PR):
 
@@ -132,7 +172,10 @@ a per-backend apply interface (vllm/trt-llm plugins) is planned.
 Planned extensions, in design order:
 
 - **Megatron-core trainers**: the same ``delta_sharded`` backend via a Megatron
-  ``get_per_tensor_param_shard`` export whose spec carries the native mcore→HF conversion as a
-  pure-permutation ``to_hf`` closure (implemented and validated in a stacked follow-up PR).
+  ``get_per_tensor_param_shard`` export. The native mcore→HF converters are whole-param
+  black boxes, outside the dim-0-separable ``to_hf_chunk`` contract; the path forward is
+  rewriting them per param family as ``to_hf_chunk`` + ``hf_slots`` — the main fusions
+  (interleaved qkv, gate_up concat) are row/block permutations and fit the contract, while
+  TP column splits are already expressible as a ``BlockPlacement`` dim-1 offset (see #7060).
 - **Quantized rollout (fp8 etc.)**: diff the quantized bytes (quantize-then-diff) so a low-precision
   rollout engine can consume deltas without a bf16 intermediate.

--- a/tests/checkpoint_engine/test_block_placement.py
+++ b/tests/checkpoint_engine/test_block_placement.py
@@ -1,0 +1,493 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the block-placement machinery behind FSDP+EP support.
+
+``BlockPlacement`` describes a rank's local shard as one hyper-rectangular block
+of the full tensor (e.g. automodel's grouped experts on the ``(ep, ep_shard)``
+mesh with ``(Shard(0), Shard(1))``). These tests pin down the two pure-math
+pieces the engine relies on -- the local->global flat index translation, and the
+NaN-sentinel full-tensor rebuild feeding a qwen3-moe-style ``to_hf`` permutation
+(per-expert slice + gate/up split + transpose) -- without torch.distributed.
+"""
+
+import itertools
+
+import pytest
+import torch
+
+from verl.workers.engine.spec import BlockPlacement, translate_flat_indices
+
+
+def _blocks_for_grid(full_shape, grid):
+    """Split ``full_shape`` into an even grid of blocks; yield BlockPlacements.
+
+    ``grid`` maps tensor dim -> number of splits (even division assumed here;
+    uneven splits are covered by the distributed test via DTensor itself).
+    """
+    per_dim = []
+    for d, size in enumerate(full_shape):
+        n = grid.get(d, 1)
+        assert size % n == 0
+        step = size // n
+        per_dim.append([(o, step) for o in range(0, size, step)])
+    for combo in itertools.product(*per_dim):
+        goff = tuple(o for o, _ in combo)
+        lshape = tuple(sz for _, sz in combo)
+        yield BlockPlacement(lshape, goff, tuple(full_shape))
+
+
+def test_translate_int_fast_path():
+    lidx = torch.tensor([0, 3, 17], dtype=torch.int64)
+    assert torch.equal(translate_flat_indices(lidx, 0), lidx)
+    assert torch.equal(translate_flat_indices(lidx, 100), lidx + 100)
+
+
+@pytest.mark.parametrize(
+    "full_shape,grid",
+    [
+        ((8, 4, 6), {0: 4, 1: 2}),  # automodel experts: ep=4 x ep_shard=2 (Shard(0), Shard(1))
+        ((16, 8), {1: 4}),  # plain Shard(1)
+        ((6, 5, 7), {2: 7}),  # shard the last dim, odd sizes
+        ((12,), {0: 3}),  # 1-D block degenerates to the flat case
+    ],
+)
+def test_translate_matches_full_coordinates(full_shape, grid):
+    torch.manual_seed(0)
+    full = torch.randn(full_shape)
+    flat = full.reshape(-1)
+    for place in _blocks_for_grid(full_shape, grid):
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
+        local = full[slices].contiguous().reshape(-1)
+        lidx = torch.arange(local.numel(), dtype=torch.int64)
+        gidx = translate_flat_indices(lidx, place)
+        assert torch.equal(flat[gidx], local), f"block {place} mistranslated"
+
+
+def test_translate_sparse_subset():
+    full_shape = (8, 4, 6)
+    torch.manual_seed(1)
+    full = torch.randn(full_shape)
+    place = BlockPlacement((2, 2, 6), (4, 2, 0), full_shape)
+    slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
+    local = full[slices].contiguous().reshape(-1)
+    lidx = torch.tensor([0, 5, 11, 23], dtype=torch.int64)
+    gidx = translate_flat_indices(lidx, place)
+    assert torch.equal(full.reshape(-1)[gidx], local[lidx])
+
+
+def _qwen3_style_to_hf(full_shape, inter_dim):
+    """Mimic the automodel expert closure: fused [n, dim, 2I] -> per-expert
+    gate/up [I, dim] via slice + split + transpose -- a pure permutation."""
+
+    def to_hf(shards):
+        (full_flat,) = shards
+        fused = full_flat.view(full_shape)
+        out = []
+        for e in range(full_shape[0]):
+            w = fused[e]
+            out.append((f"experts.{e}.gate_proj.weight", w[:, :inter_dim].transpose(0, 1)))
+            out.append((f"experts.{e}.up_proj.weight", w[:, inter_dim:].transpose(0, 1)))
+        return out
+
+    return to_hf
+
+
+def test_block_nan_rebuild_matches_full_convert_then_diff():
+    """Replicate the engine's block converter profile end to end on CPU:
+    per-block local diff -> translate-free local NaN rebuild -> slice-assign into
+    a full NaN tensor -> to_hf -> isnan scan == diff of the converted tensors."""
+    torch.manual_seed(2)
+    n_experts, dim, inter = 8, 4, 3
+    full_shape = (n_experts, dim, 2 * inter)
+    to_hf = _qwen3_style_to_hf(full_shape, inter)
+
+    old = torch.randn(full_shape, dtype=torch.bfloat16)
+    new = old.clone()
+    new[0, 1, 2] += 1.0
+    new[3, 0, 5] -= 0.5
+    new[7, 3, 0] += 0.25
+
+    # ep=4 x ep_shard=2 grid of blocks, like the (Shard(0), Shard(1)) expert mesh
+    full_nan = torch.full(full_shape, float("nan"), dtype=old.dtype)
+    for place in _blocks_for_grid(full_shape, {0: 4, 1: 2}):
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
+        lo = old[slices].contiguous().reshape(-1)
+        ln = new[slices].contiguous().reshape(-1)
+        changed = (lo.view(torch.uint8).view(lo.numel(), -1) != ln.view(torch.uint8).view(ln.numel(), -1)).any(dim=-1)
+        lidx = changed.nonzero(as_tuple=False).view(-1)
+        buf = torch.full((lo.numel(),), float("nan"), dtype=old.dtype)
+        buf[lidx] = ln[lidx]
+        full_nan[slices] = buf.view(place.local_shape)
+
+    seen = 0
+    ref_new = dict(to_hf([new.reshape(-1)]))
+    ref_old = dict(to_hf([old.reshape(-1)]))
+    for hf_name, hf_tensor in to_hf([full_nan.reshape(-1)]):
+        fl = hf_tensor.reshape(-1)
+        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        rn, ro = ref_new[hf_name].reshape(-1), ref_old[hf_name].reshape(-1)
+        ref_changed = (
+            (rn.view(torch.uint8).view(rn.numel(), -1) != ro.view(torch.uint8).view(ro.numel(), -1))
+            .any(dim=-1)
+            .nonzero(as_tuple=False)
+            .view(-1)
+        )
+        assert torch.equal(pos, ref_changed), f"{hf_name}: positions diverge"
+        assert torch.equal(fl[pos], rn[pos]), f"{hf_name}: values diverge"
+        seen += int(pos.numel())
+    assert seen == 3
+
+
+def _veomni_style_to_hf(full_shape):
+    """Mimic the veomni expert closure: fused [n, 2I, H] gate_up -> per-expert
+    gate/up via chunk(dim=1) + per-expert slice + rename -- pure permutation,
+    mirroring verl.workers.engine.veomni.utils.default_moe_param_handler."""
+
+    def to_hf(shards):
+        full_flat = shards[0] if len(shards) == 1 else torch.cat([sh.reshape(-1) for sh in shards])
+        fused = full_flat.view(full_shape)
+        gate, up = fused.chunk(2, dim=1)
+        out = []
+        for i in range(full_shape[0]):
+            out.append((f"mlp.experts.{i}.gate_proj.weight", gate[i]))
+            out.append((f"mlp.experts.{i}.up_proj.weight", up[i]))
+        return out
+
+    return to_hf
+
+
+def test_explicit_place_block_rebuild_veomni_style():
+    """veomni experts: manual ep split on dim0 (outside DTensor) + Shard(1)-style
+    block on dim1. The exporter synthesizes BlockPlacement in a virtual full
+    tensor; verify the engine-style rebuild -> to_hf -> isnan scan equals the
+    reference per-expert delta."""
+    torch.manual_seed(3)
+    n_global, two_i, h = 8, 6, 4
+    ep, fsdp = 4, 2
+    n_local = n_global // ep
+    full_shape = (n_global, two_i, h)
+    to_hf = _veomni_style_to_hf(full_shape)
+
+    old = torch.randn(full_shape, dtype=torch.bfloat16)
+    new = old.clone()
+    new[1, 2, 3] += 1.0
+    new[5, 0, 0] -= 0.5
+
+    full_nan = torch.full(full_shape, float("nan"), dtype=old.dtype)
+    for ep_rank in range(ep):
+        for f_rank in range(fsdp):
+            # manual ep split on dim0, fsdp Shard(1) on the local block's dim1
+            d1 = two_i // fsdp
+            place = BlockPlacement(
+                (n_local, d1, h),
+                (ep_rank * n_local, f_rank * d1, 0),
+                full_shape,
+            )
+            slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
+            lo = old[slices].contiguous().reshape(-1)
+            ln = new[slices].contiguous().reshape(-1)
+            changed = (lo.view(torch.uint8).view(lo.numel(), -1) != ln.view(torch.uint8).view(ln.numel(), -1)).any(
+                dim=-1
+            )
+            lidx = changed.nonzero(as_tuple=False).view(-1)
+            buf = torch.full((lo.numel(),), float("nan"), dtype=old.dtype)
+            buf[lidx] = ln[lidx]
+            full_nan[slices] = buf.view(place.local_shape)
+
+    seen = 0
+    ref_new = dict(to_hf([new.reshape(-1)]))
+    ref_old = dict(to_hf([old.reshape(-1)]))
+    for hf_name, hf_tensor in to_hf([full_nan.reshape(-1)]):
+        fl = hf_tensor.reshape(-1)
+        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        rn, ro = ref_new[hf_name].reshape(-1), ref_old[hf_name].reshape(-1)
+        ref_changed = (
+            (rn.view(torch.uint8).view(rn.numel(), -1) != ro.view(torch.uint8).view(ro.numel(), -1))
+            .any(dim=-1)
+            .nonzero(as_tuple=False)
+            .view(-1)
+        )
+        assert torch.equal(pos, ref_changed), f"{hf_name}: positions diverge"
+        assert torch.equal(fl[pos], rn[pos]), f"{hf_name}: values diverge"
+        seen += int(pos.numel())
+    assert seen == 2
+
+
+def test_explicit_place_passthrough():
+    """ShardSpec.place / gather_group short-circuit derive_placement."""
+    from verl.workers.engine.spec import ShardSpec, derive_placement
+
+    block = BlockPlacement((2, 3), (4, 0), (8, 3))
+    sentinel = object()
+    spec = ShardSpec(full_shape=(8, 3), place=block, gather_group=sentinel)
+    place, contributes, group = derive_placement(spec)
+    assert place is block and contributes and group is sentinel
+
+
+def test_flat_contiguous_block_matches_int_fast_path():
+    """A dim-0 cut expressed as a BlockPlacement (the unified derive_placement
+    output for FSDP2 ``Shard(0)``) must translate exactly like the plain-int
+    offset it replaces, via the ``is_flat_contiguous`` add fast path."""
+    full_shape = (8, 4, 6)
+    rows_per_rank = 2
+    lidx = torch.tensor([0, 1, 7, 23, 47], dtype=torch.int64)
+    for r in range(4):
+        place = BlockPlacement((rows_per_rank, 4, 6), (r * rows_per_rank, 0, 0), full_shape)
+        assert place.is_flat_contiguous
+        int_off = r * rows_per_rank * 4 * 6
+        assert place.flat_offset == int_off
+        assert torch.equal(translate_flat_indices(lidx, place), translate_flat_indices(lidx, int_off))
+    # 1-D shard degenerates to the flat case too
+    p1 = BlockPlacement((3,), (9,), (12,))
+    assert p1.is_flat_contiguous and p1.flat_offset == 9
+    # a dim-1 cut is not flat-contiguous and must take the mixed-radix path
+    p2 = BlockPlacement((8, 2, 6), (0, 2, 0), full_shape)
+    assert not p2.is_flat_contiguous
+
+
+def test_explicit_place_block_rebuild_muon_shard0_layout():
+    """veomni muon_expert_zero_comm layout: the expert stack is split on dim 0
+    TWICE -- manually by ep, then FSDP ``Shard(0)`` inside each ep slice (vs the
+    standard ``Shard(1)``). The exporter's offset math
+    (``ep_rank * n_local + goff[0]``) must place these dim-0 sub-blocks
+    correctly; the NaN rebuild must be bit-equal to a full convert-then-diff."""
+    torch.manual_seed(4)
+    n_experts, dim, inter = 8, 4, 3
+    full_shape = (n_experts, dim, 2 * inter)
+    to_hf = _qwen3_style_to_hf(full_shape, inter)
+    ep, fsdp = 2, 2  # dim0 split ep x fsdp: each rank holds n_experts/(ep*fsdp) whole experts
+    n_local = n_experts // ep  # experts per ep rank (the DTensor's global dim 0)
+    rows = n_local // fsdp  # experts per (ep, fsdp) rank
+
+    old = torch.randn(full_shape, dtype=torch.bfloat16)
+    new = old.clone()
+    new[0, 1, 2] += 1.0
+    new[3, 0, 5] -= 0.5
+    new[5, 2, 1] += 2.0
+
+    full_nan = torch.full(full_shape, float("nan"), dtype=old.dtype)
+    for ep_rank in range(ep):
+        for fsdp_rank in range(fsdp):
+            # mimic the exporter: goff from Shard(0) over the ep-local stack,
+            # then lift by ep_rank * n_local
+            goff0 = fsdp_rank * rows
+            offset = (ep_rank * n_local + goff0, 0, 0)
+            lshape = (rows, dim, 2 * inter)
+            place = BlockPlacement(lshape, offset, full_shape)
+            assert place.is_flat_contiguous  # whole experts -> flat contiguous
+            slices = tuple(slice(o, o + sz) for o, sz in zip(offset, lshape, strict=False))
+            lo = old[slices].contiguous().reshape(-1)
+            ln = new[slices].contiguous().reshape(-1)
+            changed = (
+                (lo.view(torch.uint8).view(lo.numel(), -1) != ln.view(torch.uint8).view(ln.numel(), -1))
+                .any(dim=-1)
+                .nonzero(as_tuple=False)
+                .view(-1)
+            )
+            buf = torch.full((lo.numel(),), float("nan"), dtype=old.dtype)
+            buf[changed] = ln[changed]
+            full_nan[slices] = buf.view(lshape)
+
+    seen = 0
+    ref_new = dict(to_hf([new.reshape(-1)]))
+    ref_old = dict(to_hf([old.reshape(-1)]))
+    for hf_name, hf_tensor in to_hf([full_nan.reshape(-1)]):
+        fl = hf_tensor.reshape(-1)
+        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        rn, ro = ref_new[hf_name].reshape(-1), ref_old[hf_name].reshape(-1)
+        ref_changed = (
+            (rn.view(torch.uint8).view(rn.numel(), -1) != ro.view(torch.uint8).view(ro.numel(), -1))
+            .any(dim=-1)
+            .nonzero(as_tuple=False)
+            .view(-1)
+        )
+        assert torch.equal(pos, ref_changed), f"{hf_name}: positions diverge"
+        assert torch.equal(fl[pos], rn[pos]), f"{hf_name}: values diverge"
+        seen += int(pos.numel())
+    assert seen == 3
+
+
+def _qwen3_style_to_hf_chunk(inter_dim):
+    """Segment-aware counterpart of _qwen3_style_to_hf: converts a dim-0 run of
+    whole experts starting at global expert id ``start``."""
+
+    def to_hf_chunk(start, seg):
+        out = []
+        for i in range(seg.shape[0]):
+            w = seg[i]
+            out.append((f"experts.{start + i}.gate_proj.weight", w[:, :inter_dim].transpose(0, 1)))
+            out.append((f"experts.{start + i}.up_proj.weight", w[:, inter_dim:].transpose(0, 1)))
+        return out
+
+    return to_hf_chunk
+
+
+@pytest.mark.parametrize("seg_rows", [1, 3, 8])
+def test_chunked_rebuild_matches_full_rebuild(seg_rows):
+    """The engine's segmented NaN rebuild (translate per-rank shard-local positions
+    to full coordinates, sort, scatter per dim-0 segment, convert per segment) must
+    extract exactly the same (hf_name, position, value) set as the full rebuild."""
+    torch.manual_seed(5)
+    n_experts, dim, inter = 8, 4, 3
+    full_shape = (n_experts, dim, 2 * inter)
+    inner = dim * 2 * inter
+    to_hf = _qwen3_style_to_hf(full_shape, inter)
+    to_hf_chunk = _qwen3_style_to_hf_chunk(inter)
+
+    old = torch.randn(full_shape, dtype=torch.bfloat16)
+    new = old.clone()
+    new[0, 1, 2] += 1.0
+    new[3, 0, 5] -= 0.5
+    new[5, 2, 1] += 2.0
+    new[7, 3, 0] += 0.25
+
+    # per-rank shard-local sparse deltas over an ep x ep_shard block grid
+    gidx_parts, gval_parts = [], []
+    full_nan = torch.full(full_shape, float("nan"), dtype=old.dtype)
+    for place in _blocks_for_grid(full_shape, {0: 4, 1: 2}):
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
+        lo_t = old[slices].contiguous().reshape(-1)
+        ln_t = new[slices].contiguous().reshape(-1)
+        changed = (
+            (lo_t.view(torch.uint8).view(lo_t.numel(), -1) != ln_t.view(torch.uint8).view(ln_t.numel(), -1))
+            .any(dim=-1)
+            .nonzero(as_tuple=False)
+            .view(-1)
+        )
+        gidx_parts.append(translate_flat_indices(changed, place))
+        gval_parts.append(ln_t[changed])
+        buf = torch.full((lo_t.numel(),), float("nan"), dtype=old.dtype)
+        buf[changed] = ln_t[changed]
+        full_nan[slices] = buf.view(place.local_shape)
+
+    gidx = torch.cat(gidx_parts)
+    gval = torch.cat(gval_parts)
+    order = torch.argsort(gidx)
+    gidx, gval = gidx[order], gval[order]
+
+    # reference: full rebuild -> convert -> extract
+    ref = {}
+    for hf_name, hf_tensor in to_hf([full_nan.reshape(-1)]):
+        fl = hf_tensor.reshape(-1)
+        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        ref[hf_name] = (pos, fl[pos])
+
+    # chunked: segment scatter -> convert per segment -> extract
+    got = {}
+    for row0 in range(0, n_experts, seg_rows):
+        rows = min(seg_rows, n_experts - row0)
+        lo, hi = row0 * inner, (row0 + rows) * inner
+        a = int(torch.searchsorted(gidx, lo))
+        b = int(torch.searchsorted(gidx, hi))
+        seg = torch.full((rows * inner,), float("nan"), dtype=old.dtype)
+        if b > a:
+            seg[gidx[a:b] - lo] = gval[a:b]
+        for hf_name, hf_tensor in to_hf_chunk(row0, seg.view(rows, dim, 2 * inter)):
+            fl = hf_tensor.reshape(-1)
+            pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+            if pos.numel() or hf_name in ref and ref[hf_name][0].numel():
+                got[hf_name] = (pos, fl[pos])
+
+    changed_names = {n for n, (p, _) in ref.items() if p.numel()}
+    assert changed_names == set(got.keys())
+    for name in changed_names:
+        assert torch.equal(got[name][0], ref[name][0]), f"{name}: positions diverge"
+        assert torch.equal(got[name][1], ref[name][1]), f"{name}: values diverge"
+
+
+def test_scoped_sender_side_matches_rank0_rebuild():
+    """Sender-side scoped conversion (each simulated rank converts only its own
+    touched dim-0 rows via a NaN row window + to_hf_chunk, emitting slot-keyed
+    HF-coordinate entries) must produce exactly the union the rank-0 full
+    rebuild extracts."""
+    torch.manual_seed(6)
+    n_experts, dim, inter = 8, 4, 3
+    full_shape = (n_experts, dim, 2 * inter)
+    inner = dim * 2 * inter
+    to_hf = _qwen3_style_to_hf(full_shape, inter)
+    to_hf_chunk = _qwen3_style_to_hf_chunk(inter)
+    # slot table mirroring the exporter: per expert, gate then up
+    slots = []
+    for i in range(n_experts):
+        slots.append((f"experts.{i}.gate_proj.weight", (inter, dim)))
+        slots.append((f"experts.{i}.up_proj.weight", (inter, dim)))
+    S = 2
+
+    old = torch.randn(full_shape, dtype=torch.bfloat16)
+    new = old.clone()
+    new[0, 1, 2] += 1.0
+    new[3, 0, 5] -= 0.5
+    new[3, 2, 4] += 0.75
+    new[6, 2, 1] += 2.0
+
+    # reference: full NaN rebuild -> to_hf -> per-name extraction
+    full_nan = torch.full(full_shape, float("nan"), dtype=old.dtype)
+    per_rank_payload = []
+    for place in _blocks_for_grid(full_shape, {0: 4, 1: 2}):
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
+        lo_t = old[slices].contiguous().reshape(-1)
+        ln_t = new[slices].contiguous().reshape(-1)
+        changed = (
+            (lo_t.view(torch.uint8).view(lo_t.numel(), -1) != ln_t.view(torch.uint8).view(ln_t.numel(), -1))
+            .any(dim=-1)
+            .nonzero(as_tuple=False)
+            .view(-1)
+        )
+        buf = torch.full((lo_t.numel(),), float("nan"), dtype=old.dtype)
+        buf[changed] = ln_t[changed]
+        full_nan[slices] = buf.view(place.local_shape)
+        per_rank_payload.append((place, changed, ln_t[changed]))
+
+    ref = {}
+    for hf_name, hf_tensor in to_hf([full_nan.reshape(-1)]):
+        fl = hf_tensor.reshape(-1)
+        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        if pos.numel():
+            ref[hf_name] = (pos, fl[pos])
+
+    # scoped sender-side: per rank, touched rows only -> slot-keyed entries; union by slot
+    got = {}
+    for place, lidx, lval in per_rank_payload:
+        if lidx.numel() == 0:
+            continue
+        g = translate_flat_indices(lidx, place)
+        order = torch.argsort(g)
+        g, gv = g[order], lval[order]
+        rows = torch.div(g, inner, rounding_mode="floor")
+        urows, rcounts = torch.unique_consecutive(rows, return_counts=True)
+        pos0 = 0
+        for r, cnt in zip(urows.tolist(), rcounts.tolist(), strict=False):
+            sel_g, sel_v = g[pos0 : pos0 + cnt], gv[pos0 : pos0 + cnt]
+            pos0 += cnt
+            buf = torch.full((inner,), float("nan"), dtype=old.dtype)
+            buf[sel_g - r * inner] = sel_v
+            outs = to_hf_chunk(int(r), buf.view(1, dim, 2 * inter))
+            assert len(outs) == S
+            for s_i, (hf_name, hf_tensor) in enumerate(outs):
+                fl = hf_tensor.reshape(-1)
+                p_ = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+                if p_.numel():
+                    slot_name = slots[int(r) * S + s_i][0]
+                    assert slot_name == hf_name.replace(f"experts.{int(r)}.", f"experts.{int(r)}.")
+                    prev = got.get(hf_name, (torch.empty(0, dtype=torch.int64), torch.empty(0, dtype=old.dtype)))
+                    got[hf_name] = (torch.cat([prev[0], p_]), torch.cat([prev[1], fl[p_]]))
+
+    assert set(got.keys()) == set(ref.keys())
+    for name in ref:
+        gp, gv2 = got[name]
+        order = torch.argsort(gp)
+        gp, gv2 = gp[order], gv2[order]
+        assert gp.unique().numel() == gp.numel(), f"{name}: overlapping rank contributions"
+        assert torch.equal(gp, ref[name][0]), f"{name}: positions diverge"
+        assert torch.equal(gv2, ref[name][1]), f"{name}: values diverge"

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -99,26 +99,32 @@ def test_gather_slot_entries_sub_rounds_world1():
 
     from verl.checkpoint_engine.delta_sync.sparse_gather import gather_slot_entries_to_rank0
 
-    if not dist.is_initialized():
+    owns_pg = not dist.is_initialized()
+    if owns_pg:
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
         os.environ.setdefault("MASTER_PORT", "29512")
         dist.init_process_group(backend="gloo", rank=0, world_size=1)
+    try:
+        torch.manual_seed(7)
+        k = 9
+        counts = torch.tensor([5, 0, 3, 7, 1, 0, 4, 2, 6], dtype=torch.int64)
+        n = int(counts.sum())
+        idx = torch.randint(0, 1000, (n,), dtype=torch.int32)
+        val = torch.randn(n, dtype=torch.bfloat16)
 
-    torch.manual_seed(7)
-    k = 9
-    counts = torch.tensor([5, 0, 3, 7, 1, 0, 4, 2, 6], dtype=torch.int64)
-    n = int(counts.sum())
-    idx = torch.randint(0, 1000, (n,), dtype=torch.int32)
-    val = torch.randn(n, dtype=torch.bfloat16)
-
-    ref = gather_slot_entries_to_rank0(idx, val, counts)
-    per_elem = idx.element_size() + val.element_size()
-    for budget_elems in (1, 4, 8):
-        got = gather_slot_entries_to_rank0(idx, val, counts, max_round_bytes=budget_elems * per_elem)
-        assert len(got) == k
-        for (ri, rv), (gi, gv) in zip(ref, got, strict=True):
-            assert torch.equal(ri, gi)
-            assert torch.equal(rv, gv)
+        ref = gather_slot_entries_to_rank0(idx, val, counts)
+        per_elem = idx.element_size() + val.element_size()
+        for budget_elems in (1, 4, 8):
+            got = gather_slot_entries_to_rank0(idx, val, counts, max_round_bytes=budget_elems * per_elem)
+            assert len(got) == k
+            for (ri, rv), (gi, gv) in zip(ref, got, strict=True):
+                assert torch.equal(ri, gi)
+                assert torch.equal(rv, gv)
+    finally:
+        # leaving the default pg alive leaks into whatever test runs next in the
+        # same session (repo convention: init in the test -> destroy in finally)
+        if owns_pg:
+            dist.destroy_process_group()
 
 
 def test_prime_then_hf_delta_export_roundtrip():

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -68,21 +68,102 @@ def test_derive_placement_unsharded():
     assert offset == 0 and contributes is True and group is None
 
 
-def test_spec_to_hf_pure_permutation():
-    """A converter spec (Megatron-style) must preserve NaN sentinel positions --
-    the property the engine's sparse rebuild relies on."""
+def test_spec_to_hf_chunk_preserves_nan_sentinels():
+    """A dim-0-separable converter must preserve NaN sentinel positions -- the
+    property the engine's sender-side non-NaN extraction relies on."""
     from verl.workers.engine.spec import ShardSpec
 
-    full = torch.arange(24, dtype=torch.float32).view(6, 4)
-    shards = [sh.reshape(-1) for sh in full.chunk(3, dim=0)]
+    def to_hf_chunk(dim0_start, segment):
+        # pure slice + rename, one output per dim-0 row (identity permutation)
+        return [(f"w.{dim0_start + i}", segment[i]) for i in range(segment.shape[0])]
 
-    def to_hf(shard_list):
-        return [("w", torch.cat(shard_list).view(6, 4))]
-
-    spec = ShardSpec(full_shape=(6, 4), to_hf=to_hf)
-    nan_shards = [torch.full_like(sh, float("nan")) for sh in shards]
-    nan_shards[1][3] = 42.0
-    ((_, rebuilt),) = spec.to_hf(nan_shards)
-    fl = rebuilt.reshape(-1)
+    spec = ShardSpec(
+        full_shape=(6, 4),
+        to_hf_chunk=to_hf_chunk,
+        hf_slots=[(f"w.{i}", (4,)) for i in range(6)],
+    )
+    seg = torch.full((1, 4), float("nan"), dtype=torch.float32)
+    seg[0, 3] = 42.0
+    ((name, out),) = spec.to_hf_chunk(2, seg)
+    fl = out.reshape(-1)
     pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
-    assert pos.tolist() == [8 + 3] and fl[pos[0]] == 42.0
+    assert name == "w.2" and pos.tolist() == [3] and fl[pos[0]] == 42.0
+
+
+def test_gather_slot_entries_sub_rounds_world1():
+    """max_round_bytes splits the slot list into deterministic sub-rounds; the
+    reassembled output must equal the single-round result (world=1 mechanics)."""
+    import os
+
+    import torch.distributed as dist
+
+    from verl.checkpoint_engine.delta_sync.sparse_gather import gather_slot_entries_to_rank0
+
+    if not dist.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29512")
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+
+    torch.manual_seed(7)
+    k = 9
+    counts = torch.tensor([5, 0, 3, 7, 1, 0, 4, 2, 6], dtype=torch.int64)
+    n = int(counts.sum())
+    idx = torch.randint(0, 1000, (n,), dtype=torch.int32)
+    val = torch.randn(n, dtype=torch.bfloat16)
+
+    ref = gather_slot_entries_to_rank0(idx, val, counts)
+    per_elem = idx.element_size() + val.element_size()
+    for budget_elems in (1, 4, 8):
+        got = gather_slot_entries_to_rank0(idx, val, counts, max_round_bytes=budget_elems * per_elem)
+        assert len(got) == k
+        for (ri, rv), (gi, gv) in zip(ref, got, strict=True):
+            assert torch.equal(ri, gi)
+            assert torch.equal(rv, gv)
+
+
+def test_prime_then_hf_delta_export_roundtrip():
+    """The backend-side default delta strategy: prime_delta_snapshots pins the
+    shards; a later pass through hf_delta_export yields a final-HF-coordinate
+    entry with exactly the changed elements and refreshes the snapshot (a
+    second delta pass yields a zero-count entry)."""
+    from verl.workers.engine.spec import ShardSpec
+    from verl.workers.engine.utils import _hf_entry_identity, hf_delta_export, prime_delta_snapshots
+
+    w = torch.arange(12, dtype=torch.float32)
+    spec = ShardSpec(full_shape=(12,))
+    snaps: dict = {}
+
+    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps)
+    assert "w" in snaps and snaps["w"].numel() == 12
+
+    w2 = w.clone()
+    w2[3] = -1.0
+    w2[7] = 42.0
+
+    ((slots, dtype_str, counts, hf_idx, hf_val, pg),) = list(
+        hf_delta_export(iter([("w", w2, spec)]), snaps, _hf_entry_identity)
+    )
+    assert slots == [("w", (12,))] and dtype_str == "float32" and pg is None
+    assert counts.tolist() == [2]
+    assert hf_idx.dtype == torch.int32 and hf_idx.tolist() == [3, 7]
+    assert hf_val.tolist() == [-1.0, 42.0]
+
+    ((_, _, counts2, hf_idx2, _, _),) = list(
+        hf_delta_export(iter([("w", w2.clone(), spec)]), snaps, _hf_entry_identity)
+    )
+    assert counts2.tolist() == [0] and hf_idx2.numel() == 0
+
+
+def test_hf_delta_export_requires_seed():
+    """A delta export without a prior prime must fail loud, not diff against
+    garbage."""
+    import pytest
+
+    from verl.workers.engine.spec import ShardSpec
+    from verl.workers.engine.utils import _hf_entry_identity, hf_delta_export
+
+    def raw():
+        yield "w", torch.zeros(4), ShardSpec(full_shape=(4,))
+
+    with pytest.raises(AssertionError, match="seed snapshot"):
+        list(hf_delta_export(raw(), {}, _hf_entry_identity))

--- a/tests/special_distributed/test_sharded_delta_gather.py
+++ b/tests/special_distributed/test_sharded_delta_gather.py
@@ -22,10 +22,10 @@ from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import Replicate, Shard, distribute_tensor
 
 from verl.checkpoint_engine.delta_sync.sparse_gather import (
-    gather_v_batched_to_rank0,
+    gather_slot_entries_to_rank0,
     shard_delta_indices,
 )
-from verl.workers.engine.spec import ShardSpec, derive_placement
+from verl.workers.engine.spec import ShardSpec, derive_placement, translate_flat_indices
 
 
 def _run_case(shape, placements, mesh, dev, rank, si):
@@ -43,18 +43,20 @@ def _run_case(shape, placements, mesh, dev, rank, si):
     dt_new = distribute_tensor(full_new, mesh, placements)
 
     # --- sharded path (real module) ---
-    off, contributes, _pg = derive_placement(ShardSpec.from_param(dt_new))
+    place, contributes, _pg = derive_placement(ShardSpec.from_param(dt_new))
     loc_new = dt_new.to_local().reshape(-1)
     loc_old = dt_old.to_local().reshape(-1)
-    off2, _, _ = derive_placement(ShardSpec.from_param(dt_old))
-    assert off == off2
+    place2, _, _ = derive_placement(ShardSpec.from_param(dt_old))
+    assert place == place2
     if contributes:
-        gidx, gval = shard_delta_indices(loc_new, loc_old, off)
+        # engine convention: diff in shard-local coordinates, then translate
+        lidx, gval = shard_delta_indices(loc_new, loc_old, 0)
+        gidx = translate_flat_indices(lidx, place)
     else:
         gidx = torch.empty(0, dtype=torch.int64, device=dev)
         gval = torch.empty(0, dtype=loc_new.dtype, device=dev)
     counts = torch.tensor([int(gidx.numel())], dtype=torch.int64, device=gidx.device)
-    ((sh_idx, sh_val),) = gather_v_batched_to_rank0(gidx, gval, counts)
+    gathered = gather_slot_entries_to_rank0(gidx, gval, counts)  # None on rank != 0
 
     # --- baseline: full gather + diff ---
     fo = dt_old.full_tensor().reshape(-1)
@@ -65,6 +67,7 @@ def _run_case(shape, placements, mesh, dev, rank, si):
 
     if rank != 0:
         return True
+    ((sh_idx, sh_val),) = gathered
     so = torch.argsort(sh_idx)
     bo = torch.argsort(b_idx)
     idx_ok = torch.equal(sh_idx[so], b_idx[bo])

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -25,14 +25,30 @@ and masked-applies it *in place* onto the live weights. No full-model mirror is
 staged anywhere on the rollout side: receiver peak memory is one bucket plus one
 decode chunk, independent of model size.
 
-The first sync broadcasts a full delta (every position) so a dummy-initialized
-rollout gets a correct base; subsequent syncs are sparse.
+The first (seed) sync streams the backend's FULL HF export (``get_per_tensor_
+param()``) over the values-only wire -- every backend already knows how to
+assemble and convert its own full tensors, so resume works by construction and
+the seed inherits Megatron/veomni assembly for free. After the seed the caller
+primes the backend's pinned shard snapshots; every later sync ships the
+backend-computed sparse HF delta.
+
+Data ladder (sender side, steady) -- the names in this file anchor to these::
+
+    backend HF delta ENTRY (slots, dtype, counts, hf_idx, hf_val, group)
+    --_GatherQueue--> per-SLOT delta on rank 0 --_bucket_*--> _FlushPiece
+    --_FlushBucket--> FLUSH (DeltaFlush) --_publish_flush--> wire
+
+Wire encodings: ``indices`` (int32 positions + values; every steady sync) and
+``values`` (values only; the seed). The values meta tag is ``"dense"`` for
+protocol continuity with the receiver's delta_loader.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Generator, Iterator
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import ray.util.collective as collective
@@ -42,17 +58,10 @@ import zmq
 with patch("importlib.metadata.distributions", return_value=[]):
     import cupy as cp
 
-from verl.workers.engine.spec import derive_placement
-
 from .base import CheckpointEngineRegistry
 from .delta_sync.encode import DeltaFlush, DeltaParam
 from .delta_sync.encode import checksum as _checksum
-from .delta_sync.sparse_gather import (
-    gather_dense_to_rank0,
-    gather_shards_to_rank0,
-    gather_v_batched_to_rank0,
-    shard_delta_indices,
-)
+from .delta_sync.sparse_gather import gather_slot_entries_to_rank0
 from .nccl_checkpoint_engine import MasterMetadata, NCCLCheckpointEngine
 
 logger = logging.getLogger(__name__)
@@ -65,6 +74,146 @@ def _prodshape(shape) -> int:
     return n
 
 
+@dataclass(slots=True)
+class _FlushPiece:
+    """One (possibly sliced) per-parameter piece buffered for a pending indices flush."""
+
+    name: str
+    dtype_str: str
+    shape: list
+    idx: torch.Tensor
+    val: torch.Tensor
+
+
+@dataclass(slots=True)
+class _ValuesPiece:
+    """One whole parameter's flat values buffered for the seed sync's values-only flush."""
+
+    name: str
+    dtype_str: str
+    shape: list
+    flat: torch.Tensor
+
+
+class _FlushBucket:
+    """One-flush-lookahead bucket pipeline, shared by the steady loop and both
+    seed streams. Pieces accumulate until ``cap`` bytes; ``seal`` assembles them
+    into the single pending flush, first emitting the previous pending with
+    ``is_last=False`` (the lookahead: only the caller's finale knows which flush
+    is last and emits it with ``is_last=True``). ``assemble`` and ``publish``
+    carry the only real differences between the streams -- the wire format
+    (indexed flush vs values-only flush) and the flush counters."""
+
+    __slots__ = ("cap", "pieces", "nbytes", "pending", "_assemble", "_publish")
+
+    def __init__(self, cap: int, assemble, publish):
+        self.cap = int(cap)
+        self.pieces: list = []
+        self.nbytes = 0
+        self.pending = None
+        self._assemble = assemble
+        self._publish = publish
+
+    def add(self, piece, nbytes: int) -> None:
+        self.pieces.append(piece)
+        self.nbytes += int(nbytes)
+        if self.nbytes >= self.cap:
+            self.seal()
+
+    def seal(self) -> None:
+        if not self.pieces:
+            return
+        self.emit(is_last=False)
+        self.pending = self._assemble(self.pieces)
+        self.pieces, self.nbytes = [], 0
+
+    def emit(self, is_last: bool) -> None:
+        if self.pending is not None:
+            self._publish(self.pending, is_last)
+            self.pending = None
+
+
+def _bucket_sliced(bkt: _FlushBucket, name: str, dtype_str: str, shape, aidx: torch.Tensor, aval: torch.Tensor) -> None:
+    """Slice one param's (idx, val) delta into <= MAX_ENTRY_ELEMS pieces and bucket
+    them (bounds the receiver-side decode transient; the masked apply is sequential,
+    so splitting is transparent). Bucket bytes = actual wire bytes (int32 positions
+    + values)."""
+    max_elems = DeltaShardedCheckpointEngine.MAX_ENTRY_ELEMS
+    for s in range(0, aidx.numel(), max_elems):
+        e = min(s + max_elems, aidx.numel())
+        bkt.add(
+            _FlushPiece(name, dtype_str, list(shape), aidx[s:e], aval[s:e]),
+            (e - s) * (4 + aval.element_size()),
+        )
+
+
+class _GatherQueue:
+    """Per-gather-group batching of slot-keyed queue entries
+    ``(slots, dtype_str, counts, idx, val)``. Entries carry FINAL-coordinate
+    payloads (identity specs: one slot = the param itself; converter specs: the
+    spec's hf_slots), so rank 0 never converts -- ``consume`` receives assembled
+    per-slot pieces straight from the gather.
+
+    One queue per ProcessGroup: separate queues stop pg alternation (dense fsdp
+    group vs expert world group per layer) from shattering batches. The flush
+    trigger is COUNT-ONLY: entry counts are identical on every rank while byte
+    totals are not, so a count trigger is the only one that keeps the collective
+    sequence identical across ranks (a per-rank byte trigger desyncs the gathers
+    and deadlocks NCCL). Byte bounding happens INSIDE the batched gather via
+    ``max_round_bytes``, decided from the all-gathered counts every rank sees."""
+
+    __slots__ = ("batch_k", "max_round_bytes", "is_r0", "_consume", "_queues")
+
+    def __init__(self, batch_k: int, max_round_bytes: int, is_r0: bool, consume):
+        self.batch_k = max(int(batch_k), 1)
+        self.max_round_bytes = int(max_round_bytes)
+        self.is_r0 = is_r0
+        self._consume = consume
+        self._queues: dict[int, tuple] = {}  # id(pg) -> (pg, [entries])
+
+    def put(self, pg, slots: list, dtype_str: str, counts: torch.Tensor, idx: torch.Tensor, val: torch.Tensor):
+        _pg, entries = self._queues.setdefault(id(pg), (pg, []))
+        entries.append((slots, dtype_str, counts, idx, val))
+        if len(entries) >= self.batch_k:
+            self._flush(pg, entries)
+
+    def flush_all(self) -> None:
+        for pg, entries in self._queues.values():
+            self._flush(pg, entries)
+
+    def _flush(self, pg, entries: list) -> None:
+        """One gather round for one group's queue."""
+        if not entries:
+            return
+        batch = list(entries)
+        entries.clear()
+        if pg is None:
+            # unsharded/replicated params: rank 0's local delta already is global
+            if self.is_r0:
+                for slots, dtype_str, counts, idx, val in batch:
+                    off = 0
+                    for (name, shape), c in zip(slots, counts.tolist(), strict=True):
+                        self._consume(
+                            name, dtype_str, tuple(shape), _prodshape(shape), idx[off : off + c], val[off : off + c]
+                        )
+                        off += c
+            return
+        dev = batch[0][3].device
+        counts_concat = torch.cat([c for _, _, c, _, _ in batch]).to(dev)
+        idx_concat = torch.cat([i for _, _, _, i, _ in batch])
+        val_concat = torch.cat([v for _, _, _, _, v in batch])
+        gathered = gather_slot_entries_to_rank0(
+            idx_concat, val_concat, counts_concat, group=pg, max_round_bytes=self.max_round_bytes
+        )
+        if self.is_r0 and gathered is not None:
+            slot_i = 0
+            for slots, dtype_str, _counts, _i, _v in batch:
+                for name, shape in slots:
+                    aidx, aval = gathered[slot_i]
+                    slot_i += 1
+                    self._consume(name, dtype_str, tuple(shape), _prodshape(shape), aidx, aval)
+
+
 @CheckpointEngineRegistry.register("delta_sharded")
 class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
     """Sparse delta weight sync over NCCL, diffed on each rank's local shard.
@@ -75,10 +224,12 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
     are gathered to rank 0 and streamed to the rollout side -- no rank ever holds
     a full-model snapshot.
 
-    ``send_weights`` consumes the SHARDED generator ``get_per_tensor_param_shard()``:
-    ``(name, local_shard, ShardSpec)`` per local parameter (see
-    :mod:`verl.workers.engine.spec`). All layout knowledge lives in the
-    spec, so this one engine serves any trainer backend that can describe its shards.
+    ``send_weights`` consumes the backend's HF delta export
+    ``get_per_tensor_param_delta_shard()``: per-parameter FINAL-HF-coordinate
+    entries ``(slots, dtype_str, counts, hf_idx, hf_val, gather_group)``. Naming,
+    to-HF conversion, diff and snapshot all live on the backend side (see
+    :mod:`verl.workers.engine.utils`); this engine only batches, gathers,
+    buckets and ships, and so serves any backend that can produce HF deltas.
     """
 
     # Cap on changed elements per DeltaParam entry. The receiver-side decode
@@ -136,8 +287,10 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         collective.broadcast(pos_cp, src_rank=0, group_name=self.group_name)
         collective.broadcast(val_cp, src_rank=0, group_name=self.group_name)
 
-    def _publish_dense_flush(self, params: list[DeltaParam], values: torch.Tensor, is_last: bool) -> None:
-        """Publish a dense (full-coverage, positions-free) flush -- used by the first sync."""
+    def _publish_values_flush(self, params: list[DeltaParam], values: torch.Tensor, is_last: bool) -> None:
+        """Publish a values-only (full-coverage, positions-free) flush -- used by the first
+        sync. The wire encoding tag stays ``"dense"`` -- it is protocol, shared with the
+        receiver's delta_loader decode."""
         values = values.contiguous()
         empty_pos = torch.empty(0, dtype=torch.uint8, device=values.device)
         meta = {
@@ -169,7 +322,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         self.socket.send_pyobj(meta)
 
     # ---- rollout worker side ----
-    def receive_weights(self, global_steps: int | None = None):
+    def receive_weights(self, global_steps: int | None = None) -> Iterator[tuple[list[tuple[str, torch.Tensor]], bool]]:
         """Yield the sparse flushes for the server adapter to apply in place.
 
         Each item is ``(named_tensors, is_last)``: the sentinel-encoded flush
@@ -218,27 +371,26 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         super().__init__(*args, **kwargs)
         assert encoding == "indices", f"delta_sharded ships only the 'indices' position encoding; got {encoding!r}"
         self.encoding = encoding
-        self._shard_snap: dict[str, torch.Tensor] = {}  # name -> pinned-CPU shard snapshot
         self._shard_seeded = False
-        self._placements: dict[str, tuple] = {}  # name -> (flat_offset, contributes, group)
         # Gather the per-param sparse deltas in groups of this many parameters
         # (one count-matrix all_gather + two padded gathers per group instead of
         # three collectives per parameter).
         self.batch_gather = int(batch_gather)
 
-    def _placement(self, name, spec):
-        """Derive (and cache) this rank's placement facts from the declarative spec."""
-        got = self._placements.get(name)
-        if got is None:
-            got = derive_placement(spec)
-            self._placements[name] = got
-        return got
+    @property
+    def needs_seed(self) -> bool:
+        """True until the first (seed) sync has run. The caller picks the export by
+        phase: seed consumes ``get_per_tensor_param()`` (full HF tensors, the
+        backend's own assembly/conversion) shipped values-only; steady syncs consume
+        ``get_per_tensor_param_delta_shard()`` (backend-computed HF deltas). After
+        the seed the caller must ``prime_delta_snapshots()`` on the training engine."""
+        return not self._shard_seeded
 
-    def _assemble_flush(self, per_param: list) -> DeltaFlush:
+    def _assemble_flush(self, per_param: list[_FlushPiece]) -> DeltaFlush:
         """Build one DeltaFlush (indices encoding) from rank 0's gathered per-param deltas.
 
-        ``per_param``: list of ``(name, dtype_str, shape, global_idx, values)`` where
-        ``global_idx`` are within-parameter flat positions (== what the receiver decodes).
+        ``per_param``: :class:`_FlushPiece` entries whose ``idx`` are within-parameter
+        flat positions (== what the receiver decodes).
 
         Positions stay on the GPU end to end (int32 pieces -> one cat -> uint8 view);
         the wire broadcasts from the GPU anyway, and a host round-trip here
@@ -249,21 +401,21 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         val_pieces: list[torch.Tensor] = []
         params: list[DeltaParam] = []
         pos_off = val_off = 0
-        for name, dtype_str, shape, idx, val in per_param:
-            nnz = int(idx.numel())
+        for piece in per_param:
+            nnz = int(piece.idx.numel())
             # positions ride the wire as int32 (pos_width=4); a parameter bigger than
             # 2^31 elements would silently wrap, so fail loud instead. DeltaParam
             # carries pos_width for a future 8-byte escalation if a model needs it.
-            assert _prodshape(shape) < (1 << 31), (
-                f"{name}: {_prodshape(shape)} elements exceeds the int32 position encoding"
+            assert _prodshape(piece.shape) < (1 << 31), (
+                f"{piece.name}: {_prodshape(piece.shape)} elements exceeds the int32 position encoding"
             )
-            idx_pieces.append(idx.to(torch.int32))
-            val_pieces.append(val)
+            idx_pieces.append(piece.idx.to(torch.int32))
+            val_pieces.append(piece.val)
             params.append(
                 DeltaParam(
-                    name=name,
-                    dtype=dtype_str,
-                    shape=list(shape),
+                    name=piece.name,
+                    dtype=piece.dtype_str,
+                    shape=list(piece.shape),
                     pos_start=pos_off,
                     pos_end=pos_off + nnz * 4,
                     pos_width=4,
@@ -285,44 +437,34 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             encoding=self.encoding, params=params, positions_cpu=positions_u8, values_gpu=values_gpu, checksum=cks
         )
 
-    def _send_dense_seed(self, weights, global_steps=None):
-        """First sync: assemble and broadcast the raw weights, bucketed, positions-free.
+    def _send_full_seed(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ) -> dict[str, float] | None:
+        """First sync: stream the backend's FULL HF export over the values-only wire.
 
-        Explicit dense semantics instead of the previous bitflip-forced full diff:
-        no per-element indices on the wire (values only), no whole-parameter
-        (idx, val) spike on rank 0 -- its peak is one assembled parameter plus a
-        bucket -- and the snapshot is populated as the stream goes.
-        """
+        ``weights`` is ``get_per_tensor_param()`` -- every backend already knows how
+        to assemble and convert its own full tensors (FSDP all-gather, veomni expert
+        restack, Megatron TP/PP fusion), so the seed inherits all of that for free
+        and this engine only buckets and broadcasts. Every trainer rank iterates the
+        generator (the per-tensor assembly is collective); rank 0 buckets. Resume
+        works by construction: whatever the trainer restored is what ships."""
         is_r0 = self.is_master
-        bucket: list = []  # (name, dtype_str, full_shape, flat_full_tensor)
-        bucket_bytes = 0
-        pending = None  # (params, values) awaiting emission (1-flush lookahead for is_last)
         n_flushes = 0
         total_elems = 0
         wire_bytes = 0
 
-        def _emit(is_last):
-            nonlocal pending, n_flushes, wire_bytes
-            if pending is not None:
-                self._publish_dense_flush(pending[0], pending[1], is_last=is_last)
-                n_flushes += 1
-                wire_bytes += int(pending[1].nbytes)
-                pending = None
-
-        def _seal():
-            nonlocal bucket, bucket_bytes, pending
-            if not bucket:
-                return
-            _emit(is_last=False)
+        def _assemble_values(pieces: list[_ValuesPiece]):
             params = []
             val_off = 0
-            for name, dtype_str, full_shape, flat in bucket:
-                n = int(flat.numel())
+            for piece in pieces:
+                n = int(piece.flat.numel())
                 params.append(
                     DeltaParam(
-                        name=name,
-                        dtype=dtype_str,
-                        shape=list(full_shape),
+                        name=piece.name,
+                        dtype=piece.dtype_str,
+                        shape=list(piece.shape),
                         pos_start=0,
                         pos_end=0,
                         pos_width=4,
@@ -331,62 +473,37 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
                     )
                 )
                 val_off += n
-            values = torch.cat([flat for *_, flat in bucket])
-            pending = (params, values)
-            bucket = []
-            bucket_bytes = 0
+            return params, torch.cat([piece.flat for piece in pieces])
 
-        def _bucket_dense(hf_name, tensor):
-            nonlocal total_elems, bucket_bytes
-            flat = tensor.reshape(-1)
+        def _publish_values(pending, is_last: bool) -> None:
+            nonlocal n_flushes, wire_bytes
+            params, values = pending
+            self._publish_values_flush(params, values, is_last=is_last)
+            n_flushes += 1
+            wire_bytes += int(values.nbytes)
+
+        bkt = _FlushBucket(self.bucket_size, _assemble_values, _publish_values)
+
+        for name, tensor in weights:
+            tensor = tensor.detach()
+            if tensor.is_floating_point() and tensor.dtype != self.rollout_dtype:
+                tensor = tensor.to(self.rollout_dtype)
+            if not is_r0:
+                del tensor
+                continue
+            flat = tensor.contiguous().reshape(-1)
             total_elems += int(flat.numel())
-            bucket.append((hf_name, str(flat.dtype).replace("torch.", ""), list(tensor.shape), flat))
-            bucket_bytes += int(flat.nbytes)
-            if bucket_bytes >= self.bucket_size:
-                _seal()
-
-        for name, local, spec in weights:
-            local = local.detach().contiguous().view(-1)
-            snap = self._shard_snap.get(name)
-            if snap is None or snap.numel() != local.numel():
-                snap = torch.empty_like(local, device="cpu", pin_memory=True)
-            snap.copy_(local, non_blocking=True)
-            self._shard_snap[name] = snap
-
-            offset, contributes, pg = self._placement(name, spec)
-            shard = local if contributes else torch.empty(0, dtype=local.dtype, device=local.device)
-            if spec.to_hf is None:
-                # the spec's placements map the shard straight into the full tensor
-                if pg is None:
-                    if is_r0 and contributes:
-                        _bucket_dense(name, local.view(spec.full_shape))
-                else:
-                    full = gather_dense_to_rank0(
-                        shard, offset if contributes else 0, _prodshape(spec.full_shape), group=pg
-                    )
-                    if is_r0 and full is not None:
-                        _bucket_dense(name, full.view(spec.full_shape))
-            else:
-                # converter profile (e.g. Megatron): rebuild dense shards via to_hf
-                shards = gather_shards_to_rank0(shard, group=pg)
-                if is_r0 and shards is not None:
-                    for hf_name, hf_tensor in spec.to_hf(shards):
-                        _bucket_dense(hf_name, hf_tensor)
+            bkt.add(_ValuesPiece(name, str(flat.dtype).replace("torch.", ""), list(tensor.shape), flat), flat.nbytes)
 
         self._shard_seeded = True
         if not is_r0:
             return
-        _seal()
-        if pending is not None:
-            _emit(is_last=True)
+        bkt.seal()
+        if bkt.pending is not None:
+            bkt.emit(is_last=True)
         else:
             self._publish_terminal(True)
-        logger.info(
-            "delta-sharded send v=%s DENSE-SEED flushes=%d elems=%d",
-            global_steps,
-            n_flushes,
-            total_elems,
-        )
+        logger.info("delta-sharded send v=%s FULL-SEED flushes=%d elems=%d", global_steps, n_flushes, total_elems)
         if not total_elems:
             return None
         return {
@@ -396,177 +513,69 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             "checkpoint_engine/flushes": float(n_flushes),
         }
 
-    async def send_weights(self, weights, global_steps=None):
+    async def send_weights(
+        self,
+        weights: Generator[tuple, None, None],
+        global_steps: int | None = None,
+    ) -> dict[str, float] | None:
         # All actor ranks participate (gather-v is collective); only torch rank 0 broadcasts.
         # rank 0 accumulates the gathered per-param deltas into bucket_size-sized flushes and streams
         # each one as soon as it fills (then frees it), so peak memory is ~2 buckets rather than the
         # whole model.
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
         if not self._shard_seeded:
-            return self._send_dense_seed(weights, global_steps)
+            # seed consumes the FULL export (name, full_hf_tensor); the caller
+            # selects it via ``needs_seed``.
+            return self._send_full_seed(weights, global_steps)
         is_r0 = self.is_master
-        first = False  # the dense first sync is handled by _send_dense_seed
-        bucket: list = []
-        bucket_bytes = 0
-        pending = None  # a DeltaFlush awaiting emission (1-flush lookahead so the last flush is is_last)
         n_flushes = 0
         changed_elems = 0
         total_elems = 0
         wire_bytes = 0
 
-        def _emit(is_last):
-            nonlocal pending, n_flushes
-            if pending is not None:
-                self._publish_flush(pending, first, is_last=is_last)
-                n_flushes += 1
-                pending = None
+        def _publish_steady(flush, is_last: bool) -> None:
+            nonlocal n_flushes
+            self._publish_flush(flush, first=False, is_last=is_last)
+            n_flushes += 1
 
-        def _seal():
-            nonlocal bucket, bucket_bytes, pending
-            if not bucket:
-                return
-            _emit(is_last=False)  # another bucket follows, so the prior one is not the last
-            pending = self._assemble_flush(bucket)
-            bucket = []
-            bucket_bytes = 0
+        bkt = _FlushBucket(self.bucket_size, self._assemble_flush, _publish_steady)
 
         batch_k = self.batch_gather
-        group: list = []  # (name, dtype_str, full_shape, full_numel, gidx, gval)
 
-        def _consume(name, dtype_str, full_shape, full_numel, aidx, aval):
-            nonlocal total_elems, changed_elems, wire_bytes, bucket_bytes
+        def _bucket_slot_delta(
+            name: str,
+            dtype_str: str,
+            full_shape: tuple,
+            full_numel: int,
+            aidx: torch.Tensor | None,
+            aval: torch.Tensor | None,
+        ) -> None:
+            nonlocal total_elems, changed_elems, wire_bytes
             total_elems += int(full_numel)
             if aidx is None or aidx.numel() == 0:
                 return
             changed_elems += int(aidx.numel())
             wire_bytes += int(aidx.numel()) * (4 + aval.element_size())
-            # Slice oversized per-param deltas so one entry never exceeds
-            # MAX_ENTRY_ELEMS (bounds the receiver-side decode transient).
-            for s in range(0, aidx.numel(), self.MAX_ENTRY_ELEMS):
-                e = min(s + self.MAX_ENTRY_ELEMS, aidx.numel())
-                bucket.append((name, dtype_str, list(full_shape), aidx[s:e], aval[s:e]))
-                bucket_bytes += (e - s) * 8 + (e - s) * aval.element_size()
-                if bucket_bytes >= self.bucket_size:
-                    _seal()
+            _bucket_sliced(bkt, name, dtype_str, full_shape, aidx, aval)
 
-        def _flush_group():
-            nonlocal group
-            if not group:
-                return
-            pg = group[0][6]
-            if pg is None:
-                # unsharded params: this rank's delta already is the global delta
-                if is_r0:
-                    for name, dtype_str, full_shape, full_numel, gi, gv, _pg in group:
-                        _consume(name, dtype_str, full_shape, full_numel, gi, gv)
-                group = []
-                return
-            dev = group[0][4].device
-            idx_concat = torch.cat([g[4] for g in group])
-            val_concat = torch.cat([g[5] for g in group])
-            counts = torch.tensor([int(g[4].numel()) for g in group], dtype=torch.int64, device=dev)
-            gathered = gather_v_batched_to_rank0(idx_concat, val_concat, counts, group=pg)
-            if is_r0 and gathered is not None:
-                for (name, dtype_str, full_shape, full_numel, _gi, _gv, _pg), (aidx, aval) in zip(
-                    group, gathered, strict=False
-                ):
-                    _consume(name, dtype_str, full_shape, full_numel, aidx, aval)
-            group = []
+        gq = _GatherQueue(batch_k, self.bucket_size, is_r0, _bucket_slot_delta)
 
-        nan_group: list = []  # rebuild-profile params batched per gather_group
+        # ``weights`` is the BACKEND's HF delta stream (hf_delta_export): entries
+        # already carry final HF coordinates -- naming, conversion, diff and
+        # snapshot all happened on the backend side. This engine only batches,
+        # gathers and ships.
+        for slots, dtype_str, counts, hf_idx, hf_val, pg in weights:
+            gq.put(pg, slots, dtype_str, counts, hf_idx, hf_val)
+        gq.flush_all()
 
-        def _flush_nan_group():
-            nonlocal nan_group, total_elems
-            if not nan_group:
-                return
-            pg = nan_group[0][2]
-            dev = nan_group[0][5].device
-            idx_concat = torch.cat([g[5] for g in nan_group])
-            val_concat = torch.cat([g[6] for g in nan_group])
-            counts = torch.tensor([int(g[5].numel()) for g in nan_group], dtype=torch.int64, device=dev)
-            gathered = gather_v_batched_to_rank0(idx_concat, val_concat, counts, group=pg, grouped=True)
-            if is_r0 and gathered is not None:
-                for (name, local_dtype, _pg, spec, shard_shape, _gi, _gv), per_rank in zip(
-                    nan_group, gathered, strict=False
-                ):
-                    shard_list = []
-                    for gi, gv in per_rank:
-                        buf = torch.full(shard_shape, float("nan"), dtype=local_dtype, device=dev)
-                        buf.view(-1)[gi.to(torch.int64)] = gv  # index ops need Long
-                        shard_list.append(buf)
-                    for hf_name, hf_tensor in spec.to_hf(shard_list):
-                        fl = hf_tensor.reshape(-1)
-                        total_elems += int(fl.numel())
-                        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
-                        if pos.numel():
-                            # total_elems is added inside _consume too; compensate
-                            total_elems -= int(fl.numel())
-                            _consume(
-                                hf_name,
-                                str(fl.dtype).replace("torch.", ""),
-                                tuple(hf_tensor.shape),
-                                int(fl.numel()),
-                                pos,
-                                fl[pos],
-                            )
-            nan_group = []
-
-        for name, local, spec in weights:
-            local = local.detach().contiguous().view(-1)
-            offset, contributes, pg = self._placement(name, spec)
-            snap = self._shard_snap.get(name)
-            if snap is None or snap.numel() != local.numel():
-                snap = torch.empty_like(local, device="cpu", pin_memory=True)
-            if contributes:
-                base = snap.to(local.device, non_blocking=True)
-                lidx, lval = shard_delta_indices(local, base, 0)  # shard-local coordinates
-            else:
-                # replicated param owned by another rank; contribute nothing but keep lockstep.
-                lidx = torch.empty(0, dtype=torch.int64, device=local.device)
-                lval = torch.empty(0, dtype=local.dtype, device=local.device)
-            snap.copy_(local, non_blocking=True)  # update snapshot to current shard
-            self._shard_snap[name] = snap
-
-            if spec.to_hf is not None:
-                # converter profile: boundary-preserving gather within the spec's group,
-                # NaN-sentinel rebuild through the trainer's converter on rank 0.
-                if nan_group and nan_group[0][2] is not pg:
-                    _flush_nan_group()
-                # shard-local coordinates are bounded by the shard's numel, so the
-                # full-tensor <2^31 assert in _assemble_flush covers them too.
-                nan_group.append((name, local.dtype, pg, spec, tuple(local.shape), lidx.to(torch.int32), lval))
-                if len(nan_group) >= max(batch_k, 1):
-                    _flush_nan_group()
-                continue
-
-            # placement profile: translate rank-locally, gather without boundaries.
-            # int32 halves the gather's position bytes; the wire is int32 anyway and
-            # the per-parameter <2^31 assert in _assemble_flush covers the range.
-            gidx = ((lidx + offset) if lidx.numel() else lidx).to(torch.int32)
-            gval = lval
-            full_numel = _prodshape(spec.full_shape)
-            if group and group[-1][6] is not pg:
-                _flush_group()
-            group.append((name, str(local.dtype).replace("torch.", ""), spec.full_shape, full_numel, gidx, gval, pg))
-            if len(group) >= max(batch_k, 1):
-                _flush_group()
-        _flush_group()
-        _flush_nan_group()
-
-        self._shard_seeded = True
         if not is_r0:
             return
-        _seal()  # seal the final partial bucket into `pending`
-        if pending is not None:
-            _emit(is_last=True)
+        bkt.seal()  # seal the final partial bucket into the pending flush
+        if bkt.pending is not None:
+            bkt.emit(is_last=True)
         else:
-            self._publish_terminal(first)
-        logger.info(
-            "delta-sharded send v=%s %s flushes=%d (streamed)",
-            global_steps,
-            "FULL" if first else "delta",
-            n_flushes,
-        )
+            self._publish_terminal(False)
+        logger.info("delta-sharded send v=%s delta flushes=%d (streamed)", global_steps, n_flushes)
         if not total_elems:
             return None
         return {

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -224,8 +224,11 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
     are gathered to rank 0 and streamed to the rollout side -- no rank ever holds
     a full-model snapshot.
 
-    ``send_weights`` consumes the backend's HF delta export
-    ``get_per_tensor_param_delta_shard()``: per-parameter FINAL-HF-coordinate
+    ``send_weights`` takes the TRAINING ENGINE and drives the sync itself: the
+    seed (first sync) streams the backend's full ``get_per_tensor_param()``
+    export values-only and pins the diff base (``prime_delta_snapshots``); every
+    steady sync consumes the backend's HF delta export
+    ``get_per_tensor_param_delta_shard()`` — per-parameter FINAL-HF-coordinate
     entries ``(slots, dtype_str, counts, hf_idx, hf_val, gather_group)``. Naming,
     to-HF conversion, diff and snapshot all live on the backend side (see
     :mod:`verl.workers.engine.utils`); this engine only batches, gathers,
@@ -377,15 +380,6 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         # three collectives per parameter).
         self.batch_gather = int(batch_gather)
 
-    @property
-    def needs_seed(self) -> bool:
-        """True until the first (seed) sync has run. The caller picks the export by
-        phase: seed consumes ``get_per_tensor_param()`` (full HF tensors, the
-        backend's own assembly/conversion) shipped values-only; steady syncs consume
-        ``get_per_tensor_param_delta_shard()`` (backend-computed HF deltas). After
-        the seed the caller must ``prime_delta_snapshots()`` on the training engine."""
-        return not self._shard_seeded
-
     def _assemble_flush(self, per_param: list[_FlushPiece]) -> DeltaFlush:
         """Build one DeltaFlush (indices encoding) from rank 0's gathered per-param deltas.
 
@@ -515,18 +509,30 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
 
     async def send_weights(
         self,
-        weights: Generator[tuple, None, None],
+        engine,
         global_steps: int | None = None,
     ) -> dict[str, float] | None:
+        """Drive one weight sync from the TRAINING ENGINE (unlike the full-sync
+        engines, which consume a weights iterator): the seed/steady phase choice
+        and the snapshot prime are this engine's own state machine, so the worker
+        stays delta-agnostic. The seed (first sync) streams the backend's full
+        ``get_per_tensor_param()`` export over the values-only wire, then pins the
+        diff base via ``engine.prime_delta_snapshots()``; every later sync consumes
+        ``get_per_tensor_param_delta_shard()`` (backend-computed final-HF deltas).
+        """
         # All actor ranks participate (gather-v is collective); only torch rank 0 broadcasts.
         # rank 0 accumulates the gathered per-param deltas into bucket_size-sized flushes and streams
         # each one as soon as it fills (then frees it), so peak memory is ~2 buckets rather than the
         # whole model.
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
         if not self._shard_seeded:
-            # seed consumes the FULL export (name, full_hf_tensor); the caller
-            # selects it via ``needs_seed``.
-            return self._send_full_seed(weights, global_steps)
+            full, _ = engine.get_per_tensor_param()
+            metrics = self._send_full_seed(full, global_steps)
+            # weights do not move during the sync, so the snapshots equal exactly
+            # what the rollout just received.
+            engine.prime_delta_snapshots()
+            return metrics
+        weights, _ = engine.get_per_tensor_param_delta_shard()
         is_r0 = self.is_master
         n_flushes = 0
         changed_elems = 0

--- a/verl/checkpoint_engine/delta_sync/sparse_gather.py
+++ b/verl/checkpoint_engine/delta_sync/sparse_gather.py
@@ -27,8 +27,13 @@ Other shard dims are strided in the flattened layout and raise NotImplementedErr
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import torch
 import torch.distributed as dist
+
+if TYPE_CHECKING:
+    pass
 
 _DTYPE_INT = {1: torch.uint8, 2: torch.int16, 4: torch.int32, 8: torch.int64}
 
@@ -54,12 +59,12 @@ def shard_delta_indices(
     return global_idx, values
 
 
-def gather_v_batched_to_rank0(
+def gather_slot_entries_to_rank0(
     idx_concat: torch.Tensor,
     val_concat: torch.Tensor,
     counts: torch.Tensor,
-    group=None,
-    grouped: bool = False,
+    group: dist.ProcessGroup | None = None,
+    max_round_bytes: int | None = None,
 ) -> list | None:
     """Variable-length sparse gather, batched: one collective round for K parameters.
 
@@ -79,6 +84,38 @@ def gather_v_batched_to_rank0(
     counts_all = [torch.zeros_like(counts) for _ in range(world)]
     dist.all_gather(counts_all, counts.to(dev), group=group)
     counts_cpu = torch.stack(counts_all).cpu().tolist()  # one D2H sync instead of `world`
+
+    if max_round_bytes is not None and k > 1:
+        # Deterministic sub-rounds: every rank sees the same counts matrix, so all
+        # ranks derive the SAME slot partition (no per-rank trigger asymmetry) and
+        # each padded round's largest blob stays within the byte budget.
+        per_elem = idx_concat.element_size() + val_concat.element_size()
+        budget = max(int(max_round_bytes) // per_elem, 1)  # elements per rank per round
+        cuts = [0]
+        run = [0] * world
+        for i in range(k):
+            run = [run[r] + counts_cpu[r][i] for r in range(world)]
+            if max(run) > budget and cuts[-1] != i:
+                cuts.append(i)
+                run = [counts_cpu[r][i] for r in range(world)]
+        cuts.append(k)
+        if len(cuts) > 2:
+            out_all: list = []
+            my_off = [0]
+            for i in range(k):
+                my_off.append(my_off[-1] + counts_cpu[rank][i])
+            for lo, hi in zip(cuts[:-1], cuts[1:], strict=False):
+                sub_counts = torch.tensor(counts_cpu[rank][lo:hi], dtype=torch.int64, device=dev)
+                sub = gather_slot_entries_to_rank0(
+                    idx_concat[my_off[lo] : my_off[hi]],
+                    val_concat[my_off[lo] : my_off[hi]],
+                    sub_counts,
+                    group=group,
+                )
+                if rank == 0:
+                    out_all.extend(sub)
+            return out_all if rank == 0 else None
+
     totals = [sum(c) for c in counts_cpu]
     max_n = max(totals) if totals else 0
     if max_n == 0:
@@ -86,8 +123,6 @@ def gather_v_batched_to_rank0(
             return None
         empty_i = torch.empty(0, dtype=idx_concat.dtype, device=dev)
         empty_v = torch.empty(0, dtype=val_concat.dtype, device=dev)
-        if grouped:
-            return [[(empty_i, empty_v) for _ in range(world)] for _ in range(k)]
         return [(empty_i, empty_v) for _ in range(k)]
 
     idx_pad = torch.zeros(max_n, dtype=idx_concat.dtype, device=dev)
@@ -110,15 +145,6 @@ def gather_v_batched_to_rank0(
             offs[r][i + 1] = offs[r][i] + counts_cpu[r][i]
     out = []
     for i in range(k):
-        if grouped:
-            # keep the per-rank boundary: [(idx_r, val_r) for every rank in the group]
-            out.append(
-                [
-                    (idx_list[r][offs[r][i] : offs[r][i + 1]], val_list[r][offs[r][i] : offs[r][i + 1]])
-                    for r in range(world)
-                ]
-            )
-            continue
         idx_pieces = [idx_list[r][offs[r][i] : offs[r][i + 1]] for r in range(world) if counts_cpu[r][i]]
         val_pieces = [val_list[r][offs[r][i] : offs[r][i + 1]] for r in range(world) if counts_cpu[r][i]]
         if idx_pieces:
@@ -128,122 +154,3 @@ def gather_v_batched_to_rank0(
                 (torch.empty(0, dtype=idx_concat.dtype, device=dev), torch.empty(0, dtype=val_concat.dtype, device=dev))
             )
     return out
-
-
-def gather_dense_to_rank0(
-    local_val: torch.Tensor,
-    offset: int,
-    full_numel: int,
-    group=None,
-) -> torch.Tensor | None:
-    """Assemble a full flat parameter on rank 0 from each rank's contiguous shard.
-
-    Each rank contributes ``(offset, values)`` (empty on non-contributing ranks);
-    rank 0 places every shard at its flat offset. Only the values ride the wire --
-    no per-element indices -- so the dense first sync carries none of the sparse
-    encoding overhead and rank 0 peaks at one full parameter.
-    """
-    rank = dist.get_rank(group)
-    world = dist.get_world_size(group)
-    dev = local_val.device
-
-    n = int(local_val.numel())
-    meta = torch.tensor([n, offset], dtype=torch.long, device=dev)
-    metas = [torch.zeros(2, dtype=torch.long, device=dev) for _ in range(world)]
-    dist.all_gather(metas, meta, group=group)
-    metas_cpu = torch.stack(metas).cpu().tolist()  # one D2H sync instead of 2 * `world`
-    counts = [int(m[0]) for m in metas_cpu]
-    offsets = [int(m[1]) for m in metas_cpu]
-    max_n = max(counts) if counts else 0
-    if max_n == 0:
-        return torch.empty(0, dtype=local_val.dtype, device=dev) if rank == 0 else None
-
-    val_pad = torch.zeros(max_n, dtype=local_val.dtype, device=dev)
-    val_pad[:n] = local_val
-    val_list = [torch.zeros(max_n, dtype=local_val.dtype, device=dev) for _ in range(world)] if rank == 0 else None
-    dist.gather(val_pad, val_list, dst=0, group=group)
-    if rank != 0:
-        return None
-    full = torch.empty(full_numel, dtype=local_val.dtype, device=dev)
-    for r in range(world):
-        if counts[r]:
-            full[offsets[r] : offsets[r] + counts[r]] = val_list[r][: counts[r]]
-    return full
-
-
-def gather_v_grouped_to_rank0(
-    local_idx: torch.Tensor,
-    local_val: torch.Tensor,
-    group=None,
-) -> list[tuple[torch.Tensor, torch.Tensor]] | None:
-    """Variable-length sparse gather that keeps the payloads *per rank* instead of concatenating.
-
-    Returns, on rank 0, a list ``[(idx_r, val_r) for r in range(world)]`` of each rank's sparse
-    ``(local-shard-position, value)`` pairs (padding stripped); ``None`` on the other ranks. Keeping
-    the per-rank boundary lets rank 0 rebuild each rank's shard buffer and feed the *native*
-    ``_weight_merge_across_tp`` -- so no per-parameter global-position math is needed on our side.
-    """
-    rank = dist.get_rank(group)
-    world = dist.get_world_size(group)
-    dev = local_idx.device
-
-    n = int(local_idx.numel())
-    cnt = torch.tensor([n], dtype=torch.long, device=dev)
-    counts = [torch.zeros(1, dtype=torch.long, device=dev) for _ in range(world)]
-    dist.all_gather(counts, cnt, group=group)
-    counts = torch.cat(counts).cpu().tolist()  # one D2H sync instead of `world`
-    max_n = max(counts) if counts else 0
-
-    if max_n == 0:
-        return (
-            [
-                (torch.empty(0, dtype=local_idx.dtype, device=dev), torch.empty(0, dtype=local_val.dtype, device=dev))
-                for _ in range(world)
-            ]
-            if rank == 0
-            else None
-        )
-
-    idx_pad = torch.zeros(max_n, dtype=local_idx.dtype, device=dev)
-    val_pad = torch.zeros(max_n, dtype=local_val.dtype, device=dev)
-    idx_pad[:n] = local_idx
-    val_pad[:n] = local_val
-
-    idx_list = [torch.zeros(max_n, dtype=idx_pad.dtype, device=dev) for _ in range(world)] if rank == 0 else None
-    val_list = [torch.zeros(max_n, dtype=local_val.dtype, device=dev) for _ in range(world)] if rank == 0 else None
-    dist.gather(idx_pad, idx_list, dst=0, group=group)
-    dist.gather(val_pad, val_list, dst=0, group=group)
-
-    if rank != 0:
-        return None
-    return [(idx_list[r][: counts[r]], val_list[r][: counts[r]]) for r in range(world)]
-
-
-def gather_shards_to_rank0(local_val: torch.Tensor, group=None) -> list[torch.Tensor] | None:
-    """Gather each rank's dense flat shard to the group's rank 0, per-rank boundaries kept.
-
-    Returns ``[shard_r for r in range(group world)]`` on the group's rank 0 (None
-    elsewhere). Used by the rebuild-profile dense first sync, where rank 0 hands the
-    shard list to ``ShardSpec.rebuild_dense``.
-    """
-    rank = dist.get_rank(group)
-    world = dist.get_world_size(group)
-    dst = dist.get_global_rank(group, 0) if group is not None else 0
-    dev = local_val.device
-
-    n = int(local_val.numel())
-    cnt = torch.tensor([n], dtype=torch.long, device=dev)
-    counts = [torch.zeros(1, dtype=torch.long, device=dev) for _ in range(world)]
-    dist.all_gather(counts, cnt, group=group)
-    counts = torch.cat(counts).cpu().tolist()
-    max_n = max(counts) if counts else 0
-    if max_n == 0:
-        return [torch.empty(0, dtype=local_val.dtype, device=dev) for _ in range(world)] if rank == 0 else None
-
-    val_pad = torch.zeros(max_n, dtype=local_val.dtype, device=dev)
-    val_pad[:n] = local_val
-    val_list = [torch.zeros(max_n, dtype=local_val.dtype, device=dev) for _ in range(world)] if rank == 0 else None
-    dist.gather(val_pad, val_list, dst=dst, group=group)
-    if rank != 0:
-        return None
-    return [val_list[r][: counts[r]] for r in range(world)]

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -178,6 +178,47 @@ class BaseEngine:
         """
         raise NotImplementedError
 
+    def prime_delta_snapshots(self) -> None:
+        """
+        Pin this rank's CURRENT shards as the delta diff base. Called right after the
+        seed sync (which streams :meth:`get_per_tensor_param`'s full HF export):
+        weights do not move during the sync, so the snapshots equal exactly what the
+        rollout side received and the first
+        :meth:`get_per_tensor_param_delta_shard` diff is correct.
+
+        Concrete here: it only consumes :meth:`get_per_tensor_param_shard`, so any
+        engine that implements the shard export gets it for free.
+        """
+        from verl.workers.engine.utils import prime_delta_snapshots
+
+        self._delta_shard_snap = getattr(self, "_delta_shard_snap", {})
+        gen, _ = self.get_per_tensor_param_shard()
+        prime_delta_snapshots(gen, self._delta_shard_snap)
+
+    def get_per_tensor_param_delta_shard(self, **kwargs) -> tuple[Generator, Optional[dict]]:
+        """
+        Yield the delta engine's per-parameter payloads in FINAL HF coordinates:
+        ``(slots, dtype_str, counts, hf_idx, hf_val, gather_group)``, in an order
+        identical on every rank (non-contributing replicas yield zero-count entries
+        but stay in the lockstep sequence). ``slots`` enumerates the HF tensors this
+        parameter maps to (identity params: itself; fused params: their hf_slots),
+        and ``hf_idx``/``hf_val`` are the changed elements since the previous export,
+        already converted to HF coordinates.
+
+        Everything backend-specific lives behind this call: the weight->HF naming,
+        the to-HF conversion, the diff and its base. A backend that already keeps the
+        previous step's weights (e.g. Decoupled PPO) can diff against that instead of
+        a dedicated snapshot; :func:`verl.workers.engine.utils.hf_delta_export`
+        implements the default pinned-CPU-snapshot strategy (primed by
+        :meth:`prime_delta_snapshots`). The consuming delta engine only batches,
+        gathers and ships.
+
+        Returns:
+            Generator: A generator that yields per-parameter HF-coordinate delta entries.
+            Optional[dict]: Optional peft config.
+        """
+        raise NotImplementedError
+
     def get_data_parallel_size(self):
         raise NotImplementedError
 

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -860,12 +860,9 @@ class FSDPEngine(BaseEngine):
 
     def get_per_tensor_param_shard(self, **kwargs):
         """Like :meth:`get_per_tensor_param`, but yields each rank's *local* FSDP shard
-        instead of all-gathering the full tensor -- used by the ``delta_sharded``
-        checkpoint engine, which diffs on shards and gathers only the changes.
-
-        Yields ``(name, local_flat_shard_bf16, within_param_flat_offset, full_numel,
-        full_shape, contributes)``. Non-LoRA base path only.
-        """
+        ``(name, local_flat_shard_bf16, ShardSpec)`` instead of all-gathering the full
+        tensor. Pure DTensor export, no side effects -- delta bookkeeping lives in
+        :meth:`get_per_tensor_param_delta_shard`. Non-LoRA base path only."""
 
         # FSDP1's (SHARDED_)STATE_DICT export runs through the unshard machinery and
         # asserts flat params are GPU-resident; FSDP2 state_dict() only collects
@@ -892,6 +889,33 @@ class FSDPEngine(BaseEngine):
                 yield name, local.reshape(-1), spec
 
         return _gen(), None
+
+    def _hf_delta_entry(self, name, spec, place, lidx, lval):
+        """Per-param HF delta entry builder: this engine handles DTensor identity
+        params only (weight name == HF name, coordinates translate). EP/converter
+        specs are the veomni engine's business -- it overrides this hook."""
+        from ..utils import _hf_entry_identity
+
+        if spec.to_hf_chunk is not None:
+            raise NotImplementedError(
+                f"{name}: the FSDP engine only handles DTensor identity params; "
+                "converter specs belong to the engine that declared them"
+            )
+        return _hf_entry_identity(name, spec, place, lidx, lval)
+
+    def get_per_tensor_param_delta_shard(self, **kwargs):
+        """Yield the delta engine's steady payloads -- FINAL HF-coordinate entries
+        ``(slots, dtype_str, counts, hf_idx, hf_val, gather_group)`` per parameter.
+        Weight->HF naming, to-HF conversion, diff and snapshot are all backend
+        business: the DTensor-generic pipeline lives in
+        :mod:`verl.workers.engine.utils`, the per-param entry builder is the
+        :meth:`_hf_delta_entry` hook. Requires a prior
+        :meth:`prime_delta_snapshots` call."""
+        from ..utils import hf_delta_export
+
+        self._delta_shard_snap = getattr(self, "_delta_shard_snap", {})
+        gen, _ = self.get_per_tensor_param_shard()
+        return hf_delta_export(gen, self._delta_shard_snap, self._hf_delta_entry), None
 
     def get_per_tensor_param(self, layered_summon=False, base_sync_done=False, **kwargs):
         log_gpu_memory_usage("Before load_fsdp_model_to_gpu", logger=logger)

--- a/verl/workers/engine/spec.py
+++ b/verl/workers/engine/spec.py
@@ -24,22 +24,35 @@ DTensor-based trainers (FSDP, veomni, ...) pass ``param.device_mesh`` /
 ``param.placements`` verbatim; ``mesh=None`` means the local tensor already is
 the whole parameter (replicated / unsharded).
 
-``to_hf`` is reserved for trainers whose logical parameter differs from the HF
-tensor(s) (e.g. Megatron fused qkv): a pure-permutation callable mapping the
-gather group's dense shards to ``[(hf_name, hf_tensor)]``. It is None for
-DTensor trainers and lands with the Megatron follow-up PR.
+``BaseEngine.get_per_tensor_param_delta_shard`` is the delta engine's single
+export entry and yields FINAL HF-coordinate payloads: the weight->HF naming,
+the to-HF conversion, the diff and its snapshot are all the backend's business
+(a backend may already hold a previous-step checkpoint, e.g. Decoupled PPO, and
+diff against that); the delta engine only gathers, buckets and ships. This
+module stays purely declarative -- the converter-agnostic execution helpers
+live in :mod:`verl.workers.engine.utils` (``hf_delta_export`` /
+``prime_delta_snapshots``), and backend-specific converters ride the specs.
+
+``to_hf_chunk`` + ``hf_slots`` describe trainers whose logical parameter differs
+from the HF tensor(s) (e.g. veomni's fused expert stacks): a dim-0-separable
+converter plus its static output enumeration. Both are None for identity params
+(local coordinates translate straight into HF coordinates).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 
-__all__ = ["ShardSpec", "derive_placement"]
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
+    from torch.distributed.device_mesh import DeviceMesh
+
+__all__ = ["BlockPlacement", "ShardSpec", "derive_placement", "translate_flat_indices"]
 
 
 @dataclass
@@ -49,10 +62,30 @@ class ShardSpec:
     # Logical (full) tensor shape; the distribution facts below refer to it.
     full_shape: tuple
     # Distribution: torch DeviceMesh + per-mesh-dim Placement. None = unsharded.
-    mesh: Optional[object] = None
+    mesh: Optional[DeviceMesh] = None
     placements: Optional[tuple] = None
-    # Reserved (Megatron follow-up): pure-permutation shards -> [(hf_name, hf_tensor)].
-    to_hf: Optional[Callable[[list[torch.Tensor]], list[tuple[str, torch.Tensor]]]] = None
+    # Explicit placement override for trainers whose sharding is not fully captured
+    # by DTensor placements (e.g. veomni's manual expert-dim split): ``place`` is an
+    # int flat offset or a BlockPlacement in a *virtual* full tensor, and
+    # ``gather_group`` is the ProcessGroup covering every rank that holds a block
+    # (pass a real group object -- the engine treats ``None`` as "unsharded").
+    # Every rank is assumed to contribute.
+    place: Optional[int | BlockPlacement] = None
+    gather_group: Optional[ProcessGroup] = None
+    # Optional dim-0-separable converter: ``to_hf_chunk(dim0_start, segment)`` converts a
+    # contiguous dim-0 segment ``full[dim0_start : dim0_start + segment.shape[0]]`` of the
+    # logical tensor to ``[(hf_name, hf_tensor)]``. When set on a block-converter spec the
+    # engine rebuilds and converts in bounded dim-0 segments instead of materializing the
+    # whole logical tensor on rank 0 (e.g. a fused expert stack: each segment is a run of
+    # whole experts and the converter only needs the segment plus its starting expert id).
+    to_hf_chunk: Optional[Callable[[int, torch.Tensor], list[tuple[str, torch.Tensor]]]] = None
+    # Optional full slot enumeration for dim-0-separable converters: one
+    # ``(hf_name, hf_shape)`` per converter output, in dim-0 order and matching
+    # ``to_hf_chunk``'s per-segment output order. When present (together with
+    # ``to_hf_chunk``) the engine can convert on the SENDER side: every rank
+    # converts only its own touched dim-0 rows and ships final HF-coordinate
+    # entries keyed by slot index -- rank 0 does no conversion at all.
+    hf_slots: Optional[list[tuple[str, tuple]]] = None
 
     @classmethod
     def from_param(cls, param: torch.Tensor) -> ShardSpec:
@@ -61,38 +94,118 @@ class ShardSpec:
         return cls(full_shape=tuple(param.shape))
 
 
-def _prod(xs) -> int:
+def _prod(xs: tuple | list) -> int:
     n = 1
     for x in xs:
         n *= int(x)
     return n
 
 
-def derive_placement(spec: ShardSpec):
-    """Derive ``(flat_offset, contributes, gather_group)`` for THIS rank from the spec.
+def _row_major_strides(shape: tuple | list) -> tuple:
+    strides, acc = [], 1
+    for d in reversed([int(x) for x in shape]):
+        strides.append(acc)
+        acc *= d
+    return tuple(reversed(strides))
 
-    * unsharded (``mesh is None``): offset 0; only global rank 0 contributes; no group
-      (the local tensor is already the full parameter).
-    * ``Shard(0)`` over one mesh dim (+ any number of ``Replicate`` dims): the flat
-      offset comes from ``compute_local_shape_and_global_offset`` (pure math, no
-      collective); only ranks at coordinate 0 of every Replicate dim contribute; the
-      gather group is the Shard dim's subgroup.
 
-    Other shard dims raise -- same scope as the export that produces the spec.
+@dataclass(frozen=True)
+class BlockPlacement:
+    """This rank's local shard is one hyper-rectangular block of the full tensor:
+    ``full[o0:o0+l0, o1:o1+l1, ...]`` with ``local_shape=(l0, l1, ...)`` and
+    ``global_offset=(o0, o1, ...)``. Produced by :func:`derive_placement` for every
+    sharded geometry, including the dim-0 cut (FSDP2 ``Shard(0)``): that block is
+    flat-contiguous, and :func:`translate_flat_indices` detects it via
+    ``is_flat_contiguous`` and keeps the single-add fast path."""
+
+    local_shape: tuple
+    global_offset: tuple
+    full_shape: tuple
+
+    @property
+    def local_strides(self) -> tuple:
+        return _row_major_strides(self.local_shape)
+
+    @property
+    def full_strides(self) -> tuple:
+        return _row_major_strides(self.full_shape)
+
+    @property
+    def is_flat_contiguous(self) -> bool:
+        """True when the block is one contiguous flat range (only dim 0 is cut).
+
+        Then every trailing dim is whole, so the trailing offsets are all zero
+        and the block occupies flat positions ``[flat_offset, flat_offset+numel)``.
+        """
+        return all(int(lo) == int(fu) for lo, fu in zip(self.local_shape[1:], self.full_shape[1:], strict=False))
+
+    @property
+    def flat_offset(self) -> int:
+        """Flat start of the block; only meaningful when ``is_flat_contiguous``."""
+        return int(self.global_offset[0]) * _prod(self.full_shape[1:]) if self.full_shape else 0
+
+
+def translate_flat_indices(lidx: torch.Tensor, place: int | BlockPlacement) -> torch.Tensor:
+    """Map shard-local flat positions to full-tensor flat positions.
+
+    ``place`` is what :func:`derive_placement` returned: an ``int`` for the
+    identity cases (unsharded / replicated / explicit exporter overrides, translate
+    = add), or a :class:`BlockPlacement`. A flat-contiguous block (only dim 0 cut,
+    e.g. FSDP2 ``Shard(0)``) keeps the single-add fast path; any other block does a
+    mixed-radix decompose by the local shape, adds the per-dim offset, and recomposes
+    with the full-tensor strides -- a few divmods on the nnz tensor, no collectives.
+    """
+    if isinstance(place, int):
+        return lidx + place if place else lidx
+    if place.is_flat_contiguous:
+        off = place.flat_offset
+        return lidx + off if off else lidx
+    out = torch.zeros_like(lidx)
+    rem = lidx
+    for lstride, off, fstride in zip(place.local_strides, place.global_offset, place.full_strides, strict=False):
+        coord = torch.div(rem, lstride, rounding_mode="floor")
+        rem = rem - coord * lstride
+        out = out + (coord + int(off)) * fstride
+    return out
+
+
+def derive_placement(spec: ShardSpec) -> tuple[int | BlockPlacement, bool, Optional[ProcessGroup]]:
+    """Derive ``(place, contributes, gather_group)`` for THIS rank from the spec.
+
+    ``place`` feeds :func:`translate_flat_indices`:
+
+    * unsharded (``mesh is None``) or fully replicated: ``0``; no group (the local
+      tensor is already the full parameter). Explicit exporter overrides
+      (``spec.place``) may also be plain ``int`` offsets.
+    * any sharded geometry: a :class:`BlockPlacement` computed from
+      ``compute_local_shape_and_global_offset`` (pure math, no collective). For a
+      single Shard dim, only ranks at coordinate 0 of every Replicate dim
+      contribute and the gather group is the Shard dim's subgroup; the FSDP2
+      default ``Shard(0)`` yields a flat-contiguous block, which keeps the add
+      fast path in :func:`translate_flat_indices`. With several Shard dims (e.g.
+      automodel's EP x FSDP ``(Shard(0), Shard(1))`` expert mesh) every rank holds
+      a distinct block, the gather group spans the whole mesh (created once and
+      cached), and Replicate dims are not supported alongside them.
+
+    ``_StridedShard`` placements (interleaved local tensors, from some HSDP/TP
+    orderings) are rejected: the local tensor is not a single block.
     """
     import torch.distributed as dist
+
+    if spec.place is not None:
+        return spec.place, True, spec.gather_group
 
     if spec.mesh is None:
         return 0, (dist.get_rank() == 0 if dist.is_initialized() else True), None
 
     placements = spec.placements
-    shard_dims = [d for d, p in enumerate(placements) if p.is_shard()]
-    for d in shard_dims:
-        if placements[d].dim != 0:
+    for p in placements:
+        if type(p).__name__ == "_StridedShard":
             raise NotImplementedError(
-                f"sharded delta only supports Shard(0) (FSDP2 default); got placements={placements}"
+                f"sharded delta does not support _StridedShard (local tensor is not one block); "
+                f"got placements={placements}"
             )
-    assert len(shard_dims) <= 1, f"at most one Shard dim is supported; got placements={placements}"
+    shard_dims = [d for d, p in enumerate(placements) if p.is_shard()]
 
     coord = spec.mesh.get_coordinate()
     contributes = True
@@ -106,8 +219,36 @@ def derive_placement(spec: ShardSpec):
         # replicated across every mesh dim: full tensor on each rank, no gather
         return 0, contributes, None
 
-    _, global_offset = compute_local_shape_and_global_offset(spec.full_shape, spec.mesh, list(placements))
-    inner = _prod(spec.full_shape[1:])
-    offset = int(global_offset[0]) * inner
-    group = spec.mesh.get_group(mesh_dim=shard_dims[0])
-    return offset, contributes, group
+    local_shape, global_offset = compute_local_shape_and_global_offset(spec.full_shape, spec.mesh, list(placements))
+
+    if len(shard_dims) == 1:
+        group = spec.mesh.get_group(mesh_dim=shard_dims[0])
+        return BlockPlacement(tuple(local_shape), tuple(global_offset), tuple(spec.full_shape)), contributes, group
+
+    # several Shard dims: every rank owns a distinct block; gather spans the whole mesh.
+    assert all(p.is_shard() for p in placements), (
+        f"Replicate dims are not supported alongside multiple Shard dims; got placements={placements}"
+    )
+    group = _flattened_mesh_group(spec.mesh)
+    return BlockPlacement(tuple(local_shape), tuple(global_offset), tuple(spec.full_shape)), contributes, group
+
+
+_FLAT_GROUPS: dict[tuple, ProcessGroup] = {}
+
+
+def _flattened_mesh_group(mesh: DeviceMesh) -> ProcessGroup:
+    """One process group spanning every rank of ``mesh``, created once per mesh.
+
+    ``dist.new_group`` must be called by all processes in the same order; every
+    trainer rank walks the export in an identical order, so the cache stays in
+    lockstep. The group's rank 0 is the mesh's smallest global rank, which keeps
+    the gathered result on the engine master whenever it is part of the mesh.
+    """
+    import torch.distributed as dist
+
+    ranks = tuple(sorted(int(r) for r in mesh.mesh.flatten().tolist()))
+    got = _FLAT_GROUPS.get(ranks)
+    if got is None:
+        got = dist.new_group(list(ranks))
+        _FLAT_GROUPS[ranks] = got
+    return got

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -157,3 +157,79 @@ def postprocess_batch_func(output_lst, indices, data: TensorDict):
     }
 
     return output
+
+
+# ---- sharded-delta HF export (backend side) --------------------------------
+# The delta checkpoint engine consumes FINAL HF-coordinate deltas; everything
+# backend-specific -- the weight->HF naming, the to-HF conversion, the diff and
+# its snapshot -- happens here, on the backend side of the contract. The engine
+# keeps only collectives, bucketing and the wire. This module holds only the
+# DTensor-generic pieces both backends share; EP/converter machinery lives in
+# the veomni backend's own utils.
+
+
+def _prodshape(shape) -> int:
+    n = 1
+    for x in shape:
+        n *= int(x)
+    return n
+
+
+def _hf_entry_identity(name, spec, place, lidx, lval):
+    """Identity profile: the param IS its own single slot (weight name == HF name)
+    -- translate the shard-local delta to within-param coordinates. int32
+    positions: the wire is int32 anyway and the engine asserts the range."""
+    from .spec import translate_flat_indices
+
+    gidx = (translate_flat_indices(lidx, place) if lidx.numel() else lidx).to(torch.int32)
+    counts = torch.zeros(1, dtype=torch.int64)
+    counts[0] = int(gidx.numel())
+    return [(name, tuple(spec.full_shape))], str(lval.dtype).replace("torch.", ""), counts, gidx, lval
+
+
+def hf_delta_export(gen, snaps: dict, entry_fn):
+    """STEADY export: wrap a raw ``(name, local_shard, spec)`` exporter into final
+    HF-coordinate delta entries ``(slots, dtype_str, counts, hf_idx, hf_val,
+    gather_group)`` -- diff against the pinned snapshot, refresh it, then hand the
+    shard-local delta to ``entry_fn(name, spec, place, lidx, lval)``, the engine's
+    per-param entry builder (FSDP: identity only; veomni adds the EP converter).
+    The delta engine consumes these entries verbatim (batch -> gather -> wire); no
+    spec, no placement and no conversion cross the boundary. Requires a prior seed
+    pass."""
+    from verl.checkpoint_engine.delta_sync.sparse_gather import shard_delta_indices
+
+    from .spec import derive_placement
+
+    for name, local, spec in gen:
+        local = local.detach().contiguous().view(-1)
+        snap = snaps.get(name)
+        assert snap is not None and snap.numel() == local.numel(), (
+            f"{name}: no seed snapshot for this shard; run the seed export first"
+        )
+        place, contributes, pg = derive_placement(spec)
+        if contributes:
+            base = snap.to(local.device, non_blocking=True)
+            lidx, lval = shard_delta_indices(local, base, 0)
+        else:
+            # replicated param owned by another rank; empty delta keeps lockstep.
+            lidx = torch.empty(0, dtype=torch.int64, device=local.device)
+            lval = torch.empty(0, dtype=local.dtype, device=local.device)
+        snap.copy_(local, non_blocking=True)
+        yield (*entry_fn(name, spec, place, lidx, lval), pg)
+
+
+def prime_delta_snapshots(gen, snaps: dict) -> None:
+    """Pin each rank's current shards to CPU as the steady diff base. Run right
+    after the seed's full-weight sync: weights do not move during the sync, so
+    the snapshots equal exactly what the rollout side received."""
+    from verl.utils.device import is_cuda_available
+
+    for name, local, _spec in gen:
+        local = local.detach().contiguous().view(-1)
+        snap = snaps.get(name)
+        if snap is None or snap.numel() != local.numel():
+            # pinned host memory needs an accelerator context; degrade gracefully
+            # on CPU-only environments (unit tests) where pinning is meaningless.
+            snap = torch.empty_like(local, device="cpu", pin_memory=is_cuda_available)
+            snaps[name] = snap
+        snap.copy_(local, non_blocking=True)

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -583,6 +583,16 @@ class VeOmniEngine(FSDPEngine):
         if self._is_offload_optimizer:
             offload_veomni_optimizer(self.optimizer)
 
+    def get_per_tensor_param_shard(self, **kwargs):
+        # veomni splits grouped experts twice (manual ep split outside DTensor +
+        # FSDP-sharded local block); the inherited DTensor-identity export would
+        # declare the wrong full tensor for them and corrupt the rollout weights
+        # silently. The EP-aware export lands in the follow-up PR.
+        raise NotImplementedError(
+            "delta_sharded does not support the veomni backend yet (EP-aware shard "
+            "export lands in a follow-up PR); use a full-sync checkpoint backend"
+        )
+
     def get_per_tensor_param(self, **kwargs):
         # FSDP2 CPUOffloadPolicy owns CPU<->accelerator placement; calling model.to(device)
         # here leaves the module half-moved and crashes state_dict() below (#5995). The

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -748,10 +748,20 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         # 0. send_weights only for async training with disaggregated trainer and rollout
         if effective_mode != "naive":
-            # The sharded delta engine diffs each rank's local FSDP shard (no all-gather),
-            # so it consumes the sharded param generator instead of the full-tensor one.
+            # Sharded delta: the SEED sync streams the backend's full HF export
+            # (assembly/conversion is the backend's own full-export logic, so
+            # Megatron/veomni and trainer resume work by construction), then the
+            # backend pins its shards as the diff base; every later sync ships the
+            # BACKEND-computed HF-coordinate delta.
             if effective_mode == "delta_sharded":
-                per_tensor_param, _ = self.actor.engine.get_per_tensor_param_shard()
+                if getattr(self.checkpoint_engine, "needs_seed", True):
+                    per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
+                    metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
+                    # weights do not move during the sync, so the snapshots equal
+                    # exactly what the rollout just received.
+                    self.actor.engine.prime_delta_snapshots()
+                    return metrics or {}
+                per_tensor_param, _ = self.actor.engine.get_per_tensor_param_delta_shard()
             else:
                 per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
             metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -748,22 +748,12 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         # 0. send_weights only for async training with disaggregated trainer and rollout
         if effective_mode != "naive":
-            # Sharded delta: the SEED sync streams the backend's full HF export
-            # (assembly/conversion is the backend's own full-export logic, so
-            # Megatron/veomni and trainer resume work by construction), then the
-            # backend pins its shards as the diff base; every later sync ships the
-            # BACKEND-computed HF-coordinate delta.
             if effective_mode == "delta_sharded":
-                if getattr(self.checkpoint_engine, "needs_seed", True):
-                    per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
-                    metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
-                    # weights do not move during the sync, so the snapshots equal
-                    # exactly what the rollout just received.
-                    self.actor.engine.prime_delta_snapshots()
-                    return metrics or {}
-                per_tensor_param, _ = self.actor.engine.get_per_tensor_param_delta_shard()
-            else:
-                per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
+                # the delta engine owns the sync state machine (seed vs steady,
+                # snapshot prime), so it drives the training engine itself.
+                metrics = await self.checkpoint_engine.send_weights(self.actor.engine, global_steps=global_steps)
+                return metrics or {}
+            per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
             metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
             return metrics or {}
 

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import json
 import math
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 
 import torch
@@ -54,7 +55,7 @@ CHUNK_BYTES = 512 << 20
 LOADER_FQN = "verl.workers.rollout.sglang_rollout.delta_loader.apply_delta"
 
 
-def apply_delta(model, named_tensors) -> None:
+def apply_delta(model: torch.nn.Module, named_tensors: Iterable[tuple[str, torch.Tensor]]) -> None:
     """Decode one sparse delta flush and masked-apply it onto ``model`` in place."""
     from verl.checkpoint_engine.delta_sync.encode import checksum as _checksum
 
@@ -62,7 +63,7 @@ def apply_delta(model, named_tensors) -> None:
     spec = json.loads(bytes(tensors["__delta_spec__"].cpu().numpy().tobytes()).decode())
     values = tensors["__values__"]
     positions = tensors.get("__positions__")
-    if positions is None:  # dense flush (first sync) carries values only
+    if positions is None:  # values-only flush (the seed) carries no positions
         positions = torch.empty(0, dtype=torch.uint8, device=values.device)
 
     got = _checksum(positions, values)
@@ -92,7 +93,7 @@ def apply_delta(model, named_tensors) -> None:
             model.load_weights(chunk)
 
 
-def _apply_dense(model, params: list[dict], values: torch.Tensor) -> None:
+def _apply_dense(model: torch.nn.Module, params: list[dict], values: torch.Tensor) -> None:
     """Apply a dense (full-coverage) flush: plain chunked load, no masking needed."""
     chunk: list[tuple[str, torch.Tensor]] = []
     chunk_bytes = 0
@@ -135,7 +136,7 @@ def _decode_one(encoding: str, positions: torch.Tensor, values: torch.Tensor, p:
 
 
 @contextmanager
-def _masked_copy():
+def _masked_copy() -> Iterator[None]:
     """Temporarily make ``Tensor.copy_`` skip NaN positions in the source.
 
     SGLang's per-model ``load_weights`` ultimately lands on ``param.copy_(loaded)``
@@ -145,12 +146,15 @@ def _masked_copy():
     """
     orig_copy = torch.Tensor.copy_
 
-    def masked_copy_(self, src, *args, **kwargs):
+    def masked_copy_(self: torch.Tensor, src: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        # Sync-free masked overwrite: boolean advanced indexing (and a
+        # ``mask.all()`` early-out) would force a device->host sync per
+        # parameter -- ruinous for MoE flushes carrying >10k per-expert
+        # entries. ``torch.where`` keeps everything on-stream; a NaN-free
+        # (dense) source degenerates to a plain copy.
         if isinstance(src, torch.Tensor) and src.is_floating_point() and self.shape == src.shape:
-            mask = ~torch.isnan(src)
-            if not bool(mask.all()):
-                self[mask] = src[mask].to(self.dtype)
-                return self
+            cast = src.to(self.dtype)
+            return orig_copy(self, torch.where(torch.isnan(cast), self, cast))
         return orig_copy(self, src, *args, **kwargs)
 
     torch.Tensor.copy_ = masked_copy_


### PR DESCRIPTION
## What does this PR do?

First half of the #7085 split requested in review: the sharded delta weight sync (`delta_sharded`, #6974) engine core and the FSDP backend. Extends the flat FSDP2 `Shard(0)` fast path to **block placements** (`Shard(k)`, multi-Shard-dim meshes, manual splits) and moves the whole weight→HF pipeline onto the backend side of the contract. The veomni FSDP2+EP consumer stays in #7085 (stacked on this PR). Item 1 of the #7060 roadmap and the `Shard(1)` support requested in the #6974 review.

### Engine core

- `ShardSpec` gains `BlockPlacement` (`local_shape`, `global_offset`): a rank's shard as one hyper-rectangular block of the full tensor. `translate_flat_indices` maps shard-local flat positions to full-tensor flat positions (mixed-radix decompose + per-dim offset + recompose); the existing `int` flat-offset fast path is untouched, so FSDP2 `Shard(0)` behavior is bit-identical.
- `derive_placement`: `Shard(k!=0)` and multi-Shard-dim placements return a `BlockPlacement`; multi-Shard meshes gather over one flattened whole-mesh group (created once, cached). `_StridedShard` and Replicate-alongside-multi-Shard are rejected loudly.
- **Export contract (backend-owned HF delta)**: the delta engine consumes FINAL HF-coordinate entries `(slots, dtype_str, counts, hf_idx, hf_val, gather_group)` — the weight→HF naming, the to-HF conversion, the diff and its snapshot all live on the backend side (`verl.workers.engine.utils.hf_delta_export` / `prime_delta_snapshots`; the snapshot refresh is fused into the steady diff pass). The **seed** (first sync, `needs_seed`) streams the backend's existing `get_per_tensor_param()` full export over a values-only wire, so every backend's full-assembly path (and trainer resume) is inherited for free. The engine keeps only collectives, bucketing and the wire.
- Sync-free masked apply in the SGLang delta loader: the previous per-parameter `bool(mask.all())` + boolean indexing did one device→host sync each; rewritten as an on-stream `torch.where` copy.

### FSDP backend

- `get_per_tensor_param_shard`: pure side-effect-free export of raw DTensor shards `(name, local_flat, ShardSpec)`.
- `_hf_delta_entry`: identity profile (weight name == HF name) translating shard-local deltas to within-param coordinates; converter-style specs fail loud.
- veomni + `delta_sharded` raises `NotImplementedError` until the EP-aware export lands (#7085) — the inherited identity export would silently mis-declare veomni's manually-split experts.

## Test

- CPU: `tests/checkpoint_engine/test_block_placement.py` (translate math vs full-tensor coordinates, block NaN rebuild, explicit-place passthrough) and `test_sharded_delta.py` (diff/gather/export contract, prime→delta roundtrip, seed-required fail-loud); 23 pass, bit-exact.
- E2E (H100, GSM8K GRPO, V1 `separate_async`, SGLang rollout; steady-state `timing_s/update_weights`):

| model (placement) | `delta_sharded` | `nccl` (full broadcast) | speedup |
|---|---|---|---|
| Qwen2.5-7B (1+1 nodes) | **3.9–4.9 s** | 5.5–6.0 s | ~1.3× |
| Qwen2.5-32B (2+2 nodes) | **11.2–11.9 s** | 17.7–18.1 s | 1.55× |
| Qwen2.5-32B (2+2, offload off) | **6.2 s** | 14.2 s | 2.3× |
| Qwen2.5-72B (4+4, gen TP8, offload off) | **12.0–13.0 s** | 28.5–29.1 s | 2.3× |

- 200-step GRPO equivalence at 7B (delta vs nccl, 400 syncs): reward trajectories track phase-for-phase, zero receiver checksum failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)