### PR TITLE
[vllm] fix: guard legacy FusedMoE loader patch

### DIFF
--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -32,6 +32,28 @@ def vllm_v013_weight_loader_method_wrapper(fn):
     return wrapper
 
 
+def _patch_legacy_fused_moe_weight_loader(fused_moe) -> bool:
+    """Install the NPU transpose wrapper on vLLM's legacy FusedMoE class.
+
+    Legacy vLLM releases expose ``FusedMoE`` as a class whose
+    ``weight_loader`` can be wrapped at class level. Modular vLLM releases
+    expose ``FusedMoE`` as a factory function, so this class-level patch is
+    not applicable. Loader and layout handling for constructed modules is
+    owned by their runtime and backend-specific weight-loading paths.
+    """
+    weight_loader = getattr(fused_moe, "weight_loader", None)
+    if not isinstance(fused_moe, type) or not callable(weight_loader):
+        return False
+
+    if getattr(weight_loader, "_verl_npu_weight_loader_patched", False):
+        return True
+
+    wrapped_weight_loader = vllm_v013_weight_loader_method_wrapper(weight_loader)
+    wrapped_weight_loader._verl_npu_weight_loader_patched = True
+    fused_moe.weight_loader = wrapped_weight_loader
+    return True
+
+
 def patch_vllm013_rotary_emb():
     from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 
@@ -66,10 +88,10 @@ def apply_npu_vllm_patches() -> None:
         from vllm.model_executor.layers.fused_moe import FusedMoE
 
         patch_vllm013_rotary_emb()
-        FusedMoE.weight_loader = vllm_v013_weight_loader_method_wrapper(FusedMoE.weight_loader)
+        _patch_legacy_fused_moe_weight_loader(FusedMoE)
     elif _VLLM_VERSION >= version.parse("0.18.0"):
         # Disable flash_attn in RotaryEmbedding (NPU) when VLLM >= 0.18
         from vllm.model_executor.layers.fused_moe import FusedMoE
 
         patch_vllm013_rotary_emb()
-        FusedMoE.weight_loader = vllm_v013_weight_loader_method_wrapper(FusedMoE.weight_loader)
+        _patch_legacy_fused_moe_weight_loader(FusedMoE)


### PR DESCRIPTION
### What does this PR do?

Fixes `AttributeError: 'function' object has no attribute 'weight_loader'` when importing `verl.utils.vllm` with modular vLLM.Use latest vllm-ascend&verl&vllm.
<img width="834" height="66" alt="PixPin_2026-07-25_15-32-29" src="https://github.com/user-attachments/assets/771f2fc7-bb33-447d-904a-98761e9217f4" />


The legacy class-level loader patch is now applied only when `FusedMoE` is a class with a callable `weight_loader`. Existing legacy behavior is preserved and repeated patching is idempotent.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
<img width="640" height="320" alt="PixPin_2026-07-25_15-31-37" src="https://github.com/user-attachments/assets/ace20c95-6e74-472f-8278-004c9fd4add2" />

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

