### PR TITLE
[model] fix: import crash on transformers >= 5.4.0 (is_flash_attn_greater_or_equal_2_10 removed)

### DIFF
--- a/verl/models/transformers/glm4v.py
+++ b/verl/models/transformers/glm4v.py
@@ -27,7 +27,16 @@ from transformers.models.glm4v.modeling_glm4v import (
     Glm4vForConditionalGeneration,
     Glm4vTextAttention,
 )
-from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_or_equal_2_10
+from transformers.utils import is_flash_attn_2_available
+
+try:
+    from transformers.utils import is_flash_attn_greater_or_equal_2_10
+except ImportError:  # transformers >= 5.4.0 removed the versioned helper
+    from transformers.utils import is_flash_attn_greater_or_equal
+
+    def is_flash_attn_greater_or_equal_2_10():
+        return is_flash_attn_greater_or_equal("2.10")
+
 
 from verl.utils.device import is_npu_available
 from verl.utils.ulysses import (

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -26,7 +26,16 @@ from transformers.models.qwen2_vl.modeling_qwen2_vl import (
     Qwen2VLCausalLMOutputWithPast,
     Qwen2VLForConditionalGeneration,
 )
-from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_or_equal_2_10
+from transformers.utils import is_flash_attn_2_available
+
+try:
+    from transformers.utils import is_flash_attn_greater_or_equal_2_10
+except ImportError:  # transformers >= 5.4.0 removed the versioned helper
+    from transformers.utils import is_flash_attn_greater_or_equal
+
+    def is_flash_attn_greater_or_equal_2_10():
+        return is_flash_attn_greater_or_equal("2.10")
+
 
 from verl.utils.device import is_npu_available
 from verl.utils.transformers_compat import is_transformers_version_in_range, unpack_visual_output


### PR DESCRIPTION
### What does this PR do?

Fixes an `ImportError` that breaks `import verl.trainer.sft_trainer` (and anything else importing `verl/models/transformers/qwen2_vl.py` or `glm4v.py`) on **transformers >= 5.4.0**:

```
File "verl/models/transformers/qwen2_vl.py", line 29, in <module>
    from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_or_equal_2_10
ImportError: cannot import name 'is_flash_attn_greater_or_equal_2_10' from 'transformers.utils'.
Did you mean: 'is_flash_attn_greater_or_equal'?
```

transformers 5.4.0 removed the versioned helper `is_flash_attn_greater_or_equal_2_10`; the generic `is_flash_attn_greater_or_equal("2.10")` remains. Since `setup.py` allows `transformers<5.12.0,!=5.6.0`, most of the declared-supported range currently cannot even be imported.

Why it matters in practice: the Qwen3.5 FA2-varlen crash (huggingface/transformers#44910 — 3D mrope `position_ids` misdetected by `_is_packed_sequence`, inflated `cu_seqlens`, CUDA illegal memory access under `use_remove_padding=True`) is fixed in transformers 5.4.0. This import error is what blocks verl users from upgrading to pick up that fix. Possibly related user report: #6319 (NaN/instability on Qwen3.5 SFT).

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/search?q=repo%3Averl-project%2Fverl+is_flash_attn_greater_or_equal_2_10&type=issues (no existing fix; only the possibly-related #6319)
- [x] PR title formatted as `[model] fix: ...`

### Test

Env-compat fix, not directly CI-testable without a transformers>=5.4 matrix. Validated by experiment (4x H100, torch 2.9.1+cu128, flash-attn 2.8.3):

- transformers **5.3.0** (below the removal): behavior unchanged — the `try` branch imports the original helper.
- transformers **5.4.0** + this patch: `verl.trainer.sft_trainer` imports cleanly; a multiturn **multimodal SFT run** (FSDP + LoRA r32, Qwen3.5-4B, `pad_mode=no_padding` + `use_remove_padding=True`, flash_attention_2) trains normally; step-1 train loss is **bit-identical** to the same run on 5.3.0 (0.7680922746658325), step-2 matches to ~1e-3 (sampling-free config).
- Scope note: the SFT/FSDP path is what we exercised end-to-end; other paths were verified import-only.

### API and Usage Example

No API change.

### Design & Code Changes

`try/except ImportError` shim in the two files that import the removed helper (`qwen2_vl.py`, `glm4v.py`): fall back to a tiny wrapper over `is_flash_attn_greater_or_equal("2.10")` when the versioned helper is absent. Call sites (`_flash_use_top_left_mask = not is_flash_attn_greater_or_equal_2_10()`) unchanged.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): ruff / ruff-format / mypy pass on both files (the `_generated_*.yaml` hook fails in my env for lack of hydra-core — unrelated to this diff, which touches no configs).
- [x] Documentation: n/a (no user-facing behavior change).
- [ ] CI test: not added — exercising this requires a transformers>=5.4 job in the matrix; the shim itself is covered by any existing import of these modules once such a job exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
