### PR TITLE
[training_utils, hardware] fix: unify import statements for attention utilities across test files

### DIFF
--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -23,13 +23,8 @@ from transformers import (
     Qwen2Config,
 )
 
+from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
 from verl.utils.device import get_device_name
-
-if get_device_name() == "cuda":
-    from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
-elif get_device_name() == "npu":
-    from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
-
 from verl.utils.model import compute_position_id_with_mask, create_random_mask
 from verl.utils.torch_functional import log_probs_from_logits_all_rmpad, masked_mean
 

--- a/tests/models/test_transformers_ulysses.py
+++ b/tests/models/test_transformers_ulysses.py
@@ -25,6 +25,7 @@ from transformers import AutoModelForCausalLM, LlamaConfig, PretrainedConfig, Qw
 
 from verl.models.transformers.monkey_patch import apply_monkey_patch
 from verl.protocol import DataProto
+from verl.utils.attention_utils import index_first_axis, rearrange, unpad_input
 from verl.utils.device import get_device_name, get_torch_device
 from verl.utils.distributed import initialize_global_process_group
 from verl.utils.model import compute_position_id_with_mask, create_random_mask
@@ -35,11 +36,6 @@ from verl.utils.ulysses import (
     set_ulysses_sequence_parallel_group,
     ulysses_pad_and_slice_inputs,
 )
-
-if get_device_name() == "cuda":
-    from flash_attn.bert_padding import index_first_axis, rearrange, unpad_input
-elif get_device_name() == "npu":
-    from verl.utils.attention_utils import index_first_axis, rearrange, unpad_input
 
 # TODO(sgm): add more models for test
 # we only need one scale for each model

--- a/tests/special_distributed/test_fsdp_ckpt.py
+++ b/tests/special_distributed/test_fsdp_ckpt.py
@@ -29,10 +29,7 @@ from verl.utils.fsdp_utils import MixedPrecisionPolicy, apply_fsdp2
 
 
 def create_random_input_ids(batch_size, seq_len, vocab_size):
-    if get_device_name() == "cuda":
-        from flash_attn.bert_padding import unpad_input
-    elif get_device_name() == "npu":
-        from verl.utils.attention_utils import unpad_input
+    from verl.utils.attention_utils import unpad_input
     from verl.utils.model import compute_position_id_with_mask, create_random_mask
 
     input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device=get_device_name())

--- a/tests/utils/test_activation_offload.py
+++ b/tests/utils/test_activation_offload.py
@@ -31,10 +31,7 @@ from verl.utils.fsdp_utils import MixedPrecisionPolicy, apply_fsdp2, get_fsdp_wr
 
 
 def create_random_input_ids(batch_size, seq_len, vocab_size):
-    if get_device_name() == "cuda":
-        from flash_attn.bert_padding import unpad_input
-    elif get_device_name() == "npu":
-        from verl.utils.attention_utils import unpad_input
+    from verl.utils.attention_utils import unpad_input
     from verl.utils.model import compute_position_id_with_mask, create_random_mask
 
     input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device=get_device_name())

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -624,7 +624,7 @@ def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad
         logits_rmpad: [total_nnz, vocab_size]
         response_length: int
     """
-    from flash_attn.bert_padding import pad_input, unpad_input
+    from verl.utils.attention_utils import pad_input, unpad_input
 
     batch_size, seqlen = input_ids.shape
     input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)
@@ -653,10 +653,7 @@ def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batc
         seqlen: int
         response_length: int
     """
-    if get_device_name() == "cuda":
-        from flash_attn.bert_padding import pad_input
-    elif get_device_name() == "npu":
-        from verl.utils.attention_utils import pad_input
+    from verl.utils.attention_utils import pad_input
 
     input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # transpose back to [total_nnz, 1]
     input_ids_rmpad = input_ids_rmpad.squeeze(-1)


### PR DESCRIPTION
### What does this PR do?

Would want to unify the one more attention_util file in torch_functional.py
After this [#7098] merged, then this PR should be related to merge in. To resolve the different hardware encounter bug

to tconvert the code of 
``` python
elif get_device_name() == "XXX": from npu

if get_device_name() == "cuda":
    from flash_attn.bert_padding import index_first_axis, rearrange, unpad_input
elif get_device_name() == "npu":
    from verl.utils.attention_utils import index_first_axis, rearrange, unpad_input


# become for prevent elif == XYZ
->
    from verl.utils.attention_utils import index_first_axis, rearrange, unpad_input
```

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x ] Search for similar PRs. Paste at least one query link here: ...
- https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+torch_functional
- https://github.com/verl-project/verl/issues?q=is%3Aissue%20state%3Aopen%20torch_functional
- [ x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

to run with cuda (a100), xpu (b70) path for the log.



> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

example file or trigger path for bug.
```python
# Add code snippet or script demonstrating how to use this
XXX.py ( from gist) through verl training path

```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
