### PR TITLE
[fsdp] fix: preserve Hugging Face fp32-keep modules in FSDP2

### DIFF
--- a/tests/special_distributed/run_all.sh
+++ b/tests/special_distributed/run_all.sh
@@ -20,3 +20,6 @@ torchrun --nproc-per-node=4 --standalone tests/special_distributed/test_torch_fu
 # Regression for verl#5995 (FSDP2 + CPUOffloadPolicy state_dict crash). Only
 # needs 2 ranks to exercise CPUOffloadPolicy sharding.
 torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_cpu_offload_state_dict.py
+# Regression for verl#7092 (FSDP2 must honour HF _keep_in_fp32_modules*). Two
+# ranks are enough to exercise sharded fp32 units and the full-state-dict load.
+torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_keep_in_fp32.py

--- a/tests/special_distributed/test_fsdp2_keep_in_fp32.py
+++ b/tests/special_distributed/test_fsdp2_keep_in_fp32.py
@@ -19,10 +19,10 @@ Two independent degradations are covered.
 
 ``ISOLATION`` (runnable unmodified against the pre-fix tree, where it fails):
     verl builds the actor in fp32 and relies on ``MixedPrecisionPolicy`` for
-    bf16 compute. ``fully_shard`` all-gathers *every* parameter in
-    ``mp_policy.param_dtype``, so an fp32-keep module computes in bf16 even
-    though its sharded copy is fp32. The stored values look perfect -- only the
-    compute dtype is wrong, which is exactly why the bug is silent.
+    bf16 compute. ``fully_shard`` otherwise all-gathers every parameter in
+    ``mp_policy.param_dtype``, including parameters that Hugging Face kept in
+    fp32. The sharded values look perfect while the materialized parameter dtype
+    is wrong, which is exactly why the bug is silent.
 
 ``BUILD_CAST``:
     ``FSDPEngine._build_module`` calls ``module.to(torch_dtype)`` after
@@ -150,14 +150,17 @@ class ToyKeepFp32Model(PreTrainedModel):
 
 
 class SelfCastingSensitive(ToySensitive):
-    """Casts its own input, the way real fp32-keep HF modules do.
+    """Computes in its weight dtype while preserving the activation dtype.
 
-    Lets the same graph run unsharded (as a `from_pretrained` reference) and
-    under FSDP2, so the two can be compared bit for bit.
+    This mirrors modules such as Inkling's short convolution: the FSDP boundary
+    must not force its incoming activation to fp32.
     """
 
     def forward(self, x):
-        return super().forward(x.to(self.proj.weight.dtype))
+        self.input_dtype = x.dtype
+        output = super().forward(x.to(self.proj.weight.dtype)).to(self.input_dtype)
+        self.output_dtype = output.dtype
+        return output
 
 
 class ToySelfCastingModel(ToyKeepFp32Model):
@@ -323,8 +326,8 @@ def _wrap_fsdp2(module, param_dtype, mesh):
     return module
 
 
-def _compute_dtypes(module, input_ids):
-    """Record the dtype each leaf actually computes in (post all-gather)."""
+def _forward_parameter_dtypes(module, input_ids, autocast_dtype=torch.bfloat16):
+    """Record each leaf weight after all-gather under the engine autocast."""
     seen = {}
     handles = []
 
@@ -337,7 +340,8 @@ def _compute_dtypes(module, input_ids):
     for name, sub in module.named_modules():
         if isinstance(sub, nn.Linear):
             handles.append(sub.register_forward_pre_hook(make_hook(name)))
-    out = module(input_ids)
+    with torch.autocast(device_type=get_device_name(), dtype=autocast_dtype):
+        out = module(input_ids)
     for h in handles:
         h.remove()
     return seen, out
@@ -379,10 +383,10 @@ def _gather_state(module):
 
 
 def case_isolation(path, mesh, rank, model_cls, expected_fp32_prefixes, label, compute_dtype=torch.bfloat16):
-    """fp32 storage + bf16 mp_policy: keep-fp32 modules must compute in fp32.
+    """fp32 storage + low-precision policy: kept parameters all-gather in fp32.
 
     This case never downcasts the parameters, so it runs unmodified against the
-    pre-fix tree -- where it fails purely on the compute dtype.
+    pre-fix tree -- where it fails purely on the all-gather dtype.
     """
     module = _build_module(path, model_cls, torch.float32, mesh, keep_fp32_aware=False)
     reference = {k: v.clone() for k, v in module.state_dict().items()} if rank == 0 else None
@@ -390,8 +394,8 @@ def case_isolation(path, mesh, rank, model_cls, expected_fp32_prefixes, label, c
 
     # Checked first on purpose: the stored values are bit-identical, so a
     # value-only assertion passes both before and after the fix. Only the
-    # compute dtype below exposes the degradation -- that is what makes the
-    # bug silent in practice.
+    # The all-gather dtype below exposes the degradation -- that is what makes
+    # the bug silent in practice.
     for name, param in module.named_parameters():
         assert param.dtype == torch.float32, f"[{label}] {name}: sharded dtype {param.dtype}"
     gathered = _gather_state(module)
@@ -402,13 +406,13 @@ def case_isolation(path, mesh, rank, model_cls, expected_fp32_prefixes, label, c
 
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
-    dtypes, out = _compute_dtypes(module, input_ids)
+    dtypes, out = _forward_parameter_dtypes(module, input_ids, compute_dtype)
 
     bad = []
     for name, dtype in sorted(dtypes.items()):
         want = torch.float32 if _matches(name, expected_fp32_prefixes) else compute_dtype
         if dtype != want:
-            bad.append(f"{name}: compute dtype {dtype}, expected {want}")
+            bad.append(f"{name}: all-gather dtype {dtype}, expected {want}")
     assert not bad, f"[{label}] fp32-keep modules degraded during forward:\n  " + "\n  ".join(bad)
 
     loss = out.float().pow(2).mean()
@@ -450,14 +454,14 @@ def case_build_cast(path, mesh, rank, torch_dtype, expected_fp32_prefixes, label
     module = _wrap_fsdp2(module, torch_dtype, mesh)
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
-    dtypes, out = _compute_dtypes(module, input_ids)
+    dtypes, out = _forward_parameter_dtypes(module, input_ids, torch_dtype)
 
     bad = [
         f"{n}: {d}"
         for n, d in sorted(dtypes.items())
         if d != (torch.float32 if _matches(n, expected_fp32_prefixes) else torch_dtype)
     ]
-    assert not bad, f"[{label}] compute dtype wrong after fsdp2:\n  " + "\n  ".join(bad)
+    assert not bad, f"[{label}] all-gather dtype wrong after fsdp2:\n  " + "\n  ".join(bad)
     out.float().pow(2).mean().backward()
     if rank == 0:
         print(f"[{label}] build cast + fsdp2 forward/backward OK")
@@ -491,8 +495,8 @@ def case_no_keep_list(path, mesh, rank):
 
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
-    dtypes, out = _compute_dtypes(module, input_ids)
-    assert set(dtypes.values()) == {torch.bfloat16}, f"[no-keep] compute dtypes {set(dtypes.values())}"
+    dtypes, out = _forward_parameter_dtypes(module, input_ids)
+    assert set(dtypes.values()) == {torch.bfloat16}, f"[no-keep] parameter dtypes {set(dtypes.values())}"
     out.float().pow(2).mean().backward()
     if rank == 0:
         print("[no-keep] baseline behaviour unchanged")
@@ -521,7 +525,7 @@ def case_single_wrapping(path, mesh, rank):
 
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
-    dtypes, out = _compute_dtypes(module, input_ids)
+    dtypes, out = _forward_parameter_dtypes(module, input_ids)
     for name, dtype in sorted(dtypes.items()):
         want = torch.float32 if _matches(name, ["fp32_strict", "inner", "proj"]) else torch.bfloat16
         assert dtype == want, f"[overlap] {name}: {dtype} != {want}"
@@ -533,16 +537,22 @@ def case_single_wrapping(path, mesh, rank):
 def case_matches_unsharded_reference(path, mesh, rank):
     """FSDP2 must reproduce what plain `from_pretrained` computes, bit for bit.
 
-    This is what pins ``param_dtype=torch.float32`` on the fp32-keep child unit:
-    with ``param_dtype=None`` FSDP2 would not cast the unit's inputs at all
-    (``cast_forward_inputs`` is gated on ``param_dtype`` being set), which breaks
-    every fp32-keep module that relies on the framework for the cast.
+    The self-casting child preserves its low-precision activation boundary, so
+    this pins ``param_dtype=None``: forcing fp32 inputs changes its output
+    contract even though its parameters are correctly all-gathered in fp32.
     """
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
 
     reference = ToySelfCastingModel.from_pretrained(path, torch_dtype=torch.bfloat16).to(get_device_id())
-    ref_logits = reference(input_ids)
+    with torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):
+        ref_logits = reference(input_ids)
+    ref_io_dtypes = {
+        name: (submodule.input_dtype, submodule.output_dtype)
+        for name, submodule in reference.named_modules()
+        if isinstance(submodule, SelfCastingSensitive)
+    }
+    assert set(ref_io_dtypes.values()) == {(torch.bfloat16, torch.bfloat16)}
     ref_loss = ref_logits.float().pow(2).mean()
     ref_loss.backward()
     ref_grads = {name: param.grad.detach().clone() for name, param in sorted(reference.named_parameters())}
@@ -550,7 +560,14 @@ def case_matches_unsharded_reference(path, mesh, rank):
 
     module = _build_module(path, ToySelfCastingModel, torch.bfloat16, mesh, keep_fp32_aware=True)
     module = _wrap_fsdp2(module, torch.bfloat16, mesh)
-    logits = module(input_ids)
+    with torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):
+        logits = module(input_ids)
+    io_dtypes = {
+        name: (submodule.input_dtype, submodule.output_dtype)
+        for name, submodule in module.named_modules()
+        if isinstance(submodule, SelfCastingSensitive)
+    }
+    assert io_dtypes == ref_io_dtypes, f"[reference] activation boundary dtypes differ: {io_dtypes} != {ref_io_dtypes}"
     loss = logits.float().pow(2).mean()
     loss.backward()
 
@@ -628,10 +645,10 @@ def case_keep_ancestor_absorbs_standard_targets(path, mesh, rank):
 
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
-    dtypes, out = _compute_dtypes(module, input_ids)
+    dtypes, out = _forward_parameter_dtypes(module, input_ids)
     for name, dtype in sorted(dtypes.items()):
         want = torch.float32 if _matches(name, ["stack"]) else torch.bfloat16
-        assert dtype == want, f"[keep-ancestor] {name} computed in {dtype}, expected {want}"
+        assert dtype == want, f"[keep-ancestor] {name} all-gathered in {dtype}, expected {want}"
     out.float().pow(2).mean().backward()
     for name, param in sorted(module.named_parameters()):
         assert param.grad is not None, f"[keep-ancestor] {name} has no grad"
@@ -658,13 +675,13 @@ def case_no_forward_container_is_not_a_unit(path, mesh, rank):
 
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
-    dtypes, out = _compute_dtypes(module, input_ids)
+    dtypes, out = _forward_parameter_dtypes(module, input_ids)
     assert dtypes["holder.child.proj"] == torch.float32, (
-        f"[no-forward] fp32-keep leaf computed in {dtypes['holder.child.proj']}"
+        f"[no-forward] fp32-keep leaf all-gathered in {dtypes['holder.child.proj']}"
     )
     for name, dtype in sorted(dtypes.items()):
         if not _matches(name, ["holder", "fp32_strict", "fp32_regular"]):
-            assert dtype == torch.bfloat16, f"[no-forward] control {name} computed in {dtype}"
+            assert dtype == torch.bfloat16, f"[no-forward] control {name} all-gathered in {dtype}"
 
     loss = out.float().pow(2).mean()
     loss.backward()
@@ -694,10 +711,10 @@ def case_keep_child_under_standard_parent(path, mesh, rank):
 
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
-    dtypes, out = _compute_dtypes(module, input_ids)
+    dtypes, out = _forward_parameter_dtypes(module, input_ids)
     for name, dtype in sorted(dtypes.items()):
         want = torch.float32 if _matches(name, ["fp32_strict"]) else torch.bfloat16
-        assert dtype == want, f"[keep-child] {name} computed in {dtype}, expected {want}"
+        assert dtype == want, f"[keep-child] {name} all-gathered in {dtype}, expected {want}"
     out.float().pow(2).mean().backward()
     if rank == 0:
         print(f"[keep-child] keep child + standard parent + root all present: {units}")

--- a/tests/special_distributed/test_fsdp2_keep_in_fp32.py
+++ b/tests/special_distributed/test_fsdp2_keep_in_fp32.py
@@ -45,6 +45,7 @@ import itertools
 import os
 import tempfile
 from collections import OrderedDict
+from contextlib import nullcontext
 
 import torch
 import torch.distributed
@@ -105,7 +106,7 @@ class ToyGate(nn.Module):
 class ToyBlock(nn.Module):
     def __init__(self, hidden_size):
         super().__init__()
-        # control module: must follow the low-precision compute dtype
+        # control module: its parameters follow the low-precision FSDP policy
         self.dense = nn.Linear(hidden_size, hidden_size, bias=False)
         # matched by ``_keep_in_fp32_modules`` (fp16 only, per HF semantics)
         self.fp32_regular = ToySensitive(hidden_size)
@@ -157,9 +158,15 @@ class SelfCastingSensitive(ToySensitive):
     """
 
     def forward(self, x):
-        self.input_dtype = x.dtype
-        output = super().forward(x.to(self.proj.weight.dtype)).to(self.input_dtype)
-        self.output_dtype = output.dtype
+        self.activation_input_dtype = x.dtype
+        operator_input = x.to(self.proj.weight.dtype)
+        self.operator_input_dtype = operator_input.dtype
+        projected = self.proj(operator_input)
+        self.operator_output_dtype = projected.dtype
+        computed = projected * self.running_scale.to(operator_input.dtype)
+        self.computation_result_dtype = computed.dtype
+        output = computed.to(self.activation_input_dtype)
+        self.activation_output_dtype = output.dtype
         return output
 
 
@@ -326,8 +333,15 @@ def _wrap_fsdp2(module, param_dtype, mesh):
     return module
 
 
+def _forward_context(autocast_dtype):
+    """Match FSDPEngine.forward_step: autocast for low precision, direct for fp32."""
+    if autocast_dtype is None or autocast_dtype == torch.float32:
+        return nullcontext()
+    return torch.autocast(device_type=get_device_name(), dtype=autocast_dtype)
+
+
 def _forward_parameter_dtypes(module, input_ids, autocast_dtype=torch.bfloat16):
-    """Record each leaf weight after all-gather under the engine autocast."""
+    """Record each leaf weight after materialization, separately from activations."""
     seen = {}
     handles = []
 
@@ -340,11 +354,27 @@ def _forward_parameter_dtypes(module, input_ids, autocast_dtype=torch.bfloat16):
     for name, sub in module.named_modules():
         if isinstance(sub, nn.Linear):
             handles.append(sub.register_forward_pre_hook(make_hook(name)))
-    with torch.autocast(device_type=get_device_name(), dtype=autocast_dtype):
+    with _forward_context(autocast_dtype):
         out = module(input_ids)
     for h in handles:
         h.remove()
     return seen, out
+
+
+def _self_casting_observations(module):
+    """Keep activation-boundary and internal tensor dtypes explicitly separate."""
+    return {
+        name: {
+            "activation": (submodule.activation_input_dtype, submodule.activation_output_dtype),
+            "internal": (
+                submodule.operator_input_dtype,
+                submodule.operator_output_dtype,
+                submodule.computation_result_dtype,
+            ),
+        }
+        for name, submodule in module.named_modules()
+        if isinstance(submodule, SelfCastingSensitive)
+    }
 
 
 def _matches(name, prefixes):
@@ -393,9 +423,8 @@ def case_isolation(path, mesh, rank, model_cls, expected_fp32_prefixes, label, c
     module = _wrap_fsdp2(module, compute_dtype, mesh)
 
     # Checked first on purpose: the stored values are bit-identical, so a
-    # value-only assertion passes both before and after the fix. Only the
-    # The all-gather dtype below exposes the degradation -- that is what makes
-    # the bug silent in practice.
+    # value-only assertion passes both before and after the fix. The all-gather
+    # dtype below exposes the degradation -- that is what makes the bug silent.
     for name, param in module.named_parameters():
         assert param.dtype == torch.float32, f"[{label}] {name}: sharded dtype {param.dtype}"
     gathered = _gather_state(module)
@@ -534,54 +563,67 @@ def case_single_wrapping(path, mesh, rank):
         print(f"[overlap] single wrapping OK, units={units}")
 
 
-def case_matches_unsharded_reference(path, mesh, rank):
-    """FSDP2 must reproduce what plain `from_pretrained` computes, bit for bit.
+def case_matches_unsharded_reference(path, mesh, rank, activation_dtype, use_autocast):
+    """FSDP2 must reproduce plain ``from_pretrained`` in the same context.
 
     The self-casting child preserves its low-precision activation boundary, so
     this pins ``param_dtype=None``: forcing fp32 inputs changes its output
-    contract even though its parameters are correctly all-gathered in fp32.
+    contract even though its parameters are correctly all-gathered in fp32. The
+    engine-style autocast and direct/no-autocast contexts are both covered.
     """
+    context_dtype = activation_dtype if use_autocast else None
+    context_label = "engine-autocast" if use_autocast else "direct"
+    dtype_label = str(activation_dtype).removeprefix("torch.")
+    label = f"reference/{dtype_label}/{context_label}"
+
     torch.manual_seed(SEED)
     input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
 
-    reference = ToySelfCastingModel.from_pretrained(path, torch_dtype=torch.bfloat16).to(get_device_id())
-    with torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):
-        ref_logits = reference(input_ids)
-    ref_io_dtypes = {
-        name: (submodule.input_dtype, submodule.output_dtype)
-        for name, submodule in reference.named_modules()
-        if isinstance(submodule, SelfCastingSensitive)
-    }
-    assert set(ref_io_dtypes.values()) == {(torch.bfloat16, torch.bfloat16)}
+    reference = ToySelfCastingModel.from_pretrained(path, torch_dtype=activation_dtype).to(get_device_id())
+    ref_parameter_dtypes, ref_logits = _forward_parameter_dtypes(reference, input_ids, context_dtype)
+    ref_observations = _self_casting_observations(reference)
+    assert {obs["activation"] for obs in ref_observations.values()} == {(activation_dtype, activation_dtype)}, (
+        f"[{label}] unexpected reference activation boundary: {ref_observations}"
+    )
     ref_loss = ref_logits.float().pow(2).mean()
     ref_loss.backward()
     ref_grads = {name: param.grad.detach().clone() for name, param in sorted(reference.named_parameters())}
     ref_dtypes = {name: param.dtype for name, param in reference.named_parameters()}
 
