### PR TITLE
[megatron, vllm] feat: support dynamic MXFP4 rollout weight updates

### DIFF
--- a/docs/low_precision/nvfp4_qat.md
+++ b/docs/low_precision/nvfp4_qat.md
@@ -1,13 +1,21 @@
-# NVFP4 QAT (Quantization-Aware Training) in verl
+# FP4 QAT (Quantization-Aware Training) in verl
 
 Last updated: 04/02/2026
 
-verl supports NVFP4 Quantization-Aware Training (QAT), which applies fake quantization during training so the model learns to tolerate NVFP4 quantization error. At rollout time, weights are packed into real NVFP4 format for vLLM inference. This closes the precision gap between training and inference, preventing KL divergence explosion.
+verl supports NVFP4 and OCP MXFP4 Quantization-Aware Training (QAT). QAT
+applies fake quantization during training so the model learns to tolerate the
+same representation used by rollout. At each weight resync, verl packs the
+BF16 master weights into real FP4 weights and loads them into vLLM.
 
 | Training Backend | Training Precision | Rollout Precision | vLLM Quant Method |
 |---|---|---|---|
 | **FSDP** | BF16 + fake quantization | NVFP4 W4A16 | `compressed-tensors` |
-| **Megatron** | BF16 + fake quantization | NVFP4 W4A16 | `modelopt` |
+| **Megatron** | BF16 + fake quantization | NVFP4 W4A16 | `compressed-tensors` or `modelopt` |
+
+MXFP4 currently uses the Megatron backend and vLLM's `compressed-tensors`
+path. The exporter produces E2M1 weights packed along the input dimension and
+one E8M0 scale per 32 values. Dense and MoE rollout layers use vLLM's
+`oracle.mxfp4` kernel selection.
 
 > [!TIP]
 > For ready-to-run scripts, environment setup, and experimental results, see the [QAT recipe](https://github.com/verl-project/verl-recipe/tree/main/qat).
@@ -26,6 +34,7 @@ actor_rollout_ref:
     fsdp_config:
       qat:
         enable: true
+        apply_modelopt_fake_quant: true
         mode: "w4a16"
         group_size: 16
         ignore_patterns:
@@ -64,20 +73,50 @@ actor_rollout_ref:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `megatron.qat.enable` | Enable QAT | `False` |
+| `megatron.qat.apply_modelopt_fake_quant` | Apply ModelOpt training fake quantization; disable when another backend supplies it | `True` |
 | `megatron.qat.mode` | Quantization mode | `"w4a16"` |
 | `megatron.qat.group_size` | Quantization group size | `16` |
 | `megatron.qat.ignore_patterns` | Layers to skip. Uses `fnmatch` glob syntax | `["lm_head", "*mlp.gate"]` |
 | `megatron.qat.quantization_config_path` | vLLM quantization config JSON path | Required |
+
+### MXFP4 with Megatron
+
+Set `mode` to `mxfp4`, use block size 32, and select the
+`compressed-tensors` example config:
+
+```yaml
+actor_rollout_ref:
+  actor:
+    megatron:
+      qat:
+        enable: true
+        apply_modelopt_fake_quant: false
+        mode: "mxfp4"
+        group_size: 32
+        ignore_patterns:
+          - "lm_head"
+          - "*mlp.gate"
+        quantization_config_path: "examples/qat/mxfp4_w4a16.json"
+```
+
+The dynamic resync path in `verl.utils.qat.vllm_patch` requires a
+`compressed-tensors` rollout config. `enable: true` keeps online quantized
+weight export active. Set `apply_modelopt_fake_quant: false` for a rollout-QAT
+off arm or when a backend-specific `impl_cfg.qat` supplies training fake
+quantization; this prevents two fake-quant layers from being applied. A BF16
+rollout is not a valid control for measuring whether MXFP4 QAT closes the
+train/rollout precision gap.
 
 ---
 
 ## Support Matrix
 
 - NVFP4 W4A16 (weight-only FP4 quantization)
+- MXFP4 W4A16 (weight-only FP4 quantization, block size 32)
 - Dense models and MoE models
 - FSDP and Megatron training backends
 - Full quantization and FFN-only quantization strategies
-- Verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base
+- Existing NVFP4 recipes cover Qwen3-8B-Base and Qwen3-30B-A3B-Base
 
 ---
 

--- a/examples/qat/mxfp4_w4a16.json
+++ b/examples/qat/mxfp4_w4a16.json
@@ -1,0 +1,36 @@
+{
+    "quant_method": "compressed-tensors",
+    "format": "mxfp4-pack-quantized",
+    "quantization_status": "compressed",
+    "config_groups": {
+        "group_0": {
+            "format": "mxfp4-pack-quantized",
+            "targets": [
+                "Linear"
+            ],
+            "weights": {
+                "actorder": null,
+                "block_structure": null,
+                "dynamic": false,
+                "group_size": 32,
+                "num_bits": 4,
+                "observer": "memoryless_minmax",
+                "observer_kwargs": {},
+                "scale_dtype": "torch.uint8",
+                "strategy": "group",
+                "symmetric": true,
+                "type": "float",
+                "zp_dtype": null
+            },
+            "input_activations": null,
+            "output_activations": null
+        }
+    },
+    "ignore": [
+        "lm_head"
+    ],
+    "kv_cache_scheme": null,
+    "sparsity_config": {},
+    "transform_config": {},
+    "global_compression_ratio": null
+}

--- a/tests/utils/modelopt/test_qat_weight_exporter_on_cpu.py
+++ b/tests/utils/modelopt/test_qat_weight_exporter_on_cpu.py
@@ -1,0 +1,166 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def _install_exporter_dependencies(monkeypatch):
+    quant_utils = types.ModuleType("modelopt.torch.export.quant_utils")
+    quant_utils.QUANTIZATION_NONE = "none"
+    quant_utils.QUANTIZATION_NVFP4 = "nvfp4"
+    quant_utils.QUANTIZATION_MXFP4 = "mxfp4"
+    quant_utils.get_quantization_format = lambda module: "none"
+    quant_utils.get_weight_block_size = lambda module: 0
+    quant_utils.to_quantized_weight = lambda *args, **kwargs: None
+
+    class FakeNVFP4QTensor:
+        @staticmethod
+        def get_weights_scaling_factor(weight, block_size, weights_scaling_factor_2):
+            return (torch.ones(weight.shape[-1] // block_size),)
+
+    class FakeMXFP4QTensor:
+        @classmethod
+        def quantize(cls, weight, block_size):
+            scale = torch.arange(weight.numel() // block_size, dtype=torch.uint8).reshape(-1, 1)
+            return SimpleNamespace(_quantized_data=torch.empty(0, dtype=torch.uint8)), scale
+
+    modules = {
+        "modelopt": types.ModuleType("modelopt"),
+        "modelopt.torch": types.ModuleType("modelopt.torch"),
+        "modelopt.torch.export": types.ModuleType("modelopt.torch.export"),
+        "modelopt.torch.export.quant_utils": quant_utils,
+        "modelopt.torch.quantization": types.ModuleType("modelopt.torch.quantization"),
+        "modelopt.torch.quantization.qtensor": types.ModuleType("modelopt.torch.quantization.qtensor"),
+        "modelopt.torch.quantization.qtensor.nvfp4_tensor": types.ModuleType(
+            "modelopt.torch.quantization.qtensor.nvfp4_tensor"
+        ),
+        "modelopt.torch.quantization.qtensor.mxfp4_tensor": types.ModuleType(
+            "modelopt.torch.quantization.qtensor.mxfp4_tensor"
+        ),
+    }
+    modules["modelopt.torch.quantization.qtensor.nvfp4_tensor"].NVFP4QTensor = FakeNVFP4QTensor
+    modules["modelopt.torch.quantization.qtensor.mxfp4_tensor"].MXFP4QTensor = FakeMXFP4QTensor
+
+    megatron_utils = types.ModuleType("verl.utils.megatron_utils")
+    megatron_utils.unwrap_model = lambda model: model
+    modules["verl.utils.megatron_utils"] = megatron_utils
+    modelopt_package = types.ModuleType("verl.utils.modelopt")
+    modelopt_package.__path__ = [str(Path(__file__).parents[3] / "verl" / "utils" / "modelopt")]
+    modules["verl.utils.modelopt"] = modelopt_package
+
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    sys.modules.pop("verl.utils.modelopt.qat_weight_exporter", None)
+    return importlib.import_module("verl.utils.modelopt.qat_weight_exporter")
+
+
+def test_mxfp4_export_packs_last_dimension_and_reshapes_block_scales(monkeypatch):
+    exporter_module = _install_exporter_dependencies(monkeypatch)
+    weight = torch.arange(2 * 96, dtype=torch.float32).reshape(2, 96)
+    expected_packed = torch.arange(2 * 48, dtype=torch.uint8).reshape(2, 48)
+    calls = []
+
+    def fake_to_quantized_weight(weight_arg, scale, qformat, scale_2=None, block_size=None):
+        calls.append((weight_arg, scale.clone(), qformat, scale_2, block_size))
+        return expected_packed
+
+    monkeypatch.setattr(exporter_module, "to_quantized_weight", fake_to_quantized_weight)
+    exporter = object.__new__(exporter_module.QATWeightExporter)
+    meta = exporter_module._QuantMeta(qformat="mxfp4", block_size=32, weight_amax=None)
+
+    result = list(exporter._quantize_mxfp4("model.layers.0.mlp.experts.0.gate_proj.weight", weight, meta))
+
+    assert [name for name, _ in result] == [
+        "model.layers.0.mlp.experts.0.gate_proj.weight",
+        "model.layers.0.mlp.experts.0.gate_proj.weight_scale",
+    ]
+    assert torch.equal(result[0][1], expected_packed)
+    assert result[1][1].shape == (2, 3)
+    assert result[1][1].dtype == torch.uint8
+    assert calls[0][2:] == ("mxfp4", None, 32)
+    assert torch.equal(calls[0][1], result[1][1])
+
+
+def test_mxfp4_export_rejects_non_ocp_block_size(monkeypatch):
+    exporter_module = _install_exporter_dependencies(monkeypatch)
+    exporter = object.__new__(exporter_module.QATWeightExporter)
+    meta = exporter_module._QuantMeta(qformat="mxfp4", block_size=16, weight_amax=None)
+
+    with pytest.raises(ValueError, match="block size 32"):
+        list(exporter._quantize_mxfp4("model.layers.0.mlp.experts.0.down_proj.weight", torch.ones(2, 32), meta))
+
+
+def test_process_weights_iterator_dispatches_mxfp4(monkeypatch):
+    exporter_module = _install_exporter_dependencies(monkeypatch)
+    exporter = object.__new__(exporter_module.QATWeightExporter)
+    meta = exporter_module._QuantMeta(qformat="mxfp4", block_size=32, weight_amax=None)
+    monkeypatch.setattr(exporter, "_resolve_quant_metadata", lambda name: meta)
+    monkeypatch.setattr(
+        exporter,
+        "_quantize_mxfp4",
+        lambda name, weight, metadata: iter([(name + ".mxfp4", weight)]),
+        raising=False,
+    )
+
+    result = list(
+        exporter.process_weights_iterator(iter([("model.layers.0.mlp.experts.0.up_proj.weight", torch.ones(1))]))
+    )
+
+    assert result[0][0].endswith(".mxfp4")
+
+
+def test_export_only_mode_synthesizes_mxfp4_metadata_and_honors_ignores(monkeypatch):
+    exporter_module = _install_exporter_dependencies(monkeypatch)
+    exporter = object.__new__(exporter_module.QATWeightExporter)
+    exporter._metadata = {}
+    exporter._registry = SimpleNamespace(_reverse_patterns=[])
+    exporter._use_modelopt_fake_quant = False
+    exporter.qat_mode = "mxfp4"
+    exporter._block_size = 32
+    exporter._ignore_patterns = ["lm_head", "embed_tokens", "re:.*mlp\\.gate$"]
+
+    meta = exporter._resolve_quant_metadata("model.layers.0.mlp.experts.0.gate_proj.weight")
+
+    assert meta.qformat == "mxfp4"
+    assert meta.block_size == 32
+    assert exporter._resolve_quant_metadata("model.layers.0.mlp.gate.weight") is None
+    assert exporter._resolve_quant_metadata("model.embed_tokens.weight") is None
+
+
+def test_nvfp4_export_only_mode_computes_current_weight_amax(monkeypatch):
+    exporter_module = _install_exporter_dependencies(monkeypatch)
+    calls = []
+
+    def fake_to_quantized_weight(weight, scale, qformat, scale_2=None, block_size=None):
+        calls.append((scale_2.clone(), qformat, block_size))
+        return torch.zeros(weight.shape[0], weight.shape[1] // 2, dtype=torch.uint8)
+
+    monkeypatch.setattr(exporter_module, "to_quantized_weight", fake_to_quantized_weight)
+    exporter = object.__new__(exporter_module.QATWeightExporter)
+    weight = torch.tensor([[1.0, -7.0] * 8])
+    meta = exporter_module._QuantMeta(qformat="nvfp4", block_size=16, weight_amax=None)
+
+    list(exporter._quantize_nvfp4("model.layers.0.self_attn.q_proj.weight", weight, meta))
+
+    assert calls[0][0].item() == pytest.approx(7.0 / (6.0 * 448.0))
+    assert calls[0][1:] == ("nvfp4", 16)

--- a/tests/utils/modelopt/test_quantize_on_cpu.py
+++ b/tests/utils/modelopt/test_quantize_on_cpu.py
@@ -1,0 +1,82 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parents[3]
+
+
+def _load_quantize(monkeypatch):
+    mtq = types.ModuleType("modelopt.torch.quantization")
+    mtq.normalize_quant_cfg_list = lambda config: [config]
+    config_module = types.ModuleType("modelopt.torch.quantization.config")
+    config_module._default_disabled_quantizer_cfg = {}
+
+    modules = {
+        "modelopt": types.ModuleType("modelopt"),
+        "modelopt.torch": types.ModuleType("modelopt.torch"),
+        "modelopt.torch.quantization": mtq,
+        "modelopt.torch.quantization.config": config_module,
+    }
+    modelopt_package = types.ModuleType("verl.utils.modelopt")
+    modelopt_package.__path__ = [str(_REPO_ROOT / "verl" / "utils" / "modelopt")]
+    modules["verl.utils.modelopt"] = modelopt_package
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    sys.modules.pop("verl.utils.modelopt.quantize", None)
+    return importlib.import_module("verl.utils.modelopt.quantize")
+
+
+def test_build_mxfp4_weight_only_config_is_dynamic_block32(monkeypatch):
+    quantize = _load_quantize(monkeypatch)
+
+    config = quantize.build_quantize_config("mxfp4")
+    quant_cfg = config["quant_cfg"][0]
+
+    assert quant_cfg["*weight_quantizer"] == {
+        "num_bits": (2, 1),
+        "block_sizes": {-1: 32, "type": "dynamic", "scale_bits": (8, 0)},
+        "axis": None,
+        "enable": True,
+    }
+    assert quant_cfg["*input_quantizer"] == {"enable": False}
+    assert config["algorithm"] is None
+
+
+def test_mxfp4_rollout_config_matches_exporter_contract():
+    with (_REPO_ROOT / "examples" / "qat" / "mxfp4_w4a16.json").open() as stream:
+        config = json.load(stream)
+
+    group = config["config_groups"]["group_0"]
+    assert config["quant_method"] == "compressed-tensors"
+    assert config["format"] == "mxfp4-pack-quantized"
+    assert group["weights"]["group_size"] == 32
+    assert group["weights"]["scale_dtype"] == "torch.uint8"
+    assert group["weights"]["type"] == "float"
+    assert group["input_activations"] is None
+
+
+def test_qat_engine_config_can_export_without_second_fake_quant_layer():
+    from verl.workers.config.engine import QATEngineConfig
+
+    config = QATEngineConfig(enable=True, apply_modelopt_fake_quant=False, mode="mxfp4", group_size=32)
+
+    assert config.enable is True
+    assert config.apply_modelopt_fake_quant is False

--- a/tests/utils/qat/test_vllm_patch_mxfp4_on_cpu.py
+++ b/tests/utils/qat/test_vllm_patch_mxfp4_on_cpu.py
@@ -1,0 +1,177 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from verl.utils.qat import vllm_patch
+
+
+class _FakeMxfp4Method:
+    def get_fused_moe_quant_config(self, layer):
+        return None
+
+
+class _FakeMxfp4Layer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_parameter("w13_weight_packed", self._param((2, 8, 16)))
+        self.register_parameter("w2_weight_packed", self._param((2, 4, 16)))
+        self.register_parameter("w13_weight_scale", self._param((2, 8, 1)))
+        self.register_parameter("w2_weight_scale", self._param((2, 4, 1)))
+
+    @staticmethod
+    def _param(shape):
+        param = torch.nn.Parameter(torch.zeros(shape, dtype=torch.uint8), requires_grad=False)
+        param.weight_loader = lambda *args, **kwargs: None
+        return param
+
+
+class _FakeMxfp4DenseLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_parameter("weight_packed", _FakeMxfp4Layer._param((8, 16)))
+        self.register_parameter("weight_scale", _FakeMxfp4Layer._param((8, 1)))
+
+
+def _fake_original_process(self, layer):
+    layer.w13_weight = torch.nn.Parameter(layer.w13_weight_packed.detach().clone(), requires_grad=False)
+    layer.w2_weight = torch.nn.Parameter(layer.w2_weight_packed.detach().clone(), requires_grad=False)
+    delattr(layer, "w13_weight_packed")
+    delattr(layer, "w2_weight_packed")
+
+
+def _fake_original_dense_process(self, layer):
+    layer.weight = torch.nn.Parameter(layer.weight_packed.detach().clone(), requires_grad=False)
+    delattr(layer, "weight_packed")
+
+
+def _fake_original_current_nvfp4_dense_process(self, layer):
+    layer.weight = torch.nn.Parameter(layer.weight_packed.detach().clone(), requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(layer.weight_scale.detach().clone() + 1, requires_grad=False)
+    delattr(layer, "weight_packed")
+
+
+def _fake_original_current_nvfp4_moe_process(self, layer):
+    _fake_original_process(self, layer)
+    layer.w13_weight_scale = torch.nn.Parameter(layer.w13_weight_scale.detach().clone() + 1, requires_grad=False)
+    layer.w2_weight_scale = torch.nn.Parameter(layer.w2_weight_scale.detach().clone() + 1, requires_grad=False)
+
+
+def test_current_nvfp4_dense_patch_preserves_compute_addresses(monkeypatch):
+    monkeypatch.setitem(
+        vllm_patch._original_current_nvfp4_dense_process_weights_after_loading,
+        _FakeMxfp4Method,
+        _fake_original_current_nvfp4_dense_process,
+    )
+    layer = _FakeMxfp4DenseLayer()
+    method = _FakeMxfp4Method()
+
+    vllm_patch.patched_current_nvfp4_dense_process_weights_after_loading(method, layer)
+    original_ptrs = {name: getattr(layer, name).data_ptr() for name in ("weight", "weight_scale")}
+
+    model = torch.nn.Module()
+    model.add_module("linear", layer)
+    vllm_patch.prepare_qat_for_load_weights(model, device=torch.device("cpu"))
+    layer.weight_packed.fill_(5)
+    layer.weight_scale.fill_(7)
+    vllm_patch.patched_current_nvfp4_dense_process_weights_after_loading(method, layer)
+
+    assert torch.all(layer.weight == 5)
+    assert torch.all(layer.weight_scale == 8)
+    assert {name: getattr(layer, name).data_ptr() for name in ("weight", "weight_scale")} == original_ptrs
+
+
+def test_current_nvfp4_moe_patch_preserves_compute_addresses(monkeypatch):
+    monkeypatch.setattr(
+        vllm_patch,
+        "_original_current_nvfp4_moe_process_weights_after_loading",
+        _fake_original_current_nvfp4_moe_process,
+    )
+    layer = _FakeMxfp4Layer()
+    method = _FakeMxfp4Method()
+
+    vllm_patch.patched_current_nvfp4_moe_process_weights_after_loading(method, layer)
+    original_ptrs = {
+        name: getattr(layer, name).data_ptr()
+        for name in ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale")
+    }
+
+    model = torch.nn.Module()
+    model.add_module("experts", layer)
+    vllm_patch.prepare_qat_for_load_weights(model, device=torch.device("cpu"))
+    layer.w13_weight_packed.fill_(3)
+    layer.w2_weight_packed.fill_(4)
+    layer.w13_weight_scale.fill_(5)
+    layer.w2_weight_scale.fill_(6)
+    vllm_patch.patched_current_nvfp4_moe_process_weights_after_loading(method, layer)
+
+    assert torch.all(layer.w13_weight == 3)
+    assert torch.all(layer.w2_weight == 4)
+    assert torch.all(layer.w13_weight_scale == 6)
+    assert torch.all(layer.w2_weight_scale == 7)
+    assert {
+        name: getattr(layer, name).data_ptr()
+        for name in ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale")
+    } == original_ptrs
+
+
+def test_mxfp4_dense_patch_rebuilds_hf_params_and_preserves_compute_addresses(monkeypatch):
+    monkeypatch.setattr(vllm_patch, "_original_mxfp4_dense_process_weights_after_loading", _fake_original_dense_process)
+    layer = _FakeMxfp4DenseLayer()
+
+    vllm_patch.patched_mxfp4_dense_process_weights_after_loading(object(), layer)
+    original_ptrs = {name: getattr(layer, name).data_ptr() for name in ("weight", "weight_scale")}
+
+    model = torch.nn.Module()
+    model.add_module("linear", layer)
+    vllm_patch.prepare_qat_for_load_weights(model, device=torch.device("cpu"))
+    layer.weight_packed.fill_(5)
+    layer.weight_scale.fill_(7)
+
+    vllm_patch.patched_mxfp4_dense_process_weights_after_loading(object(), layer)
+
+    assert torch.all(layer.weight == 5)
+    assert torch.all(layer.weight_scale == 7)
+    assert {name: getattr(layer, name).data_ptr() for name in ("weight", "weight_scale")} == original_ptrs
+
+
+def test_mxfp4_patch_rebuilds_hf_params_and_preserves_compute_addresses(monkeypatch):
+    monkeypatch.setattr(vllm_patch, "_original_mxfp4_moe_process_weights_after_loading", _fake_original_process)
+    layer = _FakeMxfp4Layer()
+    method = _FakeMxfp4Method()
+
+    vllm_patch.patched_mxfp4_moe_process_weights_after_loading(method, layer)
+    original_ptrs = {
+        name: getattr(layer, name).data_ptr()
+        for name in ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale")
+    }
+
+    model = torch.nn.Module()
+    model.add_module("experts", layer)
+    vllm_patch.prepare_qat_for_load_weights(model, device=torch.device("cpu"))
+    layer.w13_weight_packed.fill_(7)
+    layer.w2_weight_packed.fill_(9)
+    layer.w13_weight_scale.fill_(11)
+    layer.w2_weight_scale.fill_(13)
+
+    vllm_patch.patched_mxfp4_moe_process_weights_after_loading(method, layer)
+
+    assert torch.all(layer.w13_weight == 7)
+    assert torch.all(layer.w2_weight == 9)
+    assert torch.all(layer.w13_weight_scale == 11)
+    assert torch.all(layer.w2_weight_scale == 13)
+    assert {
+        name: getattr(layer, name).data_ptr()
+        for name in ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale")
+    } == original_ptrs

--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -242,3 +242,29 @@ def test_vllm_update_weights_syncs_buffers_to_mtp_drafter():
     expected = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
     torch.testing.assert_close(main_model.model.layers[0].e_score_correction_bias, expected)
     torch.testing.assert_close(drafter_model.model.layers[0].e_score_correction_bias, expected)
+
+
+def test_vllm_worker_detects_mxfp4_compressed_tensors_qat():
+    applied = []
+    fake_qat = types.ModuleType("verl.utils.qat")
+    fake_qat.apply_qat_patches = lambda: applied.append(True)
+    previous_qat = sys.modules.get("verl.utils.qat")
+    previous_signal = _vllm_rollout_utils.set_death_signal
+    _vllm_rollout_utils.set_death_signal = lambda: None
+
+    class _Mxfp4QuantConfig:
+        quant_format = "mxfp4-pack-quantized"
+
+    vllm_config = types.SimpleNamespace(quant_config=_Mxfp4QuantConfig())
+    try:
+        sys.modules["verl.utils.qat"] = fake_qat
+        worker = vLLMColocateWorkerExtension(vllm_config=vllm_config)
+    finally:
+        _vllm_rollout_utils.set_death_signal = previous_signal
+        if previous_qat is None:
+            sys.modules.pop("verl.utils.qat", None)
+        else:
+            sys.modules["verl.utils.qat"] = previous_qat
+
+    assert worker._is_qat_model
+    assert applied == [True]

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -77,6 +77,7 @@ actor_rollout_ref:
       qat:
         _target_: verl.workers.config.QATEngineConfig
         enable: false
+        apply_modelopt_fake_quant: true
         mode: w4a16
         group_size: 16
         ignore_patterns:
@@ -278,6 +279,7 @@ actor_rollout_ref:
       qat:
         _target_: verl.workers.config.QATEngineConfig
         enable: false
+        apply_modelopt_fake_quant: true
         mode: w4a16
         group_size: 16
         ignore_patterns:
@@ -602,6 +604,7 @@ critic:
     qat:
       _target_: verl.workers.config.QATEngineConfig
       enable: false
+      apply_modelopt_fake_quant: true
       mode: w4a16
       group_size: 16
       ignore_patterns:

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -74,7 +74,7 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only). "w4a4" is experimental and not recommended.
+  # Quantization mode: "w4a16" (weight-only). Megatron also supports "mxfp4".
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -139,11 +139,14 @@ router_replay:
 # QAT (Quantization-Aware Training) configuration
 qat:
   _target_: verl.workers.config.QATEngineConfig
-  # Whether to enable QAT
+  # Whether to enable online quantized weight export for low-precision rollout
   enable: false
-  # Quantization mode: "w4a16" (weight-only FP4) or "w4a4" (weight + activation FP4)
+  # Disable when impl_cfg.qat supplies training fake quantization. Export
+  # remains active, avoiding a second ModelOpt fake-quant layer.
+  apply_modelopt_fake_quant: true
+  # Quantization mode: "w4a16" (NVFP4 weight-only), "mxfp4" (OCP MXFP4 weight-only), or "w4a4"
   mode: "w4a16"
-  # Group size for blockwise quantization (NVFP4 requires 16)
+  # Group size for blockwise quantization (NVFP4 requires 16; MXFP4 requires 32)
   group_size: 16
   # Module name patterns to exclude from quantization (fnmatch style for Megatron)
   ignore_patterns:

--- a/verl/utils/modelopt/__init__.py
+++ b/verl/utils/modelopt/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""ModelOpt integration for NVFP4 quantization with Megatron QAT training and vLLM inference."""
+"""ModelOpt integration for FP4 quantization with Megatron QAT training and vLLM inference."""
 
 from verl.utils.modelopt.qat_utils import apply_qat_to_modules, export_qat_weights
 from verl.utils.modelopt.qat_weight_exporter import QATWeightExporter

--- a/verl/utils/modelopt/qat_utils.py
+++ b/verl/utils/modelopt/qat_utils.py
@@ -37,9 +37,9 @@ def apply_qat_to_modules(modules, qat_config):
     return modules
 
 
-def export_qat_weights(per_tensor_param, modules, qat_mode, bridge):
+def export_qat_weights(per_tensor_param, modules, qat_config, bridge):
     """Process exported weights through QATWeightExporter for quantized weight sync."""
     from verl.utils.modelopt.qat_weight_exporter import QATWeightExporter
 
-    qat_weight_exporter = QATWeightExporter(modules, bridge, qat_mode)
+    qat_weight_exporter = QATWeightExporter(modules, bridge, qat_config)
     return qat_weight_exporter.process_weights_iterator(per_tensor_param)

--- a/verl/utils/modelopt/qat_weight_exporter.py
+++ b/verl/utils/modelopt/qat_weight_exporter.py
@@ -13,20 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""QAT weight exporter for Megatron-to-vLLM NVFP4 quantized weight sync."""
+"""QAT weight exporter for Megatron-to-vLLM FP4 quantized weight sync."""
 
 import re
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from typing import Any, Iterator, Optional
 
 import torch
 from modelopt.torch.export.quant_utils import (
+    QUANTIZATION_MXFP4,
     QUANTIZATION_NONE,
     QUANTIZATION_NVFP4,
     get_quantization_format,
     get_weight_block_size,
     to_quantized_weight,
 )
+from modelopt.torch.quantization.qtensor.mxfp4_tensor import MXFP4QTensor
 from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
 
 from verl.utils.megatron_utils import unwrap_model
@@ -53,9 +56,18 @@ class QATWeightExporter:
         self,
         actor_module: list,
         bridge: Any,
-        qat_mode: str = "w4a16",
+        qat_config: Any = "w4a16",
     ):
-        self.qat_mode = qat_mode
+        if isinstance(qat_config, str):
+            self.qat_mode = qat_config
+            self._block_size = 32 if qat_config == "mxfp4" else 16
+            self._ignore_patterns = []
+            self._use_modelopt_fake_quant = True
+        else:
+            self.qat_mode = getattr(qat_config, "mode", "w4a16")
+            self._block_size = getattr(qat_config, "group_size", 32 if self.qat_mode == "mxfp4" else 16)
+            self._ignore_patterns = list(getattr(qat_config, "ignore_patterns", []))
+            self._use_modelopt_fake_quant = getattr(qat_config, "apply_modelopt_fake_quant", True)
         self._actor_module = actor_module
 
         self._registry = self._get_mapping_registry(bridge)
@@ -97,9 +109,12 @@ class QATWeightExporter:
             meta = self._resolve_quant_metadata(hf_name)
             if meta is None:
                 yield (hf_name, weight)
-            else:
-                assert meta.qformat == QUANTIZATION_NVFP4, f"Unsupported qformat: {meta.qformat}"
+            elif meta.qformat == QUANTIZATION_NVFP4:
                 yield from self._quantize_nvfp4(hf_name, weight, meta)
+            elif meta.qformat == QUANTIZATION_MXFP4:
+                yield from self._quantize_mxfp4(hf_name, weight, meta)
+            else:
+                raise ValueError(f"Unsupported qformat: {meta.qformat}")
 
     @staticmethod
     def _get_mapping_registry(bridge):
@@ -197,7 +212,21 @@ class QATWeightExporter:
             if meta is not None:
                 return meta
 
+        if not self._use_modelopt_fake_quant and not self._is_ignored(hf_name):
+            qformat = QUANTIZATION_MXFP4 if self.qat_mode == "mxfp4" else QUANTIZATION_NVFP4
+            return _QuantMeta(qformat=qformat, block_size=self._block_size, weight_amax=None)
+
         return None
+
+    def _is_ignored(self, hf_name: str) -> bool:
+        module_name = hf_name.removesuffix(".weight")
+        for pattern in self._ignore_patterns:
+            if pattern.startswith("re:"):
+                if re.search(pattern[3:], module_name):
+                    return True
+            elif pattern in module_name or fnmatch(module_name, pattern):
+                return True
+        return False
 
     def _quantize_nvfp4(
         self,
@@ -213,7 +242,7 @@ class QATWeightExporter:
           ``(weight_scale_2, global_scale_from_amax)``
           ``(input_scale, activation_scale)`` -- only when available
         """
-        w_amax = meta.weight_amax.to(weight.device)
+        w_amax = weight.detach().abs().amax() if meta.weight_amax is None else meta.weight_amax.to(weight.device)
         w_scale_2 = w_amax.float() / _NVFP4_AMAX_DENOMINATOR
 
         w_scale = NVFP4QTensor.get_weights_scaling_factor(
@@ -231,6 +260,39 @@ class QATWeightExporter:
         input_scale = _compute_input_scale(meta)
         if input_scale is not None:
             yield (_derive_scale_name(name, "input_scale"), input_scale)
+
+    def _quantize_mxfp4(
+        self,
+        name: str,
+        weight: torch.Tensor,
+        meta: _QuantMeta,
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        """OCP MXFP4 quantization with one E8M0 scale per 32 values.
+
+        Packing is always along the input (last) dimension. This preserves the
+        projection layout consumed by vLLM's fused MoE loader:
+        gate/up projections concatenate into ``w13`` while down projections
+        populate ``w2``.
+        """
+        if meta.block_size != 32:
+            raise ValueError(f"MXFP4 requires block size 32, got {meta.block_size}")
+        if weight.shape[-1] % meta.block_size != 0:
+            raise ValueError(
+                f"MXFP4 input dimension must be divisible by block size 32, got shape {tuple(weight.shape)}"
+            )
+
+        _, weight_scale = MXFP4QTensor.quantize(weight, meta.block_size)
+        scale_shape = (*weight.shape[:-1], weight.shape[-1] // meta.block_size)
+        weight_scale = weight_scale.reshape(scale_shape)
+        quantized = to_quantized_weight(
+            weight,
+            weight_scale,
+            meta.qformat,
+            block_size=meta.block_size,
+        )
+
+        yield (name, quantized)
+        yield (_derive_scale_name(name, "weight_scale"), weight_scale)
 
 
 def _iter_hf_to_megatron_matches(registry, hf_name: str):

--- a/verl/utils/modelopt/quantize.py
+++ b/verl/utils/modelopt/quantize.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""ModelOpt NVFP4 quantization config and application for Megatron QAT."""
+"""ModelOpt FP4 quantization configs and application for Megatron QAT."""
 
 import copy
 
@@ -25,6 +25,16 @@ _NVFP4_W4A16_QUANTIZER_CFG = {
     "*weight_quantizer": {
         "num_bits": (2, 1),
         "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)},
+        "axis": None,
+        "enable": True,
+    },
+    "*input_quantizer": {"enable": False},
+}
+
+_MXFP4_W4A16_QUANTIZER_CFG = {
+    "*weight_quantizer": {
+        "num_bits": (2, 1),
+        "block_sizes": {-1: 32, "type": "dynamic", "scale_bits": (8, 0)},
         "axis": None,
         "enable": True,
     },
@@ -52,21 +62,23 @@ def build_quantize_config(
     ignore_patterns: list[str] | None = None,
 ) -> dict:
     """Build a complete ModelOpt quantization config for ``mtq.quantize``."""
-    if qat_mode != "w4a16":
-        raise ValueError(f"Only 'w4a16' is supported, got: {qat_mode}")
+    if qat_mode not in {"w4a16", "mxfp4"}:
+        raise ValueError(f"Only 'w4a16' and 'mxfp4' are supported, got: {qat_mode}")
 
     if ignore_patterns is None:
         ignore_patterns = []
 
     ignore_cfg = _ignore_patterns_to_quant_cfg(ignore_patterns)
 
-    quant_cfg = mtq.normalize_quant_cfg_list(_NVFP4_W4A16_QUANTIZER_CFG)
+    quantizer_cfg = _NVFP4_W4A16_QUANTIZER_CFG if qat_mode == "w4a16" else _MXFP4_W4A16_QUANTIZER_CFG
+    quant_cfg = mtq.normalize_quant_cfg_list(quantizer_cfg)
     disabled_cfg = copy.deepcopy(_default_disabled_quantizer_cfg)
     if isinstance(disabled_cfg, dict):
         disabled_cfg = mtq.normalize_quant_cfg_list(disabled_cfg)
     quant_cfg.extend(disabled_cfg)
     quant_cfg.extend(ignore_cfg)
-    return {"quant_cfg": quant_cfg, "algorithm": "max"}
+    algorithm = "max" if qat_mode == "w4a16" else None
+    return {"quant_cfg": quant_cfg, "algorithm": algorithm}
 
 
 def apply_qat(

--- a/verl/utils/qat/__init__.py
+++ b/verl/utils/qat/__init__.py
@@ -15,7 +15,7 @@
 """
 QAT (Quantization-Aware Training) module for verl.
 
-Supports NVFP4 (W4A4 and W4A16) quantization modes for FSDP training.
+Supports NVFP4 and MXFP4 quantized dynamic weight loading for vLLM rollout.
 
 Module Structure:
 - core.py: QATConfig, apply_qat, enable_qat_fuse (training setup)

--- a/verl/utils/qat/vllm_patch.py
+++ b/verl/utils/qat/vllm_patch.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 """
-vLLM NVFP4 Patches for Dynamic Weight Updates.
+vLLM FP4 Patches for Dynamic Weight Updates.
 
-Enables dynamic weight reloading for NVFP4 quantized models in vLLM.
+Enables dynamic weight reloading for NVFP4 and MXFP4 quantized models in vLLM.
 
 Supported schemes:
 - Dense: W4A16-FP4, W4A4-FP4
 - MoE: NVFP4-MoE
+- MoE: MXFP4-MoE
 """
 
 import logging
@@ -710,6 +711,193 @@ def patched_nvfp4_moe_process_weights_after_loading(self, layer: torch.nn.Module
         delattr(layer, "w2_weight_packed")
 
 
+_original_mxfp4_dense_process_weights_after_loading = None
+_original_mxfp4_moe_process_weights_after_loading = None
+_original_current_nvfp4_dense_process_weights_after_loading = {}
+_original_current_nvfp4_moe_process_weights_after_loading = None
+_MXFP4_DENSE_HF_PARAMS = ("weight_packed", "weight_scale")
+_MXFP4_DENSE_COMPUTE_PARAMS = ("weight", "weight_scale")
+_MXFP4_HF_PARAMS = ("w13_weight_packed", "w2_weight_packed", "w13_weight_scale", "w2_weight_scale")
+_MXFP4_COMPUTE_PARAMS = ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale")
+_CURRENT_NVFP4_DENSE_HF_PARAMS = ("weight_packed", "weight_scale", "weight_global_scale", "input_global_scale")
+_CURRENT_NVFP4_MOE_HF_PARAMS = (
+    "w13_weight_packed",
+    "w2_weight_packed",
+    "w13_weight_scale",
+    "w2_weight_scale",
+    "w13_weight_global_scale",
+    "w2_weight_global_scale",
+    "w13_input_global_scale",
+    "w2_input_global_scale",
+)
+
+
+def _save_reloadable_params(layer: torch.nn.Module, param_names: tuple[str, ...]) -> None:
+    for param_name in param_names:
+        save_param_meta(layer, param_name)
+    if not hasattr(layer, "_weight_loaders"):
+        layer._weight_loaders = {}
+    for param_name in param_names:
+        param = getattr(layer, param_name, None)
+        if param is not None and hasattr(param, "weight_loader"):
+            layer._weight_loaders[param_name] = param.weight_loader
+
+
+def _save_compute_refs(layer: torch.nn.Module, prefix: str) -> None:
+    refs = {
+        name: param.data
+        for name, param in layer.named_parameters(recurse=False)
+        if name == "weight" or name.startswith(("weight_", "w13_", "w2_"))
+    }
+    setattr(layer, f"_{prefix}_tensor_refs", refs)
+    layer._marlin_tensor_refs = {
+        name: ref for name, ref in refs.items() if name in {"weight_scale", "w13_weight_scale", "w2_weight_scale"}
+    }
+
+
+def _restore_compute_refs(layer: torch.nn.Module, prefix: str) -> None:
+    refs = getattr(layer, f"_{prefix}_tensor_refs")
+    for name, stable in refs.items():
+        transformed = getattr(layer, name).data
+        if stable.shape != transformed.shape or stable.dtype != transformed.dtype:
+            raise ValueError(
+                f"NVFP4 reload changed {name} contract: "
+                f"{tuple(stable.shape)}/{stable.dtype} -> {tuple(transformed.shape)}/{transformed.dtype}"
+            )
+        stable.copy_(transformed)
+        setattr(layer, name, Parameter(stable, requires_grad=False))
+
+
+def patched_current_nvfp4_dense_process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+    """Wrap vLLM's unified NVFP4 dense scheme with reloadable stable storage."""
+    original = _original_current_nvfp4_dense_process_weights_after_loading.get(type(self))
+    if original is None:
+        raise RuntimeError(f"NVFP4 dense patch was not initialized for {type(self).__name__}")
+
+    is_first_call = _check_first_call(layer)
+    if is_first_call:
+        _save_reloadable_params(layer, _CURRENT_NVFP4_DENSE_HF_PARAMS)
+    original(self, layer)
+    if is_first_call:
+        _save_compute_refs(layer, "nvfp4")
+    else:
+        _restore_compute_refs(layer, "nvfp4")
+
+
+def patched_current_nvfp4_moe_process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+    """Wrap vLLM's modular NVFP4 MoE scheme with reloadable stable storage."""
+    if _original_current_nvfp4_moe_process_weights_after_loading is None:
+        raise RuntimeError("NVFP4 MoE patch was not initialized")
+
+    is_first_call = _check_first_call(layer)
+    if is_first_call:
+        _save_reloadable_params(layer, _CURRENT_NVFP4_MOE_HF_PARAMS)
+    _original_current_nvfp4_moe_process_weights_after_loading(self, layer)
+    if is_first_call:
+        _save_compute_refs(layer, "nvfp4")
+    else:
+        _restore_compute_refs(layer, "nvfp4")
+
+
+def patched_mxfp4_dense_process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+    """Run vLLM's dense MXFP4 transform with reloadable stable storage."""
+    if _original_mxfp4_dense_process_weights_after_loading is None:
+        raise RuntimeError("Dense MXFP4 process_weights_after_loading patch was not initialized")
+
+    is_first_call = _check_first_call(layer)
+    if is_first_call:
+        for param_name in _MXFP4_DENSE_HF_PARAMS:
+            save_param_meta(layer, param_name)
+        if not hasattr(layer, "_weight_loaders"):
+            layer._weight_loaders = {}
+        for param_name in _MXFP4_DENSE_HF_PARAMS:
+            param = getattr(layer, param_name, None)
+            if param is not None and hasattr(param, "weight_loader"):
+                layer._weight_loaders[param_name] = param.weight_loader
+
+    _original_mxfp4_dense_process_weights_after_loading(self, layer)
+
+    if is_first_call:
+        layer._mxfp4_tensor_refs = {
+            param_name: getattr(layer, param_name).data for param_name in _MXFP4_DENSE_COMPUTE_PARAMS
+        }
+        return
+
+    refs = layer._mxfp4_tensor_refs
+    for param_name in _MXFP4_DENSE_COMPUTE_PARAMS:
+        transformed = getattr(layer, param_name).data
+        stable = refs[param_name]
+        if stable.shape != transformed.shape or stable.dtype != transformed.dtype:
+            raise ValueError(
+                f"MXFP4 reload changed {param_name} contract: "
+                f"{tuple(stable.shape)}/{stable.dtype} -> {tuple(transformed.shape)}/{transformed.dtype}"
+            )
+        stable.copy_(transformed)
+        setattr(layer, param_name, Parameter(stable, requires_grad=False))
+
+
+def _rebuild_mxfp4_moe_kernel(method, layer: torch.nn.Module) -> None:
+    method.moe_quant_config = method.get_fused_moe_quant_config(layer)
+    if method.moe_quant_config is None:
+        return
+
+    from vllm.model_executor.layers.fused_moe.oracle.mxfp4 import make_mxfp4_moe_kernel
+
+    kwargs = {
+        "moe_quant_config": method.moe_quant_config,
+        "moe_config": method.moe,
+        "experts_cls": method.experts_cls,
+        "mxfp4_backend": method.mxfp4_backend,
+    }
+    routing_tables = getattr(layer, "_expert_routing_tables", None)
+    if callable(routing_tables):
+        kwargs["routing_tables"] = routing_tables()
+    method.moe_kernel = make_mxfp4_moe_kernel(**kwargs)
+
+
+def patched_mxfp4_moe_process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+    """Run vLLM's MXFP4 transform while keeping reloadable HF parameters.
+
+    The original vLLM method consumes ``w13/w2_weight_packed`` and may replace
+    the compute parameters. The patch records the packed shapes/loaders before
+    the first transform, then copies subsequent transforms back into stable
+    storage so CUDA graph addresses remain valid across RL weight resyncs.
+    """
+    if _original_mxfp4_moe_process_weights_after_loading is None:
+        raise RuntimeError("MXFP4 process_weights_after_loading patch was not initialized")
+
+    is_first_call = _check_first_call(layer)
+    if is_first_call:
+        for param_name in _MXFP4_HF_PARAMS:
+            save_param_meta(layer, param_name)
+        if not hasattr(layer, "_weight_loaders"):
+            layer._weight_loaders = {}
+        for param_name in _MXFP4_HF_PARAMS:
+            param = getattr(layer, param_name, None)
+            if param is not None and hasattr(param, "weight_loader"):
+                layer._weight_loaders[param_name] = param.weight_loader
+
+    _original_mxfp4_moe_process_weights_after_loading(self, layer)
+
+    if is_first_call:
+        layer._mxfp4_tensor_refs = {param_name: getattr(layer, param_name).data for param_name in _MXFP4_COMPUTE_PARAMS}
+        return
+
+    refs = layer._mxfp4_tensor_refs
+    for param_name in _MXFP4_COMPUTE_PARAMS:
+        transformed = getattr(layer, param_name).data
+        stable = refs[param_name]
+        if stable.shape != transformed.shape or stable.dtype != transformed.dtype:
+            raise ValueError(
+                f"MXFP4 reload changed {param_name} contract: "
+                f"{tuple(stable.shape)}/{stable.dtype} -> {tuple(transformed.shape)}/{transformed.dtype}"
+            )
+        stable.copy_(transformed)
+        setattr(layer, param_name, Parameter(stable, requires_grad=False))
+
+    _rebuild_mxfp4_moe_kernel(self, layer)
+
+
 _PATCH_TARGETS = [
     # Dense W4A16
     (
@@ -731,25 +919,88 @@ _PATCH_TARGETS = [
     ),
 ]
 
+_MXFP4_PATCH_TARGET = (
+    "vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe."
+    "compressed_tensors_moe_w4a4_mxfp4.CompressedTensorsW4A4Mxfp4MoEMethod."
+    "process_weights_after_loading"
+)
+_MXFP4_DENSE_PATCH_TARGET = (
+    "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+    "compressed_tensors_w4a4_mxfp4.CompressedTensorsW4A4Mxfp4.process_weights_after_loading"
+)
+
 _applied_patches = []
 
 
 def apply_qat_patches():
-    """Apply NVFP4 patches to support dynamic weight updates. Call before model loading."""
+    """Apply FP4 patches to support dynamic weight updates. Call before model loading."""
     global _applied_patches
+    global _original_current_nvfp4_moe_process_weights_after_loading
+    global _original_mxfp4_dense_process_weights_after_loading
+    global _original_mxfp4_moe_process_weights_after_loading
 
     if _applied_patches:
         logger.warning("QAT patches already applied, skipping")
         return _applied_patches
 
-    logger.info("Applying NVFP4 patches for dynamic weight loading...")
+    logger.info("Applying FP4 patches for dynamic weight loading...")
 
-    for target, replacement in _PATCH_TARGETS:
+    try:
+        from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_nvfp4 import (  # noqa: E501
+            CompressedTensorsW4A4Nvfp4MoEMethod,
+        )
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import (  # noqa: E501
+            CompressedTensorsW4A4Fp4,
+        )
+    except ImportError:
+        patch_targets = list(_PATCH_TARGETS)
+    else:
+        _original_current_nvfp4_dense_process_weights_after_loading[CompressedTensorsW4A4Fp4] = (
+            CompressedTensorsW4A4Fp4.process_weights_after_loading
+        )
+        _original_current_nvfp4_moe_process_weights_after_loading = (
+            CompressedTensorsW4A4Nvfp4MoEMethod.process_weights_after_loading
+        )
+        patch_targets = [
+            (
+                "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+                "compressed_tensors_w4a4_nvfp4.CompressedTensorsW4A4Fp4."
+                "process_weights_after_loading",
+                patched_current_nvfp4_dense_process_weights_after_loading,
+            ),
+            (
+                "vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe."
+                "compressed_tensors_moe_w4a4_nvfp4.CompressedTensorsW4A4Nvfp4MoEMethod."
+                "process_weights_after_loading",
+                patched_current_nvfp4_moe_process_weights_after_loading,
+            ),
+        ]
+    try:
+        from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a4_mxfp4 import (  # noqa: E501
+            CompressedTensorsW4A4Mxfp4MoEMethod,
+        )
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_mxfp4 import (  # noqa: E501
+            CompressedTensorsW4A4Mxfp4,
+        )
+    except ImportError:
+        logger.info("vLLM has no compressed-tensors MXFP4 scheme; applying NVFP4 patches only")
+    else:
+        _original_mxfp4_dense_process_weights_after_loading = CompressedTensorsW4A4Mxfp4.process_weights_after_loading
+        _original_mxfp4_moe_process_weights_after_loading = (
+            CompressedTensorsW4A4Mxfp4MoEMethod.process_weights_after_loading
+        )
+        patch_targets.extend(
+            [
+                (_MXFP4_DENSE_PATCH_TARGET, patched_mxfp4_dense_process_weights_after_loading),
+                (_MXFP4_PATCH_TARGET, patched_mxfp4_moe_process_weights_after_loading),
+            ]
+        )
+    for target, replacement in patch_targets:
         p = patch(target, replacement)
         _applied_patches.append(p)
         p.start()
 
-    logger.info(f"Applied {len(_applied_patches)} NVFP4 patches for dynamic weight loading")
+    logger.info(f"Applied {len(_applied_patches)} FP4 patches for dynamic weight loading")
     return _applied_patches
 
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -130,15 +130,19 @@ class QATEngineConfig(BaseConfig):
     """Configuration for QAT (Quantization-Aware Training) within an engine.
 
     Args:
-        enable (bool): Whether to enable QAT, default False
-        mode (str): Quantization mode, "w4a16" or "w4a4", default "w4a16"
-        group_size (int): Group size for blockwise quantization, default 16
+        enable (bool): Whether to enable quantized weight export, default False
+        apply_modelopt_fake_quant (bool): Apply ModelOpt fake quantization during
+            training. Disable this when another training backend supplies fake
+            quantization but quantized rollout export is still required.
+        mode (str): Quantization mode, "w4a16", "w4a4", or "mxfp4", default "w4a16"
+        group_size (int): Group size for blockwise quantization (NVFP4: 16, MXFP4: 32)
         ignore_patterns (list[str]): Module name patterns to exclude from quantization
         activation_observer (str): Observer strategy for activation global_scale (W4A4 only)
         quantization_config_path (Optional[str]): Path to quantization config JSON for vLLM
     """
 
     enable: bool = False
+    apply_modelopt_fake_quant: bool = True
     mode: str = "w4a16"
     group_size: int = 16
     ignore_patterns: list[str] = field(default_factory=lambda: ["lm_head", "embed_tokens", "re:.*mlp.gate$"])

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -109,6 +109,7 @@ class MegatronEngine(BaseEngine):
         # QAT configuration
         self._qat_config = getattr(self.engine_config, "qat", None)
         self._qat_enabled = self._qat_config is not None and getattr(self._qat_config, "enable", False)
+        self._modelopt_qat_enabled = self._qat_enabled and getattr(self._qat_config, "apply_modelopt_fake_quant", True)
         if self._qat_enabled:
             if self.engine_config.vanilla_mbridge:
                 raise ValueError(
@@ -251,7 +252,7 @@ class MegatronEngine(BaseEngine):
                 else:
                     provider_overrides["enable_routing_replay"] = True
 
-            if self._qat_enabled:
+            if self._modelopt_qat_enabled:
                 from megatron.bridge.models.gpt_provider import modelopt_transformer_layer_spec
 
                 provider.transformer_layer_spec = modelopt_transformer_layer_spec
@@ -420,7 +421,7 @@ class MegatronEngine(BaseEngine):
 
         self.module = self._build_megatron_module()
 
-        if self._qat_enabled and not self.engine_config.forward_only:
+        if self._modelopt_qat_enabled and not self.engine_config.forward_only:
             from verl.utils.modelopt import apply_qat_to_modules
 
             self.module = apply_qat_to_modules(self.module, self._qat_config)
@@ -830,7 +831,7 @@ class MegatronEngine(BaseEngine):
         if self._qat_enabled:
             from verl.utils.modelopt import export_qat_weights
 
-            per_tensor_param = export_qat_weights(per_tensor_param, self.module, self._qat_config.mode, self.bridge)
+            per_tensor_param = export_qat_weights(per_tensor_param, self.module, self._qat_config, self.bridge)
 
         return per_tensor_param, peft_config
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -181,9 +181,10 @@ class vLLMColocateWorkerExtension:
         # fp8 from the HF config rather than an explicit rollout quantization arg.
         if os.environ.get("VERL_VLLM_FP8_QUANT_ENABLED", "0") == "1" or is_fp8_model(vllm_config):
             apply_vllm_fp8_patches()
-        # 3. patch QAT (compressed-tensors NVFP4) for dynamic weight loading
+        # 3. patch QAT (compressed-tensors FP4) for dynamic weight loading
         quant_config = getattr(vllm_config, "quant_config", None) if vllm_config else None
-        _is_qat_model = getattr(quant_config, "quant_format", None) == "nvfp4-pack-quantized"
+        _qat_format = getattr(quant_config, "quant_format", None)
+        _is_qat_model = _qat_format in {"nvfp4-pack-quantized", "mxfp4-pack-quantized"}
         _is_modelopt_qat = type(quant_config).__name__ == "ModelOptNvFp4Config"
         if _is_qat_model:
             from verl.utils.qat import apply_qat_patches


### PR DESCRIPTION
### What does this PR do?

This PR extends the Megatron QAT weight-sync path from NVFP4 to MXFP4. At every rollout resync, BF16 master weights are packed along the input dimension into OCP E2M1 values with one E8M0 scale per 32 values, then loaded by vLLM's compressed-tensors dense and MoE paths. The vLLM reload patch preserves compute tensor addresses across repeated updates and rebuilds the `oracle.mxfp4` MoE kernel.

This also separates online low-precision export from ModelOpt training fake quantization. A backend-specific QAT implementation can therefore supply fake quantization without applying a second ModelOpt layer, while the QAT-off control still uses the same genuinely quantized rollout.

This does not duplicate an existing contribution. Searches for open PRs matching `MXFP4 QAT exporter dynamic weight update` and `qat_weight_exporter` returned no matching work: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+MXFP4+QAT+exporter+dynamic+weight+update

AI assistance was used to implement and test this change. Human review of every changed line is still required before this draft is marked ready.

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+MXFP4+QAT+exporter+dynamic+weight+update
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `python -m pytest -q tests/utils/modelopt/test_quantize_on_cpu.py tests/utils/modelopt/test_qat_weight_exporter_on_cpu.py tests/utils/qat/test_vllm_patch_mxfp4_on_cpu.py tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py` — 16 passed.
- `pre-commit run --all-files` — all hooks passed, including ruff, ruff-format, mypy, generated config verification, license checks, and Python compilation.
- Real vLLM GPU engine initialization, repeated online resync, one-token generation, and matched RL measurements are pending and will be added before the draft is marked ready.

### API and Usage Example

```yaml
actor_rollout_ref:
  actor:
    engine:
      qat:
        enable: true
        apply_modelopt_fake_quant: false
        mode: mxfp4
        group_size: 32
        quantization_config_path: examples/qat/mxfp4_w4a16.json
```

Use `apply_modelopt_fake_quant: false` when `impl_cfg.qat` supplies training fake quantization, or for a low-precision-rollout QAT-off control. In both cases, `enable: true` keeps online quantized weight export active.

### Design & Code Changes

- Add ModelOpt MXFP4 configuration and extend `QATWeightExporter` with block-32 E2M1 packing and E8M0 scale export for dense and MoE projections.
- Detect `mxfp4-pack-quantized` vLLM models and patch repeated dense/MoE weight processing while preserving stable tensor addresses.
- Rebuild the MXFP4 MoE kernel through `fused_moe.oracle.mxfp4` after each reload.
- Add an explicit switch that separates ModelOpt training fake quantization from online quantized rollout export.
- Add a compressed-tensors MXFP4 W4A16 example, documentation, generated configuration, and CPU contract tests.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply `pre-commit run --all-files`.
- [x] Add / update the documentation.
- [x] Add unit tests covering exporter packing, configuration, vLLM detection, and repeated reload address stability. GPU end-to-end evidence is pending.
- [ ] Request project CI after human review and GPU validation are complete.
