### PR TITLE
[data, ray] fix: prevent overlong prompt filtering hang in Ray workers

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -19,8 +19,10 @@ import copy
 import logging
 import os
 import re
+import signal
 import traceback
 from collections import defaultdict
+from contextlib import contextmanager
 from io import BytesIO
 from typing import Any, Optional
 
@@ -36,6 +38,32 @@ from verl.utils.import_utils import load_extern_object
 from verl.utils.tokenizer import build_multimodal_processor_inputs, normalize_token_ids
 
 logger = logging.getLogger(__name__)
+
+@contextmanager
+def _default_sigterm_in_forked_children(num_proc: int | None):
+    """Prevent forked dataset workers from inheriting a custom SIGTERM handler."""
+    original_handler = signal.getsignal(signal.SIGTERM)
+    if os.name != "posix" or num_proc is None or num_proc <= 1 or not callable(original_handler):
+        yield
+        return
+
+    parent_pid = os.getpid()
+
+    def sigterm_handler(signum, frame):
+        if os.getpid() == parent_pid:
+            original_handler(signum, frame)
+            return
+
+        # Ray installs a SIGTERM handler that raises SystemExit. Forked
+        # datasets workers must use the default behavior when their pool
+        # terminates them, otherwise pool shutdown can hang.
+        os._exit(128 + signum)
+
+    signal.signal(signal.SIGTERM, sigterm_handler)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, original_handler)
 
 
 def collate_fn(data_list: list[dict]) -> dict:
@@ -265,11 +293,12 @@ class RLHFDataset(Dataset):
                         traceback.print_exc()
                         return self.max_prompt_length + 1
 
-            dataframe = dataframe.filter(
-                lambda doc: doc2len(doc) <= self.max_prompt_length,
-                num_proc=self.num_workers,
-                desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
-            )
+            with _default_sigterm_in_forked_children(self.num_workers):
+                dataframe = dataframe.filter(
+                    lambda doc: doc2len(doc) <= self.max_prompt_length,
+                    num_proc=self.num_workers,
+                    desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
+                )
 
             print(f"filter dataset len: {len(dataframe)}")
         return dataframe


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

fix issue https://github.com/verl-project/verl/issues/7163

The fix logic is as follows：
- Enabled only when num_proc > 1, and the current SIGTERM handler is a custom one.
- When the parent process receives SIGTERM, the original handler continues to be invoked to preserve the exit semantics of Ray actors.
- Child processes of datasets spawned via fork exit directly upon receiving SIGTERM to avoid executing Ray's handler.
- Restore the original SIGTERM handler of the parent process in the finally block to prevent impacts on subsequent Ray behaviors.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: nothing about this fix https://github.com/verl-project/verl/pulls?q=is%3Apr+filter+overlong+prompts+is%3Aopen
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

The configurations are as follows, and the program resumes running successfully:：
```
    data.filter_overlong_prompts=True
    data.filter_overlong_prompts_workers=32
```
<img width="1812" height="362" alt="image" src="https://github.com/user-attachments/assets/4864a212-a7a4-4fa1-93c1-eae29b3bd2ce" />

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