-    module = _build_module(path, ToySelfCastingModel, torch.bfloat16, mesh, keep_fp32_aware=True)
-    module = _wrap_fsdp2(module, torch.bfloat16, mesh)
-    with torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):
-        logits = module(input_ids)
-    io_dtypes = {
-        name: (submodule.input_dtype, submodule.output_dtype)
-        for name, submodule in module.named_modules()
-        if isinstance(submodule, SelfCastingSensitive)
-    }
-    assert io_dtypes == ref_io_dtypes, f"[reference] activation boundary dtypes differ: {io_dtypes} != {ref_io_dtypes}"
+    module = _build_module(path, ToySelfCastingModel, activation_dtype, mesh, keep_fp32_aware=True)
+    module = _wrap_fsdp2(module, activation_dtype, mesh)
+    parameter_dtypes, logits = _forward_parameter_dtypes(module, input_ids, context_dtype)
+    observations = _self_casting_observations(module)
+    assert observations == ref_observations, (
+        f"[{label}] activation/internal dtypes differ: {observations} != {ref_observations}"
+    )
+    assert parameter_dtypes == ref_parameter_dtypes, (
+        f"[{label}] materialized parameter dtypes differ: {parameter_dtypes} != {ref_parameter_dtypes}"
+    )
+    kept_parameter_dtypes = {name: dtype for name, dtype in parameter_dtypes.items() if dtype == torch.float32}
+    assert kept_parameter_dtypes, f"[{label}] no fp32 parameter was observed during forward"
+    assert all(dtype == torch.float32 for dtype in kept_parameter_dtypes.values())
+
     loss = logits.float().pow(2).mean()
     loss.backward()
 
-    assert logits.dtype == ref_logits.dtype, f"[reference] logits dtype {logits.dtype} != {ref_logits.dtype}"
-    assert torch.equal(logits, ref_logits), "[reference] logits differ from the unsharded model"
-    assert loss.item() == ref_loss.item(), f"[reference] loss {loss.item()!r} != {ref_loss.item()!r}"
+    assert logits.dtype == ref_logits.dtype, f"[{label}] logits dtype {logits.dtype} != {ref_logits.dtype}"
+    assert torch.equal(logits, ref_logits), f"[{label}] logits differ from the unsharded model"
+    assert loss.item() == ref_loss.item(), f"[{label}] loss {loss.item()!r} != {ref_loss.item()!r}"
 
     for name, param in sorted(module.named_parameters()):
-        assert param.dtype == ref_dtypes[name], f"[reference] {name}: dtype {param.dtype} != {ref_dtypes[name]}"
+        assert param.dtype == ref_dtypes[name], f"[{label}] {name}: dtype {param.dtype} != {ref_dtypes[name]}"
         grad = _full_tensor(param.grad)
-        assert grad.dtype == ref_grads[name].dtype, f"[reference] {name}: grad dtype {grad.dtype}"
-        assert torch.equal(grad, ref_grads[name]), f"[reference] {name}: gradient differs from the unsharded model"
+        assert grad.dtype == ref_grads[name].dtype, f"[{label}] {name}: grad dtype {grad.dtype}"
+        assert torch.equal(grad, ref_grads[name]), f"[{label}] {name}: gradient differs from the unsharded model"
     if rank == 0:
-        print(f"[reference] fsdp2 matches unsharded from_pretrained bit-for-bit (loss={loss.item():.10e})")
+        activation_observations = {name: obs["activation"] for name, obs in observations.items()}
+        internal_observations = {name: obs["internal"] for name, obs in observations.items()}
+        print(
+            f"[{label}] activation={activation_observations}; internal={internal_observations}; "
+            f"all-gathered-fp32={sorted(kept_parameter_dtypes)}"
+        )
+        print(f"[{label}] fsdp2 matches unsharded from_pretrained bit-for-bit (loss={loss.item():.10e})")
 
 
 def case_loader_does_not_mutate_full_state(path, mesh, rank):
@@ -855,9 +897,12 @@ def main():
     case_build_cast(path, mesh, rank, torch.float16, ["fp32_strict", "fp32_regular"], "build/fp16")
     get_torch_device().empty_cache()
 
-    # 5. parity with the unsharded `from_pretrained` graph.
-    case_matches_unsharded_reference(self_cast_path, mesh, rank)
-    get_torch_device().empty_cache()
+    # 5. BF16/FP16 parity with the unsharded `from_pretrained` graph, both in
+    #    FSDPEngine's autocast context and through a direct/no-autocast call.
+    for activation_dtype in (torch.bfloat16, torch.float16):
+        for use_autocast in (True, False):
+            case_matches_unsharded_reference(self_cast_path, mesh, rank, activation_dtype, use_autocast)
+            get_torch_device().empty_cache()
 
     # 5b. the loader must not touch the caller's state dict.
     case_loader_does_not_mutate_full_state(path, mesh, rank)

