### PR TITLE
[rollout] fix: fail fast on invalid replica topologies

### DIFF
--- a/tests/workers/rollout/test_llm_server_topology_on_cpu.py
+++ b/tests/workers/rollout/test_llm_server_topology_on_cpu.py
@@ -1,0 +1,269 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.workers.rollout.llm_server import LLMServerManager
+from verl.workers.rollout.topology import get_rollout_num_replicas, get_rollout_replica_world_size
+
+
+def _rollout_config(
+    *,
+    name: str = "vllm",
+    tp: int = 2,
+    dp: int = 1,
+    pp: int = 1,
+    pd_enabled: bool = False,
+    prefill_replicas: int = 1,
+    decode_replicas: int = 1,
+    decode_tp: int | None = None,
+    nnodes: int = 1,
+    n_gpus_per_node: int = 8,
+):
+    return SimpleNamespace(
+        name=name,
+        tensor_model_parallel_size=tp,
+        data_parallel_size=dp,
+        pipeline_model_parallel_size=pp,
+        disaggregation=SimpleNamespace(
+            enabled=pd_enabled,
+            prefill_replicas=prefill_replicas,
+            decode_replicas=decode_replicas,
+            decode_tensor_model_parallel_size=decode_tp,
+        ),
+        nnodes=nnodes,
+        n_gpus_per_node=n_gpus_per_node,
+        prometheus=SimpleNamespace(enable=False),
+        disable_log_stats=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "resource_world_size,config_kwargs,expected_replica_world_size,expected_num_replicas",
+    [
+        (16, {"tp": 2, "dp": 2, "pp": 1}, 4, 4),
+        (4, {"tp": 2, "dp": 2, "pp": 1}, 4, 1),
+        (
+            12,
+            {"tp": 2, "pd_enabled": True, "prefill_replicas": 1, "decode_replicas": 2, "decode_tp": 1},
+            4,
+            3,
+        ),
+        (
+            12,
+            {
+                "tp": 2,
+                "pd_enabled": True,
+                "prefill_replicas": 1,
+                "decode_replicas": 2,
+                "n_gpus_per_node": 6,
+            },
+            6,
+            2,
+        ),
+    ],
+)
+def test_valid_topologies(
+    resource_world_size,
+    config_kwargs,
+    expected_replica_world_size,
+    expected_num_replicas,
+):
+    config = _rollout_config(**config_kwargs)
+
+    assert get_rollout_replica_world_size(config) == expected_replica_world_size
+    assert get_rollout_num_replicas(config, resource_world_size) == expected_num_replicas
+
+
+def test_dictconfig_topology():
+    config = OmegaConf.create(
+        {
+            "name": "vllm",
+            "tensor_model_parallel_size": 2,
+            "data_parallel_size": 1,
+            "pipeline_model_parallel_size": 1,
+            "n_gpus_per_node": 8,
+            "disaggregation": {
+                "enabled": True,
+                "prefill_replicas": 1,
+                "decode_replicas": 2,
+                "decode_tensor_model_parallel_size": 1,
+            },
+        }
+    )
+
+    assert get_rollout_replica_world_size(config) == 4
+    assert get_rollout_num_replicas(config, 8) == 2
+
+
+@pytest.mark.parametrize(
+    "config_kwargs,field",
+    [
+        ({"tp": 0}, "tensor_model_parallel_size"),
+        ({"tp": -1}, "tensor_model_parallel_size"),
+        ({"dp": 0}, "data_parallel_size"),
+        ({"dp": -1}, "data_parallel_size"),
+        ({"pp": 0}, "pipeline_model_parallel_size"),
+        ({"pp": -1}, "pipeline_model_parallel_size"),
+        ({"pd_enabled": True, "prefill_replicas": 0}, "prefill_replicas"),
+        ({"pd_enabled": True, "prefill_replicas": -1}, "prefill_replicas"),
+        ({"pd_enabled": True, "decode_replicas": 0}, "decode_replicas"),
+        ({"pd_enabled": True, "decode_replicas": -1}, "decode_replicas"),
+        ({"pd_enabled": True, "decode_tp": 0}, "decode_tensor_model_parallel_size"),
+        ({"pd_enabled": True, "decode_tp": -1}, "decode_tensor_model_parallel_size"),
+    ],
+)
+def test_non_positive_parallel_sizes_are_rejected(config_kwargs, field):
+    with pytest.raises(ValueError, match=field):
+        get_rollout_replica_world_size(_rollout_config(**config_kwargs))
+
+
+@pytest.mark.parametrize("resource_world_size", [0, -1])
+def test_non_positive_resource_world_size_is_rejected(resource_world_size):
+    with pytest.raises(ValueError, match="resource_world_size"):
+        get_rollout_num_replicas(_rollout_config(), resource_world_size)
+
+
+@pytest.mark.parametrize("n_gpus_per_node", [0, -1])
+def test_non_positive_gpus_per_node_is_rejected(n_gpus_per_node):
+    with pytest.raises(ValueError, match="rollout.n_gpus_per_node"):
+        get_rollout_num_replicas(_rollout_config(n_gpus_per_node=n_gpus_per_node), 8)
+
+
+@pytest.mark.parametrize(
+    "resource_world_size,config_kwargs,message",
+    [
+        (3, {"tp": 2, "dp": 2}, "smaller than replica_world_size=4"),
+        (10, {"tp": 2, "dp": 2}, r"replica_world_size=4 \(remainder=2\)"),
+        (
+            3,
+            {"tp": 2, "pd_enabled": True, "decode_replicas": 2, "decode_tp": 1},
+            "smaller than replica_world_size=4",
+        ),
+        (
+            10,
+            {"tp": 2, "pd_enabled": True, "decode_replicas": 2, "decode_tp": 1},
+            r"replica_world_size=4 \(remainder=2\)",
+        ),
+        (24, {"tp": 6}, "replica_world_size=6 is not node-aligned"),
+        (24, {"tp": 12}, "replica_world_size=12 is not node-aligned"),
+        (
+            24,
+            {"tp": 2, "pd_enabled": True, "decode_replicas": 2, "decode_tp": 2},
+            "replica_world_size=6 is not node-aligned",
+        ),
+    ],
+)
+def test_resource_pool_must_fit_complete_replicas(resource_world_size, config_kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        get_rollout_num_replicas(_rollout_config(**config_kwargs), resource_world_size)
+
+
+def test_trtllm_allows_cross_placement_group_replica_slices():
+    config = _rollout_config(name="trtllm", tp=6)
+
+    assert get_rollout_num_replicas(config, 24) == 4
+
+
+def test_allow_empty_only_permits_an_empty_resource_pool():
+    config = _rollout_config(tp=2, dp=2)
+
+    assert get_rollout_num_replicas(config, 0, allow_empty=True) == 0
+    with pytest.raises(ValueError, match="resource_world_size"):
+        get_rollout_num_replicas(config, -1, allow_empty=True)
+    with pytest.raises(ValueError, match="smaller than replica_world_size=4"):
+        get_rollout_num_replicas(config, 2, allow_empty=True)
+
+
+def _build_manager(config, events, worker_world_size=None):
+    class FakeReplica:
+        def __init__(self, replica_rank, **_):
+            self.replica_rank = replica_rank
+            self._server_address = f"server-{replica_rank}"
+            self._server_handle = f"handle-{replica_rank}"
+            events.append(("created", replica_rank))
+
+        async def init_hybrid(self, worker_group):
+            events.append(("hybrid", self.replica_rank, worker_group.world_size))
+
+        async def init_standalone(self):
+            events.append(("standalone", self.replica_rank))
+
+    manager = LLMServerManager.__new__(LLMServerManager)
+    manager.rollout_config = config
+    manager.model_config = object()
+    manager.worker_group = SimpleNamespace(world_size=worker_world_size) if worker_world_size is not None else None
+    manager.rollout_resource_pool = None
+    manager.start_rank = 0
+    manager.rollout_replica_class = FakeReplica
+    return manager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_world_size,expected_mode", [(None, "standalone"), (8, "hybrid")])
+async def test_manager_launches_exact_replica_count(worker_world_size, expected_mode):
+    events = []
+    manager = _build_manager(_rollout_config(tp=2), events, worker_world_size)
+
+    await manager._initialize_llm_servers(start_rank=3)
+
+    assert [replica.replica_rank for replica in manager.rollout_replicas] == [3, 4, 5, 6]
+    assert [event[0] for event in events].count("created") == 4
+    assert [event[0] for event in events].count(expected_mode) == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "worker_world_size,available_world_size,message",
+    [
+        (None, 2, "smaller than replica_world_size=4"),
+        (2, 2, "smaller than replica_world_size=4"),
+        (None, 6, r"replica_world_size=4 \(remainder=2\)"),
+        (6, 6, r"replica_world_size=4 \(remainder=2\)"),
+    ],
+)
+async def test_manager_rejects_invalid_topology_before_constructing_replicas(
+    worker_world_size,
+    available_world_size,
+    message,
+):
+    events = []
+    config = _rollout_config(
+        tp=2,
+        dp=2,
+        nnodes=available_world_size // 2,
+        n_gpus_per_node=2,
+    )
+    manager = _build_manager(config, events, worker_world_size)
+
+    with pytest.raises(ValueError, match=message):
+        await manager._initialize_llm_servers()
+
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_manager_allows_fully_async_empty_standalone_phase():
+    events = []
+    manager = _build_manager(_rollout_config(nnodes=0), events)
+
+    await manager._initialize_llm_servers(allow_empty=True)
+
+    assert manager.rollout_replicas == []
+    assert manager.server_handles == []
+    assert manager.server_addresses == []
+    assert events == []

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -120,7 +120,10 @@ class FullyAsyncLLMServerManager(LLMServerManager):
             if standalone_gmu is not None and original_gmu is not None:
                 with open_dict(self.rollout_config):
                     self.rollout_config.gpu_memory_utilization = standalone_gmu
