### PR TITLE
[ray, single_controller] fix: sort placement groups by numeric IP so rank order follows node order

### DIFF
--- a/tests/single_controller/test_ip_sort_key_on_cpu.py
+++ b/tests/single_controller/test_ip_sort_key_on_cpu.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl.single_controller.ray.base import _ip_sort_key
+
+
+def test_mixed_width_ips_sort_numerically():
+    ips = ["10.0.0.7", "10.0.0.66", "10.0.0.8", "10.0.0.70"]
+    assert sorted(ips, key=_ip_sort_key) == ["10.0.0.7", "10.0.0.8", "10.0.0.66", "10.0.0.70"]
+
+
+def test_equal_width_order_is_byte_identical_to_lexicographic():
+    ips = ["10.0.0.101", "10.0.0.100", "10.0.0.103", "10.0.0.102"]
+    assert sorted(ips, key=_ip_sort_key) == sorted(ips)
+
+
+def test_full_octet_boundaries():
+    ips = ["192.168.1.5", "9.0.0.1", "10.42.13.2", "10.42.9.66", "10.42.9.7"]
+    assert sorted(ips, key=_ip_sort_key) == [
+        "9.0.0.1",
+        "10.42.9.7",
+        "10.42.9.66",
+        "10.42.13.2",
+        "192.168.1.5",
+    ]
+
+
+def test_non_ipv4_sorts_after_ipv4_and_keeps_string_order():
+    mixed = ["nodeb", "10.0.0.9", "nodea", "10.0.0.10", "fe80::1"]
+    assert sorted(mixed, key=_ip_sort_key) == ["10.0.0.9", "10.0.0.10", "fe80::1", "nodea", "nodeb"]
+
+
+def test_malformed_dotted_quad_falls_back_to_string():
+    vals = ["10.0.0.x", "10.0.0.2"]
+    assert sorted(vals, key=_ip_sort_key) == ["10.0.0.2", "10.0.0.x"]

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -84,7 +84,19 @@ def sort_placement_group_by_node_ip(pgs: list[PlacementGroup]) -> list[Placement
         # all bunles should be on the same node
         node_id = specs["bundles_to_node_id"][0]
         pg_ip[pg.id] = node_ip[node_id]
-    return sorted(pgs, key=lambda pg: pg_ip[pg.id])
+    def _ip_sort_key(ip: str):
+        # Sort dotted-quad IPs numerically; lexicographic order breaks whenever the
+        # allocation spans an octet-width boundary (e.g. .9 vs .66), which lands
+        # ring-adjacent ranks on physically distant nodes. Non-IPv4 keeps string order.
+        parts = ip.split(".")
+        if len(parts) == 4:
+            try:
+                return (0, tuple(int(p) for p in parts), "")
+            except ValueError:
+                pass
+        return (1, (), ip)
+
+    return sorted(pgs, key=lambda pg: _ip_sort_key(pg_ip[pg.id]))
 
 
 @ray.remote

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -67,6 +67,23 @@ def func_generator(self, method_name, dispatch_fn, collect_fn, execute_fn, block
     return type(method_name, (Functor,), {})()
 
 
+def _ip_sort_key(ip: str):
+    """Sort key that orders dotted-quad IPs numerically.
+
+    Lexicographic string order breaks whenever an allocation spans an octet-width
+    boundary (e.g. ``.9`` vs ``.66``), which lands ring-adjacent ranks on
+    physically distant nodes. Non-IPv4 addresses keep plain string order and sort
+    after all IPv4 addresses, so mixed deployments stay deterministic.
+    """
+    parts = ip.split(".")
+    if len(parts) == 4:
+        try:
+            return (0, tuple(int(p) for p in parts), "")
+        except ValueError:
+            pass
+    return (1, (), ip)
+
+
 def sort_placement_group_by_node_ip(pgs: list[PlacementGroup]) -> list[PlacementGroup]:
     """
     Sort the placement groups by node ip, all bundles in a single placement group should be on the same node.
@@ -84,18 +101,6 @@ def sort_placement_group_by_node_ip(pgs: list[PlacementGroup]) -> list[Placement
         # all bunles should be on the same node
         node_id = specs["bundles_to_node_id"][0]
         pg_ip[pg.id] = node_ip[node_id]
-    def _ip_sort_key(ip: str):
-        # Sort dotted-quad IPs numerically; lexicographic order breaks whenever the
-        # allocation spans an octet-width boundary (e.g. .9 vs .66), which lands
-        # ring-adjacent ranks on physically distant nodes. Non-IPv4 keeps string order.
-        parts = ip.split(".")
-        if len(parts) == 4:
-            try:
-                return (0, tuple(int(p) for p in parts), "")
-            except ValueError:
-                pass
-        return (1, (), ip)
-
     return sorted(pgs, key=lambda pg: _ip_sort_key(pg_ip[pg.id]))
 
 


### PR DESCRIPTION
### What does this PR do?

`sort_placement_group_by_node_ip` orders placement groups — and therefore global ranks — by the **string** form of each node's IP, so on a mixed-width allocation the rank order stops following the node order. This PR sorts by the parsed address instead. On equal-width allocations the result is byte-identical to today's order, so it is a no-op there.

Related open work: #4792 (IP-based worker sorting). Upstream PyTorch is making the same default change in `torchelastic`: pytorch/pytorch#191285 (approved by a repository collaborator) and the issue it came from, pytorch/pytorch#191190.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+placement+group+ip+sort — closest is #4792.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### The problem

`verl/single_controller/ray/base.py`:

```python
return sorted(pgs, key=lambda pg: pg_ip[pg.id])
```

Because the last octet is not zero-padded, string order and numeric order diverge whenever the allocated nodes span an octet-width boundary. For a 16-node job on `10.0.0.2…9` plus `10.0.0.66…73`, the resulting rank order is

```
2, 3, 4, 5, 6, 66, 67, 68, 69, 7, 70, 71, 72, 73, 8, 9
```

Node `.7` ends up isolated between two blocks of the other group. Ranks that are adjacent in ring collectives land on nodes that are far apart in the physical fabric.

### Test

**Unit tests (CPU only, no cluster):** `tests/single_controller/test_ip_sort_key_on_cpu.py` covers mixed-width numeric ordering, byte-identical behaviour on equal-width allocations, non-IPv4 fallback ordering, and malformed input.

**Reproduction of the underlying behaviour, no cluster needed:**

```python
ips = ["10.0.0.7", "10.0.0.66", "10.0.0.8", "10.0.0.70"]
sorted(ips)                                            # ['10.0.0.66', '10.0.0.7', '10.0.0.70', '10.0.0.8']
sorted(ips, key=lambda s: tuple(int(o) for o in s.split(".")))
                                                       # ['10.0.0.7', '10.0.0.8', '10.0.0.66', '10.0.0.70']
```

**Measured impact on a cluster:** on a 16-node MoE RL post-training job (GRPO, Qwen3-Coder-30B-A3B, EP=128, TP=4, Ascend 910C/HCCL), comparing the current string order against a contiguous order on the same nodes, everything else identical: **pure rank-order effect +8.4% step time** (weight-refit bucketing off) / **+9.3%** (on); 2×2 factorial, 5 epochs per cell, steady-state steps 3–12. The cost is a roughly constant seconds-per-step tax (it did not grow when mean generated length went 193→677 tokens).

Scoping this honestly: one interconnect, one model, one framework version. What transfers by code inspection is the permutation itself and the fact that ring collectives derive adjacency from rank order. Zero-padded / equal-width naming is immune; AWS IP-based private DNS names are not zero-padded and are mandatory on IPv4-only subnets.

### API and Usage Example

No API change: no CLI argument, config field, or function signature is added or altered. The only observable difference is the order in which placement groups are returned, and only for mixed-width allocations.

```python
# before: rank order follows the string form of the address
sorted(["10.0.0.9", "10.0.0.10"])          # ['10.0.0.10', '10.0.0.9']
# after: rank order follows the address
sorted(["10.0.0.9", "10.0.0.10"], key=_ip_sort_key)   # ['10.0.0.9', '10.0.0.10']
```

### Design & Code Changes

One module-level helper, so it is importable and unit-testable, plus its use as the sort key. It sorts by the parsed 4-tuple and falls back to string comparison for anything that is not a dotted quad (IPv6, hostnames), so non-IPv4 configurations keep today's order:

```python
def _ip_sort_key(ip: str):
    parts = ip.split(".")
    if len(parts) == 4:
        try:
            return (0, tuple(int(p) for p in parts), "")
        except ValueError:
            pass
    return (1, (), ip)
```

**Backward compatibility.** Equal-width allocations: order is byte-identical to today's. Mixed-width allocations: the order changes, which is the fix — it changes which node gets which rank, so jobs resuming from checkpoints that assumed the old order should restart instead. Happy to gate this behind a flag if maintainers prefer a staged rollout.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting). Left unchecked deliberately rather than assumed: the branch is unchanged since submission and I have not re-run the hooks against current `main`. Say the word and I will re-run and push any formatting fix.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not applicable as far as I can tell: there is no user-facing API or config change, and no page in `docs/` describes placement-group ordering. Glad to add one if you would like the behaviour documented.
- [x] Add unit or end-to-end test(s): `tests/single_controller/test_ip_sort_key_on_cpu.py`, CPU-only, no cluster required.
- [ ] Send a message in the `ci-request` Slack channel. This is the step I missed when opening the PR, which is why CI has never run here; it is being sent now.