--- a/tests/special_distributed/test_fsdp2_keep_in_fp32.py
+++ b/tests/special_distributed/test_fsdp2_keep_in_fp32.py
@@ -1,0 +1,877 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression for verl#7092: FSDP2 must honour HF ``_keep_in_fp32_modules`` /
+``_keep_in_fp32_modules_strict``.
+
+Two independent degradations are covered.
+
+``ISOLATION`` (runnable unmodified against the pre-fix tree, where it fails):
+    verl builds the actor in fp32 and relies on ``MixedPrecisionPolicy`` for
+    bf16 compute. ``fully_shard`` all-gathers *every* parameter in
+    ``mp_policy.param_dtype``, so an fp32-keep module computes in bf16 even
+    though its sharded copy is fp32. The stored values look perfect -- only the
+    compute dtype is wrong, which is exactly why the bug is silent.
+
+``BUILD_CAST``:
+    ``FSDPEngine._build_module`` calls ``module.to(torch_dtype)`` after
+    ``from_pretrained``. HF had already materialised the fp32-keep modules in
+    fp32; the blanket cast destroys them (values are rounded through bf16 and
+    cannot be recovered). The probe compares the legacy blanket cast against the
+    keep-fp32-aware cast.
+
+Everything runs on a locally constructed toy ``PreTrainedModel``; no weights are
+downloaded.
+
+Launch:
+    torchrun --nproc-per-node=1 --standalone \\
+        tests/special_distributed/test_fsdp2_keep_in_fp32.py
+    torchrun --nproc-per-node=2 --standalone \\
+        tests/special_distributed/test_fsdp2_keep_in_fp32.py
+"""
+
+import itertools
+import os
+import tempfile
+from collections import OrderedDict
+
+import torch
+import torch.distributed
+import torch.nn as nn
+from torch.distributed import init_device_mesh
+from transformers import PretrainedConfig, PreTrainedModel
+
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
+from verl.utils.distributed import initialize_global_process_group
+from verl.utils.fsdp_utils import (
+    MixedPrecisionPolicy,
+    apply_fsdp2,
+    fsdp2_load_full_state_dict,
+    get_init_weight_context_manager,
+)
+
+SEED = 7092
+
+# ---------------------------------------------------------------------------
+# Toy PreTrainedModel
+# ---------------------------------------------------------------------------
+
+
+class ToyKeepFp32Config(PretrainedConfig):
+    model_type = "verl_toy_keep_fp32"
+
+    def __init__(self, hidden_size=32, num_hidden_layers=2, vocab_size=64, **kwargs):
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.vocab_size = vocab_size
+        kwargs.setdefault("tie_word_embeddings", False)
+        super().__init__(**kwargs)
+
+
+class ToySensitive(nn.Module):
+    """Leaf that owns a float parameter *and* a float buffer."""
+
+    def __init__(self, hidden_size):
+        super().__init__()
+        self.proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.register_buffer("running_scale", torch.ones(hidden_size))
+
+    def forward(self, x):
+        return self.proj(x) * self.running_scale.to(x.dtype)
+
+
+class ToyGate(nn.Module):
+    """Container without direct parameters -- exercises nested name matching."""
+
+    def __init__(self, hidden_size):
+        super().__init__()
+        self.inner = ToySensitive(hidden_size)
+
+    def forward(self, x):
+        return self.inner(x)
+
+
+class ToyBlock(nn.Module):
+    def __init__(self, hidden_size):
+        super().__init__()
+        # control module: must follow the low-precision compute dtype
+        self.dense = nn.Linear(hidden_size, hidden_size, bias=False)
+        # matched by ``_keep_in_fp32_modules`` (fp16 only, per HF semantics)
+        self.fp32_regular = ToySensitive(hidden_size)
+        # matched by ``_keep_in_fp32_modules_strict`` (fp16 and bf16)
+        self.fp32_strict = ToyGate(hidden_size)
+
+    def forward(self, x):
+        # An fp32-keep sub-module returns fp32 activations (this is also what
+        # `from_pretrained` produces); real models cast back at the residual, so
+        # the toy model does the same.
+        dtype = x.dtype
+        x = x + self.dense(x)
+        x = x + self.fp32_regular(x).to(dtype)
+        x = x + self.fp32_strict(x).to(dtype)
+        return x
+
+
+class ToyKeepFp32Model(PreTrainedModel):
+    config_class = ToyKeepFp32Config
+    base_model_prefix = "toy"
+    _no_split_modules = ["ToyBlock"]
+    _keep_in_fp32_modules = ["fp32_regular"]
+    _keep_in_fp32_modules_strict = ["fp32_strict"]
+    _supports_sdpa = False
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = nn.ModuleList([ToyBlock(config.hidden_size) for _ in range(config.num_hidden_layers)])
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+    def _init_weights(self, module):
+        if isinstance(module, nn.Linear | nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=0.05)
+
+    def forward(self, input_ids):
+        x = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        return self.lm_head(x)
+
+
+class SelfCastingSensitive(ToySensitive):
+    """Casts its own input, the way real fp32-keep HF modules do.
+
+    Lets the same graph run unsharded (as a `from_pretrained` reference) and
+    under FSDP2, so the two can be compared bit for bit.
+    """
+
+    def forward(self, x):
+        return super().forward(x.to(self.proj.weight.dtype))
+
+
+class ToySelfCastingModel(ToyKeepFp32Model):
+    def __init__(self, config):
+        super().__init__(config)
+        for layer in self.layers:
+            for owner, attr in ((layer, "fp32_regular"), (layer.fp32_strict, "inner")):
+                old = getattr(owner, attr)
+                new = SelfCastingSensitive(config.hidden_size)
+                new.load_state_dict(old.state_dict())
+                setattr(owner, attr, new)
+
+
+class ToyStack(nn.Module):
+    """A wrappable container holding the standard transformer-layer targets."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.blocks = nn.ModuleList([ToyBlock(config.hidden_size) for _ in range(config.num_hidden_layers)])
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+class ToyKeepAncestorModel(ToyKeepFp32Model):
+    """The keep declaration hits the container that holds the standard targets.
+
+    ``stack`` owns both ``ToyBlock`` wrap targets, so the keep unit is an
+    *ancestor* of them and they must not be wrapped again underneath it.
+    """
+
+    # Declared per instance below: the base __init__ validates the keep list
+    # against the modules that exist at that point, and `stack` is not one yet.
+    _keep_in_fp32_modules = None
+    _keep_in_fp32_modules_strict = None
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.stack = ToyStack(config)
+        self.layers = nn.ModuleList()  # the stack replaces them
+        self._keep_in_fp32_modules_strict = ["stack"]
+        self.post_init()
+
+    def forward(self, input_ids):
+        return self.lm_head(self.stack(self.embed_tokens(input_ids)))
+
+
+class ToyNoForwardContainerModel(ToyKeepFp32Model):
+    """A fp32-keep leaf behind a container that has no ``forward`` of its own.
+
+    ``holder`` is a plain ``nn.Module`` used purely for namespacing, and the
+    model reaches straight past it to ``holder.child``. FSDP2 unshards a unit's
+    parameters from that unit's *own* forward hook, so making ``holder`` the
+    unit would leave the hook unreachable and the parameters sharded during
+    compute. The keep declaration names the container, so the selector has to
+    descend to ``holder.child``.
+    """
+
+    _keep_in_fp32_modules = None
+    _keep_in_fp32_modules_strict = None
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.holder = nn.Module()
+        self.holder.child = ToySensitive(config.hidden_size)
+        self._keep_in_fp32_modules_strict = ["holder"]
+        self.post_init()
+
+    def forward(self, input_ids):
+        x = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            x = layer(x)
+        # deliberately *not* self.holder(x): the container is never called
+        x = x + self.holder.child(x).to(x.dtype)
+        return self.lm_head(x)
+
+
+class ToyTiedAliasModel(ToyKeepFp32Model):
+    """A kept weight exposed under two FQNs inside a single keep unit.
+
+    ``state_dict()`` lists both aliases, so the loader's dtype map has to see
+    both -- ``named_parameters()`` alone de-duplicates them away.
+    """
+
+    _keep_in_fp32_modules = None
+    _keep_in_fp32_modules_strict = ["fp32_strict"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        for layer in self.layers:
+            inner = layer.fp32_strict.inner
+            inner.proj_alias = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+            inner.proj_alias.weight = inner.proj.weight
+
+
+class ToyOverlapModel(ToyKeepFp32Model):
+    """Parent/child overlap plus a duplicate entry in the keep list.
+
+    ``fp32_strict`` is a parent of ``inner``/``proj``; ``proj`` additionally
+    matches inside ``fp32_regular``. The resulting FSDP2 units must be the
+    topmost fully-matched modules, each wrapped exactly once.
+    """
+
+    _keep_in_fp32_modules = None
+    _keep_in_fp32_modules_strict = ["fp32_strict", "inner", "proj", "fp32_strict"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_checkpoint(tmpdir, model_cls, rank, safe_serialization=True):
+    """Rank 0 materialises a deterministic fp32 checkpoint on local disk.
+
+    ``safe_serialization=False`` is needed for models that deliberately tie two
+    parameters: safetensors refuses to store shared storage.
+    """
+    path = os.path.join(tmpdir, model_cls.__name__)
+    if rank == 0:
+        torch.manual_seed(SEED)
+        config = ToyKeepFp32Config()
+        model = model_cls(config)
+        model.save_pretrained(path, safe_serialization=safe_serialization)
+    torch.distributed.barrier()
+    return path
+
+
+def _build_module(path, model_cls, torch_dtype, mesh, keep_fp32_aware):
+    """Mirror ``FSDPEngine._build_module``'s meta-init + dtype cast."""
+    init_context = get_init_weight_context_manager(use_meta_tensor=True, mesh=mesh)
+    with init_context():
+        module = model_cls.from_pretrained(path, torch_dtype=torch_dtype)
+        if keep_fp32_aware:
+            from verl.utils.fsdp_utils import cast_module_to_dtype_keeping_fp32_modules
+
+            cast_module_to_dtype_keeping_fp32_modules(module, torch_dtype)
+        else:
+            # legacy behaviour: blanket cast, wipes HF's fp32-keep modules
+            module.to(torch_dtype)
+    return module
+
+
+def _fsdp_kwargs(param_dtype, mesh):
+    return {
+        "mesh": mesh,
+        "mp_policy": MixedPrecisionPolicy(
+            param_dtype=param_dtype, reduce_dtype=torch.float32, cast_forward_inputs=True
+        ),
+        "offload_policy": None,
+        "reshard_after_forward": True,
+    }
+
+
+def _wrap_fsdp2(module, param_dtype, mesh):
+    """Mirror ``FSDPEngine._build_fsdp_module``'s fsdp2 branch."""
+    fsdp_kwargs = _fsdp_kwargs(param_dtype, mesh)
+    full_state = module.state_dict()
+    apply_fsdp2(module, fsdp_kwargs, {})
+    fsdp2_load_full_state_dict(module, full_state, mesh, None)
+    return module
+
+
+def _compute_dtypes(module, input_ids):
+    """Record the dtype each leaf actually computes in (post all-gather)."""
+    seen = {}
+    handles = []
+
+    def make_hook(name):
+        def hook(mod, args):
+            seen[name] = mod.weight.dtype
+
+        return hook
+
+    for name, sub in module.named_modules():
+        if isinstance(sub, nn.Linear):
+            handles.append(sub.register_forward_pre_hook(make_hook(name)))
+    out = module(input_ids)
+    for h in handles:
+        h.remove()
+    return seen, out
+
+
+def _matches(name, prefixes):
+    """HF matches whole dot-separated path segments, anywhere in the FQN."""
+    segments = name.split(".")
+    return any(prefix in segments for prefix in prefixes)
+
+
+def _reference_model(path, model_cls, torch_dtype):
+    """What ``from_pretrained`` alone produces -- the behaviour verl must match."""
+    return model_cls.from_pretrained(path, torch_dtype=torch_dtype)
+
+
+def _local_dtypes(module):
+    out = {}
+    for name, param in module.named_parameters():
+        out[name] = param.dtype
+    for name, buf in module.named_buffers():
+        out[name] = buf.dtype
+    return out
+
+
+def _full_tensor(t):
+    return t.full_tensor() if hasattr(t, "full_tensor") else t
+
+
+def _gather_state(module):
+    """All-gather every sharded state. Collective: must run on every rank, in a
+    deterministic (sorted) order, otherwise ranks mismatch on the collective."""
+    return {name: _full_tensor(t).cpu().float() for name, t in sorted(module.state_dict().items())}
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+
+def case_isolation(path, mesh, rank, model_cls, expected_fp32_prefixes, label, compute_dtype=torch.bfloat16):
+    """fp32 storage + bf16 mp_policy: keep-fp32 modules must compute in fp32.
+
+    This case never downcasts the parameters, so it runs unmodified against the
+    pre-fix tree -- where it fails purely on the compute dtype.
+    """
+    module = _build_module(path, model_cls, torch.float32, mesh, keep_fp32_aware=False)
+    reference = {k: v.clone() for k, v in module.state_dict().items()} if rank == 0 else None
+    module = _wrap_fsdp2(module, compute_dtype, mesh)
+
+    # Checked first on purpose: the stored values are bit-identical, so a
+    # value-only assertion passes both before and after the fix. Only the
+    # compute dtype below exposes the degradation -- that is what makes the
+    # bug silent in practice.
+    for name, param in module.named_parameters():
+        assert param.dtype == torch.float32, f"[{label}] {name}: sharded dtype {param.dtype}"
+    gathered = _gather_state(module)
+    if rank == 0:
+        for name, ref in reference.items():
+            assert torch.equal(gathered[name], ref.cpu().float()), f"[{label}] {name} value mismatch"
+        print(f"[{label}] parameter values are bit-identical to the checkpoint")
+
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+    dtypes, out = _compute_dtypes(module, input_ids)
+
+    bad = []
+    for name, dtype in sorted(dtypes.items()):
+        want = torch.float32 if _matches(name, expected_fp32_prefixes) else compute_dtype
+        if dtype != want:
+            bad.append(f"{name}: compute dtype {dtype}, expected {want}")
+    assert not bad, f"[{label}] fp32-keep modules degraded during forward:\n  " + "\n  ".join(bad)
+
+    loss = out.float().pow(2).mean()
+    loss.backward()
+    for name, param in sorted(module.named_parameters()):
+        assert param.grad is not None, f"[{label}] {name} has no grad"
+        assert param.grad.dtype == param.dtype, f"[{label}] {name}: grad dtype {param.grad.dtype} != {param.dtype}"
+        assert torch.isfinite(_full_tensor(param.grad).float()).all(), f"[{label}] {name} grad not finite"
+
+    if rank == 0:
+        print(f"[{label}] isolation case OK (loss={loss.item():.6f})")
+    return module
+
+
+def case_build_cast(path, mesh, rank, torch_dtype, expected_fp32_prefixes, label):
+    """The blanket ``module.to(torch_dtype)`` must not wipe HF's fp32 modules."""
+    reference = _reference_model(path, ToyKeepFp32Model, torch_dtype) if rank == 0 else None
+    module = _build_module(path, ToyKeepFp32Model, torch_dtype, mesh, keep_fp32_aware=True)
+
+    if rank == 0:
+        ref_dtypes = _local_dtypes(reference)
+        got_dtypes = _local_dtypes(module)
+        bad = [
+            f"{n}: {got_dtypes[n]} != {d}" for n, d in ref_dtypes.items() if got_dtypes[n] != d and d.is_floating_point
+        ]
+        assert not bad, f"[{label}] dtype drift vs from_pretrained:\n  " + "\n  ".join(bad)
+
+        ref_state = reference.state_dict()
+        for name, tensor in module.state_dict().items():
+            if not tensor.dtype.is_floating_point:
+                continue
+            assert torch.equal(tensor.cpu(), ref_state[name].cpu()), f"[{label}] {name} value drift vs from_pretrained"
+
+        kept = [n for n, d in got_dtypes.items() if d == torch.float32]
+        for prefix in expected_fp32_prefixes:
+            assert any(_matches(n, [prefix]) for n in kept), f"[{label}] nothing kept in fp32 for '{prefix}'"
+        print(f"[{label}] build cast OK ({len(kept)} fp32 states kept)")
+
+    module = _wrap_fsdp2(module, torch_dtype, mesh)
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+    dtypes, out = _compute_dtypes(module, input_ids)
+
+    bad = [
+        f"{n}: {d}"
+        for n, d in sorted(dtypes.items())
+        if d != (torch.float32 if _matches(n, expected_fp32_prefixes) else torch_dtype)
+    ]
+    assert not bad, f"[{label}] compute dtype wrong after fsdp2:\n  " + "\n  ".join(bad)
+    out.float().pow(2).mean().backward()
+    if rank == 0:
+        print(f"[{label}] build cast + fsdp2 forward/backward OK")
+
+
+def probe_legacy_build_cast(path, mesh, rank, torch_dtype, label):
+    """Show the legacy blanket cast still degrades (informational)."""
+    module = _build_module(path, ToyKeepFp32Model, torch_dtype, mesh, keep_fp32_aware=False)
+    if rank == 0:
+        degraded = [n for n, d in _local_dtypes(module).items() if "fp32_strict" in n and d != torch.float32]
+        print(f"[{label}] legacy module.to({torch_dtype}) degraded {len(degraded)} fp32-keep states: {degraded}")
+
+
+def case_no_keep_list(path, mesh, rank):
+    """Models without keep lists must be completely unaffected."""
+
+    class PlainModel(ToyKeepFp32Model):
+        _keep_in_fp32_modules = None
+        _keep_in_fp32_modules_strict = None
+
+    module = _build_module(path, PlainModel, torch.float32, mesh, keep_fp32_aware=True)
+    for name, param in module.named_parameters():
+        assert param.dtype == torch.float32, f"[no-keep] {name}: {param.dtype}"
+    module = _wrap_fsdp2(module, torch.bfloat16, mesh)
+
+    from torch.distributed.fsdp import FSDPModule
+
+    units = [n for n, m in module.named_modules() if isinstance(m, FSDPModule)]
+    expected = {"", "embed_tokens", "lm_head", "layers.0", "layers.1"}
+    assert set(units) == expected, f"[no-keep] fsdp2 units changed: {sorted(units)}"
+
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+    dtypes, out = _compute_dtypes(module, input_ids)
+    assert set(dtypes.values()) == {torch.bfloat16}, f"[no-keep] compute dtypes {set(dtypes.values())}"
+    out.float().pow(2).mean().backward()
+    if rank == 0:
+        print("[no-keep] baseline behaviour unchanged")
+
+
+def case_single_wrapping(path, mesh, rank):
+    """Overlapping / duplicated keep entries must yield one unit per module."""
+    from torch.distributed.fsdp import FSDPModule
+
+    module = _build_module(path, ToyOverlapModel, torch.float32, mesh, keep_fp32_aware=True)
+    module = _wrap_fsdp2(module, torch.bfloat16, mesh)
+
+    units = sorted(n for n, m in module.named_modules() if isinstance(m, FSDPModule))
+    assert len(units) == len(set(units)), f"[overlap] duplicate fsdp2 units: {units}"
+    for layer in range(2):
+        # 'fp32_strict' (parent), 'inner' and 'proj' (descendants) all match, and
+        # 'fp32_strict' is listed twice -- the topmost match wins, exactly once.
+        assert f"layers.{layer}.fp32_strict" in units, units
+        assert f"layers.{layer}.fp32_strict.inner" not in units, units
+        assert f"layers.{layer}.fp32_strict.inner.proj" not in units, units
+        # 'fp32_regular' is not named in the list, but its only parameter is
+        # 'fp32_regular.proj.weight', so the whole module is fully matched and
+        # becomes the unit (its unmatched float *buffer* is not FSDP-managed).
+        assert f"layers.{layer}.fp32_regular" in units, units
+        assert f"layers.{layer}.fp32_regular.proj" not in units, units
+
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+    dtypes, out = _compute_dtypes(module, input_ids)
+    for name, dtype in sorted(dtypes.items()):
+        want = torch.float32 if _matches(name, ["fp32_strict", "inner", "proj"]) else torch.bfloat16
+        assert dtype == want, f"[overlap] {name}: {dtype} != {want}"
+    out.float().pow(2).mean().backward()
+    if rank == 0:
+        print(f"[overlap] single wrapping OK, units={units}")
+
+
+def case_matches_unsharded_reference(path, mesh, rank):
+    """FSDP2 must reproduce what plain `from_pretrained` computes, bit for bit.
+
+    This is what pins ``param_dtype=torch.float32`` on the fp32-keep child unit:
+    with ``param_dtype=None`` FSDP2 would not cast the unit's inputs at all
+    (``cast_forward_inputs`` is gated on ``param_dtype`` being set), which breaks
+    every fp32-keep module that relies on the framework for the cast.
+    """
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+
+    reference = ToySelfCastingModel.from_pretrained(path, torch_dtype=torch.bfloat16).to(get_device_id())
+    ref_logits = reference(input_ids)
+    ref_loss = ref_logits.float().pow(2).mean()
+    ref_loss.backward()
+    ref_grads = {name: param.grad.detach().clone() for name, param in sorted(reference.named_parameters())}
+    ref_dtypes = {name: param.dtype for name, param in reference.named_parameters()}
+
+    module = _build_module(path, ToySelfCastingModel, torch.bfloat16, mesh, keep_fp32_aware=True)
+    module = _wrap_fsdp2(module, torch.bfloat16, mesh)
+    logits = module(input_ids)
+    loss = logits.float().pow(2).mean()
+    loss.backward()
+
+    assert logits.dtype == ref_logits.dtype, f"[reference] logits dtype {logits.dtype} != {ref_logits.dtype}"
+    assert torch.equal(logits, ref_logits), "[reference] logits differ from the unsharded model"
+    assert loss.item() == ref_loss.item(), f"[reference] loss {loss.item()!r} != {ref_loss.item()!r}"
+
+    for name, param in sorted(module.named_parameters()):
+        assert param.dtype == ref_dtypes[name], f"[reference] {name}: dtype {param.dtype} != {ref_dtypes[name]}"
+        grad = _full_tensor(param.grad)
+        assert grad.dtype == ref_grads[name].dtype, f"[reference] {name}: grad dtype {grad.dtype}"
+        assert torch.equal(grad, ref_grads[name]), f"[reference] {name}: gradient differs from the unsharded model"
+    if rank == 0:
+        print(f"[reference] fsdp2 matches unsharded from_pretrained bit-for-bit (loss={loss.item():.10e})")
+
+
+def case_loader_does_not_mutate_full_state(path, mesh, rank):
+    """`fsdp2_load_full_state_dict` documents that it modifies the *model*.
+
+    The dtype alignment must therefore land in a private copy: callers keep and
+    reuse the state dict they passed in.
+    """
+    module = _build_module(path, ToyKeepFp32Model, torch.bfloat16, mesh, keep_fp32_aware=True)
+    full_state = module.state_dict()
+
+    # Feed a low-precision source for every floating state, as a bf16 checkpoint
+    # would, so the alignment has real work to do on the fp32-keep entries.
+    full_state = {
+        name: (tensor.to(torch.bfloat16) if tensor.dtype.is_floating_point else tensor)
+        for name, tensor in full_state.items()
+    }
+    before_keys = set(full_state)
+    before_ids = {name: id(tensor) for name, tensor in full_state.items()}
+    before_dtypes = {name: tensor.dtype for name, tensor in full_state.items()}
+    # Ranks other than 0 build on meta, exactly as the engine does, and meta
+    # tensors have no values to compare.
+    before_values = {name: tensor.detach().clone() for name, tensor in full_state.items() if not tensor.is_meta}
+    floating = [name for name, tensor in full_state.items() if tensor.dtype.is_floating_point]
+    assert floating, "expected floating entries in the source state"
+
+    apply_fsdp2(module, _fsdp_kwargs(torch.bfloat16, mesh), {})
+    fsdp2_load_full_state_dict(module, full_state, mesh, None)
+
+    assert set(full_state) == before_keys, "[no-mutate] key set changed"
+    for name, tensor in full_state.items():
+        assert id(tensor) == before_ids[name], f"[no-mutate] {name}: tensor object was replaced"
+        assert tensor.dtype == before_dtypes[name], f"[no-mutate] {name}: dtype changed to {tensor.dtype}"
+        if name in before_values:
+            assert torch.equal(tensor, before_values[name]), f"[no-mutate] {name}: value changed"
+
+    # ...and the model still took the target dtype, for parameters and buffers.
+    targets = dict(itertools.chain(module.named_parameters(), module.named_buffers()))
+    for name in ("layers.0.fp32_strict.inner.proj.weight", "layers.0.fp32_strict.inner.running_scale"):
+        assert targets[name].dtype == torch.float32, f"[no-mutate] {name} loaded as {targets[name].dtype}"
+    assert targets["layers.0.dense.weight"].dtype == torch.bfloat16
+    if rank == 0:
+        print(f"[no-mutate] loader left all {len(before_keys)} source entries untouched")
+
+
+def case_keep_ancestor_absorbs_standard_targets(path, mesh, rank):
+    """A keep unit above the standard targets must swallow them, not race them.
+
+    ``layers`` is wrapped first; re-wrapping ``layers.0`` / ``layers.1`` beneath
+    it would double-wrap them and invert FSDP2's children-before-parents order.
+    """
+    from torch.distributed.fsdp import FSDPModule
+
+    module = _build_module(path, ToyKeepAncestorModel, torch.float32, mesh, keep_fp32_aware=True)
+    module = _wrap_fsdp2(module, torch.bfloat16, mesh)
+
+    units = sorted(name for name, mod in module.named_modules() if isinstance(mod, FSDPModule))
+    assert units == ["", "embed_tokens", "lm_head", "stack"], units
+    assert not [u for u in units if u.startswith("stack.")], f"[keep-ancestor] descendant re-wrapped: {units}"
+    assert len(units) == len(set(units)), f"[keep-ancestor] a module was wrapped twice: {units}"
+
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+    dtypes, out = _compute_dtypes(module, input_ids)
+    for name, dtype in sorted(dtypes.items()):
+        want = torch.float32 if _matches(name, ["stack"]) else torch.bfloat16
+        assert dtype == want, f"[keep-ancestor] {name} computed in {dtype}, expected {want}"
+    out.float().pow(2).mean().backward()
+    for name, param in sorted(module.named_parameters()):
+        assert param.grad is not None, f"[keep-ancestor] {name} has no grad"
+    if rank == 0:
+        print(f"[keep-ancestor] units={units} (standard descendants absorbed)")
+
+
+def case_no_forward_container_is_not_a_unit(path, mesh, rank):
+    """A unit must have a forward hook that actually fires.
+
+    ``holder`` inherits ``nn.Module.forward`` and is never called, so wrapping
+    it would leave its parameters sharded during compute. The unit has to be
+    ``holder.child``.
+    """
+    from torch.distributed.fsdp import FSDPModule
+
+    module = _build_module(path, ToyNoForwardContainerModel, torch.float32, mesh, keep_fp32_aware=True)
+    module = _wrap_fsdp2(module, torch.bfloat16, mesh)
+
+    units = sorted(name for name, mod in module.named_modules() if isinstance(mod, FSDPModule))
+    assert "holder" not in units, f"[no-forward] container without forward became a unit: {units}"
+    assert "holder.child" in units, f"[no-forward] callable child was not made a unit: {units}"
+    assert len(units) == len(set(units)), f"[no-forward] a module was wrapped twice: {units}"
+
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+    dtypes, out = _compute_dtypes(module, input_ids)
+    assert dtypes["holder.child.proj"] == torch.float32, (
+        f"[no-forward] fp32-keep leaf computed in {dtypes['holder.child.proj']}"
+    )
+    for name, dtype in sorted(dtypes.items()):
+        if not _matches(name, ["holder", "fp32_strict", "fp32_regular"]):
+            assert dtype == torch.bfloat16, f"[no-forward] control {name} computed in {dtype}"
+
+    loss = out.float().pow(2).mean()
+    loss.backward()
+    for name, param in sorted(module.named_parameters()):
+        assert param.grad is not None, f"[no-forward] {name} has no grad"
+        assert torch.isfinite(_full_tensor(param.grad).float()).all(), f"[no-forward] {name} grad not finite"
+    if rank == 0:
+        print(f"[no-forward] units={units} (loss={loss.item():.6f})")
+
+
+def case_keep_child_under_standard_parent(path, mesh, rank):
+    """Reverse control: a standard target that is an *ancestor* of a keep unit.
+
+    It must survive, and be wrapped after the keep child.
+    """
+    from torch.distributed.fsdp import FSDPModule
+
+    module = _build_module(path, ToyKeepFp32Model, torch.float32, mesh, keep_fp32_aware=True)
+    module = _wrap_fsdp2(module, torch.bfloat16, mesh)
+
+    units = sorted(name for name, mod in module.named_modules() if isinstance(mod, FSDPModule))
+    for layer in range(2):
+        assert f"layers.{layer}.fp32_strict" in units, units  # keep child
+        assert f"layers.{layer}" in units, units  # standard parent survives
+    assert "" in units, units  # root
+    assert len(units) == len(set(units)), units
+
+    torch.manual_seed(SEED)
+    input_ids = torch.randint(0, 64, (2, 8), device=get_device_id())
+    dtypes, out = _compute_dtypes(module, input_ids)
+    for name, dtype in sorted(dtypes.items()):
+        want = torch.float32 if _matches(name, ["fp32_strict"]) else torch.bfloat16
+        assert dtype == want, f"[keep-child] {name} computed in {dtype}, expected {want}"
+    out.float().pow(2).mean().backward()
+    if rank == 0:
+        print(f"[keep-child] keep child + standard parent + root all present: {units}")
+
+
+def case_loader_aligns_every_tied_alias(path, mesh, rank):
+    """Both state-dict aliases of a tied keep weight must reach the fp32 target.
+
+    ``named_parameters()`` de-duplicates tied tensors, so a de-duplicated dtype
+    map would leave the second alias to define the parameter's dtype.
+    """
+    import torch.distributed.checkpoint.state_dict as dcp_state_dict
+
+    module = _build_module(path, ToyTiedAliasModel, torch.bfloat16, mesh, keep_fp32_aware=True)
+
+    alias_a = "layers.0.fp32_strict.inner.proj.weight"
+    alias_b = "layers.0.fp32_strict.inner.proj_alias.weight"
+    # Captured before wrapping, exactly as FSDPEngine._build_fsdp_module does:
+    # after `fully_shard` the entries are DTensors and cannot be broadcast.
+    full_state = module.state_dict()
+    assert alias_a in full_state and alias_b in full_state, sorted(full_state)
+
+    # a low-precision source for every floating entry, as a bf16 checkpoint gives
+    source = OrderedDict(
+        (name, tensor.to(torch.bfloat16) if tensor.dtype.is_floating_point else tensor)
+        for name, tensor in full_state.items()
+    )
+    source._metadata = OrderedDict({"": {"version": 1}})
+    before = {name: (id(t), t.dtype) for name, t in source.items()}
+
+    apply_fsdp2(module, _fsdp_kwargs(torch.bfloat16, mesh), {})
+
+    captured = {}
+    original = dcp_state_dict.set_model_state_dict
+
+    def _capture(model, state, options=None):
+        captured["state"] = state
+        return original(model, state, options=options)
+
+    dcp_state_dict.set_model_state_dict = _capture
+    try:
+        fsdp2_load_full_state_dict(module, source, mesh, None)
+    finally:
+        dcp_state_dict.set_model_state_dict = original
+
+    working = captured["state"]
+    assert working is not source, "[tied-alias] loader must not pass the caller's dict through"
+    assert isinstance(working, OrderedDict), f"[tied-alias] mapping type became {type(working).__name__}"
+    assert getattr(working, "_metadata", None) == {"": {"version": 1}}, "[tied-alias] _metadata was dropped"
+    for alias in (alias_a, alias_b):
+        assert working[alias].dtype == torch.float32, f"[tied-alias] {alias} not aligned: {working[alias].dtype}"
+
+    # the caller's dict is untouched
+    for name, tensor in source.items():
+        assert (id(tensor), tensor.dtype) == before[name], f"[tied-alias] source entry {name} was modified"
+    assert source._metadata == {"": {"version": 1}}
+
+    loaded = dict(module.named_parameters())
+    for alias in (alias_a, alias_b):
+        assert loaded[alias].dtype == torch.float32, f"[tied-alias] {alias} loaded as {loaded[alias].dtype}"
+    assert loaded[alias_a] is loaded[alias_b] or torch.equal(
+        _full_tensor(loaded[alias_a].detach()), _full_tensor(loaded[alias_b].detach())
+    ), "[tied-alias] aliases diverged"
+
+    # a plain dict source must still work
+    plain = {name: tensor for name, tensor in source.items()}
+    fsdp2_load_full_state_dict(module, plain, mesh, None)
+    assert dict(module.named_parameters())[alias_a].dtype == torch.float32
+    if rank == 0:
+        print(f"[tied-alias] both aliases aligned to fp32; _metadata preserved ({len(working)} entries)")
+
+
+def case_state_dict_round_trip(module, mesh, rank):
+    """Full state dict save/load round trip preserves dtypes and values."""
+    from verl.utils.fsdp_utils import get_fsdp_full_state_dict
+
+    saved = get_fsdp_full_state_dict(module, offload_to_cpu=True, rank0_only=True)
+    before = {n: _full_tensor(p.detach()).cpu().float().clone() for n, p in sorted(module.named_parameters())}
+    dtypes = {n: p.dtype for n, p in module.named_parameters()}
+
+    fsdp2_load_full_state_dict(module, saved, mesh, None)
+
+    for name, param in sorted(module.named_parameters()):
+        assert param.dtype == dtypes[name], f"[round-trip] {name}: dtype {param.dtype} != {dtypes[name]}"
+        after = _full_tensor(param.detach()).cpu().float()
+        assert torch.equal(after, before[name]), f"[round-trip] {name} value drift"
+    if rank == 0:
+        print("[round-trip] full state dict save/load OK")
+
+
+def main():
+    assert get_torch_device().device_count() >= 1, "need at least 1 gpu for test"
+    _, rank, world_size = initialize_global_process_group()
+    mesh = init_device_mesh(get_device_name(), mesh_shape=(world_size,), mesh_dim_names=("fsdp",))
+
+    tmpdir = os.environ.get("VERL_TEST_TMPDIR")
+    ctx = tempfile.TemporaryDirectory() if tmpdir is None else None
+    if ctx is not None:
+        tmpdir = ctx.name
+    # all ranks must agree on the checkpoint path
+    obj = [tmpdir]
+    torch.distributed.broadcast_object_list(obj, src=0)
+    tmpdir = obj[0]
+    os.makedirs(tmpdir, exist_ok=True)
+
+    path = _make_checkpoint(tmpdir, ToyKeepFp32Model, rank)
+    overlap_path = _make_checkpoint(tmpdir, ToyOverlapModel, rank)
+    self_cast_path = _make_checkpoint(tmpdir, ToySelfCastingModel, rank)
+    tied_path = _make_checkpoint(tmpdir, ToyTiedAliasModel, rank, safe_serialization=False)
+    ancestor_path = _make_checkpoint(tmpdir, ToyKeepAncestorModel, rank)
+    no_forward_path = _make_checkpoint(tmpdir, ToyNoForwardContainerModel, rank)
+
+    # 1. strict list under bf16 compute (regular list must NOT apply -- HF only
+    #    honours it for fp16 / quantized loads).
+    module = case_isolation(path, mesh, rank, ToyKeepFp32Model, ["fp32_strict"], "strict/bf16")
+    case_state_dict_round_trip(module, mesh, rank)
+    del module
+    get_torch_device().empty_cache()
+
+    # 2. union of both lists under fp16 compute.
+    case_isolation(
+        path,
+        mesh,
+        rank,
+        ToyKeepFp32Model,
+        ["fp32_strict", "fp32_regular"],
+        "union/fp16-compute",
+        compute_dtype=torch.float16,
+    )
+    get_torch_device().empty_cache()
+
+    # 3. build-time cast, bf16 target dtype (strict list only).
+    probe_legacy_build_cast(path, mesh, rank, torch.bfloat16, "strict/bf16")
+    case_build_cast(path, mesh, rank, torch.bfloat16, ["fp32_strict"], "build/bf16")
+    get_torch_device().empty_cache()
+
+    # 4. build-time cast, fp16 target dtype (union of both lists).
+    case_build_cast(path, mesh, rank, torch.float16, ["fp32_strict", "fp32_regular"], "build/fp16")
+    get_torch_device().empty_cache()
+
+    # 5. parity with the unsharded `from_pretrained` graph.
+    case_matches_unsharded_reference(self_cast_path, mesh, rank)
+    get_torch_device().empty_cache()
+
+    # 5b. the loader must not touch the caller's state dict.
+    case_loader_does_not_mutate_full_state(path, mesh, rank)
+    get_torch_device().empty_cache()
+
+    # 5c. tied state-dict aliases and mapping metadata.
+    case_loader_aligns_every_tied_alias(tied_path, mesh, rank)
+    get_torch_device().empty_cache()
+
+    # 5d. keep unit above / below the standard wrap targets.
+    case_keep_ancestor_absorbs_standard_targets(ancestor_path, mesh, rank)
+    get_torch_device().empty_cache()
+    case_keep_child_under_standard_parent(path, mesh, rank)
+    get_torch_device().empty_cache()
+
+    # 5e. a keep container whose forward hook would never fire.
+    case_no_forward_container_is_not_a_unit(no_forward_path, mesh, rank)
+    get_torch_device().empty_cache()
+
+    # 6. overlap / duplicate handling, and the untouched baseline.
+    case_single_wrapping(overlap_path, mesh, rank)
+    get_torch_device().empty_cache()
+    case_no_keep_list(path, mesh, rank)
+
+    torch.distributed.barrier()
+    torch.distributed.destroy_process_group()
+    if ctx is not None:
+        ctx.cleanup()
+    if rank == 0:
+        print("test_fsdp2_keep_in_fp32 passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/utils/test_keep_in_fp32_utils_on_cpu.py
+++ b/tests/utils/test_keep_in_fp32_utils_on_cpu.py
@@ -1,0 +1,697 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``_keep_in_fp32_modules`` helpers used by FSDP2 (verl#7092).
+
+These cover the pure matching / casting / unit-selection logic on CPU; the
+end-to-end FSDP2 behaviour lives in
+``tests/special_distributed/test_fsdp2_keep_in_fp32.py``.
+"""
+
+import re
+
+import pytest
+import torch
+import torch.nn as nn
+import transformers
+
+from verl.utils import fsdp_utils
+from verl.utils.fsdp_utils import (
+    _defines_forward,
+    _keep_in_fp32_regex,
+    _select_keep_in_fp32_wrap_targets,
+    cast_module_to_dtype_keeping_fp32_modules,
+    get_keep_in_fp32_module_names,
+)
+
+
+# The fixtures define real `forward` methods on purpose: a module that never
+# runs cannot be an FSDP2 unit, so a parameter-holding module without forward
+# would not be a realistic stand-in for anything verl wraps.
+class Leaf(nn.Module):
+    def __init__(self, size=4):
+        super().__init__()
+        self.proj = nn.Linear(size, size, bias=False)
+        self.register_buffer("scale", torch.ones(size))
+        self.register_buffer("steps", torch.zeros(size, dtype=torch.int64))
+
+    def forward(self, x):
+        return self.proj(x) * self.scale.to(x.dtype)
+
+
+class Wrapper(nn.Module):
+    """Container with no direct parameters but a real forward."""
+
+    def __init__(self, size=4):
+        super().__init__()
+        self.nested = Leaf(size)
+
+    def forward(self, x):
+        return self.nested(x)
+
+
+class Block(nn.Module):
+    def __init__(self, size=4):
+        super().__init__()
+        self.dense = nn.Linear(size, size, bias=False)
+        self.sensitive = Leaf(size)
+        self.wrapper = Wrapper(size)
+
+    def forward(self, x):
+        return self.dense(x) + self.sensitive(x) + self.wrapper(x)
+
+
+class Model(nn.Module):
+    _keep_in_fp32_modules = ["dense"]
+    _keep_in_fp32_modules_strict = ["sensitive"]
+
+    def __init__(self, size=4):
+        super().__init__()
+        self.embed = nn.Embedding(8, size)
+        self.blocks = nn.ModuleList([Block(size) for _ in range(2)])
+
+    def forward(self, idx):
+        x = self.embed(idx)
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+def _dtypes(model):
+    return {name: state.dtype for name, state in list(model.named_parameters()) + list(model.named_buffers())}
+
+
+# ---------------------------------------------------------------------------
+# name resolution
+# ---------------------------------------------------------------------------
+
+
+def test_regular_list_is_fp16_only():
+    """HF only honours the non-strict list for fp16 -- not for bf16."""
+    model = Model()
+    assert get_keep_in_fp32_module_names(model, torch.bfloat16) == ["sensitive"]
+    assert get_keep_in_fp32_module_names(model, torch.float16) == ["dense", "sensitive"]
+
+
+def test_no_low_precision_target_matches_nothing():
+    model = Model()
+    assert get_keep_in_fp32_module_names(model, torch.float32) == []
+    assert get_keep_in_fp32_module_names(model, None) == []
+
+
+def test_names_are_deduplicated_deterministically():
+    model = Model()
+    model._keep_in_fp32_modules_strict = ["sensitive", "dense", "sensitive"]
+    model._keep_in_fp32_modules = ["dense"]
+    assert get_keep_in_fp32_module_names(model, torch.float16) == ["dense", "sensitive"]
+
+
+def test_only_the_top_most_declaration_is_read():
+    """4.56.1 reads the top-level model; 5.11.0's post_init has already folded
+    every child's declaration into it. Re-collecting from nested models would
+    widen 4.56.1's behaviour."""
+    model = Model()
+    model.blocks[0]._keep_in_fp32_modules_strict = ["nested"]
+    assert get_keep_in_fp32_module_names(model, torch.bfloat16) == ["sensitive"]
+
+
+def test_declarations_are_read_through_a_wrapper():
+    """verl may hand us a PEFT-style wrapper around the PreTrainedModel."""
+
+    class Wrapper(nn.Module):
+        def __init__(self, inner):
+            super().__init__()
+            self.base_model = inner
+
+    model = Model()
+    assert get_keep_in_fp32_module_names(Wrapper(model), torch.bfloat16) == ["sensitive"]
+
+
+def test_set_valued_declarations_resolve_deterministically():
+    """Transformers 5.x stores these as `set`, whose iteration order varies."""
+    model = Model()
+    model._keep_in_fp32_modules_strict = {"sensitive", "dense", "wrapper"}
+    model._keep_in_fp32_modules = {"dense"}
+    assert get_keep_in_fp32_module_names(model, torch.float16) == ["dense", "sensitive", "wrapper"]
+
+
+def test_list_and_set_declarations_agree():
+    as_list, as_set = Model(), Model()
+    as_list._keep_in_fp32_modules_strict = ["wrapper", "sensitive"]
+    as_set._keep_in_fp32_modules_strict = {"wrapper", "sensitive"}
+    assert get_keep_in_fp32_module_names(as_list, torch.bfloat16) == get_keep_in_fp32_module_names(
+        as_set, torch.bfloat16
+    )
+
+
+def test_glob_declarations_are_parsed_not_rejected():
+    """A glob is legal in 5.x; resolution must never reject the declaration."""
+    model = Model()
+    model._keep_in_fp32_modules_strict = ["sensitive", "block*"]
+    assert get_keep_in_fp32_module_names(model, torch.bfloat16) == ["block*", "sensitive"]
+    assert get_keep_in_fp32_module_names(model, torch.float32) == []
+
+
+def test_model_without_keep_lists_resolves_empty():
+    assert get_keep_in_fp32_module_names(Block(), torch.bfloat16) == []
+
+
+# ---------------------------------------------------------------------------
+# matching semantics
+# ---------------------------------------------------------------------------
+
+
+# Oracles derived from the upstream sources, not from this implementation:
+#   4.56.1 modeling_utils.py:5127
+#       re.compile("|".join(rf"((^|\.){m}($|\.))" for m in keep_in_fp32_modules))
+#   5.11.0 core_model_loading.build_glob_alternation
+#       branches.append(f"(?P<{group}>{glob.replace('*', '.*')})"); re.compile("|".join(branches))
+def _oracle_4x(names):
+    return re.compile("|".join(rf"((^|\.){name}($|\.))" for name in names))
+
+
+def _oracle_5x(names):
+    branches = [f"(?P<g{i}>{name.replace('*', '.*')})" for i, name in enumerate(names)]
+    return re.compile("|".join(branches))
+
+
+SEGMENT_CASES = [
+    ("sensitive.proj.weight", True),  # leading segment
+    ("blocks.0.sensitive.proj.weight", True),  # nested segment
+    ("blocks.0.sensitive", True),  # trailing segment
+    ("blocks.0.dense.weight", False),
+]
+# these differ between the two versions: substrings of a segment
+SUBSTRING_CASES = ["blocks.0.insensitive.proj.weight", "blocks.0.sensitive_extra.weight"]
+
+
+@pytest.mark.parametrize("fqn,expected", SEGMENT_CASES)
+def test_matcher_handles_plain_segment_names(fqn, expected, monkeypatch):
+    """A plain segment name resolves identically on both versions."""
+    for glob_matching in (False, True):
+        monkeypatch.setattr(fsdp_utils, "_keep_in_fp32_uses_glob_matching", lambda v=glob_matching: v)
+        assert bool(_keep_in_fp32_regex(["sensitive"]).search(fqn)) is expected
+
+
+@pytest.mark.parametrize("fqn", SUBSTRING_CASES)
+def test_substring_does_not_match_on_4x(fqn, monkeypatch):
+    monkeypatch.setattr(fsdp_utils, "_keep_in_fp32_uses_glob_matching", lambda: False)
+    assert _keep_in_fp32_regex(["sensitive"]).search(fqn) is None
+    assert _oracle_4x(["sensitive"]).search(fqn) is None
+
+
+@pytest.mark.parametrize("fqn", SUBSTRING_CASES)
+def test_substring_matches_on_5x(fqn, monkeypatch):
+    monkeypatch.setattr(fsdp_utils, "_keep_in_fp32_uses_glob_matching", lambda: True)
+    assert _keep_in_fp32_regex(["sensitive"]).search(fqn) is not None
+    assert _oracle_5x(["sensitive"]).search(fqn) is not None
+
+
+@pytest.mark.parametrize(
+    "fqn,expected",
+    [
+        ("blocks.0.dense.weight", True),  # 'block*.dense' expands across the index
+        ("blocks.12.dense.weight", True),
+        ("blocks.0.sensitive.proj.weight", False),  # right prefix, wrong leaf
+        ("stack.0.dense.weight", False),  # wrong prefix
+    ],
+)
+def test_glob_declarations_match_on_5x(fqn, expected, monkeypatch):
+    monkeypatch.setattr(fsdp_utils, "_keep_in_fp32_uses_glob_matching", lambda: True)
+    assert bool(_keep_in_fp32_regex(["block*.dense"]).search(fqn)) is expected
+    assert bool(_oracle_5x(["block*.dense"]).search(fqn)) is expected
+
+
+@pytest.mark.parametrize("glob_matching", [False, True])
+@pytest.mark.parametrize("fqn", [*[c[0] for c in SEGMENT_CASES], *SUBSTRING_CASES])
+def test_matcher_agrees_with_the_upstream_oracle(glob_matching, fqn, monkeypatch):
+    """Full agreement with the pattern each version builds internally."""
+    monkeypatch.setattr(fsdp_utils, "_keep_in_fp32_uses_glob_matching", lambda: glob_matching)
+    oracle = _oracle_5x if glob_matching else _oracle_4x
+    names = ["sensitive", "wrapper"]
+    assert bool(_keep_in_fp32_regex(names).search(fqn)) is bool(oracle(names).search(fqn))
+
+
+def test_installed_transformers_selects_the_4x_matcher():
+    """This environment runs 4.56.1, which has no `core_model_loading`."""
+    assert transformers.__version__.startswith("4.")
+    assert fsdp_utils._keep_in_fp32_uses_glob_matching() is False
+
+
+def test_regex_is_none_without_names():
+    assert _keep_in_fp32_regex([]) is None
+
+
+# ---------------------------------------------------------------------------
+# dtype casting
+# ---------------------------------------------------------------------------
+
+
+def test_cast_keeps_matched_params_and_float_buffers_in_fp32():
+    model = Model()
+    kept = cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+
+    dtypes = _dtypes(model)
+    for layer in range(2):
+        assert dtypes[f"blocks.{layer}.sensitive.proj.weight"] == torch.float32
+        assert dtypes[f"blocks.{layer}.sensitive.scale"] == torch.float32
+        # non-keep control module follows the target dtype
+        assert dtypes[f"blocks.{layer}.dense.weight"] == torch.bfloat16
+        assert dtypes[f"blocks.{layer}.wrapper.nested.proj.weight"] == torch.bfloat16
+        # integer buffers are never touched
+        assert dtypes[f"blocks.{layer}.sensitive.steps"] == torch.int64
+    assert dtypes["embed.weight"] == torch.bfloat16
+    assert sorted(kept) == [
+        "blocks.0.sensitive.proj.weight",
+        "blocks.0.sensitive.scale",
+        "blocks.1.sensitive.proj.weight",
+        "blocks.1.sensitive.scale",
+    ]
+
+
+def test_cast_under_fp16_keeps_the_union_of_both_lists():
+    model = Model()
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.float16)
+    dtypes = _dtypes(model)
+    assert dtypes["blocks.0.dense.weight"] == torch.float32
+    assert dtypes["blocks.0.sensitive.proj.weight"] == torch.float32
+    assert dtypes["blocks.0.wrapper.nested.proj.weight"] == torch.float16
+
+
+def test_cast_preserves_values_of_kept_modules():
+    model = Model()
+    before = model.blocks[0].sensitive.proj.weight.detach().clone()
+    control = model.blocks[0].dense.weight.detach().clone()
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+    assert torch.equal(model.blocks[0].sensitive.proj.weight, before)
+    assert torch.equal(model.blocks[0].dense.weight.float(), control.to(torch.bfloat16).float())
+
+
+def test_cast_without_keep_lists_matches_plain_to():
+    model, reference = Block(), Block()
+    reference.load_state_dict(model.state_dict())
+    assert cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16) == []
+    reference.to(torch.bfloat16)
+    assert _dtypes(model) == _dtypes(reference)
+
+
+def _tie(model, layer, target_attr):
+    """Tie ``sensitive.proj.weight`` to another parameter, returning both FQNs."""
+    block = model.blocks[layer]
+    holder = block if target_attr == "dense" else block.sensitive
+    getattr(holder, target_attr).weight = block.sensitive.proj.weight
+    prefix = f"blocks.{layer}"
+    other = f"{prefix}.dense.weight" if target_attr == "dense" else f"{prefix}.sensitive.{target_attr}.weight"
+    return f"{prefix}.sensitive.proj.weight", other
+
+
+def test_cast_keeps_tied_group_when_every_alias_matches():
+    model = Model()
+    model.blocks[0].sensitive.proj2 = nn.Linear(4, 4, bias=False)
+    matched, also_matched = _tie(model, 0, "proj2")
+
+    kept = cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+
+    assert matched in kept and also_matched in kept
+    assert model.blocks[0].sensitive.proj.weight.dtype == torch.float32
+    assert model.blocks[0].sensitive.proj2.weight is model.blocks[0].sensitive.proj.weight
+
+
+def test_cast_keeps_tied_group_when_only_one_alias_matches():
+    """The aliases are one tensor: a single matching name keeps the whole group.
+
+    Deciding per name would depend on which alias ``named_parameters`` yields
+    first, and would silently downcast a weight a keep rule explicitly named.
+    """
+    model = Model()
+    matched, unmatched = _tie(model, 0, "dense")
+    assert not _keep_in_fp32_regex(["sensitive"]).search(unmatched)
+
+    kept = cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+
+    assert matched in kept and unmatched in kept
+    assert model.blocks[0].dense.weight.dtype == torch.float32
+    assert model.blocks[0].sensitive.proj.weight is model.blocks[0].dense.weight
+    # untied siblings are unaffected
+    assert model.blocks[1].sensitive.proj.weight.dtype == torch.float32
+    assert model.blocks[1].dense.weight.dtype == torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
+# FSDP2 unit selection
+# ---------------------------------------------------------------------------
+
+
+def _names(model, modules):
+    lookup = {id(m): n for n, m in model.named_modules()}
+    return [lookup[id(m)] for m in modules]
+
+
+def test_wrap_targets_are_the_matched_modules():
+    model = Model()
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    assert targets == ["blocks.0.sensitive", "blocks.1.sensitive"]
+
+
+def test_partially_matched_ancestors_are_skipped():
+    """A unit must be all-or-nothing: FSDP2 rejects mixed original dtypes."""
+    model = Model()
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    # 'blocks' / 'blocks.0' also hold unmatched parameters (dense, wrapper)
+    assert "blocks" not in targets
+    assert "blocks.0" not in targets
+
+
+def test_wrap_targets_collapse_parent_child_overlap_and_duplicates():
+    model = Model()
+    model._keep_in_fp32_modules_strict = ["sensitive", "proj", "sensitive"]
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    # 'sensitive' is listed twice and 'proj' is its child -- one unit results.
+    # 'proj' also matches inside 'wrapper.nested'; since that is 'wrapper''s only
+    # parameter, the topmost fully-matched module ('wrapper') becomes the unit.
+    assert targets == [
+        "blocks.0.sensitive",
+        "blocks.0.wrapper",
+        "blocks.1.sensitive",
+        "blocks.1.wrapper",
+    ]
+
+
+def test_fully_matched_ancestor_collapses_to_one_unit():
+    """A wrappable ancestor whose whole subtree matches becomes a single unit."""
+    model = Model()
+    model._keep_in_fp32_modules_strict = ["wrapper"]
+    model._keep_in_fp32_modules = None
+    # 'wrapper' has no direct parameters, yet it owns every matched one below it
+    assert _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)) == [
+        "blocks.0.wrapper",
+        "blocks.1.wrapper",
+    ]
+    assert "blocks.0.wrapper.nested" not in _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+
+
+def test_module_list_descends_to_its_children():
+    """`fully_shard` rejects ModuleList outright, so select the children.
+
+    Selecting the container would raise inside the wrapping loop, after earlier
+    units had already been wrapped.
+    """
+    model = Model()
+    model._keep_in_fp32_modules_strict = ["blocks"]
+    model._keep_in_fp32_modules = None
+    # every parameter lives under the ModuleList, so its children carry the policy
+    assert _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)) == ["blocks.0", "blocks.1"]
+
+
+def test_module_dict_descends_to_its_children():
+    model = Model()
+    model.bag = nn.ModuleDict({"leaf": Leaf()})
+    model._keep_in_fp32_modules_strict = ["bag"]
+    model._keep_in_fp32_modules = None
+    assert _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)) == ["bag.leaf"]
+
+
+def test_plain_container_without_forward_descends_to_its_child():
+    """A namespacing `nn.Module` is accepted by fully_shard but never called.
+
+    Its forward hook would never fire, so its parameters would stay sharded
+    during compute. The callable child has to be the unit instead.
+    """
+    model = Model()
+    model.holder = nn.Module()
+    model.holder.child = Leaf()
+    model._keep_in_fp32_modules_strict = ["holder"]
+    model._keep_in_fp32_modules = None
+
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    assert targets == ["holder.child"], targets
+    assert not _defines_forward(model.holder)
+    assert _defines_forward(model.holder.child.proj)
+
+
+def test_container_with_custom_forward_is_still_a_unit():
+    """A parameter-less container that implements forward stays eligible."""
+
+    class Gate(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.inner = Leaf()
+
+        def forward(self, x):
+            return self.inner(x)
+
+    model = Model()
+    model.gate = Gate()
+    model._keep_in_fp32_modules_strict = ["gate"]
+    model._keep_in_fp32_modules = None
+
+    assert _defines_forward(model.gate)
+    assert _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)) == ["gate"]
+
+
+@pytest.mark.parametrize("container", ["ParameterList", "ParameterDict"])
+def test_parameter_containers_fail_closed(container):
+    """They define no forward and own parameters directly: no unit can hold them."""
+    model = Model()
+    if container == "ParameterList":
+        model.bag = nn.ParameterList([nn.Parameter(torch.ones(4))])
+    else:
+        model.bag = nn.ParameterDict({"scale": nn.Parameter(torch.ones(4))})
+    model._keep_in_fp32_modules_strict = ["bag"]
+    model._keep_in_fp32_modules = None
+
+    assert not _defines_forward(model.bag)
+    with pytest.raises(ValueError, match="no fp32-keep unit owns it"):
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+
+
+def test_parameter_container_failure_leaves_no_partially_wrapped_model():
+    from torch.distributed.fsdp import FSDPModule
+
+    model = Model()
+    model.bag = nn.ParameterList([nn.Parameter(torch.ones(4))])
+    model._keep_in_fp32_modules_strict = ["bag"]
+    model._keep_in_fp32_modules = None
+
+    with pytest.raises(ValueError):
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+    assert not [name for name, mod in model.named_modules() if isinstance(mod, FSDPModule)]
+
+
+def test_parameterless_module_is_never_a_target():
+    model = Model()
+    model.blocks[0].empty = nn.Module()
+    model._keep_in_fp32_modules_strict = ["empty"]
+    model._keep_in_fp32_modules = None
+    assert _select_keep_in_fp32_wrap_targets(model, torch.bfloat16) == []
+
+
+def test_tied_group_inside_one_unit_is_isolated():
+    """All aliases under a single candidate unit -> that unit owns the tensor."""
+    model = Model()
+    model.blocks[0].sensitive.proj2 = nn.Linear(4, 4, bias=False)
+    _tie(model, 0, "proj2")
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    assert targets == ["blocks.0.sensitive", "blocks.1.sensitive"]
+
+
+def test_tied_group_matched_via_one_alias_is_isolated_at_the_covering_unit():
+    """Only 'proj' matches, but the tied sibling sits in the same unit."""
+    model = Model()
+    model.blocks[0].sensitive.other = nn.Linear(4, 4, bias=False)
+    model.blocks[0].sensitive.other.weight = model.blocks[0].sensitive.proj.weight
+    model._keep_in_fp32_modules_strict = ["proj"]
+    model._keep_in_fp32_modules = None
+
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    # 'sensitive' covers both aliases; 'wrapper' covers the untied block-1 match
+    assert "blocks.0.sensitive" in targets
+    assert "blocks.0.sensitive.proj" not in targets
+
+
+def test_tie_across_candidate_units_fails_closed():
+    """FSDP2 gives a parameter to exactly one unit -- refuse before wrapping."""
+    model = Model()
+    matched, unmatched = _tie(model, 0, "dense")
+    model._keep_in_fp32_modules_strict = ["sensitive", "dense"]
+    model._keep_in_fp32_modules = None
+
+    with pytest.raises(ValueError, match="tied across FSDP2 unit boundaries") as excinfo:
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+    message = str(excinfo.value)
+    assert matched in message and unmatched in message
+    assert "tie_word_embeddings" in message
+
+
+def test_tie_reaching_outside_every_unit_fails_closed():
+    """One alias matches, its sibling lives in a module that is not a unit."""
+    model = Model()
+    matched, unmatched = _tie(model, 0, "dense")
+
+    with pytest.raises(ValueError, match="tied across FSDP2 unit boundaries"):
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# mixed parameter dtypes inside a matched unit (adapter-style injection)
+# ---------------------------------------------------------------------------
+
+
+def _inject_adapter(module, dtype):
+    """A local LoRA-shaped adapter. Deliberately not peft: no extra dependency."""
+    module.lora_A = nn.Linear(4, 2, bias=False)
+    module.lora_B = nn.Linear(2, 4, bias=False)
+    for adapter in (module.lora_A, module.lora_B):
+        adapter.weight.data = adapter.weight.data.to(dtype)
+    return module
+
+
+def test_all_fp32_keep_unit_is_isolated_with_adapter():
+    """An adapter that stays fp32 keeps the unit uniform, so isolation works."""
+    model = Model()
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+    _inject_adapter(model.blocks[0].sensitive, torch.float32)
+
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    assert targets == ["blocks.0.sensitive", "blocks.1.sensitive"]
+
+
+def test_mixed_dtype_keep_unit_fails_closed():
+    """A bf16 adapter inside an fp32-keep module cannot be expressed."""
+    model = Model()
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+    _inject_adapter(model.blocks[0].sensitive, torch.bfloat16)
+
+    with pytest.raises(ValueError) as excinfo:
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+
+    message = str(excinfo.value)
+    assert "blocks.0.sensitive" in message  # matched module FQN
+    assert "blocks.0.sensitive.proj.weight" in message  # the fp32 keep parameter
+    assert "blocks.0.sensitive.lora_A.weight" in message  # the offending parameter
+    assert "torch.bfloat16" in message  # and its dtype
+    assert "all-gathers all of its parameters at one dtype" in message
+
+
+def test_mixed_dtype_failure_leaves_no_partially_wrapped_model():
+    """The check must run before the first fully_shard call."""
+    from torch.distributed.fsdp import FSDPModule
+
+    model = Model()
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+    _inject_adapter(model.blocks[0].sensitive, torch.bfloat16)
+
+    with pytest.raises(ValueError):
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+    assert not [name for name, mod in model.named_modules() if isinstance(mod, FSDPModule)]
+
+
+def test_mixed_dtype_without_keep_list_is_untouched():
+    """The same mixed-dtype model is unaffected when nothing declares fp32-keep."""
+    model = Model()
+    model._keep_in_fp32_modules = None
+    model._keep_in_fp32_modules_strict = None
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+    _inject_adapter(model.blocks[0].sensitive, torch.bfloat16)
+
+    assert _select_keep_in_fp32_wrap_targets(model, torch.bfloat16) == []
+    assert model.blocks[0].sensitive.proj.weight.dtype == torch.bfloat16
+
+
+def test_unmatched_module_with_mixed_dtypes_is_not_an_error():
+    """Only a *matched* unit is a contract violation; others just are not units."""
+    model = Model()
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+    _inject_adapter(model.blocks[0].dense, torch.bfloat16)
+
+    targets = _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16))
+    assert targets == ["blocks.0.sensitive", "blocks.1.sensitive"]
+
+
+# ---------------------------------------------------------------------------
+# every keep parameter must end up owned by exactly one unit
+# ---------------------------------------------------------------------------
+
+
+def test_root_level_keep_parameter_fails_closed():
+    """A parameter hanging off the root can never become its own unit.
+
+    Leaving it would keep it in the bf16 root unit -- a silent contract breach.
+    """
+    model = Model()
+    model.logit_scale = nn.Parameter(torch.ones(1))
+    model._keep_in_fp32_modules_strict = ["logit_scale"]
+    model._keep_in_fp32_modules = None
+
+    with pytest.raises(ValueError, match="no fp32-keep unit owns it") as excinfo:
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+    message = str(excinfo.value)
+    assert "logit_scale" in message
+    assert "torch.bfloat16" in message  # the dtype it would have been degraded to
+
+
+def test_keep_module_already_degraded_fails_closed():
+    """All matched parameters already low precision => preservation was bypassed."""
+    model = Model()
+    model.to(torch.bfloat16)  # the blanket cast this fix exists to replace
+
+    with pytest.raises(ValueError, match="already in a lower precision") as excinfo:
+        _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+    message = str(excinfo.value)
+    assert "blocks.0.sensitive" in message
+    assert "torch.bfloat16" in message
+    assert "cast_module_to_dtype_keeping_fp32_modules" in message
+
+
+def test_owner_failures_leave_no_partially_wrapped_model():
+    from torch.distributed.fsdp import FSDPModule
+
+    for build in (
+        lambda: _root_keep_model(),
+        lambda: _degraded_keep_model(),
+    ):
+        model = build()
+        with pytest.raises(ValueError):
+            _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)
+        assert not [name for name, mod in model.named_modules() if isinstance(mod, FSDPModule)]
+
+
+def _root_keep_model():
+    model = Model()
+    model.logit_scale = nn.Parameter(torch.ones(1))
+    model._keep_in_fp32_modules_strict = ["logit_scale"]
+    model._keep_in_fp32_modules = None
+    return model
+
+
+def _degraded_keep_model():
+    model = Model()
+    model.to(torch.bfloat16)
+    return model
+
+
+def test_child_owned_keep_parameters_still_resolve():
+    """The healthy shape is unaffected by the ownership checks."""
+    model = Model()
+    cast_module_to_dtype_keeping_fp32_modules(model, torch.bfloat16)
+    assert _names(model, _select_keep_in_fp32_wrap_targets(model, torch.bfloat16)) == [
+        "blocks.0.sensitive",
+        "blocks.1.sensitive",
+    ]
+
+
+def test_no_targets_without_keep_lists_or_low_precision():
+    assert _select_keep_in_fp32_wrap_targets(Block(), torch.bfloat16) == []
+    assert _select_keep_in_fp32_wrap_targets(Model(), torch.float32) == []
+    assert _select_keep_in_fp32_wrap_targets(Model(), None) == []