-            await super()._initialize_llm_servers(start_rank=num_hybrid)
+            await super()._initialize_llm_servers(
+                start_rank=num_hybrid,
+                allow_empty=self.rollout_config.nnodes == 0,
+            )
         finally:
             # Always restore the original value to avoid affecting downstream logic.
             if standalone_gmu is not None and original_gmu is not None:

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -35,6 +35,7 @@ from verl.utils.ray_utils import auto_await
 from verl.utils.rollout_trace import rollout_trace_op
 from verl.utils.tracking import RLInsightLogger
 from verl.workers.rollout.replica import RolloutReplica, TokenOutput, get_rollout_replica_class
+from verl.workers.rollout.topology import get_rollout_num_replicas
 from verl.workers.rollout.utils import update_prometheus_config
 
 logger = logging.getLogger(__file__)
@@ -468,43 +469,28 @@ class LLMServerManager:
         await instance._init_global_load_balancer()
         return instance
 
-    async def _initialize_llm_servers(self, start_rank: int = None):
+    async def _initialize_llm_servers(self, start_rank: int = None, *, allow_empty: bool = False):
         """Initialize the LLM server replicas.
 
         Args:
             start_rank: First ``replica_rank`` to assign.  Defaults to ``self.start_rank``
                 so standalone replicas can avoid Ray named-actor collisions with hybrid
                 replicas (which start at 0) when both coexist (e.g. separate async).
+            allow_empty: Allow an empty resource pool. Reserved for fully-async
+                hybrid-only mode's intentionally empty standalone phase.
         """
         if start_rank is None:
             start_rank = self.start_rank
