### PR TITLE
[rollout, doc] feat: add OpenAgora sandbox agent loop integration

### DIFF
--- a/docs/advance/agent_loop.rst
+++ b/docs/advance/agent_loop.rst
@@ -1,7 +1,7 @@
 Agent Loop
 ==========
 
-Last updated: 07/17/2025.
+Last updated: 07/23/2026.
 
 .. versionadded:: 0.4.2
    [status: alpha]
@@ -229,6 +229,73 @@ they can call ``LLMServerClient.generate`` to generate response_ids.
                List[int]: List of generated token ids.
            """
            ...
+
+OpenAgora Sandbox Agent Loop
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.9.0
+   [status: experimental]
+
+`OpenAgora <https://github.com/albert-lv/OpenAgora>`_ is an external agent execution
+infrastructure that turns the agent loop into a fully sandboxed, observable, and
+reward-decoupled pipeline. The ``arena_agent`` loop
+(``verl.experimental.agent_loop.arena_agent_loop.ArenaAgentLoop``) delegates agent
+execution to the OpenAgora server instead of calling tools in the trainer process:
+
+- **Sandboxed execution**: agents run inside Docker containers orchestrated by the OpenAgora server.
+- **Active LLM proxy**: the OpenAgora proxy injects sampling parameters and records per-token
+  logprobs for every LLM call the agent makes. It can be pointed at an external
+  vLLM/SGLang server serving the policy model.
+- **Decoupled verification**: the reward is computed by OpenAgora's independent verification
+  plane, not by the agent itself, and is returned as ``AgentLoopOutput.reward_score``.
+- **RL-grade trajectories**: every proxy request/response pair is stored in a structured
+  trajectory log and converted back into ``AgentLoopOutput`` (response token ids,
+  response mask, per-token logprobs, and OpenAgora metadata in ``extra_fields``).
+
+**Setup**
+
+1. Install the OpenAgora SDK into the verl environment (imported lazily; only needed
+   when the ``arena_agent`` loop is used)::
+
+      pip install openagora-sdk
+
+2. Start the OpenAgora server (see the OpenAgora repository for installation)::
+
+      openagora-server --sandbox=docker --grpc :9090 --http :9093
+
+3. Start an OpenAI-compatible LLM backend that the proxy forwards agent requests to,
+   e.g. vLLM::
+
+      vllm serve Qwen/Qwen2.5-0.5B-Instruct --port 8001 --dtype bfloat16 --enforce-eager
+
+4. Build the agent sandbox image on the host (default ``openagora-agent-minimal:latest``).
+
+**Environment variables**
+
+- ``ARENA_ENDPOINT``: gRPC endpoint of the OpenAgora server (default ``localhost:9090``).
+- ``ARENA_AGENT_IMAGE``: sandbox image for the agent.
+- ``ARENA_LLM_BACKEND``: LLM backend URL the proxy forwards to (default ``http://localhost:8000/v1``).
+- ``ARENA_VERIFY_COMMAND``: fallback verification command (default ``true``). A per-sample
+  ``openagora_verify`` key in the dataset's ``extra_info`` column takes precedence.
+- ``ARENA_TIMEOUT_SECONDS``: rollout timeout in seconds (default ``3600``).
+
+**Launch**
+
+.. code:: bash
+
+   export ARENA_ENDPOINT=localhost:9090
+   export ARENA_AGENT_IMAGE=openagora-agent-minimal:latest
+   export ARENA_LLM_BACKEND=http://localhost:8001/v1
+
+   python3 examples/arena_grpo/train_grpo_arena.py \
+     algorithm.adv_estimator=grpo \
+     actor_rollout_ref.rollout.agent.default_agent_loop=arena_agent \
+     actor_rollout_ref.rollout.agent.agent_loop_config_path=examples/arena_grpo/arena_agent_loop.yaml \
+     ...
+
+or simply ``bash examples/arena_grpo/run_qwen2_5_0_5b_fsdp.sh``. See
+``examples/arena_grpo/README.md`` for the dataset format (``extra_info`` struct column with
+optional ``openagora_verify`` / ``task_file`` keys) and full setup instructions.
 
 Next
 ----

--- a/examples/arena_grpo/README.md
+++ b/examples/arena_grpo/README.md
@@ -1,0 +1,89 @@
+# GRPO with the OpenAgora Sandbox Agent Loop
+
+This example trains a model with GRPO while the agent executes inside
+[OpenAgora](https://github.com/albert-lv/OpenAgora) sandboxes (Docker
+containers) instead of calling tools in the trainer process:
+
+- **Sandboxed execution**: agents run inside Docker containers orchestrated by
+  the OpenAgora server.
+- **Active LLM proxy**: the OpenAgora proxy injects sampling parameters and
+  records per-token logprobs for every LLM call the agent makes.
+- **Decoupled verification**: rewards are computed by OpenAgora's independent
+  verification plane, not by the agent or a trainer-side reward function.
+- **RL-grade trajectories**: every proxy request/response pair is stored in a
+  structured trajectory log and converted back into verl's `AgentLoopOutput`.
+
+## Prerequisites
+
+1. Install verl as usual, plus the OpenAgora SDK in the same environment:
+
+   ```bash
+   pip install openagora-sdk
+   # or from source:
+   # pip install git+https://github.com/albert-lv/OpenAgora.git#subdirectory=python/openagora-sdk
+   ```
+
+2. Start the OpenAgora server (see the OpenAgora repository for installation):
+
+   ```bash
+   openagora-server --sandbox=docker --grpc :9090 --http :9093
+   ```
+
+3. Start an OpenAI-compatible LLM backend that the OpenAgora proxy forwards
+   agent requests to, e.g. vLLM:
+
+   ```bash
+   vllm serve Qwen/Qwen2.5-0.5B-Instruct \
+     --port 8001 --dtype bfloat16 --enforce-eager --max-model-len 2048
+   ```
+
+4. Build the agent sandbox image on the host (default
+   `openagora-agent-minimal:latest`; see the OpenAgora repository).
+
+## Dataset format
+
+Standard verl RL parquet dataset (`prompt`/`reward_model`/... columns) with an
+`extra_info` struct column. `extra_info` may carry these optional keys:
+
+- `openagora_verify`: per-sample verification command executed by the
+  OpenAgora verification plane (e.g. `pytest -q /tests`). Takes precedence over
+  the `ARENA_VERIFY_COMMAND` environment variable.
+- `task_file`: per-sample task definition that replaces the default
+  prompt-based task payload sent to the sandbox.
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `ARENA_ENDPOINT` | `localhost:9090` | gRPC endpoint of the OpenAgora server |
+| `ARENA_AGENT_IMAGE` | `openagora-agent-minimal:latest` | Sandbox image for the agent |
+| `ARENA_LLM_BACKEND` | `http://localhost:8001/v1` | LLM backend URL the proxy forwards to |
+| `ARENA_VERIFY_COMMAND` | `true` | Fallback verify command (per-sample `openagora_verify` wins) |
+| `ARENA_TIMEOUT_SECONDS` | `600` | Rollout timeout in seconds |
+
+## Launch
+
+```bash
+bash examples/arena_grpo/run_qwen2_5_0_5b_fsdp.sh
+```
+
+The script sets the `ARENA_*` environment variables, then runs
+`train_grpo_arena.py`, which imports `verl.experimental.agent_loop.arena_agent_loop`
+to register the `arena_agent` loop and delegates to `verl.trainer.main_ppo`.
+Ray workers that do not inherit the driver's imports register the loop through
+`arena_agent_loop.yaml` (passed via
+`actor_rollout_ref.rollout.agent.agent_loop_config_path`).
+
+The equivalent minimal Python invocation is:
+
+```bash
+export ARENA_ENDPOINT=localhost:9090
+export ARENA_AGENT_IMAGE=openagora-agent-minimal:latest
+export ARENA_LLM_BACKEND=http://localhost:8001/v1
+
+python3 examples/arena_grpo/train_grpo_arena.py \
+  algorithm.adv_estimator=grpo \
+  actor_rollout_ref.rollout.agent.default_agent_loop=arena_agent \
+  actor_rollout_ref.rollout.agent.agent_loop_config_path=examples/arena_grpo/arena_agent_loop.yaml \
+  ...
+```

--- a/examples/arena_grpo/arena_agent_loop.yaml
+++ b/examples/arena_grpo/arena_agent_loop.yaml
@@ -1,0 +1,8 @@
+# Agent loop registration for Ray workers that do not inherit the driver's
+# Python imports (e.g. TransferQueue-based rollout workers). Point verl at this
+# file with:
+#
+#   actor_rollout_ref.rollout.agent.agent_loop_config_path=./arena_agent_loop.yaml
+#
+- name: arena_agent
+  _target_: verl.experimental.agent_loop.arena_agent_loop.ArenaAgentLoop

--- a/examples/arena_grpo/run_qwen2_5_0_5b_fsdp.sh
+++ b/examples/arena_grpo/run_qwen2_5_0_5b_fsdp.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# GRPO + OpenAgora sandbox agent loop | Qwen2.5-0.5B-Instruct | FSDP training
+#
+# The agent runs inside OpenAgora sandboxes (Docker). LLM calls made by the
+# agent are proxied by the OpenAgora server to an external OpenAI-compatible
+# backend, and rewards are computed by OpenAgora's verification plane instead
+# of a reward function in the trainer.
+#
+# Prerequisites:
+#   1. openagora-server running on ARENA_ENDPOINT (default localhost:9090), see
+#      https://github.com/albert-lv/OpenAgora
+#   2. An OpenAI-compatible LLM backend reachable at ARENA_LLM_BACKEND, e.g.:
+#        vllm serve Qwen/Qwen2.5-0.5B-Instruct --port 8001 --dtype bfloat16 --enforce-eager
+#   3. The agent sandbox image available on the host
+#      (default openagora-agent-minimal:latest)
+#   4. An RL dataset in parquet format whose extra_info struct column may carry
+#      a per-sample `openagora_verify` command (see README.md in this directory)
+#   5. openagora-sdk installed in the verl environment (`pip install openagora-sdk`)
+
+set -xeuo pipefail
+
+########################### user-adjustable ###########################
+# OpenAgora server / sandbox configuration.
+export ARENA_ENDPOINT=${ARENA_ENDPOINT:-localhost:9090}
+export ARENA_AGENT_IMAGE=${ARENA_AGENT_IMAGE:-openagora-agent-minimal:latest}
+export ARENA_LLM_BACKEND=${ARENA_LLM_BACKEND:-http://localhost:8001/v1}
+# Fallback verify command; per-sample extra_info.openagora_verify takes precedence.
+export ARENA_VERIFY_COMMAND=${ARENA_VERIFY_COMMAND:-true}
+export ARENA_TIMEOUT_SECONDS=${ARENA_TIMEOUT_SECONDS:-600}
+
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen2.5-0.5B-Instruct}
+TRAIN_FILES=${TRAIN_FILES:-./data/train.parquet}
+VAL_FILES=${VAL_FILES:-./data/test.parquet}
+
+train_batch_size=${TRAIN_BATCH_SIZE:-8}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-8}
+max_prompt_length=${MAX_PROMPT_LENGTH:-256}
+max_response_length=${MAX_RESPONSE_LENGTH:-512}
+
+actor_lr=${ACTOR_LR:-1e-6}
+kl_loss_coef=${KL_LOSS_COEF:-0.01}
+rollout_n=${ROLLOUT_N:-4}
+
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-1}
+NNODES=${NNODES:-1}
+total_epochs=${TOTAL_EPOCHS:-10}
+save_freq=${SAVE_FREQ:-5}
+test_freq=${TEST_FREQ:-1}
+
+PROJECT_NAME=${PROJECT_NAME:-verl_arena_grpo}
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-qwen2_5_0_5b_arena_grpo_fsdp_$(date +%Y%m%d_%H%M)}
+########################### end user-adjustable ###########################
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+python3 "${SCRIPT_DIR}/train_grpo_arena.py" \
+  algorithm.adv_estimator=grpo \
+  data.train_files="${TRAIN_FILES}" \
+  data.val_files="${VAL_FILES}" \
+  data.train_batch_size=${train_batch_size} \
+  data.max_prompt_length=${max_prompt_length} \
+  data.max_response_length=${max_response_length} \
+  data.filter_overlong_prompts=True \
+  actor_rollout_ref.model.path="${MODEL_PATH}" \
+  actor_rollout_ref.actor.optim.lr=${actor_lr} \
+  actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size} \
+  actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+  actor_rollout_ref.actor.use_kl_loss=True \
+  actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
+  actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+  actor_rollout_ref.model.enable_gradient_checkpointing=True \
+  actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+  actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+  actor_rollout_ref.rollout.name=vllm \
+  actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+  actor_rollout_ref.rollout.max_model_len=2048 \
+  actor_rollout_ref.rollout.n=${rollout_n} \
+  actor_rollout_ref.rollout.agent.default_agent_loop=arena_agent \
+  actor_rollout_ref.rollout.agent.agent_loop_config_path="${SCRIPT_DIR}/arena_agent_loop.yaml" \
+  actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+  algorithm.use_kl_in_reward=False \
+  trainer.critic_warmup=0 \
+  trainer.logger=['console'] \
+  trainer.project_name="${PROJECT_NAME}" \
+  trainer.experiment_name="${EXPERIMENT_NAME}" \
+  trainer.n_gpus_per_node=${NGPUS_PER_NODE} \
+  trainer.nnodes=${NNODES} \
+  trainer.save_freq=${save_freq} \
+  trainer.test_freq=${test_freq} \
+  trainer.total_epochs=${total_epochs} \
+  "$@"

--- a/examples/arena_grpo/train_grpo_arena.py
+++ b/examples/arena_grpo/train_grpo_arena.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Individual Contributor: albert-lv
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Launcher for GRPO training with the OpenAgora (Arena) sandbox agent loop.
+
+verl discovers agent loops by importing modules that decorate subclasses of
+``AgentLoopBase`` with ``@register(...)``. Setting
+``actor_rollout_ref.rollout.agent.default_agent_loop=arena_agent`` in the Hydra
+config is not enough if the module that performs the registration has never
+been imported in the trainer process.
+
+This wrapper imports ``verl.experimental.agent_loop.arena_agent_loop`` (which
+registers ``ArenaAgentLoop`` as ``arena_agent``) and then delegates to verl's
+``main_ppo`` entry point. All command line arguments and environment variables
+are forwarded unchanged. Ray workers that do not inherit this process's imports
+register the loop via ``actor_rollout_ref.rollout.agent.agent_loop_config_path``
+(see ``arena_agent_loop.yaml`` next to this file).
+"""
+
+import verl.experimental.agent_loop.arena_agent_loop  # noqa: F401
+from verl.trainer.main_ppo import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/experimental/agent_loop/test_arena_agent_loop_on_cpu.py
+++ b/tests/experimental/agent_loop/test_arena_agent_loop_on_cpu.py
@@ -1,0 +1,318 @@
+# Copyright 2025 Individual Contributor: albert-lv
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU unit tests for the OpenAgora (Arena) sandbox agent loop.
+
+The external ``openagora-sdk`` package is not required: a fake ``openagora_sdk``
+module is injected into ``sys.modules`` before ``ArenaAgentLoop`` is constructed,
+so the tests exercise the full ``run()`` path without an OpenAgora server.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from typing import Any, Optional
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.experimental.agent_loop.agent_loop import DictConfigWrap, _agent_loop_registry
+from verl.utils.dataset.rl_dataset import RLHFDataset
+
+
+class _FakeArenaClient:
+    """Stand-in for ``openagora_sdk.client.ArenaClient`` recording every call."""
+
+    instances: list[_FakeArenaClient] = []
+
+    def __init__(self, endpoint: str = "localhost:9090"):
+        self.endpoint = endpoint
+        self.create_rollout_calls: list[dict[str, Any]] = []
+        self.wait_calls: list[tuple[str, float]] = []
+        self.trajectory: list[dict[str, Any]] = [
+            {
+                "step_id": 1,
+                "request": {
+                    "endpoint": "/v1/chat/completions",
+                    "messages_json": b'{"messages": [{"role": "user", "content": "hello"}]}',
+                },
+                "response": {
+                    "choices_json": b'[{"message": {"role": "assistant", "content": "def add pass"}}]',
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+                    "logprobs_json": b'{"content": [{"token": "def", "logprob": -0.5},'
+                    b' {"token": " add", "logprob": -0.3}, {"token": " pass", "logprob": -0.2}]}',
+                },
+            }
+        ]
+        self.wait_result: dict[str, Any] = {
+            "status": "success",
+            "reward": 1.0,
+            "verification_report": {"passed": True},
+        }
+        _FakeArenaClient.instances.append(self)
+
+    def create_rollout(self, **kwargs: Any) -> dict[str, Any]:
+        self.create_rollout_calls.append(kwargs)
+        return {"rollout_id": "rollout-123", "proxy_url": "http://proxy:9000", "token": "tok"}
+
+    def wait(self, rollout_id: str, poll_interval: float = 1.0, timeout: float = 3600.0) -> dict[str, Any]:
+        self.wait_calls.append((rollout_id, timeout))
+        return dict(self.wait_result)
+
+    def get_trajectory(self, rollout_id: str) -> list[dict[str, Any]]:
+        return self.trajectory
+
+
+def _install_fake_openagora_sdk() -> None:
+    """Inject a fake ``openagora_sdk`` package so tests run without the real SDK."""
+    sdk_module = types.ModuleType("openagora_sdk")
+    client_module = types.ModuleType("openagora_sdk.client")
+    client_module.ArenaClient = _FakeArenaClient
+    sdk_module.client = client_module
+    sys.modules["openagora_sdk"] = sdk_module
+    sys.modules["openagora_sdk.client"] = client_module
+
+
+_install_fake_openagora_sdk()
+
+from verl.experimental.agent_loop.arena_agent_loop import ArenaAgentLoop  # noqa: E402
+
+
+class _FakeTokenizer:
+    """Deterministic word-level tokenizer supporting the chat-template probes."""
+
+    pad_token_id = 0
+    padding_side = "right"
+
+    def __init__(self):
+        self._vocab: dict[str, int] = {}
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: Optional[list[dict]] = None,
+        add_generation_prompt: bool = True,
+        tokenize: bool = True,
+        return_dict: bool = False,
+        **kwargs: Any,
+    ):
+        del tools, return_dict, kwargs
+        text = "".join(f"{m['role']}: {m['content']}\n" for m in messages)
+        if add_generation_prompt:
+            text += "assistant:"
+        if tokenize:
+            return self.encode(text)
+        return text
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        ids = []
+        for word in text.split():
+            if word not in self._vocab:
+                self._vocab[word] = len(self._vocab) + 1
+            ids.append(self._vocab[word])
+        return ids
+
+
+def _make_config(prompt_length: int = 64, response_length: int = 64):
+    return OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "rollout": {
+                    "prompt_length": prompt_length,
+                    "response_length": response_length,
+                    "multi_turn": {"tool_config_path": None},
+                },
+                "model": {},
+            },
+            "data": {
+                "tool_config_path": None,
+                "apply_chat_template_kwargs": {},
+                "continuous_token": {"enable": False, "model_family": "auto"},
+            },
+        }
+    )
+
+
+def _build_loop(monkeypatch, prompt_length: int = 64, response_length: int = 64, **env_overrides):
+    env = {
+        "ARENA_ENDPOINT": "localhost:9090",
+        "ARENA_AGENT_IMAGE": "test-image:latest",
+        "ARENA_LLM_BACKEND": "http://test:8000/v1",
+        "ARENA_VERIFY_COMMAND": "true",
+        "ARENA_TIMEOUT_SECONDS": "60",
+    }
+    env.update(env_overrides)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    config = _make_config(prompt_length=prompt_length, response_length=response_length)
+    loop = ArenaAgentLoop(
+        trainer_config=DictConfigWrap(config),
+        server_manager=None,
+        tokenizer=_FakeTokenizer(),
+        processor=None,
+        dataset_cls=RLHFDataset,
+        data_config=DictConfigWrap(config.data),
+    )
+    return loop, _FakeArenaClient.instances[-1]
+
+
+_RAW_PROMPT = [{"role": "user", "content": "Write a function."}]
+
+
+def test_arena_agent_registered_on_cpu():
+    assert "arena_agent" in _agent_loop_registry
+    assert _agent_loop_registry["arena_agent"]["_target_"].endswith("ArenaAgentLoop")
+
+
+@pytest.mark.asyncio
+async def test_run_full_pipeline_on_cpu(monkeypatch):
+    # Build inside the async test so the base class captures the running event loop.
+    loop, client = _build_loop(monkeypatch)
+    out = await loop.run(
+        sampling_params={"temperature": 0.5, "top_p": 0.9, "seed": 7},
+        raw_prompt=_RAW_PROMPT,
+        index=0,
+        global_steps=42,
+    )
+
+    assert out.reward_score == 1.0
+    assert len(out.prompt_ids) > 0
+    assert len(out.prompt_ids) <= loop.prompt_length
+    # Trajectory response "def add pass" tokenizes to 3 word tokens.
+    assert len(out.response_ids) == 3
+    assert out.response_mask == [1] * len(out.response_ids)
+    assert out.response_logprobs is not None
+    assert len(out.response_logprobs) == len(out.response_ids)
+    assert out.num_turns == 1
+    assert out.metrics.generate_sequences >= 0
+    assert out.metrics.tool_calls == 1.0
+
+    assert out.extra_fields["arena_rollout_id"] == "rollout-123"
+    assert out.extra_fields["arena_status"] == "success"
+    assert out.extra_fields["trajectory_steps"] == 1
+    assert out.extra_fields["verification_report"] == {"passed": True}
+    assert out.extra_fields["min_global_steps"] == 42
+    assert out.extra_fields["max_global_steps"] == 42
+
+    # The sandbox task embeds the rendered prompt and original messages, and
+    # sampling params are forwarded to the OpenAgora proxy.
+    call = client.create_rollout_calls[0]
+    assert call["sampling"] == {"temperature": 0.5, "top_p": 0.9, "seed": 7}
+    assert call["image"] == "test-image:latest"
+    assert call["llm_backend"] == "http://test:8000/v1"
+    assert call["verify"] == {"command": "true"}
+    payload = json.loads(call["task_file"].decode("utf-8"))
+    assert payload["messages"] == _RAW_PROMPT
+    assert "Write a function." in payload["prompt"]
+
+    # wait() was called on the created rollout id.
+    assert client.wait_calls[0][0] == "rollout-123"
+
+
+@pytest.mark.asyncio
+async def test_run_extra_info_json_string_on_cpu(monkeypatch):
+    loop, client = _build_loop(monkeypatch)
+    out = await loop.run(
+        sampling_params={},
+        raw_prompt=_RAW_PROMPT,
+        index=1,
+        extra_info=json.dumps({"openagora_verify": "pytest -q"}),
+    )
+    assert client.create_rollout_calls[0]["verify"] == {"command": "pytest -q"}
+    # No global_steps kwarg -> no policy-version tags.
+    assert "min_global_steps" not in out.extra_fields
+    assert "max_global_steps" not in out.extra_fields
+
+
+@pytest.mark.asyncio
+async def test_run_extra_info_invalid_json_string_on_cpu(monkeypatch):
+    loop, client = _build_loop(monkeypatch)
+    await loop.run(
+        sampling_params={},
+        raw_prompt=_RAW_PROMPT,
+        index=2,
+        extra_info="not-a-json-string",
+    )
+    # Invalid JSON extra_info falls back to the environment verify command.
+    assert client.create_rollout_calls[0]["verify"] == {"command": "true"}
+
+
+@pytest.mark.asyncio
+async def test_run_extra_info_dict_and_task_file_override_on_cpu(monkeypatch):
+    loop, client = _build_loop(monkeypatch)
+    await loop.run(
+        sampling_params={},
+        raw_prompt=_RAW_PROMPT,
+        index=3,
+        extra_info={"task_file": "custom task content", "openagora_verify": "make check"},
+    )
+    call = client.create_rollout_calls[0]
+    assert call["task_file"] == b"custom task content"
+    assert call["verify"] == {"command": "make check"}
+
+
+@pytest.mark.asyncio
+async def test_verify_command_priority_on_cpu(monkeypatch):
+    loop, client = _build_loop(monkeypatch, ARENA_VERIFY_COMMAND="env-cmd")
+
+    # Per-sample openagora_verify wins over the environment fallback.
+    await loop.run(
+        sampling_params={},
+        raw_prompt=_RAW_PROMPT,
+        index=0,
+        extra_info={"openagora_verify": "sample-cmd"},
+    )
+    assert client.create_rollout_calls[-1]["verify"] == {"command": "sample-cmd"}
+
+    # Without the per-sample key, the environment fallback is used.
+    await loop.run(sampling_params={}, raw_prompt=_RAW_PROMPT, index=1)
+    assert client.create_rollout_calls[-1]["verify"] == {"command": "env-cmd"}
+
+
+@pytest.mark.asyncio
+async def test_run_empty_response_fallback_on_cpu(monkeypatch):
+    loop, client = _build_loop(monkeypatch)
+    client.trajectory = []  # agent never replied
+    out = await loop.run(sampling_params={}, raw_prompt=_RAW_PROMPT, index=0)
+    assert out.response_ids  # fallback text still produces tokens
+    assert out.response_mask == [1] * len(out.response_ids)
+    assert out.response_logprobs is None
+    assert out.num_turns == 1
+    assert out.extra_fields["trajectory_steps"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_response_truncation_on_cpu(monkeypatch):
+    loop, _ = _build_loop(monkeypatch, response_length=2)
+    out = await loop.run(sampling_params={}, raw_prompt=_RAW_PROMPT, index=0)
+    assert len(out.response_ids) == 2
+    assert out.response_mask == [1, 1]
+    assert out.response_logprobs is not None
+    assert len(out.response_logprobs) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_prompt_truncation_on_cpu(monkeypatch):
+    loop, _ = _build_loop(monkeypatch, prompt_length=3)
+    out = await loop.run(sampling_params={}, raw_prompt=_RAW_PROMPT, index=0)
+    assert len(out.prompt_ids) == 3
+
+
+@pytest.mark.asyncio
+async def test_run_requires_raw_prompt_on_cpu(monkeypatch):
+    loop, _ = _build_loop(monkeypatch)
+    with pytest.raises(ValueError, match="raw_prompt"):
+        await loop.run(sampling_params={}, index=0)

--- a/verl/experimental/agent_loop/__init__.py
+++ b/verl/experimental/agent_loop/__init__.py
@@ -19,10 +19,11 @@ from .agent_loop import (
     AgentLoopWorker,
     get_trajectory_info,
 )
+from .arena_agent_loop import ArenaAgentLoop
 from .single_turn_agent_loop import SingleTurnAgentLoop
 from .tool_agent_loop import ToolAgentLoop
 
-_ = [SingleTurnAgentLoop, ToolAgentLoop]
+_ = [ArenaAgentLoop, SingleTurnAgentLoop, ToolAgentLoop]
 
 __all__ = [
     "AgentLoopBase",

--- a/verl/experimental/agent_loop/arena_agent_loop.py
+++ b/verl/experimental/agent_loop/arena_agent_loop.py
@@ -1,0 +1,442 @@
+# Copyright 2025 Individual Contributor: albert-lv
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+OpenAgora (Arena) agent loop: sandboxed agent execution for verl rollouts.
+
+This module provides an ``AgentLoopBase`` implementation that delegates agent
+execution to the OpenAgora sandbox infrastructure
+(https://github.com/albert-lv/OpenAgora) instead of calling the LLM server
+in-process:
+
+1. The prompt messages are rendered with the tokenizer chat template and
+   tokenized (left-truncated to ``rollout.prompt_length``).
+2. The task is submitted to the OpenAgora server, which runs the agent inside
+   a sandbox (e.g. Docker). All LLM calls made by the agent are transparently
+   proxied through the OpenAgora LLM proxy, which can be pointed at verl's
+   vLLM/SGLang inference server.
+3. The loop waits for the rollout to finish and reads the reward computed by
+   OpenAgora's independent verification plane (not by the agent itself).
+4. The captured trajectory is converted back into verl's ``AgentLoopOutput``
+   format: response text and per-token logprobs are extracted from the
+   recorded proxy requests/responses and tokenized (right-truncated to
+   ``rollout.response_length``).
+
+Usage in the training config::
+
+    actor_rollout_ref.rollout.agent.default_agent_loop=arena_agent
+
+Required environment variables:
+
+- ``ARENA_ENDPOINT``: gRPC endpoint of the OpenAgora server (default: localhost:9090).
+- ``ARENA_AGENT_IMAGE``: sandbox image for the agent (default: openagora-agent-minimal:latest).
+- ``ARENA_LLM_BACKEND``: URL of the LLM backend the proxy forwards to
+  (default: http://localhost:8000/v1).
+
+Optional environment variables:
+
+- ``ARENA_VERIFY_COMMAND``: fallback verification command (default: "true").
+  Per-sample ``extra_info.openagora_verify`` takes precedence over this.
+- ``ARENA_TIMEOUT_SECONDS``: rollout timeout in seconds (default: 3600).
+
+The integration depends on the external ``openagora-sdk`` package, which is
+imported lazily so that verl works without it when the arena agent loop is
+not used. Install it with ``pip install openagora-sdk`` or from source at
+https://github.com/albert-lv/OpenAgora/tree/main/python/openagora-sdk
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Optional
+
+from verl.experimental.agent_loop.agent_loop import (
+    AgentLoopBase,
+    AgentLoopMetrics,
+    AgentLoopOutput,
+    register,
+)
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+_OPENAGORA_SDK_HINT = (
+    "ArenaAgentLoop requires the `openagora-sdk` package, which is not installed. "
+    "Install it with `pip install openagora-sdk`, or from source: "
+    "https://github.com/albert-lv/OpenAgora/tree/main/python/openagora-sdk"
+)
+
+
+def _extract_response_text(trajectory: list[dict[str, Any]]) -> str:
+    """Extract the agent's final response text from the Arena trajectory.
+
+    Trajectory steps contain raw HTTP request/response bodies recorded by the
+    OpenAgora proxy. Parse each step's response choices and concatenate the
+    assistant messages. Handles both raw ``choices`` arrays and full OpenAI
+    response JSON.
+
+    Args:
+        trajectory: List of trajectory step dicts from OpenAgora.
+
+    Returns:
+        Concatenated assistant response text.
+    """
+    texts = []
+    for step in trajectory:
+        resp = step.get("response") or {}
+        choices_json = resp.get("choices_json") or resp.get("choices")
+        if not choices_json:
+            continue
+        try:
+            if isinstance(choices_json, bytes):
+                choices_json = choices_json.decode("utf-8")
+            data = json.loads(choices_json)
+            # choices_json may be the full OpenAI response dict or just the choices list.
+            if isinstance(data, dict):
+                choices = data.get("choices", [])
+            elif isinstance(data, list):
+                choices = data
+            else:
+                continue
+            if isinstance(choices, list) and len(choices) > 0:
+                choice = choices[0]
+                msg = choice.get("message", {})
+                content = msg.get("content", "")
+                if content:
+                    texts.append(content)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            logger.debug("Failed to parse choices JSON in trajectory step")
+            continue
+    return "\n".join(texts)
+
+
+def _extract_logprobs(trajectory: list[dict[str, Any]], response_length: int) -> Optional[list[float]]:
+    """Extract per-token logprobs from the trajectory if available.
+
+    Expects the OpenAI-compatible logprobs format recorded by the proxy::
+
+        {
+            "content": [
+                {"token": "...", "logprob": -0.123, "top_logprobs": [...]},
+                ...
+            ]
+        }
+
+    Args:
+        trajectory: List of trajectory step dicts from OpenAgora.
+        response_length: Expected number of response tokens (for padding/truncation).
+
+    Returns:
+        A flat list of logprob floats aligned with the response tokens, or None if unavailable.
+    """
+    logprobs: list[float] = []
+    for step in trajectory:
+        resp = step.get("response") or {}
+        lp_raw = resp.get("logprobs_json")
+        if lp_raw:
+            try:
+                if isinstance(lp_raw, bytes):
+                    lp_raw = lp_raw.decode("utf-8")
+                # strict=False allows stray control characters in token strings.
+                lp_data = json.loads(lp_raw, strict=False)
+                content = lp_data.get("content") or lp_data.get("text")
+                if isinstance(content, list):
+                    for item in content:
+                        lp = item.get("logprob")
+                        if lp is not None:
+                            logprobs.append(float(lp))
+            except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+                continue
+    if not logprobs:
+        return None
+    # Pad or truncate to response_length.
+    if len(logprobs) < response_length:
+        logprobs.extend([0.0] * (response_length - len(logprobs)))
+    return logprobs[:response_length]
+
+
+def _step_role(step: dict[str, Any]) -> str:
+    """Infer the role of a trajectory step from request/response messages.
+
+    Returns one of: ``assistant``, ``tool``, ``observation``, ``unknown``.
+    """
+    req = step.get("request") or {}
+    messages_json = req.get("messages_json")
+    if messages_json:
+        try:
+            if isinstance(messages_json, bytes):
+                messages_json = messages_json.decode("utf-8")
+            data = json.loads(messages_json)
+            msgs = data.get("messages", [])
+            if msgs:
+                last_role = msgs[-1].get("role", "unknown")
+                if last_role in ("user", "system"):
+                    return "assistant"  # LLM is generating a response to user/system
+                if last_role == "assistant":
+                    return "tool"  # Next call is likely tool execution
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError, TypeError):
+            pass
+    # Fallback: inspect response content.
+    resp = step.get("response") or {}
+    choices_json = resp.get("choices_json") or resp.get("choices")
+    if choices_json:
+        try:
+            if isinstance(choices_json, bytes):
+                choices_json = choices_json.decode("utf-8")
+            choices = json.loads(choices_json)
+            if isinstance(choices, list) and len(choices) > 0:
+                msg = choices[0].get("message", {})
+                if msg.get("tool_calls"):
+                    return "tool"
+                if msg.get("role") == "assistant":
+                    return "assistant"
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError, TypeError):
+            pass
+    return "unknown"
+
+
+def _count_agent_turns(trajectory: list[dict[str, Any]]) -> int:
+    """Count the number of assistant/tool turns in the trajectory.
+
+    The initial user prompt is not counted; each assistant response or tool
+    call/observation emitted by the agent counts as one turn.
+    """
+    count = 0
+    for step in trajectory:
+        if _step_role(step) in ("assistant", "tool", "observation"):
+            count += 1
+    return max(count, 1)
+
+
+@register("arena_agent")
+class ArenaAgentLoop(AgentLoopBase):
+    """OpenAgora-backed agent loop: run the agent in a sandbox, score via the verification plane.
+
+    The agent runs inside an OpenAgora sandbox (e.g. Docker). All LLM calls
+    made by the agent are transparently proxied through OpenAgora's LLM proxy,
+    which can be pointed at verl's vLLM/SGLang inference server. The reward is
+    computed by OpenAgora's independent verification plane and returned as
+    ``AgentLoopOutput.reward_score``.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.prompt_length = self.rollout_config.prompt_length
+        self.response_length = self.rollout_config.response_length
+
+        # Imported lazily so verl does not require openagora-sdk unless this
+        # agent loop is actually instantiated.
+        try:
+            from openagora_sdk.client import ArenaClient
+        except ImportError as e:
+            raise ImportError(_OPENAGORA_SDK_HINT) from e
+
+        arena_endpoint = os.environ.get("ARENA_ENDPOINT", "localhost:9090")
+        self._arena = ArenaClient(arena_endpoint)
+
+        self._agent_image = os.environ.get("ARENA_AGENT_IMAGE", "openagora-agent-minimal:latest")
+        self._llm_backend = os.environ.get("ARENA_LLM_BACKEND", "http://localhost:8000/v1")
+        self._verify_command = os.environ.get("ARENA_VERIFY_COMMAND", "true")
+        self._timeout_seconds = int(os.environ.get("ARENA_TIMEOUT_SECONDS", "3600"))
+
+        logger.info(
+            "ArenaAgentLoop initialized: endpoint=%s image=%s backend=%s",
+            arena_endpoint,
+            self._agent_image,
+            self._llm_backend,
+        )
+
+    async def run(self, sampling_params: dict[str, Any], **kwargs: Any) -> AgentLoopOutput:
+        """Run one OpenAgora sandboxed rollout and return tokenized results.
+
+        Args:
+            sampling_params: LLM sampling params forwarded to the sandboxed agent
+                (temperature, top_p, seed are propagated through the OpenAgora proxy).
+            **kwargs: dataset fields from ``verl.utils.dataset.RLHFDataset``. Requires
+                ``raw_prompt``; honors ``extra_info`` (dict or JSON string) with optional
+                ``task_file`` and ``openagora_verify`` keys, ``index``, and ``global_steps``.
+
+        Returns:
+            AgentLoopOutput with prompt/response token ids, per-token logprobs (if the
+            proxy recorded them), the reward from OpenAgora verification, and Arena
+            metadata in ``extra_fields``.
+        """
+        messages: list[dict[str, Any]] = list(kwargs.get("raw_prompt", []))
+        if not messages:
+            raise ValueError("ArenaAgentLoop requires 'raw_prompt' in kwargs")
+
+        total_start = time.time()
+
+        # 1. Render the prompt text (sent to the sandbox as the task), then
+        # tokenize the prompt. ``apply_chat_template`` left-truncates to
+        # ``rollout.prompt_length``.
+        prompt_text = self._render_prompt_text(messages)
+        prompt_ids = await self.apply_chat_template(messages)
+
+        # 2. Build the task payload. Allow a per-sample task file override via
+        # extra_info (e.g. coding-competition problems).
+        extra = kwargs.get("extra_info", {})
+        if isinstance(extra, str):
+            try:
+                extra = json.loads(extra)
+            except json.JSONDecodeError:
+                extra = {}
+        if not isinstance(extra, dict):
+            extra = {}
+
+        custom_task_file = extra.get("task_file")
+        if custom_task_file:
+            if isinstance(custom_task_file, str):
+                task_payload = custom_task_file.encode("utf-8")
+            else:
+                task_payload = custom_task_file
+        else:
+            task_payload = json.dumps(
+                {
+                    "task_id": kwargs.get("index", "0"),
+                    "prompt": prompt_text,
+                    "messages": messages,
+                }
+            ).encode("utf-8")
+
+        sampling_cfg = {
+            "temperature": sampling_params.get("temperature", 1.0),
+            "top_p": sampling_params.get("top_p", 1.0),
+            "seed": sampling_params.get("seed", 0),
+        }
+
+        # Per-sample verify command takes precedence over the environment fallback.
+        verify_cmd = extra.get("openagora_verify", self._verify_command)
+
+        # 3. Submit the task to the OpenAgora server.
+        rollout_create_start = time.time()
+        rollout_info = self._arena.create_rollout(
+            task_id=f"verl-{kwargs.get('index', '0')}",
+            image=self._agent_image,
+            llm_backend=self._llm_backend,
+            sampling=sampling_cfg,
+            verify={"command": verify_cmd} if verify_cmd else None,
+            task_file=task_payload,
+            timeout_seconds=self._timeout_seconds,
+        )
+        rollout_create_time = time.time() - rollout_create_start
+        rollout_id = rollout_info["rollout_id"]
+        logger.info("Arena rollout created: %s (%.2fs)", rollout_id, rollout_create_time)
+
+        # 4. Wait for the sandboxed agent to finish and read the reward from
+        # the verification plane.
+        wait_start = time.time()
+        result = self._arena.wait(rollout_id, timeout=self._timeout_seconds)
+        wait_time = time.time() - wait_start
+        status = result.get("status", "unknown")
+        reward_score = float(result.get("reward", 0.0))
+        logger.info(
+            "Arena rollout %s finished: status=%s reward=%s (waited %.2fs)",
+            rollout_id,
+            status,
+            reward_score,
+            wait_time,
+        )
+
+        # 5. Fetch the recorded trajectory and extract the response text.
+        trajectory = self._arena.get_trajectory(rollout_id)
+        response_text = _extract_response_text(trajectory)
+
+        # Handle empty response (e.g. agent never replied).
+        if not response_text or not response_text.strip():
+            response_text = "I could not generate a response."
+
+        # 6. Tokenize the response and truncate to the response budget.
+        response_ids = self._encode_text(response_text)
+        if len(response_ids) > self.response_length:
+            logger.warning(
+                "Response truncated from %d to %d tokens",
+                len(response_ids),
+                self.response_length,
+            )
+            response_ids = response_ids[: self.response_length]
+
+        response_mask = [1] * len(response_ids)
+
+        # 7. Align per-token logprobs with the (possibly truncated) response.
+        response_logprobs = _extract_logprobs(trajectory, len(response_ids))
+
+        # 8. Count agent turns from the trajectory.
+        num_turns = _count_agent_turns(trajectory)
+
+        total_time = time.time() - total_start
+        metrics = AgentLoopMetrics(
+            generate_sequences=total_time,
+            tool_calls=float(num_turns),
+            compute_score=wait_time,
+        )
+
+        # Policy-version tags enable verl's staleness tracking and off-policy
+        # detection in async trainers. For single-shot Arena rollouts the
+        # policy version does not change between request and response, so both
+        # are equal to the current global_steps when the caller provides it.
+        global_steps = kwargs.get("global_steps", None)
+
+        extra_fields = {
+            "arena_rollout_id": rollout_id,
+            "arena_status": status,
+            "trajectory_steps": len(trajectory),
+            "verification_report": result.get("verification_report"),
+        }
+        if global_steps is not None:
+            extra_fields["min_global_steps"] = global_steps
+            extra_fields["max_global_steps"] = global_steps
+
+        return AgentLoopOutput(
+            prompt_ids=prompt_ids,
+            response_ids=response_ids,
+            response_mask=response_mask,
+            response_logprobs=response_logprobs,
+            reward_score=reward_score,
+            num_turns=num_turns,
+            metrics=metrics,
+            extra_fields=extra_fields,
+        )
+
+    def _render_prompt_text(self, messages: list[dict[str, Any]]) -> str:
+        """Render messages to a single text string for the Arena task payload."""
+        processing_class = self.processor if self.processor is not None else self.tokenizer
+        if processing_class is None:
+            raise RuntimeError("ArenaAgentLoop requires a tokenizer or processor")
+
+        if hasattr(processing_class, "apply_chat_template"):
+            try:
+                return processing_class.apply_chat_template(
+                    messages, add_generation_prompt=True, tokenize=False, **self.apply_chat_template_kwargs
+                )
+            except Exception:
+                # chat_template not usable on this tokenizer; fall back below.
+                logger.debug("apply_chat_template failed; using naive message concatenation", exc_info=True)
+        # Fallback: naive concatenation.
+        parts = []
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            parts.append(f"<{role}>\n{content}\n</{role}>")
+        return "\n".join(parts)
+
+    def _encode_text(self, text: str) -> list[int]:
+        """Encode text to token ids without special tokens."""
+        processing_class = self.processor if self.processor is not None else self.tokenizer
+        if processing_class is None:
+            raise RuntimeError("ArenaAgentLoop requires a tokenizer or processor")
+
+        if hasattr(processing_class, "encode"):
+            return processing_class.encode(text, add_special_tokens=False)
+        # Fallback for HF tokenizers.
+        return processing_class(text, add_special_tokens=False)["input_ids"]


### PR DESCRIPTION
### What does this PR do?

Adds an [OpenAgora](https://github.com/albert-lv/OpenAgora) integration to the agent-loop framework: a new `ArenaAgentLoop` (registered as `arena_agent`) that executes the agent inside OpenAgora-managed sandboxes (Docker) instead of running tools in the trainer process, and obtains the reward from OpenAgora's independent verification plane.

Today, users who want sandboxed agent execution during rollout have to hand-roll their own sandbox/verification glue. This PR turns the agent loop into a fully sandboxed, observable, and reward-decoupled pipeline:

- **Sandboxed execution**: agents run inside Docker containers orchestrated by the OpenAgora server.
- **Active LLM proxy**: the OpenAgora proxy injects sampling parameters and records per-token logprobs for every LLM call the agent makes; it can be pointed at an external vLLM/SGLang server serving the policy model.
- **Decoupled verification**: rewards are computed by an independent verifier plane, not by the agent itself, and returned as `AgentLoopOutput.reward_score`.
- **RL-grade trajectories**: every proxy request/response pair is stored in a structured trajectory log and converted back into `AgentLoopOutput` (response token ids, response mask, per-token logprobs, OpenAgora metadata in `extra_fields`, and `min/max_global_steps` policy-version tags when the caller provides `global_steps`).

The gRPC client lives in the external `openagora-sdk` package, which is imported **lazily** (inside `ArenaAgentLoop.__init__`) with a clear error message, so verl works unchanged when the loop is not used. It is intentionally **not** added to `setup.py`/`requirements.txt`; install it with `pip install openagora-sdk` (published on PyPI) or from the OpenAgora repository. No changes to existing verl code paths are required except one import line in `verl/experimental/agent_loop/__init__.py` that registers the loop alongside the built-in ones.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+sandbox+agent+loop
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - Title: `[rollout, doc] feat: add OpenAgora sandbox agent loop integration`

### Test

- **Unit tests** (this PR): `pytest tests/experimental/agent_loop/test_arena_agent_loop_on_cpu.py -q` — 10 tests, all passing on CPU. They inject a fake `openagora_sdk` module via `sys.modules` (so no OpenAgora server or SDK is needed) and cover: the full `run()` pipeline (prompt/response ids, mask and logprob alignment, `reward_score`, `num_turns`, `min/max_global_steps`), `extra_info` as dict vs JSON string (and invalid JSON fallback), `extra_info.task_file` override, empty-response fallback, response truncation, prompt truncation, and per-sample `openagora_verify` taking precedence over `ARENA_VERIFY_COMMAND`.
- **Pre-commit**: `pre-commit run --files <all added/modified files>` — all hooks pass (ruff, ruff-format, mypy, generated-config check, docs time info, docstrings, license, device API usage, DataProto usage, structure validation, naming conventions, example naming, compileall).
- **End-to-end GPU validation on this branch** (upstream main @ `d8acd86`): the author re-ran GRPO training with the `arena_agent` loop end-to-end — OpenAgora server + external vLLM backend behind the proxy + `openagora-sdk` installed from PyPI — and training completed successfully. Training logs are available on request and will be attached to this PR.
- **Earlier full-metrics run** (same integration via the OpenAgora-side adapter, against verl @ `8f5e161`): GRPO training of `Qwen/Qwen2.5-0.5B-Instruct` for 10 epochs on a single node with 2× RTX 4090 (24 GB). Peak reward reached **96.9%** with no crashes/OOM; rollout-vs-training logprob consistency: `rollout_probs_diff_mean ≈ 0.01`, `pearson ≈ 0.99`. Reproduction guide: `docs/veRL-GPU-validation-plan-2x4090.md` in the OpenAgora repository.

### API and Usage Example

No existing API changes. New usage:

```bash
# 1. Start the OpenAgora server (see the OpenAgora repository for installation)
openagora-server --sandbox=docker --grpc :9090 --http :9093

# 2. Start an OpenAI-compatible LLM backend the proxy forwards agent requests to
vllm serve Qwen/Qwen2.5-0.5B-Instruct --port 8001 --dtype bfloat16 --enforce-eager

# 3. Launch GRPO training with the arena_agent loop
export ARENA_ENDPOINT=localhost:9090
export ARENA_AGENT_IMAGE=openagora-agent-minimal:latest
export ARENA_LLM_BACKEND=http://localhost:8001/v1

python3 examples/arena_grpo/train_grpo_arena.py \
  algorithm.adv_estimator=grpo \
  actor_rollout_ref.rollout.agent.default_agent_loop=arena_agent \
  actor_rollout_ref.rollout.agent.agent_loop_config_path=examples/arena_grpo/arena_agent_loop.yaml \
  ...
```

or simply `bash examples/arena_grpo/run_qwen2_5_0_5b_fsdp.sh`. Dataset: standard RL parquet with an `extra_info` struct column that may carry per-sample `openagora_verify` (verification command) and `task_file` (task payload override) keys. See `examples/arena_grpo/README.md` and the new "OpenAgora Sandbox Agent Loop" section in `docs/advance/agent_loop.rst`.

### Design & Code Changes

1. **`verl/experimental/agent_loop/arena_agent_loop.py`** (new)
   - `ArenaAgentLoop(AgentLoopBase)` registered as `arena_agent`.
   - Renders the prompt with the chat template, tokenizes via the base-class `apply_chat_template` (left-truncated to `rollout.prompt_length`), and submits the task to the OpenAgora server (`create_rollout` → `wait` → `get_trajectory`).
   - Extracts response text and per-token logprobs from the recorded trajectory (private helpers `_extract_response_text` / `_extract_logprobs`), tokenizes and right-truncates the response to `rollout.response_length`, and returns `AgentLoopOutput` with `reward_score` from the verification plane, `num_turns`, `AgentLoopMetrics`, and `extra_fields` (`arena_rollout_id`, `arena_status`, `trajectory_steps`, `verification_report`, plus `min/max_global_steps` when `global_steps` is provided).
   - `extra_info` is accepted as dict or JSON string; `extra_info.task_file` overrides the default task payload; per-sample `extra_info.openagora_verify` takes precedence over the `ARENA_VERIFY_COMMAND` environment variable.
   - Environment variables: `ARENA_ENDPOINT` / `ARENA_AGENT_IMAGE` / `ARENA_LLM_BACKEND` / `ARENA_VERIFY_COMMAND` / `ARENA_TIMEOUT_SECONDS`.
   - `openagora-sdk` is imported lazily with an actionable `ImportError` message; it is not a verl dependency.
2. **`verl/experimental/agent_loop/__init__.py`** (1-line change + list): import `ArenaAgentLoop` so `arena_agent` is registered together with the built-in loops.
3. **`tests/experimental/agent_loop/test_arena_agent_loop_on_cpu.py`** (new): CPU unit tests described above.
4. **`examples/arena_grpo/`** (new): `train_grpo_arena.py` (imports the loop module to trigger registration, delegates to `verl.trainer.main_ppo`), `run_qwen2_5_0_5b_fsdp.sh` (canonical-named launcher), `arena_agent_loop.yaml` (registration for Ray workers that do not inherit driver imports), `README.md` (setup, environment variables, dataset format).
5. **`docs/advance/agent_loop.rst`**: new "OpenAgora Sandbox Agent Loop" section (setup, environment variables, launch commands, verification-plane reward note).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` (run with `--files` on all added/modified files; all hooks pass).
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU unit tests added under `tests/experimental/agent_loop/` following the existing `*_on_cpu` convention; no CI workflow change needed since the directory is already covered. End-to-end training requires a running OpenAgora server + Docker and is validated on GPU externally (see Test section).
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. (Not related.)