--- a/tests/utils/test_keep_in_fp32_utils_on_cpu.py
+++ b/tests/utils/test_keep_in_fp32_utils_on_cpu.py
@@ -25,6 +25,7 @@ import pytest
 import torch
 import torch.nn as nn
 import transformers
+from packaging.version import Version
 
 from verl.utils import fsdp_utils
 from verl.utils.fsdp_utils import (
@@ -118,7 +119,7 @@ def test_names_are_deduplicated_deterministically():
 
 
 def test_only_the_top_most_declaration_is_read():
-    """4.56.1 reads the top-level model; 5.11.0's post_init has already folded
+    """4.56.1 reads the top-level model; 5.10.0's post_init has already folded
     every child's declaration into it. Re-collecting from nested models would
     widen 4.56.1's behaviour."""
     model = Model()
@@ -175,7 +176,7 @@ def test_model_without_keep_lists_resolves_empty():
 # Oracles derived from the upstream sources, not from this implementation:
 #   4.56.1 modeling_utils.py:5127
 #       re.compile("|".join(rf"((^|\.){m}($|\.))" for m in keep_in_fp32_modules))
-#   5.11.0 core_model_loading.build_glob_alternation
+#   5.10.0 core_model_loading.build_glob_alternation
 #       branches.append(f"(?P<{group}>{glob.replace('*', '.*')})"); re.compile("|".join(branches))
 def _oracle_4x(names):
     return re.compile("|".join(rf"((^|\.){name}($|\.))" for name in names))
@@ -243,10 +244,9 @@ def test_matcher_agrees_with_the_upstream_oracle(glob_matching, fqn, monkeypatch
     assert bool(_keep_in_fp32_regex(names).search(fqn)) is bool(oracle(names).search(fqn))
 
 
-def test_installed_transformers_selects_the_4x_matcher():
-    """This environment runs 4.56.1, which has no `core_model_loading`."""
-    assert transformers.__version__.startswith("4.")
-    assert fsdp_utils._keep_in_fp32_uses_glob_matching() is False
+def test_installed_transformers_selects_its_native_matcher():
+    uses_glob_matching = Version(transformers.__version__).major >= 5
+    assert fsdp_utils._keep_in_fp32_uses_glob_matching() is uses_glob_matching
 
 
 def test_regex_is_none_without_names():

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -587,7 +587,7 @@ def get_keep_in_fp32_module_names(model: nn.Module, target_dtype: Optional[torch
 
     Transformers declares two independent lists, with *different* activation
     rules. The gate below is verified identical in 4.56.1
-    (``modeling_utils.from_pretrained``) and 5.11.0
+    (``modeling_utils.from_pretrained``) and 5.10.0
     (``modeling_utils._get_dtype_plan``), which span verl's supported range:
 
     * ``_keep_in_fp32_modules`` guards against bf16 -> fp16 rounding only, so HF
@@ -602,7 +602,7 @@ def get_keep_in_fp32_module_names(model: nn.Module, target_dtype: Optional[torch
     does not build the FSDP2 path through ``hf_quantizer``.
 
     Only the top-most declaration is read, which is what both versions do:
-    4.56.1 consults the top-level model alone, and 5.11.0's ``post_init``
+    4.56.1 consults the top-level model alone, and 5.10.0's ``post_init``
     already folds every child's declaration into it. Collecting from nested
     models directly would widen 4.56.1's behaviour.
 
@@ -863,13 +863,13 @@ def apply_fsdp2(model, fsdp_kwargs, config):
 
     # Modules HF declares as fp32-keep must be their own units, wrapped *before*
     # any parent so that the parent no longer manages their parameters (FSDP2
-    # skips nested units when collecting managed modules). Only `param_dtype` is
-    # overridden -- reduce/output dtype and `cast_forward_inputs` keep the
-    # caller's semantics, and inputs are then cast to fp32 at the unit boundary.
+    # skips nested units when collecting managed modules). Leaving `param_dtype`
+    # unset preserves each parameter's original fp32 all-gather dtype without
+    # changing the module's input dtype. All other policy fields are retained.
     mp_policy = fsdp_kwargs.get("mp_policy")
     keep_fp32_modules = _select_keep_in_fp32_wrap_targets(model, getattr(mp_policy, "param_dtype", None))
     if keep_fp32_modules:
-        keep_fp32_kwargs = {**fsdp_kwargs, "mp_policy": replace(mp_policy, param_dtype=torch.float32)}
+        keep_fp32_kwargs = {**fsdp_kwargs, "mp_policy": replace(mp_policy, param_dtype=None)}
         for module in keep_fp32_modules:
             with maybe_patch_fsdp_module(module):
                 fully_shard(module, **keep_fp32_kwargs)

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import functools
+import importlib.util
 import itertools
 import json
 import logging
 import math
 import os
+import re
 from abc import ABC
 from collections import OrderedDict
 from contextlib import contextmanager, nullcontext
+from dataclasses import replace
 from typing import Optional, cast
 
 import torch
@@ -496,9 +500,38 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
     else:
         model = model.to_empty(device=get_device_id())
 
+    # Align the source dtypes with the destination states before anything is
+    # broadcast, distributed or assigned. The broadcast carries rank 0's dtype,
+    # and the meta/assign path in `_distribute_tensors` adopts it verbatim, so a
+    # source that disagrees with the target (e.g. a bf16 checkpoint feeding an
+    # fp32-keep module) would silently redefine the parameter's dtype.
+    # FSDP2 preserves FQNs, so these names still address the same states.
+    # Parameters and persistent buffers are treated alike because both appear in
+    # `state_dict()` and both are loaded by `set_model_state_dict`.
+    # `remove_duplicate=False` is required: `state_dict()` lists a tied tensor
+    # under *every* alias, so a de-duplicated map would leave the second alias
+    # unaligned and let it define the parameter's dtype instead.
+    # The alignment goes into a shallow copy: this function is documented to
+    # modify the model, not the caller's state dict, and callers reuse it.
+    # `copy.copy` (not `dict(...)`) keeps the mapping subclass and carries over
+    # `_metadata`, which `load_state_dict` reads and a plain dict would drop.
+    target_dtypes = {
+        name: state.dtype
+        for name, state in itertools.chain(
+            model.named_parameters(remove_duplicate=False),
+            model.named_buffers(remove_duplicate=False),
+        )
+        if state.dtype.is_floating_point
+    }
+    aligned_state = copy.copy(full_state)
+    for name, tensor in full_state.items():
+        target = target_dtypes.get(name)
+        if target is not None and torch.is_tensor(tensor) and tensor.dtype != target:
+            aligned_state[name] = tensor.to(target)
+
     cpu_offload = cpu_offload is not None
     options = StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload, broadcast_from_rank0=True)
-    set_model_state_dict(model, full_state, options=options)
+    set_model_state_dict(model, aligned_state, options=options)
 
     # rotary_emb is not in state_dict, so we need to broadcast it manually
     # Sort by name to ensure deterministic order across ranks. FSDP2 can return
@@ -532,6 +565,258 @@ def maybe_patch_fsdp_module(model):
         yield
     finally:
         fully_shard_module.FSDPModule = orig_fsdp_module
+
+
+def _hf_keep_in_fp32_root(model: nn.Module) -> Optional[nn.Module]:
+    """The module ``from_pretrained`` reads the fp32-keep declarations from.
+
+    Transformers attaches both attributes to every ``PreTrainedModel``, and the
+    loader consults only the top-most one. verl may hand us a wrapper (a PEFT
+    model, for instance), so the outermost declaring module is resolved instead
+    of assuming the root is the model itself. ``modules()`` is a pre-order walk,
+    so the first hit is the outermost.
+    """
+    for submodule in model.modules():
+        if hasattr(submodule, "_keep_in_fp32_modules") or hasattr(submodule, "_keep_in_fp32_modules_strict"):
+            return submodule
+    return None
+
+
+def get_keep_in_fp32_module_names(model: nn.Module, target_dtype: Optional[torch.dtype]) -> list[str]:
+    """Resolve the HF fp32-keep module names that apply for ``target_dtype``.
+
+    Transformers declares two independent lists, with *different* activation
+    rules. The gate below is verified identical in 4.56.1
+    (``modeling_utils.from_pretrained``) and 5.11.0
+    (``modeling_utils._get_dtype_plan``), which span verl's supported range:
+
+    * ``_keep_in_fp32_modules`` guards against bf16 -> fp16 rounding only, so HF
+      honours it for ``float16`` (and, in 4.x, for quantizers that opt in) --
+      **not** for ``bfloat16``.
+    * ``_keep_in_fp32_modules_strict`` forbids any low-precision cast, so HF
+      honours it for both ``float16`` and ``bfloat16``.
+
+    Mirroring that gate is what keeps verl consistent with ``from_pretrained``;
+    a broader rule would silently promote modules HF deliberately leaves in
+    bf16. Quantizer opt-in (``use_keep_in_fp32_modules``) is out of scope: verl
+    does not build the FSDP2 path through ``hf_quantizer``.
+
+    Only the top-most declaration is read, which is what both versions do:
+    4.56.1 consults the top-level model alone, and 5.11.0's ``post_init``
+    already folds every child's declaration into it. Collecting from nested
+    models directly would widen 4.56.1's behaviour.
+
+    Transformers 5.x stores these as ``set``, whose iteration order is not
+    stable, so the result is sorted.
+    """
+    if target_dtype not in (torch.float16, torch.bfloat16):
+        return []
+
+    root = _hf_keep_in_fp32_root(model)
+    if root is None:
+        return []
+
+    names = set()
+    if target_dtype == torch.float16:
+        names.update(getattr(root, "_keep_in_fp32_modules", None) or [])
+    names.update(getattr(root, "_keep_in_fp32_modules_strict", None) or [])
+    return sorted(names)
+
+
+def _keep_in_fp32_uses_glob_matching() -> bool:
+    """Whether the installed transformers matches keep names as unanchored globs.
+
+    5.x resolves them through ``core_model_loading.build_glob_alternation``;
+    4.x compiles the pattern inline in ``from_pretrained``. That module does not
+    exist before 5.0, which makes it a reliable capability probe -- and it is
+    only probed, never imported, since it is private and unstable.
+    """
+    return importlib.util.find_spec("transformers.core_model_loading") is not None
+
+
+def _keep_in_fp32_regex(module_names: list[str]):
+    """Compile the installed transformers' fp32-keep matcher.
+
+    Both branches reproduce the upstream pattern construction verbatim, so a
+    declaration that is legal for the installed version resolves the same way it
+    would inside ``from_pretrained``:
+
+    * 4.x (``modeling_utils.py:5127``) anchors on whole dot-separated path
+      segments: ``((^|\\.)name($|\\.))``. A name that is merely a substring of a
+      segment does not match.
+    * 5.x (``core_model_loading.build_glob_alternation``) searches unanchored
+      and expands ``*`` to ``.*``, so substrings *do* match and glob
+      declarations are honoured.
+
+    Neither branch escapes the name, matching upstream: these come from model
+    class attributes, and escaping would silently reinterpret a 5.x glob.
+    """
+    if not module_names:
+        return None
+    if _keep_in_fp32_uses_glob_matching():
+        return re.compile("|".join(name.replace("*", r".*") for name in module_names))
+    return re.compile("|".join(rf"((^|\.){name}($|\.))" for name in module_names))
+
+
+def _defines_forward(module: nn.Module) -> bool:
+    """Whether ``module`` can serve as an FSDP2 unit boundary.
+
+    FSDP2 unshards a unit's parameters from a hook on that unit's own forward,
+    so a module that is never called cannot be one. A container that does not
+    override ``nn.Module.forward`` is exactly that case: models reach past it to
+    its children (``holder.child(x)``), leaving the hook unreachable and the
+    parameters sharded during compute. ``fully_shard`` rejects the two
+    best-known examples outright -- ``nn.ModuleList`` and ``nn.ModuleDict`` --
+    but a plain ``nn.Module`` used for namespacing is accepted and then silently
+    misbehaves, so the check is on the behaviour rather than on a class list.
+    ``nn.ParameterList`` / ``nn.ParameterDict`` are covered too: they hold
+    parameters directly and define no forward, so their states end up with no
+    owner and are rejected by the ownership check below.
+    """
+    return type(module).forward is not nn.Module.forward
+
+
+def _named_floating_states(model: nn.Module, params_only: bool = False):
+    """Every floating parameter/buffer under *every* name it is reachable by.
+
+    ``remove_duplicate=False`` is essential: tied weights are a single tensor
+    exposed under several FQNs, and a keep rule may name any one of them.
+    """
+    states = model.named_parameters(remove_duplicate=False)
+    if not params_only:
+        states = itertools.chain(states, model.named_buffers(remove_duplicate=False))
+    return ((name, state) for name, state in states if state.dtype.is_floating_point)
+
+
+def _resolve_keep_in_fp32_states(model: nn.Module, regex, params_only: bool = False) -> dict[int, list[str]]:
+    """Map each fp32-keep tensor to *all* of the names it is reachable by.
+
+    A tied tensor is kept in fp32 as soon as **any** of its aliases matches: the
+    aliases are one tensor, so a per-name decision would be order dependent and
+    would silently downcast a weight that a keep rule named.
+    """
+    aliases: dict[int, list[str]] = {}
+    matched: set[int] = set()
+    for name, state in _named_floating_states(model, params_only):
+        aliases.setdefault(id(state), []).append(name)
+        if regex.search(name):
+            matched.add(id(state))
+    return {state_id: names for state_id, names in aliases.items() if state_id in matched}
+
+
+def cast_module_to_dtype_keeping_fp32_modules(model: nn.Module, dtype: torch.dtype) -> list[str]:
+    """``model.to(dtype)`` that honours HF's ``_keep_in_fp32_modules*`` declarations.
+
+    A blanket ``model.to(bf16)`` after ``from_pretrained`` destroys the fp32
+    copies HF just materialised, and the rounding is not recoverable. This casts
+    every other floating state instead and leaves the declared modules alone.
+
+    Returns:
+        The FQNs kept in fp32, including every alias of a tied weight (empty when
+        the model declares nothing, in which case behaviour is identical to
+        ``model.to(dtype)``).
+    """
+    regex = _keep_in_fp32_regex(get_keep_in_fp32_module_names(model, dtype))
+    if regex is None:
+        model.to(dtype)
+        return []
+
+    keep = _resolve_keep_in_fp32_states(model, regex)
+    cast_ids = set()
+    for name, state in _named_floating_states(model):
+        if id(state) in cast_ids:
+            continue  # tied alias: the tensor was already handled
+        cast_ids.add(id(state))
+        state.data = state.data.to(torch.float32 if id(state) in keep else dtype)
+
+    kept = sorted(itertools.chain.from_iterable(keep.values()))
+    if kept:
+        logger.info(f"kept {len(kept)} states in fp32 per HF _keep_in_fp32_modules: {kept}")
+    return kept
+
+
+def _select_keep_in_fp32_wrap_targets(model: nn.Module, param_dtype: Optional[torch.dtype]) -> list[nn.Module]:
+    """Modules that must become their own FSDP2 unit to stay out of ``param_dtype``.
+
+    ``fully_shard`` all-gathers every parameter of a unit in
+    ``mp_policy.param_dtype`` and rejects a unit whose parameters do not share
+    one original dtype, so an fp32-keep module can only stay in fp32 by being a
+    separate unit.
+
+    A module qualifies when *all* of its floating parameters are kept, which
+    collapses parent/child overlap and duplicate entries onto the topmost
+    matching module -- each is therefore wrapped exactly once.
+
+    Raises:
+        ValueError: if a kept parameter is tied across a unit boundary, or if a
+            matched module mixes fp32 keep parameters with lower-precision ones
+            (an adapter injected into it, for instance). FSDP2 gives each
+            parameter to exactly one unit and all-gathers a unit at a single
+            dtype, so neither shape can be expressed. Both checks run before
+            anything is wrapped, so the model is never left partially wrapped.
+    """
+    regex = _keep_in_fp32_regex(get_keep_in_fp32_module_names(model, param_dtype))
+    if regex is None:
+        return []
+
+    keep = _resolve_keep_in_fp32_states(model, regex, params_only=True)
+    targets: list[nn.Module] = []
+    selected_prefixes: list[str] = []
+    # named_modules() is a pre-order walk, so a parent is always visited first.
+    for name, submodule in model.named_modules():
+        if not name or any(name.startswith(prefix) for prefix in selected_prefixes):
+            continue  # root, or already covered by a selected ancestor
+        if not _defines_forward(submodule):
+            # No forward of its own, so no hook that could unshard it. Descend
+            # instead: its children are matched too, and each of them can carry
+            # the fp32 policy.
+            continue
+        params = [(f"{name}.{n}", p) for n, p in submodule.named_parameters() if p.dtype.is_floating_point]
+        if not params or not all(id(p) in keep for _, p in params):
+            continue
+        fp32 = sorted(fqn for fqn, p in params if p.dtype == torch.float32)
+        others = sorted(f"{fqn} ({p.dtype})" for fqn, p in params if p.dtype != torch.float32)
+        if others and fp32:
+            raise ValueError(
+                f"cannot keep '{name}' in fp32 under FSDP2: it mixes fp32 keep parameters {fp32} with "
+                f"lower-precision parameters {others}. An FSDP2 unit all-gathers all of its parameters at one "
+                "dtype, so it cannot satisfy the keep-in-fp32 contract and the mixed parameter dtypes at the "
+                "same time. Adjust the wrapping or adapter configuration so the fp32-keep module does not share "
+                "a unit with lower-precision parameters."
+            )
+        if others:
+            raise ValueError(
+                f"cannot keep '{name}' in fp32 under FSDP2: every parameter it declares as fp32-keep is already "
+                f"in a lower precision {others}. The declaration is a precision contract, so the build-time "
+                "preservation must have been bypassed -- casting the model with plain `.to(dtype)` instead of "
+                "`cast_module_to_dtype_keeping_fp32_modules` does exactly that. Refusing rather than silently "
+                "sharding the module at the low precision it was already degraded to."
+            )
+        targets.append(submodule)
+        selected_prefixes.append(f"{name}.")
+
+    # Fail closed: every kept parameter must resolve to exactly one unit under
+    # all of its names. Anything else would leave it all-gathered twice, or in
+    # the surrounding low-precision unit.
+    for names in keep.values():
+        owners = {next((prefix for prefix in selected_prefixes if name.startswith(prefix)), None) for name in names}
+        if owners == {None}:
+            raise ValueError(
+                f"cannot keep {sorted(names)} in fp32 under FSDP2: no fp32-keep unit owns it, so it would stay "
+                f"in the surrounding unit and be all-gathered in {param_dtype}. This happens when the parameter "
+                "hangs directly off the root module, or off a module that also holds parameters which are not "
+                "kept. Move it into a dedicated submodule so it can become its own FSDP2 unit, or drop the "
+                "module from the keep list."
+            )
+        if len(owners) > 1 or None in owners:
+            raise ValueError(
+                f"cannot keep {sorted(names)} in fp32 under FSDP2: the parameter is tied across FSDP2 unit "
+                f"boundaries (resolved units: {sorted(o for o in owners if o)}). HF declares it via "
+                "_keep_in_fp32_modules / _keep_in_fp32_modules_strict, but FSDP2 assigns each parameter to "
+                "exactly one unit. Untie the weight (e.g. set tie_word_embeddings=False) or drop the module "
+                "from the keep list."
+            )
+    return targets
 
 
 def _select_fsdp2_wrap_targets(model, fsdp_transformer_layer_cls_to_wrap):
@@ -575,6 +860,28 @@ def apply_fsdp2(model, fsdp_kwargs, config):
     assert len(fsdp_transformer_layer_cls_to_wrap) > 0 and fsdp_transformer_layer_cls_to_wrap[0] is not None
 
     modules = _select_fsdp2_wrap_targets(model, fsdp_transformer_layer_cls_to_wrap)
+
+    # Modules HF declares as fp32-keep must be their own units, wrapped *before*
+    # any parent so that the parent no longer manages their parameters (FSDP2
+    # skips nested units when collecting managed modules). Only `param_dtype` is
+    # overridden -- reduce/output dtype and `cast_forward_inputs` keep the
+    # caller's semantics, and inputs are then cast to fp32 at the unit boundary.
+    mp_policy = fsdp_kwargs.get("mp_policy")
+    keep_fp32_modules = _select_keep_in_fp32_wrap_targets(model, getattr(mp_policy, "param_dtype", None))
+    if keep_fp32_modules:
+        keep_fp32_kwargs = {**fsdp_kwargs, "mp_policy": replace(mp_policy, param_dtype=torch.float32)}
+        for module in keep_fp32_modules:
+            with maybe_patch_fsdp_module(module):
+                fully_shard(module, **keep_fp32_kwargs)
+        # A keep unit already covers itself and everything beneath it. Wrapping
+        # any of those again would double-wrap the module, and for a descendant
+        # it would also invert FSDP2's children-before-parents ordering, since
+        # the ancestor is wrapped by the time we get here. Ancestors of a keep
+        # unit are deliberately kept: wrapping them after the keep child is the
+        # correct order. Membership is by module identity, since FQN prefixes
+        # can collide across differently named subtrees.
+        covered = {id(covered_module) for unit in keep_fp32_modules for covered_module in unit.modules()}
+        modules = [module for module in modules if id(module) not in covered]
 
     for idx, module in enumerate(modules):
         # if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -45,6 +45,7 @@ from verl.utils.fsdp_utils import (
     FSDPModule,
     MixedPrecisionPolicy,
     apply_fsdp2,
+    cast_module_to_dtype_keeping_fp32_modules,
     collect_lora_params,
     fsdp2_clip_grad_norm_,
     fsdp2_load_full_state_dict,
@@ -307,7 +308,16 @@ class FSDPEngine(BaseEngine):
             )
 
             # some parameters may not in torch_dtype
-            module.to(torch_dtype)
+            if self.engine_config.strategy == "fsdp2":
+                # Modules that HF declares via `_keep_in_fp32_modules` /
+                # `_keep_in_fp32_modules_strict` stay in fp32: `from_pretrained`
+                # just materialised them in fp32 and a blanket cast would round
+                # them through the low-precision dtype irrecoverably (verl#7092).
+                # FSDP1 is left alone on purpose -- its flat parameters require a
+                # uniform dtype per group, so it cannot represent the result.
+                cast_module_to_dtype_keeping_fp32_modules(module, torch_dtype)
+            else:
+                module.to(torch_dtype)
 
             if self.model_config.enable_gradient_checkpointing:
                 module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})


### PR DESCRIPTION
### What does this PR do?

Fixes #7092.

verl's FSDP2 path did not honor Hugging Face's `_keep_in_fp32_modules` and `_keep_in_fp32_modules_strict` declarations. As a result, parameters and floating-point buffers that Hugging Face intentionally keeps in FP32 could be silently reduced during model construction, FSDP2 parameter materialization/all-gather, or full-state-dict loading.

This PR preserves the Hugging Face FP32-keep parameter contract throughout the FSDP2 lifecycle:

* Replaces the blanket FSDP2 build-time cast with a keep-aware cast, preserving matched parameters and floating-point buffers in FP32.
* Wraps eligible FP32-keep modules as child FSDP2 parameter units with `param_dtype=None`, so their parameters materialize/all-gather in their original FP32 dtype.
* Does not force floating activations to FP32 at the child FSDP2 boundary.
* Preserves all other fields from the caller's mixed-precision policy.
* Aligns full-state-dict tensors with destination parameter and persistent-buffer dtypes before broadcast and assignment.
* Fails early for layouts that FSDP2 cannot represent safely instead of silently reducing precision.

FSDP1 behavior is unchanged. This PR introduces no user-facing API, CLI, or configuration changes.

AI assistance was used in preparing this change; I reviewed every changed line and independently executed all validation reported below.

### Checklist Before Starting

* [x] Searched for similar open PRs using the issue number and `keep_in_fp32_modules` keywords; no existing PR implements this contract.
* [x] Reviewed related PR [#4275](https://github.com/verl-project/verl/pull/4275), which adds dtype-aware FSDP2 wrapping for LoRA modules but does not implement Hugging Face `_keep_in_fp32_modules` / `_keep_in_fp32_modules_strict` semantics.
* [x] Formatted the title as `[{modules}] {type}: {description}`:

  * `[fsdp] fix: preserve Hugging Face fp32-keep modules in FSDP2`

### Test

| Command / coverage | Result |
| --- | --- |
| `pytest tests/utils/test_keep_in_fp32_utils_on_cpu.py -q` | 67 passed |
| `pytest tests/utils/test_fsdp_wrap_policy_on_cpu.py tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py tests/utils/test_fsdp2_peft_wrapping.py -q` | 14 passed; 1 existing NPU router-replay warning |
| `CUDA_VISIBLE_DEVICES=0 torchrun --standalone --nproc-per-node=1 tests/special_distributed/test_fsdp2_keep_in_fp32.py` | PASS on 1 × A100-SXM4-80GB |
| `CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc-per-node=2 tests/special_distributed/test_fsdp2_keep_in_fp32.py` | PASS on 2 × A100-SXM4-80GB |
| `CUDA_VISIBLE_DEVICES=0,1 torchrun --standalone --nproc-per-node=2 tests/special_distributed/test_fsdp2_cpu_offload_state_dict.py` | PASS |
| BF16/FP16 × engine-autocast/direct reference transparency | Activation input/output dtypes match the unsharded reference; logits, loss, and every gradient are bit-exact; FP32-keep weights materialize/all-gather in FP32 |
| CPU helper suite with Transformers 4.56.1, 5.3.0, 5.5.3, and 5.10.0 | 67 passed on every installed version |
| Negative control: temporarily restore child `param_dtype=torch.float32` in an isolated worktree | Expected non-zero exit; caught the BF16 activation boundary changing from the reference's BF16 to FP32 |
| `pre-commit run --all-files --show-diff-on-failure --color=always` | Final run: 13/13 hooks passed; no files modified |
| Ruff, Ruff format, and mypy | PASS via the repository pre-commit configuration |
| `git diff --check` for the worktree and complete PR diff | PASS |

Test environment:

* Python 3.12.3
* PyTorch 2.8.0+cu128
* CUDA 12.8
* NCCL 2.27.3
* NVIDIA A100-SXM4-80GB
* Transformers 4.56.1, 5.3.0, 5.5.3, and 5.10.0

Transformers 5.10.0 was reported as yanked by the installer, but the requested wheel was installed successfully and its CPU helper suite completed with 67 passed tests.

Two distinct regressions are covered:

1. On the unmodified base, stored parameter values can remain correct while a matched weight materializes/all-gathers in the low-precision policy dtype instead of FP32. The `weight.dtype` forward hook observes only the materialized/all-gathered parameter dtype; it is not evidence of an operator's execution dtype.
2. The earlier child `param_dtype=torch.float32` policy forces a different activation boundary. The isolated negative control changes the matched module's BF16 activation input/output to FP32 and fails reference-transparency assertions as expected.

The distributed regression coverage includes:

* Regular and strict FP32-keep declarations.
* FP16 and BF16 dtype-gating behavior.
* Nested matching, parent/child overlap, and duplicate declarations.
* Tied parameter aliases and FP32 buffers.
* Forward, backward, and gradient correctness.
* Full-state-dict round trips.
* Non-callable containers and unsupported fail-closed layouts.
* Models without an FP32-keep declaration.
* Separate observations for activation input/output dtype, internal operator/result tensor dtypes, and materialized/all-gathered parameter dtype.
* Bit-exact logits, loss, and gradient parity against an unsharded reference in identical BF16/FP16 autocast and direct-forward contexts.

### API and Usage Example

No user action is required. Existing Hugging Face declarations are honored automatically when verl uses FSDP2:

```python
class MyModel(PreTrainedModel):
    _keep_in_fp32_modules_strict = ["sensitive"]
```

With `strategy=fsdp2` and a low-precision `mixed_precision.param_dtype`, eligible matched parameters remain stored in FP32 and materialize/all-gather in FP32. The FSDP2 boundary does not redefine module activation input/output or execution dtypes; those remain determined by the caller's autocast context and the module's own casting logic.

### Design & Code Changes

#### Honor Hugging Face declaration semantics

The resolver applies the same dtype gates as Hugging Face Transformers:

* `_keep_in_fp32_modules` applies when the model dtype is FP16.
* `_keep_in_fp32_modules_strict` applies when the model dtype is FP16 or BF16.

Matching follows the installed Transformers capability: whole-segment matching for supported 4.x versions and unanchored glob matching for supported 5.x versions. The helper suite was executed with Transformers 4.56.1, 5.3.0, 5.5.3, and 5.10.0.

#### Preserve FP32 before sharding

`FSDPEngine._build_module` uses a keep-aware cast for FSDP2. Matched floating-point parameters and buffers remain FP32, including all aliases of tied tensors. Other floating-point states are cast to the configured model dtype.

The FSDP1 construction path is unchanged.

#### Isolate FP32 parameter units without changing activation boundaries

Each topmost eligible matched module is wrapped before its parent using:

```python
dataclasses.replace(mp_policy, param_dtype=None)
```

The keep-aware build cast has already preserved the matched parameters in FP32. Leaving the child policy's `param_dtype` unset makes FSDP2 materialize/all-gather those parameters in their original FP32 dtype without inserting an FP32 activation conversion at the child boundary. Activation input/output and internal execution dtypes remain controlled by the caller's autocast context and the module's own casting logic. All other policy fields are retained.

#### Reject unsafe or ambiguous layouts

A selected FP32 child absorbs its subtree from the standard wrap-target list to avoid duplicate wrapping. Containers without their own callable `forward` resolve to eligible callable descendants.

The implementation raises a descriptive error before wrapping for layouts that cannot safely preserve the requested precision, including:

* Root-owned FP32-keep parameters.
* Tied parameters spanning incompatible FSDP units.
* FP32-keep parameters already degraded before wrapping.
* Units that mix kept FP32 parameters with lower-precision parameters.

This fail-closed behavior prevents silent precision loss.

#### Make destination dtype authoritative during state-dict loading

`fsdp2_load_full_state_dict` aligns incoming parameters and persistent buffers with their destination dtypes before broadcast and distribution.

The loader:

* Processes every alias with `remove_duplicate=False`.
* Preserves state-dict metadata.
* Operates on a shallow copy instead of mutating the caller's mapping.

### Validation Scope and Limitations

* The regression suite uses a locally constructed toy `PreTrainedModel`; no large FP32-keep checkpoint was downloaded or executed.
* Validation covers one A100 and DP=2 across two A100s.
* No end-to-end PPO or SFT run is claimed.
* No Inkling 975B, Qwen3-Next, or B300 validation is claimed.
* FSDP1, Megatron, VeOmni, AutoModel, NPU, HSDP/2-D meshes, and other untested backends receive no new support claim from this validation.
* The general FSDP2 CPU-offload state-dict regression passed, but CPU offload combined specifically with FP32-keep child units was not exercised.
* Unsupported FSDP2 layouts now fail explicitly instead of silently degrading precision. This is an intentional behavior change for those layouts.

### Checklist Before Submitting

* [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
* [x] Applied the required pre-commit checks: `pre-commit run --all-files --show-diff-on-failure --color=always`.
* [x] Confirmed that a documentation update is not required because this PR adds no user-facing API, CLI flag, or configuration option.
* [x] Added CPU and distributed regression coverage.
* [x] Registered the distributed regression in `tests/special_distributed/run_all.sh`.
* [x] Confirmed that the CPU regression is collected by the CPU test workflow.
* [ ] Request CI in the `ci-request` Slack channel when the PR is ready for CI, or use the Feishu group if Slack is unavailable.
* [x] Recipe submodule update is not applicable.
