### PR TITLE
[worker] fix: close temporary TransferQueue event loop

### DIFF
--- a/tests/utils/test_transferqueue_utils_on_cpu.py
+++ b/tests/utils/test_transferqueue_utils_on_cpu.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import os
+
+import pytest
+
+from verl.utils.transferqueue_utils import _run_async_in_temp_loop
+
+
+async def _noop():
+    return None
+
+
+def _open_fd_count() -> int:
+    if not os.path.isdir("/proc/self/fd"):
+        pytest.skip("requires Linux /proc file descriptor accounting")
+    return len(os.listdir("/proc/self/fd"))
+
+
+def test_temp_event_loop_releases_file_descriptors():
+    gc.collect()
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        before = _open_fd_count()
+        for _ in range(32):
+            _run_async_in_temp_loop(_noop)
+        leaked = _open_fd_count() - before
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+        gc.collect()
+
+    assert leaked == 0

--- a/verl/utils/transferqueue_utils.py
+++ b/verl/utils/transferqueue_utils.py
@@ -87,15 +87,13 @@ def _run_async_in_temp_loop(async_func: Callable[..., Any], *args, **kwargs) -> 
         future = asyncio.run_coroutine_threadsafe(coroutine, tmp_event_loop)
         return future.result()
 
-    async def stop_loop():
-        tmp_event_loop.stop()
-
     try:
         return run_coroutine(async_func(*args, **kwargs))
     finally:
         if thread.is_alive():
-            asyncio.run_coroutine_threadsafe(stop_loop(), tmp_event_loop)
+            tmp_event_loop.call_soon_threadsafe(tmp_event_loop.stop)
             thread.join()
+        tmp_event_loop.close()
 
 
 def _find_meta(*args, **kwargs):


### PR DESCRIPTION
### What does this PR do?

Fixes #7156.

`_run_async_in_temp_loop` creates a temporary event loop for synchronous TransferQueue bridge calls. The loop thread was stopped and joined, but the loop itself was never closed. Each loop therefore retained its selector file descriptors until garbage collection, and long-running workers could eventually hit `EMFILE` (`Too many open files`). Other ranks then observed secondary distributed-communication failures such as Gloo connection resets.

This PR:

- schedules `loop.stop()` directly with `call_soon_threadsafe()`;
- waits for the event-loop thread to exit before closing the loop;
- closes the loop even if the thread was never started or had already exited;
- adds a Linux CPU regression test that repeats the operation with cyclic GC disabled and verifies that file-descriptor usage does not grow.

### Checklist Before Starting

- [x] Searched for similar open PRs:
  - [Issue-number search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7156)
  - [TransferQueue event-loop FD search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+TransferQueue+event+loop+file+descriptor)
- [x] No open PR was found for this issue or fix as of 2026-07-27.
- [x] PR title follows the required format.

### Test

- `PYTHONPATH=. pytest -q tests/utils/test_transferqueue_utils_on_cpu.py` — 1 passed.
- `pre-commit run --files verl/utils/transferqueue_utils.py tests/utils/test_transferqueue_utils_on_cpu.py` — all configured hooks passed.
- Isolated A/B stress test with cyclic GC disabled:
  - upstream: 64 success/exception calls leaked 192 file descriptors; 64/64 loops remained open;
  - patched: 1,000 success/exception calls leaked 0 file descriptors; thread count did not grow; 1,000/1,000 loops were closed.
- End-to-end training completed all 78 steps with exit code 0 and no recurrence of `Too many open files` or the subsequent Gloo peer reset. The submitter will add the training-result screenshot in a follow-up PR comment.

### API and Usage Example

No public API, configuration, or command-line behavior changes.

### Design & Code Changes

The change preserves the existing temporary-loop architecture. Cleanup now follows the event-loop lifecycle in order: request `stop()` from the caller thread, join the loop thread, then call `close()` after the loop is no longer running. The direct callback also avoids creating a second coroutine solely to stop the loop.

### AI Assistance

OpenAI Codex was used to diagnose the failure, prepare the implementation and regression test, run validation, and draft this PR description. The submitter reviewed the diff and validation evidence and can explain and defend the lifecycle change.

### Checklist Before Submitting

- [x] Read the Contribute Guide and repository agent instructions.
- [x] Applied pre-commit checks to all changed files.
- [x] No documentation update is required because there is no user-facing or API change.
- [x] Added a CPU regression test covering the leaked resource.
- [ ] Send the CI request in the project Slack or Feishu channel.