-        rollout_world_size = (
-            self.rollout_config.tensor_model_parallel_size
-            * self.rollout_config.data_parallel_size
-            * self.rollout_config.pipeline_model_parallel_size
-        )
-        # PD inflates per-replica footprint; miss this and init_hybrid slices
-        # past worker_group → empty workers on replica_rank>=1.
-        disagg = getattr(self.rollout_config, "disaggregation", None)
-        if disagg is not None and getattr(disagg, "enabled", False):
-            prefill_tp = self.rollout_config.tensor_model_parallel_size
-            # Inline decode_tp default: OmegaConf/Ray serialization drops dataclass methods.
-            decode_tp = (
-                disagg.decode_tensor_model_parallel_size
-                if disagg.decode_tensor_model_parallel_size is not None
-                else prefill_tp
-            )
-            rollout_world_size = (
-                (prefill_tp * disagg.prefill_replicas + decode_tp * disagg.decode_replicas)
-                * self.rollout_config.data_parallel_size
-                * self.rollout_config.pipeline_model_parallel_size
-            )
         world_size = (
             self.worker_group.world_size
             if self.worker_group
             else self.rollout_config.n_gpus_per_node * self.rollout_config.nnodes
         )
-        num_replicas = world_size // rollout_world_size
+        num_replicas = get_rollout_num_replicas(
+            self.rollout_config,
+            world_size,
+            allow_empty=allow_empty,
+        )
 
         self.rollout_replicas = [
             self.rollout_replica_class(

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -45,6 +45,7 @@ from verl.workers.rollout.sglang_rollout.utils import (
     SGLANG_LORA_NAME,
     get_named_tensor_buckets,
 )
+from verl.workers.rollout.topology import get_rollout_replica_world_size
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -131,24 +132,9 @@ class ServerAdapter(BaseRollout):
 
         rank = int(os.environ["RANK"])
         local_world_size = int(os.environ["RAY_LOCAL_WORLD_SIZE"])
-        # PD asymmetric layout inflates per-replica footprint; must match
-        # agent_loop.py:_initialize_llm_servers or trainer-to-replica mapping breaks.
         disagg = getattr(self.config, "disaggregation", None)
         prefill_tp = self.config.tensor_model_parallel_size
-        if disagg is not None and getattr(disagg, "enabled", False):
-            # Inline decode_tp default: OmegaConf/Ray serialization drops dataclass methods.
-            decode_tp = (
-                disagg.decode_tensor_model_parallel_size
-                if disagg.decode_tensor_model_parallel_size is not None
-                else prefill_tp
-            )
-            rollout_world_size = (
-                (prefill_tp * disagg.prefill_replicas + decode_tp * disagg.decode_replicas)
-                * self.config.data_parallel_size
-                * self.config.pipeline_model_parallel_size
-            )
-        else:
-            rollout_world_size = prefill_tp * self.config.data_parallel_size * self.config.pipeline_model_parallel_size
+        rollout_world_size = get_rollout_replica_world_size(self.config)
         if replica_rank == -1:
             self.replica_rank = rank // rollout_world_size
         else:

--- a/verl/workers/rollout/topology.py
+++ b/verl/workers/rollout/topology.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numbers import Integral
+from typing import Any
+
+
+def _require_int_at_least(name: str, value: Any, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"Invalid rollout topology: {name} must be an integer >= {minimum}, got {value!r}.")
+
+    value = int(value)
+    if value < minimum:
+        raise ValueError(f"Invalid rollout topology: {name} must be >= {minimum}, got {value}.")
+    return value
+
+
+def get_rollout_replica_world_size(config: Any) -> int:
+    """Return the accelerator footprint of one rollout replica."""
+    tensor_parallel_size = _require_int_at_least(
+        "rollout.tensor_model_parallel_size", config.tensor_model_parallel_size, 1
+    )
+    data_parallel_size = _require_int_at_least("rollout.data_parallel_size", config.data_parallel_size, 1)
+    pipeline_parallel_size = _require_int_at_least(
+        "rollout.pipeline_model_parallel_size", config.pipeline_model_parallel_size, 1
+    )
+
+    disaggregation = getattr(config, "disaggregation", None)
+    if disaggregation is None or not getattr(disaggregation, "enabled", False):
+        return tensor_parallel_size * data_parallel_size * pipeline_parallel_size
+
+    prefill_replicas = _require_int_at_least(
+        "rollout.disaggregation.prefill_replicas", disaggregation.prefill_replicas, 1
+    )
+    decode_replicas = _require_int_at_least("rollout.disaggregation.decode_replicas", disaggregation.decode_replicas, 1)
+    decode_parallel_size = getattr(disaggregation, "decode_tensor_model_parallel_size", None)
+    if decode_parallel_size is None:
+        decode_parallel_size = tensor_parallel_size
+    else:
+        decode_parallel_size = _require_int_at_least(
+            "rollout.disaggregation.decode_tensor_model_parallel_size", decode_parallel_size, 1
+        )
+
+    return (
+        (tensor_parallel_size * prefill_replicas + decode_parallel_size * decode_replicas)
+        * data_parallel_size
+        * pipeline_parallel_size
+    )
+
+
+def get_rollout_num_replicas(config: Any, resource_world_size: int, *, allow_empty: bool = False) -> int:
+    """Validate a rollout resource pool and return the number of replicas it can host."""
+    replica_world_size = get_rollout_replica_world_size(config)
+    resource_world_size = _require_int_at_least("resource_world_size", resource_world_size, 0 if allow_empty else 1)
+
+    if resource_world_size == 0:
+        return 0
+    gpus_per_node = _require_int_at_least("rollout.n_gpus_per_node", config.n_gpus_per_node, 1)
+    if resource_world_size < replica_world_size:
+        raise ValueError(
+            f"Invalid rollout topology: resource_world_size={resource_world_size} is smaller than "
+            f"replica_world_size={replica_world_size}. Adjust the resource pool or rollout parallel sizes."
+        )
+
+    num_replicas, remainder = divmod(resource_world_size, replica_world_size)
+    if remainder:
+        raise ValueError(
+            f"Invalid rollout topology: resource_world_size={resource_world_size} must be divisible by "
+            f"replica_world_size={replica_world_size} (remainder={remainder}). "
+            "Adjust the resource pool or rollout parallel sizes."
+        )
+
+    if getattr(config, "name", None) in ("vllm", "sglang"):
+        smaller, larger = sorted((replica_world_size, gpus_per_node))
+        if larger % smaller:
+            raise ValueError(
+                f"Invalid rollout topology: replica_world_size={replica_world_size} is not node-aligned with "
+                f"rollout.n_gpus_per_node={gpus_per_node}; one must divide the other so replicas do not cross "
+                "partial-node boundaries."
+            )
+    return num_replicas

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -41,6 +41,7 @@ from verl.third_party.vllm import VLLM_SLEEP_LEVEL, get_version
 from verl.utils.device import get_device_id, is_support_ipc
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
+from verl.workers.rollout.topology import get_rollout_replica_world_size
 from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
 from verl.workers.rollout.vllm_rollout.utils import get_device_uuid
 
@@ -76,8 +77,6 @@ class ServerAdapter(BaseRollout):
 
         rank = int(os.environ["RANK"])
         local_world_size = int(os.environ["RAY_LOCAL_WORLD_SIZE"])
-        # PD asymmetric layout inflates per-replica footprint; must match
-        # llm_server.py:_initialize_llm_servers or trainer-to-replica mapping breaks.
         prefill_tp = self.config.tensor_model_parallel_size
         disagg = getattr(self.config, "disaggregation", None)
         if disagg is not None and getattr(disagg, "enabled", False):
@@ -86,11 +85,9 @@ class ServerAdapter(BaseRollout):
                 if disagg.decode_tensor_model_parallel_size is not None
                 else prefill_tp
             )
-            per_replica = prefill_tp * disagg.prefill_replicas + decode_tp * disagg.decode_replicas
         else:
             decode_tp = prefill_tp
-            per_replica = prefill_tp
-        rollout_world_size = per_replica * self.config.data_parallel_size * self.config.pipeline_model_parallel_size
+        rollout_world_size = get_rollout_replica_world_size(self.config)
         if replica_rank == -1:
             self.replica_rank = rank // rollout_world_size
         else:


### PR DESCRIPTION
### What does this PR do?

Rollout server setup currently floor-divides the available GPU pool by each replica's footprint. Invalid configurations can therefore reach distributed startup before failing, create zero replicas, or silently leave GPUs unused.

This PR validates the topology before constructing replicas, centralizes the standard and prefill/decode footprint calculation, and reuses it in the vLLM and SGLang rank mapping. It also preserves the intentional empty standalone phase in fully async mode and TRTLLM's cross-placement-group slicing.

This is not a duplicate. I searched open issues and PRs for rollout topology, replica sizing, and `LLMServerManager` divisibility ([query](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22rollout+topology%22)). Issue #6856 is related to a valid multi-node vLLM topology failing inside vLLM; this PR only rejects invalid resource layouts before startup.

### Checklist Before Starting

- [x] Searched for similar PRs.
- [x] Formatted the title as `[{modules}] {type}: {description}`.

### Test

- `python -m pytest -q tests/workers/rollout/test_llm_server_topology_on_cpu.py tests/workers/rollout/test_vllm_pd_disaggregation_on_cpu.py tests/workers/rollout/test_pd_disaggregation.py tests/workers/rollout/test_llm_server_routed_experts_on_cpu.py tests/experimental/fully_async_policy/test_async_genrm_config_on_cpu.py -k "not dispatcher_vllm_with_flag_returns_pd_replica"` — 110 passed, 23 skipped, 1 deselected.
- `pre-commit run --all-files --show-diff-on-failure --color=always` — passed on Ubuntu 24.04 against commit `3ed336be`.
- `python -m compileall` on all changed Python files passed.

All added tests are deterministic CPU tests and require no GPU.

### API and Usage Example

No public API or configuration changes.

### Design & Code Changes

- Validate positive parallel sizes, pool capacity, exact divisibility, and vLLM/SGLang node alignment before replica construction.
- Cover both standard and prefill/decode-disaggregated footprints through one lightweight helper.
- Keep backend-specific placement behavior and fully async's empty standalone phase intact.

### Checklist Before Submitting

- [x] Human submitter has reviewed every changed line and read the contribution guide.
- [x] Run the complete pre-commit suite in a Linux development environment before marking ready.
- [x] Added CPU unit tests using the repository's `_on_cpu.py` convention.
- [x] Documentation is not needed because no user-facing API or configuration changed.
- [x] Request CI when the draft is ready for review.
- [x] Recipe submodule changes are not applicable.

### AI assistance

OpenAI Codex assisted with repository analysis, implementation, test development, and PR preparation. The human submitter reviewed every changed line and remains responsible for the contribution.
