### PR TITLE
[rollout, vllm] fix: fall back to bucketed weight sync when vLLM reload_weights lacks weights_iterator

### DIFF
--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import importlib.util
 import sys
 import types
 from pathlib import Path
+from unittest import mock
 
 import torch
 
@@ -211,6 +213,58 @@ def test_vllm_update_weights_loads_params_and_buffers():
     torch.testing.assert_close(
         model.model.layers[0].e_score_correction_bias, torch.tensor([5, 6, 7, 8], dtype=torch.float32)
     )
+
+
+def _fake_vllm_config_module():
+    """Provide vllm.config.set_current_vllm_config for the lazy import in the reload path."""
+    fake_config = types.ModuleType("vllm.config")
+    fake_config.set_current_vllm_config = contextlib.nullcontext
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.config = fake_config
+    return mock.patch.dict(sys.modules, {"vllm": fake_vllm, "vllm.config": fake_config})
+
+
+def _fake_receiver(weights):
+    return types.SimpleNamespace(iter_weights=lambda: iter(weights))
+
+
+def _make_reload_worker(model_runner_reload=None):
+    """Build a worker whose reload_weights mirrors vLLM's worker-level *args/**kwargs forwarding."""
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = _FakeModelRunner(_ToyModel())
+    if model_runner_reload is not None:
+        worker.model_runner.reload_weights = model_runner_reload
+        worker.reload_weights = lambda *args, **kwargs: worker.model_runner.reload_weights(*args, **kwargs)
+    return worker
+
+
+def test_maybe_reload_standard_weights_falls_back_on_legacy_signature():
+    calls = []
+    worker = _make_reload_worker(model_runner_reload=lambda: calls.append("reload"))
+
+    with _fake_vllm_config_module():
+        used = worker._maybe_reload_standard_weights_from_ipc(_fake_receiver([]))
+
+    assert used is False
+    assert calls == []
+
+
+def test_maybe_reload_standard_weights_uses_layerwise_reload_when_supported():
+    received = {}
+
+    def _reload_weights(weights_iterator=None, weights_path=None, is_checkpoint_format=True):
+        received["weights"] = [(name, tensor.clone()) for name, tensor in weights_iterator]
+        received["is_checkpoint_format"] = is_checkpoint_format
+
+    worker = _make_reload_worker(model_runner_reload=_reload_weights)
+    weights = [("model.layers.0.linear.weight", torch.ones(4, 4, dtype=torch.float32))]
+
+    with _fake_vllm_config_module():
+        used = worker._maybe_reload_standard_weights_from_ipc(_fake_receiver(weights))
+
+    assert used is True
+    assert received["is_checkpoint_format"] is True
+    assert [name for name, _ in received["weights"]] == ["model.layers.0.linear.weight"]
 
 
 def test_vllm_update_weights_syncs_buffers_to_mtp_drafter():

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ctypes
+import inspect
 import json
 import logging
 import os
@@ -366,6 +367,22 @@ class vLLMColocateWorkerExtension:
 
             yield normalized_name, tensor
 
+    def _supports_layerwise_reload(self) -> bool:
+        """Return whether reload_weights accepts the weights_iterator kwarg (added in vLLM 0.16.0)."""
+        # Platform workers without the layerwise reload API (e.g. vllm-ascend's
+        # NPUWorker) fall back to bucketed load_weights.
+        if not callable(getattr(self, "reload_weights", None)):
+            return False
+
+        # The worker-level method forwards *args/**kwargs; the model runner declares the real signature.
+        runner_reload = getattr(getattr(self, "model_runner", None), "reload_weights", None)
+        if not callable(runner_reload):
+            return False
+        try:
+            return "weights_iterator" in inspect.signature(runner_reload).parameters
+        except (TypeError, ValueError):
+            return False
+
     def _maybe_reload_standard_weights_from_ipc(self, receiver) -> bool:
         from vllm.config import set_current_vllm_config
 
@@ -373,9 +390,8 @@ class vLLMColocateWorkerExtension:
         if self._use_mtp_drafter_weight_sync():
             return False
 
-        # Platform workers without the layerwise reload API (e.g. vllm-ascend's
-        # NPUWorker) fall back to bucketed load_weights.
-        if not callable(getattr(self, "reload_weights", None)):
+        if not self._supports_layerwise_reload():
+            logger.info("vLLM layerwise reload_weights unavailable; falling back to bucketed load_weights")
             return False
 
         logger.info("Loading standard weights via vLLM reload_weights (async)")


### PR DESCRIPTION
### What does this PR do?

Fixes #7130.

The standard weight sync calls `reload_weights(weights_iterator=..., is_checkpoint_format=True)`, but that kwarg only exists in vLLM >= 0.16. On older versions — including 0.12.0, the newest the `.[vllm]` extra installs — `reload_weights()` takes no arguments, so the first weight sync dies with:

```
TypeError: Worker.reload_weights() got an unexpected keyword argument 'weights_iterator'
```

The current guard only checks that the method is callable, which passes on every version. This PR adds a signature check (against `model_runner.reload_weights`, since the worker-level method on newer vLLM just forwards `*args/**kwargs`) and falls back to the existing bucketed `load_weights` path when `weights_iterator` isn't supported. vLLM >= 0.16 keeps the fast path; no API or config changes.

AI assistance was used (Claude). I reviewed every changed line and ran the tests below.

### Checklist Before Starting

- [x] Similar PR search: [`7130 in:body`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7130+in%3Abody) (0 results), [`reload_weights`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+reload_weights) (only #7136 — FP8 path, no overlap)
- [x] PR title follows the `[{modules}] {type}: {description}` format

### Test

- `pytest tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py -q` → 7 passed. Two new tests: old signature falls back cleanly, new signature still uses the layerwise path.
- End-to-end on 1x GB10 with vLLM 0.12.0 (installed via `.[vllm]`), Qwen3-0.6B GRPO on GSM8K, FSDP2, TP=1: without the patch, the first weight sync crashes with the `TypeError` above; with it, both syncs complete via the fallback (logged) and step 1 finishes with `rollout_actor_probs_pearson_corr: 0.9992`, confirming the fallback loads weights correctly.
- `pre-commit run` passes on changed files.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update documentation — N/A, no API or config changes
- [x] Unit tests added to the existing CI-covered CPU test file
- [ ] Send a message in the `ci-request` channel once ready for CI
