### PR TITLE
[megatron] feat: delta_sharded on Megatron-Bridge param mappings (TP+EP, hybrid-Mamba)

### DIFF
--- a/tests/checkpoint_engine/test_sglang_loader.py
+++ b/tests/checkpoint_engine/test_sglang_loader.py
@@ -178,3 +178,52 @@ def test_dense_flush_applies_full_tensors():
 
     for name, expected in named:
         assert torch.equal(model.params[name].view(torch.int16), expected.view(torch.int16)), name
+
+
+def _dense_verify_flush(named, is_last=True, verify=True):
+    params, pieces, val_off = [], [], 0
+    for name, t in named:
+        flat = t.contiguous().view(-1)
+        params.append(
+            {
+                "name": name,
+                "dtype": str(t.dtype).replace("torch.", ""),
+                "shape": list(t.shape),
+                "pos_start": 0,
+                "pos_end": 0,
+                "pos_width": 4,
+                "val_start": val_off,
+                "val_end": val_off + flat.numel(),
+            }
+        )
+        pieces.append(flat)
+        val_off += flat.numel()
+    values = torch.cat(pieces)
+    spec = {
+        "encoding": "dense",
+        "verify": verify,
+        "is_last": is_last,
+        "params": params,
+        "checksum": int(checksum(torch.empty(0, dtype=torch.uint8), values)),
+    }
+    spec_t = torch.frombuffer(bytearray(json.dumps(spec).encode()), dtype=torch.uint8)
+    return [("__delta_spec__", spec_t), ("__values__", values)]
+
+
+def test_verify_sweep_passes_on_identical_state():
+    """A verify flush against a bit-identical model reports zero mismatches."""
+    named = _make_named()
+    model = _FakeModel([(n, t.clone()) for n, t in named])
+    apply_delta(model, _dense_verify_flush(named))  # must not raise
+
+
+def test_verify_sweep_fails_loud_on_divergence():
+    """A single flipped element in the server state must fail the sweep."""
+    import pytest
+
+    named = _make_named()
+    diverged = [(n, t.clone()) for n, t in named]
+    diverged[1][1].view(-1)[3] += 1.0
+    model = _FakeModel(diverged)
+    with pytest.raises(RuntimeError, match="verification FAILED"):
+        apply_delta(model, _dense_verify_flush(named))

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -139,7 +139,7 @@ def test_prime_then_hf_delta_export_roundtrip():
     spec = ShardSpec(full_shape=(12,))
     snaps: dict = {}
 
-    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps)
+    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps, pin=False)
     assert "w" in snaps and snaps["w"].numel() == 12
 
     w2 = w.clone()
@@ -191,7 +191,7 @@ def test_hf_delta_export_converter_param():
     )
     w = torch.arange(12, dtype=torch.float32)
     snaps: dict = {}
-    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps)
+    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps, pin=False)
 
     w2 = w.clone()
     w2[5] = -1.0  # row 1, col 1

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -242,7 +242,7 @@ def test_hf_delta_export_converter_nontrivial_block():
     )
     local = torch.arange(24, dtype=torch.float32)  # this rank's block, flat
     snaps: dict = {}
-    prime_delta_snapshots(iter([("w", local.clone(), spec)]), snaps)
+    prime_delta_snapshots(iter([("w", local.clone(), spec)]), snaps, pin=False)
 
     touched = local.clone()
     touched[5] = -1.0  # block (0,1,1) -> full (2,4,1) -> slot w.2, row-flat 17
@@ -276,7 +276,7 @@ def test_hf_delta_export_replica_rank_stays_lockstep():
     )
     w = torch.arange(12, dtype=torch.float32)
     snaps: dict = {}
-    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps)
+    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps, pin=False)
 
     w2 = w.clone()
     w2[5] = -1.0

--- a/tests/special_distributed/test_mcore_probe_differential.py
+++ b/tests/special_distributed/test_mcore_probe_differential.py
@@ -1,0 +1,208 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TP>1 differential oracle for the comm-stubbed mcore probe.
+
+For every conversion task of a tiny model the REAL ``megatron_to_hf`` (true
+collectives, run in lockstep by all ranks) must equal the probe assembly:
+each rank runs its comm-stubbed probe on its own local shard, the non-NaN
+contributions are merged across ranks, and the merged tensor is compared to
+the real output BITWISE. This is the regression oracle for the probe's two
+assumptions (communication confined to the stubbed helpers; transforms
+rearrange rather than blend) -- rerun it whenever Megatron-Bridge is upgraded.
+
+Run under torchrun on >=2 GPUs, e.g.::
+
+    MODEL_KIND=qwen2 torchrun --nproc_per_node=2 tests/special_distributed/test_mcore_probe_differential.py
+    MODEL_KIND=nemotron_h torchrun --nproc_per_node=2 tests/special_distributed/test_mcore_probe_differential.py
+
+``MODEL_KIND``: ``qwen2`` (Column/Row/QKV/GatedMLP/Replicated), ``qwen3_moe``
+(adds fused-MoE expert mappings; uses etp=TP), ``nemotron_h`` (Mamba mixers --
+the tp_size-dependent de-interleave the probe must reproduce).
+"""
+
+import os
+import pathlib
+import sys
+
+import torch
+import torch.distributed as dist
+
+sys.path.insert(0, os.environ.get("VERL_PATH", "/home/changyi/verl_ab_pre"))
+
+MODEL_KIND = os.environ.get("MODEL_KIND", "qwen2")
+TP = int(os.environ.get("TP_SIZE", "2"))
+
+
+def _build_tiny_hf_dir(rank: int) -> str:
+    from transformers import AutoConfig
+
+    cfg_dir = f"/tmp/tiny_{MODEL_KIND}_probe_diff"
+    if MODEL_KIND == "qwen2":
+        hf_config = AutoConfig.for_model(
+            "qwen2",
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=512,
+            max_position_embeddings=256,
+            tie_word_embeddings=False,
+        )
+        hf_config.architectures = ["Qwen2ForCausalLM"]
+    elif MODEL_KIND == "qwen3_moe":
+        hf_config = AutoConfig.for_model(
+            "qwen3_moe",
+            hidden_size=64,
+            intermediate_size=128,
+            moe_intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            num_experts=4,
+            num_experts_per_tok=2,
+            vocab_size=512,
+            max_position_embeddings=256,
+            tie_word_embeddings=False,
+        )
+        hf_config.architectures = ["Qwen3MoeForCausalLM"]
+    elif MODEL_KIND == "nemotron_h":
+        # hybrid mamba2+attention+mlp stack; sizes divisible by TP=2
+        # (n_groups and mamba_num_heads both TP-divisible).
+        hf_config = AutoConfig.for_model(
+            "nemotron_h",
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=4,
+            hybrid_override_pattern="M*M-",
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            attention_head_dim=16,
+            ssm_state_size=16,
+            conv_kernel=4,
+            expand=2,
+            mamba_num_heads=8,
+            mamba_head_dim=16,
+            n_groups=2,
+            chunk_size=32,
+            vocab_size=512,
+            max_position_embeddings=256,
+            tie_word_embeddings=False,
+        )
+        hf_config.architectures = ["NemotronHForCausalLM"]
+    else:
+        raise ValueError(f"unknown MODEL_KIND {MODEL_KIND!r}")
+
+    if rank == 0 and not pathlib.Path(cfg_dir, "model.safetensors").exists():
+        from transformers import AutoModelForCausalLM
+
+        m = AutoModelForCausalLM.from_config(hf_config).to(torch.bfloat16)
+        m.save_pretrained(cfg_dir, safe_serialization=True)
+        del m
+    dist.barrier()
+    return cfg_dir
+
+
+def main():
+    dist.init_process_group(backend="nccl")
+    rank, world = dist.get_rank(), dist.get_world_size()
+    torch.cuda.set_device(rank)
+    assert world >= 2, "differential needs TP>1 to be meaningful"
+
+    from megatron.core import parallel_state as mpu
+
+    mpu.initialize_model_parallel(tensor_model_parallel_size=TP, pipeline_model_parallel_size=1)
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    model_parallel_cuda_manual_seed(1234)
+
+    cfg_dir = _build_tiny_hf_dir(rank)
+
+    from megatron.bridge import AutoBridge
+
+    bridge = AutoBridge.from_hf_pretrained(cfg_dir, trust_remote_code=True)
+    provider = bridge.to_megatron_provider(load_weights=False)
+    provider.tensor_model_parallel_size = TP
+    provider.pipeline_model_parallel_size = 1
+    provider.bf16 = True
+    provider.params_dtype = torch.bfloat16
+    provider.finalize()
+    model = provider.provide_distributed_model(wrap_with_ddp=False)
+    model = [m.cuda().to(torch.bfloat16) for m in (model if isinstance(model, list) else [model])]
+
+    from verl.workers.engine.megatron.delta_export import make_probe
+
+    tasks = bridge.get_conversion_tasks(model)
+    n_checked = n_pass = 0
+    failures = []
+    for t in tasks:
+        p = t.param_weight
+        if p is None or not p.is_floating_point():
+            continue
+        local = p.data.to(torch.bfloat16)
+
+        # REAL path: true collectives, all ranks in lockstep; full tensors everywhere.
+        real = {k: v.detach().clone() for k, v in t.mapping.megatron_to_hf(local, t.megatron_module).items()}
+
+        # PROBE path: comm-stubbed, purely local. Feed the real local shard so
+        # the surviving (non-NaN) elements carry real values.
+        probe = make_probe(t.mapping, t.megatron_module)
+        mine = {k: v.detach().to("cpu") for k, v in probe.megatron_to_hf(local.clone(), t.megatron_module).items()}
+
+        # Assemble: union of every rank's non-NaN contributions.
+        all_outs: list = [None] * world
+        dist.all_gather_object(all_outs, mine)
+        if rank == 0:
+            names = {k for d in all_outs for k in d}
+            for name in sorted(names):
+                ref = real.get(name)
+                if ref is None:
+                    failures.append(f"{t.global_param_name}: probe slot {name} absent from real output")
+                    continue
+                merged = torch.full_like(ref.cpu(), float("nan"))
+                covered = torch.zeros(ref.shape, dtype=torch.int32)
+                for d in all_outs:
+                    if name not in d:
+                        continue
+                    part = d[name]
+                    mask = ~torch.isnan(part)
+                    overlap = (covered[mask] > 0).any().item()
+                    if overlap:
+                        failures.append(f"{t.global_param_name}/{name}: rank contributions overlap")
+                    merged[mask] = part[mask]
+                    covered[mask] += 1
+                n_checked += 1
+                if torch.isnan(merged).any():
+                    failures.append(f"{t.global_param_name}/{name}: uncovered positions remain NaN")
+                elif not torch.equal(merged.view(torch.int16), ref.cpu().view(torch.int16)):
+                    failures.append(f"{t.global_param_name}/{name}: bitwise mismatch")
+                else:
+                    n_pass += 1
+        dist.barrier()
+
+    if rank == 0:
+        print("=" * 60)
+        for f in failures[:20]:
+            print("FAIL:", f)
+        print(f"PROBE DIFFERENTIAL [{MODEL_KIND} tp={TP}]: {n_pass}/{n_checked} bitwise-equal")
+        print("PROBE DIFFERENTIAL PASSED" if (n_checked > 0 and not failures) else "PROBE DIFFERENTIAL FAILED")
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0 and (failures or n_checked == 0):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/special_distributed/test_mcore_probe_differential.py
+++ b/tests/special_distributed/test_mcore_probe_differential.py
@@ -47,7 +47,7 @@ TP = int(os.environ.get("TP_SIZE", "2"))
 def _build_tiny_hf_dir(rank: int) -> str:
     from transformers import AutoConfig
 
-    cfg_dir = f"/tmp/tiny_{MODEL_KIND}_probe_diff"
+    cfg_dir = f"/tmp/tiny_{MODEL_KIND}_probe_diff_v2"
     if MODEL_KIND == "qwen2":
         hf_config = AutoConfig.for_model(
             "qwen2",
@@ -102,17 +102,43 @@ def _build_tiny_hf_dir(rank: int) -> str:
             tie_word_embeddings=False,
         )
         hf_config.architectures = ["NemotronHForCausalLM"]
+    elif MODEL_KIND == "falcon_h1":
+        # mamba2+attention parallel-hybrid; mamba_n_heads/n_groups TP=2 divisible
+        hf_config = AutoConfig.for_model(
+            "falcon_h1",
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            mamba_d_ssm=64,
+            mamba_n_heads=8,
+            mamba_d_head=8,
+            mamba_n_groups=2,
+            mamba_d_state=16,
+            mamba_d_conv=4,
+            mamba_expand=2,
+            mamba_chunk_size=32,
+            mamba_norm_before_gate=False,
+            vocab_size=512,
+            max_position_embeddings=256,
+            tie_word_embeddings=False,
+        )
+        hf_config.architectures = ["FalconH1ForCausalLM"]
     else:
         raise ValueError(f"unknown MODEL_KIND {MODEL_KIND!r}")
 
-    if MODEL_KIND == "nemotron_h":
+    if MODEL_KIND in ("nemotron_h", "falcon_h1"):
         # NemotronH's mixer pulls causal-conv1d / mamba-ssm kernels from the hub
         # at layer init; offline runs must fall back to the reference path.
         try:
             import transformers.integrations.hub_kernels as _hk
 
             _hk.lazy_load_kernel = lambda *a, **k: None
-            import transformers.models.nemotron_h.modeling_nemotron_h as _mnh
+            import importlib
+
+            _mnh = importlib.import_module(f"transformers.models.{MODEL_KIND}.modeling_{MODEL_KIND}")
 
             for _sym in ("lazy_load_kernel", "get_kernel"):
                 if hasattr(_mnh, _sym):

--- a/tests/special_distributed/test_mcore_probe_differential.py
+++ b/tests/special_distributed/test_mcore_probe_differential.py
@@ -226,9 +226,7 @@ def main():
                     # replicated params legitimately arrive from every rank --
                     # overlap only counts as failure when the values CONFLICT.
                     both = mask & (covered > 0)
-                    if both.any() and not torch.equal(
-                        merged[both].view(torch.int16), part[both].view(torch.int16)
-                    ):
+                    if both.any() and not torch.equal(merged[both].view(torch.int16), part[both].view(torch.int16)):
                         failures.append(f"{t.global_param_name}/{name}: conflicting rank contributions")
                     merged[mask] = part[mask]
                     covered[mask] += 1

--- a/tests/special_distributed/test_mcore_probe_differential.py
+++ b/tests/special_distributed/test_mcore_probe_differential.py
@@ -105,6 +105,21 @@ def _build_tiny_hf_dir(rank: int) -> str:
     else:
         raise ValueError(f"unknown MODEL_KIND {MODEL_KIND!r}")
 
+    if MODEL_KIND == "nemotron_h":
+        # NemotronH's mixer pulls causal-conv1d / mamba-ssm kernels from the hub
+        # at layer init; offline runs must fall back to the reference path.
+        try:
+            import transformers.integrations.hub_kernels as _hk
+
+            _hk.lazy_load_kernel = lambda *a, **k: None
+            import transformers.models.nemotron_h.modeling_nemotron_h as _mnh
+
+            for _sym in ("lazy_load_kernel", "get_kernel"):
+                if hasattr(_mnh, _sym):
+                    setattr(_mnh, _sym, lambda *a, **k: None)
+        except Exception as e:  # pragma: no cover
+            print(f"kernel stub patch failed: {e}")
+
     if rank == 0 and not pathlib.Path(cfg_dir, "model.safetensors").exists():
         from transformers import AutoModelForCausalLM
 
@@ -141,6 +156,10 @@ def main():
     provider.finalize()
     model = provider.provide_distributed_model(wrap_with_ddp=False)
     model = [m.cuda().to(torch.bfloat16) for m in (model if isinstance(model, list) else [model])]
+    # real HF weights, identically loaded on every rank: replicated params
+    # (layernorms, routers) must be bit-identical across TP ranks or the
+    # differential would flag test artifacts instead of probe bugs.
+    bridge.load_hf_weights(model)
 
     from verl.workers.engine.megatron.delta_export import make_probe
 
@@ -178,9 +197,13 @@ def main():
                         continue
                     part = d[name]
                     mask = ~torch.isnan(part)
-                    overlap = (covered[mask] > 0).any().item()
-                    if overlap:
-                        failures.append(f"{t.global_param_name}/{name}: rank contributions overlap")
+                    # replicated params legitimately arrive from every rank --
+                    # overlap only counts as failure when the values CONFLICT.
+                    both = mask & (covered > 0)
+                    if both.any() and not torch.equal(
+                        merged[both].view(torch.int16), part[both].view(torch.int16)
+                    ):
+                        failures.append(f"{t.global_param_name}/{name}: conflicting rank contributions")
                     merged[mask] = part[mask]
                     covered[mask] += 1
                 n_checked += 1

--- a/tests/special_distributed/test_sglang_delta_loop.py
+++ b/tests/special_distributed/test_sglang_delta_loop.py
@@ -1,0 +1,221 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Closed-loop delta apply test against a REAL sglang engine on tiny models.
+
+randomize -> perturb -> sparse delta flush -> engine.update_weights_from_tensor
+(the production ``load_format=<delta loader FQN>`` path) -> idempotence verify
+flush asserting ZERO mismatched elements. This exercises everything the
+``_FakeModel`` CPU tests cannot: sglang's name remapping, fused-tensor slicing
+(qkv / gate_up), TP shard loaders, and multi-stage transform loaders (mamba's
+``A = -exp(A_log)``). ``MODEL_KIND=nemotron_h`` needs mamba-ssm/causal-conv1d.
+
+Run on 1 GPU::
+
+    MODEL_KIND=qwen2 python tests/special_distributed/test_sglang_delta_loop.py
+    MODEL_KIND=nemotron_h python tests/special_distributed/test_sglang_delta_loop.py
+"""
+
+import json
+import os
+import pathlib
+import sys
+
+import torch
+
+sys.path.insert(0, os.environ.get("VERL_PATH", "/home/changyi/verl_ab_pre"))
+
+MODEL_KIND = os.environ.get("MODEL_KIND", "qwen2")
+
+
+def _build_tiny_hf_dir() -> str:
+    from transformers import AutoConfig
+
+    cfg_dir = f"/tmp/tiny_{MODEL_KIND}_delta_loop_v2"
+    if MODEL_KIND == "qwen2":
+        hf_config = AutoConfig.for_model(
+            "qwen2",
+            hidden_size=256,
+            intermediate_size=512,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=151936,
+            max_position_embeddings=1024,
+            tie_word_embeddings=False,
+        )
+        hf_config.architectures = ["Qwen2ForCausalLM"]
+    elif MODEL_KIND == "nemotron_h":
+        import transformers.integrations.hub_kernels as _hk
+
+        _hk.lazy_load_kernel = lambda *a, **k: None
+        import transformers.models.nemotron_h.modeling_nemotron_h as _mnh
+
+        for _sym in ("lazy_load_kernel", "get_kernel"):
+            if hasattr(_mnh, _sym):
+                setattr(_mnh, _sym, lambda *a, **k: None)
+        hf_config = AutoConfig.for_model(
+            "nemotron_h",
+            hidden_size=256,
+            intermediate_size=512,
+            num_hidden_layers=4,
+            hybrid_override_pattern="M*M-",
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            attention_head_dim=64,
+            ssm_state_size=64,
+            conv_kernel=4,
+            expand=2,
+            mamba_num_heads=8,
+            mamba_head_dim=64,
+            n_groups=2,
+            chunk_size=128,
+            vocab_size=151936,
+            max_position_embeddings=1024,
+            tie_word_embeddings=False,
+        )
+        hf_config.architectures = ["NemotronHForCausalLM"]
+    else:
+        raise ValueError(MODEL_KIND)
+
+    if not pathlib.Path(cfg_dir, "model.safetensors").exists():
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        m = AutoModelForCausalLM.from_config(hf_config).to(torch.bfloat16)
+        m.save_pretrained(cfg_dir, safe_serialization=True)
+        del m
+        # the engine needs a real tokenizer; any cached one with a matching
+        # vocab budget works -- the weights are random anyway.
+        tok = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-7B-Instruct")
+        tok.save_pretrained(cfg_dir)
+    return cfg_dir
+
+
+def _load_named(cfg_dir: str) -> dict[str, torch.Tensor]:
+    from safetensors.torch import load_file
+
+    return {k: v.to(torch.bfloat16).cuda() for k, v in load_file(f"{cfg_dir}/model.safetensors").items()}
+
+
+def _spec_tensor(spec: dict) -> torch.Tensor:
+    return torch.frombuffer(bytearray(json.dumps(spec).encode()), dtype=torch.uint8)
+
+
+def _sparse_flush(old: dict, new: dict):
+    """Encode changed elements exactly like the sender's indices wire."""
+    from verl.checkpoint_engine.delta_sync import DeltaParam, checksum
+    from verl.checkpoint_engine.delta_sync.sparse_gather import shard_delta_indices
+
+    params, idx_pieces, val_pieces = [], [], []
+    pos_off = val_off = 0
+    for name, t_new in new.items():
+        lidx, lval = shard_delta_indices(t_new.reshape(-1), old[name].reshape(-1), 0)
+        nnz = int(lidx.numel())
+        if nnz == 0:
+            continue
+        params.append(
+            DeltaParam(
+                name=name,
+                dtype="bfloat16",
+                shape=list(t_new.shape),
+                pos_start=pos_off,
+                pos_end=pos_off + nnz * 4,
+                pos_width=4,
+                val_start=val_off,
+                val_end=val_off + nnz,
+            )
+        )
+        idx_pieces.append(lidx.to(torch.int32))
+        val_pieces.append(lval)
+        pos_off += nnz * 4
+        val_off += nnz
+    positions = torch.cat(idx_pieces).contiguous().view(torch.uint8)
+    values = torch.cat(val_pieces)
+    spec = {
+        "encoding": "indices",
+        "params": [vars(p) for p in params],
+        "checksum": int(checksum(positions, values)),
+    }
+    return [("__delta_spec__", _spec_tensor(spec)), ("__positions__", positions), ("__values__", values)]
+
+
+def _verify_flush(expected: dict):
+    from verl.checkpoint_engine.delta_sync import DeltaParam, checksum
+
+    params, pieces, val_off = [], [], 0
+    for name, t in expected.items():
+        flat = t.contiguous().reshape(-1)
+        params.append(
+            DeltaParam(
+                name=name,
+                dtype="bfloat16",
+                shape=list(t.shape),
+                pos_start=0,
+                pos_end=0,
+                pos_width=4,
+                val_start=val_off,
+                val_end=val_off + flat.numel(),
+            )
+        )
+        pieces.append(flat)
+        val_off += flat.numel()
+    values = torch.cat(pieces)
+    spec = {
+        "encoding": "dense",
+        "verify": True,
+        "is_last": True,
+        "params": [vars(p) for p in params],
+        "checksum": int(checksum(torch.empty(0, dtype=torch.uint8), values)),
+    }
+    return [("__delta_spec__", _spec_tensor(spec)), ("__values__", values)]
+
+
+def main():
+    import sglang as sgl
+
+    from verl.workers.rollout.sglang_rollout.delta_loader import LOADER_FQN
+
+    cfg_dir = _build_tiny_hf_dir()
+    named = _load_named(cfg_dir)
+
+    engine = sgl.Engine(
+        model_path=cfg_dir,
+        mem_fraction_static=0.35,
+        disable_cuda_graph=True,
+        disable_radix_cache=True,
+        trust_remote_code=True,
+        custom_weight_loader=[LOADER_FQN],
+        random_seed=1234,
+    )
+
+    torch.manual_seed(11)
+    perturbed = {}
+    for name, t in named.items():
+        p = t.clone()
+        flat = p.reshape(-1)
+        k = max(1, flat.numel() // 100)  # ~1% of elements per tensor
+        pos = torch.randperm(flat.numel(), device=flat.device)[:k]
+        flat[pos] += torch.randn(k, device=flat.device, dtype=flat.dtype) * 0.05
+        perturbed[name] = p
+
+    # sparse delta: server state (checkpoint) -> perturbed
+    engine.update_weights_from_tensor(_sparse_flush(named, perturbed), load_format=LOADER_FQN, flush_cache=False)
+    # idempotence verify against the expected end state: must report 0 mismatches
+    engine.update_weights_from_tensor(_verify_flush(perturbed), load_format=LOADER_FQN, flush_cache=False)
+
+    print(f"DELTA-LOOP [{MODEL_KIND}]: sparse apply + verify sweep PASSED")
+    engine.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -47,7 +47,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass
@@ -396,10 +395,15 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
                 break
         logger.info("delta recv v=%s flushes=%d (yielded to server adapter)", global_steps, applied)
 
-    def __init__(self, *args, encoding: str = "indices", batch_gather: int = 32, **kwargs) -> None:
+    def __init__(
+        self, *args, encoding: str = "indices", batch_gather: int = 32, verify_every: int = 0, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
         assert encoding == "indices", f"delta_sharded ships only the 'indices' position encoding; got {encoding!r}"
         self.encoding = encoding
+        # every K-th steady sync appends a full state-verification sweep
+        # (0 = off); see _verify_due / delta_loader._verify_dense.
+        self.verify_every = int(verify_every)
         self._shard_seeded = False
         # Gather the per-param sparse deltas in groups of this many parameters
         # (one count-matrix all_gather + two padded gathers per group instead of
@@ -407,12 +411,11 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         self.batch_gather = int(batch_gather)
 
     def _verify_due(self) -> bool:
-        """True on every K-th steady sync when ``VERL_DELTA_VERIFY_EVERY=K``."""
-        every = int(os.getenv("VERL_DELTA_VERIFY_EVERY", "0") or 0)
-        if every <= 0:
+        """True on every K-th steady sync when constructed with ``verify_every=K``."""
+        if self.verify_every <= 0:
             return False
         self._steady_count = getattr(self, "_steady_count", 0) + 1
-        return self._steady_count % every == 0
+        return self._steady_count % self.verify_every == 0
 
     def _assemble_flush(self, per_param: list[_FlushPiece]) -> DeltaFlush:
         """Build one DeltaFlush (indices encoding) from rank 0's gathered per-param deltas.
@@ -514,7 +517,14 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
 
         bkt = _FlushBucket(self.bucket_size, _assemble_values, _publish_values)
 
+        seen_names: set = set()
         for name, tensor in weights:
+            # duplicate names in a full export mean two source params mapped to
+            # the same HF tensor -- the receiver would apply whichever came last
+            # and the delta diff base would silently disagree with the trainer
+            # (observed: NemotronH A_log). Fail loud instead.
+            assert name not in seen_names, f"full export yields duplicate HF tensor {name!r}"
+            seen_names.add(name)
             tensor = tensor.detach()
             if tensor.is_floating_point() and tensor.dtype != self.rollout_dtype:
                 tensor = tensor.to(self.rollout_dtype)
@@ -626,7 +636,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             gq.put(pg, slots, dtype_str, counts, hf_idx, hf_val)
         gq.flush_all()
 
-        # VERL_DELTA_VERIFY_EVERY=K appends a full state-verification sweep to
+        # verify_every=K (engine kwarg) appends a full state-verification sweep to
         # every K-th steady sync, inside the SAME receive session: the steady
         # bucket keeps is_last unset and the sweep's final flush carries it. The
         # receiver bit-compares each copy_ destination before overwriting and

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -501,6 +501,11 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             self._publish_terminal(True)
         # warning level on purpose: worker default log level swallows info, and the
         # one-off seed cost is the number people ask for when sizing a run.
+        # the cupy staging pool does not return its blocks to CUDA on its own;
+        # after streaming up to 2x bucket_size through it, give the memory back
+        # so the trainer's next optimizer/forward pass can use it (raw cudaMalloc
+        # OOMs on tight mcore shapes otherwise).
+        cp.get_default_memory_pool().free_all_blocks()
         logger.warning(
             "delta-sharded FULL-SEED v=%s done in %.1fs (flushes=%d elems=%d wire=%.1fGB)",
             global_steps,
@@ -592,6 +597,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             bkt.emit(is_last=True)
         else:
             self._publish_terminal(False)
+        cp.get_default_memory_pool().free_all_blocks()  # return staging blocks to CUDA between syncs
         logger.info("delta-sharded send v=%s delta flushes=%d (streamed)", global_steps, n_flushes)
         if not total_elems:
             return None

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass
@@ -291,7 +292,9 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         collective.broadcast(pos_cp, src_rank=0, group_name=self.group_name)
         collective.broadcast(val_cp, src_rank=0, group_name=self.group_name)
 
-    def _publish_values_flush(self, params: list[DeltaParam], values: torch.Tensor, is_last: bool) -> None:
+    def _publish_values_flush(
+        self, params: list[DeltaParam], values: torch.Tensor, is_last: bool, verify: bool = False
+    ) -> None:
         """Publish a values-only (full-coverage, positions-free) flush -- used by the first
         sync. The wire encoding tag stays ``"dense"`` -- it is protocol, shared with the
         receiver's delta_loader decode."""
@@ -307,6 +310,8 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             "val_dtype": str(values.dtype).replace("torch.", ""),
             "spec": {
                 "encoding": "dense",
+                "verify": verify,
+                "is_last": is_last,
                 "params": [vars(p) for p in params],
                 "checksum": int(_checksum(empty_pos, values)),
             },
@@ -401,6 +406,14 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         # three collectives per parameter).
         self.batch_gather = int(batch_gather)
 
+    def _verify_due(self) -> bool:
+        """True on every K-th steady sync when ``VERL_DELTA_VERIFY_EVERY=K``."""
+        every = int(os.getenv("VERL_DELTA_VERIFY_EVERY", "0") or 0)
+        if every <= 0:
+            return False
+        self._steady_count = getattr(self, "_steady_count", 0) + 1
+        return self._steady_count % every == 0
+
     def _assemble_flush(self, per_param: list[_FlushPiece]) -> DeltaFlush:
         """Build one DeltaFlush (indices encoding) from rank 0's gathered per-param deltas.
 
@@ -456,6 +469,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         self,
         weights: Generator[tuple[str, torch.Tensor], None, None],
         global_steps: int | None = None,
+        verify: bool = False,
     ) -> dict[str, float] | None:
         """First sync: stream the backend's FULL HF export over the values-only wire.
 
@@ -494,7 +508,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         def _publish_values(pending, is_last: bool) -> None:
             nonlocal n_flushes, wire_bytes
             params, values = pending
-            self._publish_values_flush(params, values, is_last=is_last)
+            self._publish_values_flush(params, values, is_last=is_last, verify=verify)
             n_flushes += 1
             wire_bytes += int(values.nbytes)
 
@@ -511,7 +525,8 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             total_elems += int(flat.numel())
             bkt.add(_ValuesPiece(name, str(flat.dtype).replace("torch.", ""), list(tensor.shape), flat), flat.nbytes)
 
-        self._shard_seeded = True
+        if not verify:
+            self._shard_seeded = True
         if not is_r0:
             return
         bkt.seal()
@@ -527,7 +542,8 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         # OOMs on tight mcore shapes otherwise).
         self._release_staging_pool("seed")
         logger.warning(
-            "delta-sharded FULL-SEED v=%s done in %.1fs (flushes=%d elems=%d wire=%.1fGB)",
+            "delta-sharded FULL-%s v=%s done in %.1fs (flushes=%d elems=%d wire=%.1fGB)",
+            "VERIFY" if verify else "SEED",
             global_steps,
             time.time() - t0,
             n_flushes,
@@ -610,13 +626,24 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             gq.put(pg, slots, dtype_str, counts, hf_idx, hf_val)
         gq.flush_all()
 
+        # VERL_DELTA_VERIFY_EVERY=K appends a full state-verification sweep to
+        # every K-th steady sync, inside the SAME receive session: the steady
+        # bucket keeps is_last unset and the sweep's final flush carries it. The
+        # receiver bit-compares each copy_ destination before overwriting and
+        # fails loud on any mismatch (see delta_loader._verify_dense).
+        verify = self._verify_due()
+        if is_r0:
+            bkt.seal()  # seal the final partial bucket into the pending flush
+            if bkt.pending is not None:
+                bkt.emit(is_last=not verify)
+            elif not verify:
+                self._publish_terminal(False)
+        if verify:
+            # collective on every rank: the full export assembles per tensor.
+            full, _ = engine.get_per_tensor_param()
+            self._send_full_seed(full, global_steps, verify=True)
         if not is_r0:
             return
-        bkt.seal()  # seal the final partial bucket into the pending flush
-        if bkt.pending is not None:
-            bkt.emit(is_last=True)
-        else:
-            self._publish_terminal(False)
         self._release_staging_pool("steady")  # return staging blocks to CUDA between syncs
         logger.info("delta-sharded send v=%s delta flushes=%d (streamed)", global_steps, n_flushes)
         if not total_elems:

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -319,6 +319,26 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         val_cp[:] = cp.asarray(val_u8)
         collective.broadcast(val_cp, src_rank=0, group_name=self.group_name)
 
+    def _release_staging_pool(self, phase: str) -> None:
+        """Return the cupy staging pool's blocks to CUDA and log the evidence:
+        ``held`` is what the pool would have kept from the device without this
+        release, and the device-free delta shows the memory actually coming
+        back (warning level so the default worker log level records it)."""
+        from verl.utils.device import get_torch_device
+
+        pool = cp.get_default_memory_pool()
+        held = pool.total_bytes()
+        free_before, _ = get_torch_device().mem_get_info()
+        pool.free_all_blocks()
+        free_after, _ = get_torch_device().mem_get_info()
+        logger.warning(
+            "cupy staging pool after %s send: held %.2fGB; device free %.2f->%.2fGB on release",
+            phase,
+            held / (1 << 30),
+            free_before / (1 << 30),
+            free_after / (1 << 30),
+        )
+
     def _publish_terminal(self, first: bool) -> None:
         """End-of-stream marker when zero flushes were produced (no broadcast, just a signal)."""
         meta = {"is_full": first, "encoding": self.encoding, "is_last": True, "terminal_empty": True}
@@ -505,7 +525,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         # after streaming up to 2x bucket_size through it, give the memory back
         # so the trainer's next optimizer/forward pass can use it (raw cudaMalloc
         # OOMs on tight mcore shapes otherwise).
-        cp.get_default_memory_pool().free_all_blocks()
+        self._release_staging_pool("seed")
         logger.warning(
             "delta-sharded FULL-SEED v=%s done in %.1fs (flushes=%d elems=%d wire=%.1fGB)",
             global_steps,
@@ -597,7 +617,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             bkt.emit(is_last=True)
         else:
             self._publish_terminal(False)
-        cp.get_default_memory_pool().free_all_blocks()  # return staging blocks to CUDA between syncs
+        self._release_staging_pool("steady")  # return staging blocks to CUDA between syncs
         logger.info("delta-sharded send v=%s delta flushes=%d (streamed)", global_steps, n_flushes)
         if not total_elems:
             return None

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import Generator, Iterator
 from dataclasses import dataclass
 from unittest.mock import patch
@@ -445,6 +446,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         generator (the per-tensor assembly is collective); rank 0 buckets. Resume
         works by construction: whatever the trainer restored is what ships."""
         is_r0 = self.is_master
+        t0 = time.time()
         n_flushes = 0
         total_elems = 0
         wire_bytes = 0
@@ -497,7 +499,16 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             bkt.emit(is_last=True)
         else:
             self._publish_terminal(True)
-        logger.info("delta-sharded send v=%s FULL-SEED flushes=%d elems=%d", global_steps, n_flushes, total_elems)
+        # warning level on purpose: worker default log level swallows info, and the
+        # one-off seed cost is the number people ask for when sizing a run.
+        logger.warning(
+            "delta-sharded FULL-SEED v=%s done in %.1fs (flushes=%d elems=%d wire=%.1fGB)",
+            global_steps,
+            time.time() - t0,
+            n_flushes,
+            total_elems,
+            wire_bytes / (1 << 30),
+        )
         if not total_elems:
             return None
         return {

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -230,7 +230,12 @@ def make_megatron_module(
 ):
     from verl.models.mcore.config_converter import get_hf_rope_theta
 
-    hf_config.rope_theta = get_hf_rope_theta(hf_config)
+    try:
+        hf_config.rope_theta = get_hf_rope_theta(hf_config)
+    except AttributeError:
+        # NoPE / hybrid-SSM configs (e.g. NemotronH) carry no rope at all; the
+        # provider/bridge owns rotary setup, so absence is not an error here.
+        pass
 
     if override_model_config is None:
         override_model_config = {}

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -195,9 +195,8 @@ class BaseEngine:
         Concrete here: it only consumes :meth:`get_per_tensor_param_shard`, so any
         engine that implements the shard export gets it for free.
         """
-        from verl.workers.engine.utils import prime_delta_snapshots
-
         from verl.utils.device import is_cuda_available
+        from verl.workers.engine.utils import prime_delta_snapshots
 
         self._delta_shard_snap = getattr(self, "_delta_shard_snap", {})
         gen, _ = self.get_per_tensor_param_shard()

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -178,9 +178,15 @@ class BaseEngine:
         """
         raise NotImplementedError
 
+    # Host-memory policy for the delta diff base: pinned (cudaHostAlloc) gives a
+    # faster H2D on the diff read-back but competes with every other pinned pool
+    # on the node; backends whose memory profile makes that competition
+    # dangerous override this to False (see MegatronEngine).
+    delta_pin_snapshots: bool = True
+
     def prime_delta_snapshots(self) -> None:
         """
-        Pin this rank's CURRENT shards as the delta diff base. Called right after the
+        Snapshot this rank's CURRENT shards as the delta diff base. Called right after the
         seed sync (which streams :meth:`get_per_tensor_param`'s full HF export):
         weights do not move during the sync, so the snapshots equal exactly what the
         rollout side received and the first
@@ -191,9 +197,11 @@ class BaseEngine:
         """
         from verl.workers.engine.utils import prime_delta_snapshots
 
+        from verl.utils.device import is_cuda_available
+
         self._delta_shard_snap = getattr(self, "_delta_shard_snap", {})
         gen, _ = self.get_per_tensor_param_shard()
-        prime_delta_snapshots(gen, self._delta_shard_snap)
+        prime_delta_snapshots(gen, self._delta_shard_snap, pin=is_cuda_available and self.delta_pin_snapshots)
 
     def get_per_tensor_param_delta_shard(self, **kwargs) -> tuple[Generator, Optional[dict]]:
         """

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -170,8 +170,13 @@ def build_export_index(bridge, megatron_model, hf_path: Optional[str] = None) ->
             continue
         module = task.megatron_module
 
-        is_expert = bool(getattr(mapping, "is_expert", False))
+        is_expert = bool(getattr(mapping, "is_expert", False)) or ".mlp.experts." in name
         pdim = _mapping_partition_dim(mapping, param)
+        if is_expert and pdim is None and etp_size > 1:
+            # mcore expert weights do not always carry the standard
+            # tensor_model_parallel attribute; fall back to the layout rule
+            # (fc1 = column-parallel dim 0, fc2 = row-parallel dim 1).
+            pdim = 0 if "linear_fc1" in name else 1
         local_shape = tuple(int(x) for x in param.shape)
 
         if is_expert and ep_size > 1:

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -67,23 +67,44 @@ def single_rank_pg_collection() -> SimpleNamespace:
     return _SINGLE_RANK_PGS
 
 
-def make_probe(mapping):
+def _warm_lazy_mappings(mapping, module) -> None:
+    """Force AutoMapping's lazy inner mapping into existence BEFORE the probe is
+    copied: AutoMapping resolves its concrete Column/Row/Replicated delegate on
+    first use, snapshotting whatever process groups exist at that moment -- if
+    that first use happened inside the probe, the delegate would be born with
+    the REAL groups and gather for real (the qkv-bias double-size bug)."""
+    for obj in [mapping, *[v for v in vars(mapping).values() if hasattr(v, "megatron_to_hf")]]:
+        if hasattr(obj, "_detect_parallelism_type") and getattr(obj, "_mapping", None) is None and module is not None:
+            try:
+                t = obj._detect_parallelism_type(module)
+                obj._mapping = obj._get_or_create_mapping(t)
+                obj._detected_type = t
+            except Exception as e:  # pragma: no cover - defensive; probe falls back to real groups
+                logger.warning("could not warm lazy mapping %s: %s", type(obj).__name__, e)
+
+
+def make_probe(mapping, module=None):
     """Copy a Megatron-Bridge param mapping and install degenerate single-rank
-    process groups on it AND on any nested mapping (composite mappings like
-    QKVMapping delegate their TP gather to an inner ``_tp_mapping`` that does
-    not receive the outer injection), turning ``megatron_to_hf`` into a pure
-    transform with zero collectives."""
+    process groups on it and on EVERY nested mapping, recursively (composite
+    mappings delegate to inner mappings -- QKVMapping._tp_mapping is an
+    AutoMapping which itself delegates to a lazily-created concrete mapping;
+    none of these receive the outer injection on their own). The result's
+    ``megatron_to_hf`` is a pure transform with zero collectives."""
     from megatron.bridge.models.conversion.param_mapping import MegatronParamMapping
 
+    _warm_lazy_mappings(mapping, module)
     pgs = single_rank_pg_collection()
-    probe = copy.copy(mapping)
-    probe.set_process_groups_from_pg_collection(pgs)
-    for attr, value in list(vars(probe).items()):
-        if isinstance(value, MegatronParamMapping):
-            inner = copy.copy(value)
-            inner.set_process_groups_from_pg_collection(pgs)
-            setattr(probe, attr, inner)
-    return probe
+
+    def _inject(m):
+        c = copy.copy(m)
+        c.set_process_groups_from_pg_collection(pgs)
+        for attr, value in list(vars(c).items()):
+            if isinstance(value, MegatronParamMapping):
+                _warm_lazy_mappings(value, module)
+                setattr(c, attr, _inject(value))
+        return c
+
+    return _inject(mapping)
 
 
 @dataclass
@@ -190,7 +211,7 @@ def build_export_index(bridge, megatron_model, hf_path: Optional[str] = None) ->
                 megatron_name=name,
                 param=param,
                 spec=spec,
-                probe=make_probe(mapping),
+                probe=make_probe(mapping, module),
                 module=module,
                 buffer_offset=buffer_offset,
             )

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -1,0 +1,255 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Megatron-side delta export machinery, built on Megatron-Bridge param mappings.
+
+The delta engine consumes final HF-coordinate entries; everything mcore-specific
+lives here: enumerating parameters through :meth:`AutoBridge.get_conversion_tasks`,
+declaring each parameter's geometry as a :class:`ShardSpec`, and probing the
+bridge's own ``megatron_to_hf`` converters with NaN sentinels to translate a
+shard-local delta into HF coordinates.
+
+The probe (form B) never runs a collective: every mapping is (shallow-)copied and
+its process groups are replaced with this rank's single-rank groups, so
+``megatron_to_hf`` short-circuits its TP gather (``tp_size == 1``) and PP
+broadcast (``pp_size == 1``) and degrades into a pure permutation transform.
+Feeding it a full-logical-shape NaN buffer with the rank's own delta scattered
+into its TP slice yields HF tensors whose non-NaN survivors are exactly this
+rank's contributions in final HF coordinates.
+
+Scope (asserted in the exporter): TP + EP, PP=1, VPP=1, no LoRA.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import torch
+
+from verl.workers.engine.spec import BlockPlacement, ShardSpec, translate_flat_indices
+
+logger = logging.getLogger(__name__)
+
+_SINGLE_RANK_PGS: Optional[SimpleNamespace] = None
+
+
+def single_rank_pg_collection() -> SimpleNamespace:
+    """This rank's degenerate ProcessGroupCollection: every parallel dim is a
+    single-rank group, so any mapping carrying it sees tp/pp/ep/etp size 1 and
+    short-circuits its collectives. ``dist.new_group`` must be called by every
+    rank in the same order, so ALL ranks build ALL single-rank groups once."""
+    global _SINGLE_RANK_PGS
+    if _SINGLE_RANK_PGS is None:
+        import torch.distributed as dist
+
+        own = None
+        for r in range(dist.get_world_size()):
+            g = dist.new_group([r])
+            if r == dist.get_rank():
+                own = g
+        # field names are what set_process_groups_from_pg_collection reads:
+        # pp -> pp_group, ep -> ep_group, tp -> _tp_group, expt_tp -> _etp_group
+        _SINGLE_RANK_PGS = SimpleNamespace(pp=own, ep=own, tp=own, expt_tp=own)
+    return _SINGLE_RANK_PGS
+
+
+def make_probe(mapping):
+    """Copy a Megatron-Bridge param mapping and install degenerate single-rank
+    process groups on it AND on any nested mapping (composite mappings like
+    QKVMapping delegate their TP gather to an inner ``_tp_mapping`` that does
+    not receive the outer injection), turning ``megatron_to_hf`` into a pure
+    transform with zero collectives."""
+    from megatron.bridge.models.conversion.param_mapping import MegatronParamMapping
+
+    pgs = single_rank_pg_collection()
+    probe = copy.copy(mapping)
+    probe.set_process_groups_from_pg_collection(pgs)
+    for attr, value in list(vars(probe).items()):
+        if isinstance(value, MegatronParamMapping):
+            inner = copy.copy(value)
+            inner.set_process_groups_from_pg_collection(pgs)
+            setattr(probe, attr, inner)
+    return probe
+
+
+@dataclass
+class McoreParamExport:
+    """One mcore parameter's export record: geometry + probe + module handle."""
+
+    megatron_name: str
+    param: torch.Tensor
+    spec: ShardSpec
+    probe: Any  # degenerate-PG mapping copy (form-B evaluator)
+    module: Any  # module handle megatron_to_hf reads config from
+    # dim-0 offset of this rank's slice inside the probe's input buffer, per dim
+    buffer_offset: tuple
+
+
+def _mapping_partition_dim(mapping, param) -> Optional[int]:
+    """TP partition dim of ``param`` under ``mapping``: mcore convention keeps
+    it on the parameter (``tensor_model_parallel``/``partition_dim``); mappings
+    that gather (Column/Row/QKV/GatedMLP inner AutoMapping) follow it."""
+    if getattr(param, "tensor_model_parallel", False):
+        return int(getattr(param, "partition_dim", 0))
+    return None
+
+
+def build_export_index(bridge, megatron_model, hf_path: Optional[str] = None) -> list[McoreParamExport]:
+    """Enumerate every local mcore parameter through the bridge's conversion
+    tasks and precompute its geometry declaration + form-B probe.
+
+    The index is built once (parameter sets are static) and reused by both the
+    shard export and the delta entry hook. Order follows the bridge's task
+    enumeration, identical on every rank (lockstep requirement).
+    """
+    from megatron.core import parallel_state as mpu
+
+    assert mpu.get_pipeline_model_parallel_world_size() == 1, (
+        "megatron delta_sharded supports TP+EP only for now (PP=1); the seed full "
+        "sync supports PP already, the steady relay is roadmapped"
+    )
+
+    tp_group = mpu.get_tensor_model_parallel_group()
+    tp_world = torch.distributed.get_world_size(group=tp_group)
+    tp_rank = torch.distributed.get_rank(group=tp_group)
+    ep_size = mpu.get_expert_model_parallel_world_size()
+    ep_rank = mpu.get_expert_model_parallel_rank() if ep_size > 1 else 0
+    etp_size = mpu.get_expert_tensor_parallel_world_size() if ep_size > 1 else 1
+    etp_rank = mpu.get_expert_tensor_parallel_rank() if ep_size > 1 else 0
+    etp_ep_group = mpu.get_expert_tensor_and_model_parallel_group() if ep_size > 1 else None
+
+    # hf_path is only needed when the bridge was built from a bare config (tests);
+    # the production engine builds it from_hf_pretrained and passes None.
+    tasks = (
+        bridge.get_conversion_tasks(megatron_model, hf_path=hf_path)
+        if hf_path
+        else bridge.get_conversion_tasks(megatron_model)
+    )
+    index: list[McoreParamExport] = []
+    for task in tasks:
+        mapping = task.mapping
+        param = task.param_weight
+        name = task.global_param_name
+        if param is None:
+            # parameter not owned by this rank (pp scope guard keeps this rare)
+            continue
+        module = task.megatron_module
+
+        is_expert = bool(getattr(mapping, "is_expert", False))
+        pdim = _mapping_partition_dim(mapping, param)
+        local_shape = tuple(int(x) for x in param.shape)
+
+        if is_expert and ep_size > 1:
+            # one LOCAL expert tensor; the virtual logical tensor stacks the ep
+            # dim in front: [ep_size, *etp_full_shape]. The probe consumes the
+            # ETP-full single-expert shape (its ep gather is short-circuited and
+            # handled by the engine gather over etp_ep_group instead).
+            etp_full = list(local_shape)
+            inner_off = [0] * len(local_shape)
+            if etp_size > 1 and pdim is not None:
+                etp_full[pdim] *= etp_size
+                inner_off[pdim] = etp_rank * local_shape[pdim]
+            block = BlockPlacement(
+                (1, *local_shape),
+                (ep_rank, *inner_off),
+                (ep_size, *etp_full),
+            )
+            spec = ShardSpec(full_shape=(ep_size, *etp_full), place=block, gather_group=etp_ep_group)
+            buffer_offset = (ep_rank, *inner_off)
+        elif pdim is not None and tp_world > 1:
+            full = list(local_shape)
+            full[pdim] *= tp_world
+            offset = [0] * len(local_shape)
+            offset[pdim] = tp_rank * local_shape[pdim]
+            block = BlockPlacement(tuple(local_shape), tuple(offset), tuple(full))
+            spec = ShardSpec(full_shape=tuple(full), place=block, gather_group=tp_group)
+            buffer_offset = tuple(offset)
+        else:
+            # replicated across TP: single-slot geometry, engine's pg=None path
+            # (rank 0 consumes its own entry directly, replicas contribute later
+            # via lockstep zero counts -- ReplicatedMapping itself dedups too).
+            spec = ShardSpec(full_shape=local_shape)
+            buffer_offset = (0,) * len(local_shape)
+
+        index.append(
+            McoreParamExport(
+                megatron_name=name,
+                param=param,
+                spec=spec,
+                probe=make_probe(mapping),
+                module=module,
+                buffer_offset=buffer_offset,
+            )
+        )
+    return index
+
+
+def mcore_hf_delta_entry(rec: McoreParamExport, place, lidx: torch.Tensor, lval: torch.Tensor, slot_cache: dict):
+    """Form-B probe: translate one mcore param's shard-local delta into its
+    final HF-coordinate entry ``(slots, dtype_str, counts, hf_idx, hf_val)``.
+
+    Scatters the delta into a NaN buffer of the probe's input shape (the LOCAL
+    mcore param shape for replicated/expert params, the TP-full shape for TP
+    params -- other ranks' slices stay NaN), runs the degenerate-PG
+    ``megatron_to_hf`` (pure permutation), and extracts each output slot's
+    surviving positions. The slot list is cached after the first call (the
+    converter's output names are deterministic, so every rank's cache agrees
+    and the batched gather stays aligned)."""
+    spec = rec.spec
+    dtype_str = str(lval.dtype).replace("torch.", "")
+
+    # The probe consumes the mcore-logical single-param shape. For expert params
+    # the engine-facing logical tensor prepends the ep dim; strip it for the
+    # probe buffer (dim 0 of the virtual tensor selects the expert, the probe
+    # sees one expert's ETP-full tensor).
+    is_expert_virtual = isinstance(place, BlockPlacement) and len(place.full_shape) == len(rec.param.shape) + 1
+    probe_shape = tuple(spec.full_shape[1:]) if is_expert_virtual else tuple(spec.full_shape)
+
+    buf = torch.full(probe_shape, float("nan"), dtype=lval.dtype, device=lval.device)
+    if lidx.numel():
+        g = translate_flat_indices(lidx, place)
+        if is_expert_virtual:
+            inner = 1
+            for x in probe_shape:
+                inner *= int(x)
+            g = g - int(place.global_offset[0]) * inner  # drop the ep-dim offset
+        buf.view(-1)[g] = lval
+
+    outs = rec.probe.megatron_to_hf(buf, rec.module)
+
+    key = rec.megatron_name
+    slots = slot_cache.get(key)
+    if slots is None:
+        slots = [(n, tuple(int(x) for x in t.shape)) for n, t in outs.items()]
+        slot_cache[key] = slots
+    counts = torch.zeros(len(slots), dtype=torch.int64)
+    idx_pieces: list[torch.Tensor] = []
+    val_pieces: list[torch.Tensor] = []
+    for s_i, (sname, _sshape) in enumerate(slots):
+        fl = outs[sname].reshape(-1)
+        p_ = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        if p_.numel():
+            counts[s_i] = p_.numel()
+            idx_pieces.append(p_.to(torch.int32))
+            val_pieces.append(fl[p_])
+    if idx_pieces:
+        hf_idx = torch.cat(idx_pieces)
+        hf_val = torch.cat(val_pieces)
+    else:
+        hf_idx = torch.empty(0, dtype=torch.int32, device=lval.device)
+        hf_val = torch.empty(0, dtype=lval.dtype, device=lval.device)
+    return slots, dtype_str, counts, hf_idx, hf_val

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -91,11 +91,7 @@ def _warm_lazy_mappings(mapping, module) -> None:
     gather for real (the qkv-bias double-size bug). Self-only on purpose:
     ``_inject`` warms every child right before copying it, so each node of the
     mapping tree is warmed exactly once."""
-    if (
-        hasattr(mapping, "_detect_parallelism_type")
-        and getattr(mapping, "_mapping", None) is None
-        and module is not None
-    ):
+    if hasattr(mapping, "_detect_parallelism_type") and getattr(mapping, "_mapping", None) is None:
         try:
             t = mapping._detect_parallelism_type(module)
             mapping._mapping = mapping._get_or_create_mapping(t)
@@ -104,7 +100,7 @@ def _warm_lazy_mappings(mapping, module) -> None:
             logger.warning("could not warm lazy mapping %s: %s", type(mapping).__name__, e)
 
 
-def make_probe(mapping, module=None):
+def make_probe(mapping, module):
     """Copy a Megatron-Bridge param mapping tree and turn ``megatron_to_hf``
     into a communication-free LOCAL transform that still runs the REAL
     (tp_size > 1) code paths: every copy's groups become size-faithful

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -19,23 +19,29 @@ declaring each parameter's geometry as a :class:`ShardSpec`, and probing the
 bridge's own ``megatron_to_hf`` converters with NaN sentinels to translate a
 shard-local delta into HF coordinates.
 
-The probe (form B) never runs a collective: every mapping is (shallow-)copied and
-its process groups are replaced with this rank's single-rank groups, so
-``megatron_to_hf`` short-circuits its TP gather (``tp_size == 1``) and PP
-broadcast (``pp_size == 1``) and degrades into a pure permutation transform.
-Feeding it a full-logical-shape NaN buffer with the rank's own delta scattered
-into its TP slice yields HF tensors whose non-NaN survivors are exactly this
-rank's contributions in final HF coordinates.
+The probe never runs a collective, yet executes the mapping's REAL parallel
+code paths: a "group" carries two separable meanings -- its SIZE/RANK (which
+value math like Mamba's ``local_dim = global // tp_size`` consumes) and its
+COMMUNICATION. The probe copies keep the first faithful and replace only the
+second: groups become :class:`_ProbeGroup` (real size/rank, any actual use for
+communication raises), and the bridge's comm helpers are stubbed with local
+synthesis -- ``gather_from_tp_ranks`` returns this rank's shard at its true
+rank index with NaN placeholders for every other rank (their contributions are
+exported by those ranks' own probes). Feeding ``megatron_to_hf`` the LOCAL
+shard as a NaN buffer with the rank's own delta scattered in yields HF tensors
+whose non-NaN survivors are exactly this rank's contributions in final HF
+coordinates.
 
 Scope (asserted in the exporter): TP + EP, PP=1, VPP=1, no LoRA.
 
-Safety boundary of the degenerate-PG trick: it relies on ``megatron_to_hf``
-using group state for COMMUNICATION only (gathers/broadcasts, and the ep-name
-fan-out that its ``ep_size == 1`` fast path bypasses); the post-gather
-transform is a pure permutation. A future mapping that let ``tp_size`` or
-``ep_rank`` into VALUE math would skew the probe silently -- rerun the D1
-bitwise probe (probe output vs real ``megatron_to_hf``, single GPU) as the
-regression oracle whenever Megatron-Bridge is upgraded.
+Safety boundary: communication must stay confined to the four stubbed helpers
+(``gather_from_tp_ranks`` / ``gather_from_ep_ranks[_scale]`` / the PP
+broadcasts, whose ``pp_size == 1`` fast path the probe keeps) -- anything else
+touching a probe group raises instead of skewing silently. The remaining
+assumption is that transforms REARRANGE elements rather than arithmetically
+BLEND chunks (blending would eat the NaN sentinels); the TP>1 differential
+test (real ``megatron_to_hf`` vs probe assembly, bitwise) is the regression
+oracle for both assumptions on every Megatron-Bridge upgrade.
 """
 
 from __future__ import annotations
@@ -43,36 +49,38 @@ from __future__ import annotations
 import copy
 import logging
 from dataclasses import dataclass
-from types import SimpleNamespace
 from typing import Any, Optional
 
 import torch
 
-from verl.workers.engine.spec import BlockPlacement, ShardSpec, translate_flat_indices
+from verl.workers.engine.spec import BlockPlacement, ShardSpec
 
 logger = logging.getLogger(__name__)
 
-_SINGLE_RANK_PGS: Optional[SimpleNamespace] = None
 
+class _ProbeGroup:
+    """Size/rank-faithful stand-in for a process group on probe copies: value
+    math inside ``megatron_to_hf`` (e.g. Mamba's per-rank de-interleave dims)
+    sees the REAL parallel sizes, while any attempt to actually communicate
+    through the group fails loud (the probe stubs the bridge's comm helpers;
+    anything else reaching a group is an unstubbed communication pattern)."""
 
-def single_rank_pg_collection() -> SimpleNamespace:
-    """This rank's degenerate ProcessGroupCollection: every parallel dim is a
-    single-rank group, so any mapping carrying it sees tp/pp/ep/etp size 1 and
-    short-circuits its collectives. ``dist.new_group`` must be called by every
-    rank in the same order, so ALL ranks build ALL single-rank groups once."""
-    global _SINGLE_RANK_PGS
-    if _SINGLE_RANK_PGS is None:
-        import torch.distributed as dist
+    def __init__(self, size: int, rank: int):
+        self._size = int(size)
+        self._rank = int(rank)
 
-        own = None
-        for r in range(dist.get_world_size()):
-            g = dist.new_group([r])
-            if r == dist.get_rank():
-                own = g
-        # field names are what set_process_groups_from_pg_collection reads:
-        # pp -> pp_group, ep -> ep_group, tp -> _tp_group, expt_tp -> _etp_group
-        _SINGLE_RANK_PGS = SimpleNamespace(pp=own, ep=own, tp=own, expt_tp=own)
-    return _SINGLE_RANK_PGS
+    def size(self) -> int:
+        return self._size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def __getattr__(self, name):
+        raise RuntimeError(
+            f"probe process group asked for {name!r}: this mapping communicates outside "
+            "the stubbed helpers (gather_from_tp_ranks / gather_from_ep_ranks[_scale] / "
+            "pp broadcasts) -- extend make_probe's comm stubs before trusting its export"
+        )
 
 
 def _warm_lazy_mappings(mapping, module) -> None:
@@ -83,7 +91,11 @@ def _warm_lazy_mappings(mapping, module) -> None:
     gather for real (the qkv-bias double-size bug). Self-only on purpose:
     ``_inject`` warms every child right before copying it, so each node of the
     mapping tree is warmed exactly once."""
-    if hasattr(mapping, "_detect_parallelism_type") and getattr(mapping, "_mapping", None) is None and module is not None:
+    if (
+        hasattr(mapping, "_detect_parallelism_type")
+        and getattr(mapping, "_mapping", None) is None
+        and module is not None
+    ):
         try:
             t = mapping._detect_parallelism_type(module)
             mapping._mapping = mapping._get_or_create_mapping(t)
@@ -93,20 +105,47 @@ def _warm_lazy_mappings(mapping, module) -> None:
 
 
 def make_probe(mapping, module=None):
-    """Copy a Megatron-Bridge param mapping and install degenerate single-rank
-    process groups on it and on EVERY nested mapping, recursively (composite
-    mappings delegate to inner mappings -- QKVMapping._tp_mapping is an
-    AutoMapping which itself delegates to a lazily-created concrete mapping;
-    none of these receive the outer injection on their own). The result's
-    ``megatron_to_hf`` is a pure transform with zero collectives."""
+    """Copy a Megatron-Bridge param mapping tree and turn ``megatron_to_hf``
+    into a communication-free LOCAL transform that still runs the REAL
+    (tp_size > 1) code paths: every copy's groups become size-faithful
+    :class:`_ProbeGroup` stand-ins and the bridge's comm helpers are stubbed
+    with local synthesis. The copy is recursive (composite mappings delegate to
+    inner mappings -- QKVMapping._tp_mapping is an AutoMapping which itself
+    delegates to a lazily-created concrete mapping; none of these receive the
+    outer stubbing on their own)."""
     from megatron.bridge.models.conversion.param_mapping import MegatronParamMapping
+    from megatron.core.utils import get_pg_rank, get_pg_size
 
     _warm_lazy_mappings(mapping, module)
-    pgs = single_rank_pg_collection()
+
+    def _stub(c):
+        # size-faithful groups, sizes/ranks read from the ORIGINAL (real) groups
+        # BEFORE replacement. PP is asserted =1 in the exporter; a (1, 0) group
+        # keeps the pp broadcast helpers on their identity fast path.
+        c.pp_group = _ProbeGroup(1, 0)
+        for attr in ("ep_group", "_tp_group", "_etp_group"):
+            g = getattr(c, attr, None)
+            setattr(c, attr, _ProbeGroup(get_pg_size(g), get_pg_rank(g)))
+
+        def _gather_tp(tensor, _c=c):
+            # what a real all_gather over the tp group would produce, minus the
+            # other ranks' data: our shard rides at its true rank index, every
+            # other chunk is NaN (those ranks export their own contributions).
+            out = [torch.full_like(tensor, float("nan")) for _ in range(_c.tp_size)]
+            out[_c.tp_rank] = tensor
+            return out
+
+        c.gather_from_tp_ranks = _gather_tp
+        # the probe sees ONE expert (the engine's virtual-ep tensor handles the
+        # expert dim); the hf name was bound with the GLOBAL expert id at task
+        # construction, so the ep fan-out reduces to the bound name.
+        c.gather_from_ep_ranks = lambda w, mod, name: {str(name): w}
+        # mirrors the real helper's tail (unsqueeze(0) ... squeeze().unsqueeze(-1))
+        c.gather_from_ep_ranks_scale = lambda w, mod, name: {str(name): w.unsqueeze(0).squeeze().unsqueeze(-1)}
+        return c
 
     def _inject(m):
-        c = copy.copy(m)
-        c.set_process_groups_from_pg_collection(pgs)  # sets only c's own groups
+        c = _stub(copy.copy(m))
         for attr, value in list(vars(c).items()):
             if isinstance(value, MegatronParamMapping):
                 # warm BEFORE copying the child: the lazy delegate must exist so
@@ -125,10 +164,8 @@ class McoreParamExport:
     megatron_name: str
     param: torch.Tensor
     spec: ShardSpec
-    probe: Any  # degenerate-PG mapping copy (form-B evaluator)
+    probe: Any  # comm-stubbed mapping copy (local megatron_to_hf evaluator)
     module: Any  # module handle megatron_to_hf reads config from
-    # dim-0 offset of this rank's slice inside the probe's input buffer, per dim
-    buffer_offset: tuple
 
 
 def _mapping_partition_dim(mapping, param) -> Optional[int]:
@@ -201,7 +238,6 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
                 (ep_size, *etp_full),
             )
             spec = ShardSpec(full_shape=(ep_size, *etp_full), place=block, gather_group=etp_ep_group)
-            buffer_offset = (ep_rank, *inner_off)
         elif pdim is not None and tp_world > 1:
             full = list(local_shape)
             full[pdim] *= tp_world
@@ -209,13 +245,11 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
             offset[pdim] = tp_rank * local_shape[pdim]
             block = BlockPlacement(tuple(local_shape), tuple(offset), tuple(full))
             spec = ShardSpec(full_shape=tuple(full), place=block, gather_group=tp_group)
-            buffer_offset = tuple(offset)
         else:
             # replicated across TP: single-slot geometry, engine's pg=None path
             # (rank 0 consumes its own entry directly, replicas contribute later
             # via lockstep zero counts -- ReplicatedMapping itself dedups too).
             spec = ShardSpec(full_shape=local_shape)
-            buffer_offset = (0,) * len(local_shape)
 
         index.append(
             McoreParamExport(
@@ -224,42 +258,30 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
                 spec=spec,
                 probe=make_probe(mapping, module),
                 module=module,
-                buffer_offset=buffer_offset,
             )
         )
     return index
 
 
-def mcore_hf_delta_entry(rec: McoreParamExport, place, lidx: torch.Tensor, lval: torch.Tensor, slot_cache: dict):
-    """Form-B probe: translate one mcore param's shard-local delta into its
-    final HF-coordinate entry ``(slots, dtype_str, counts, hf_idx, hf_val)``.
+def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval: torch.Tensor, slot_cache: dict):
+    """Probe one mcore param's shard-local delta into its final HF-coordinate
+    entry ``(slots, dtype_str, counts, hf_idx, hf_val)``.
 
-    Scatters the delta into a NaN buffer of the probe's input shape (the LOCAL
-    mcore param shape for replicated/expert params, the TP-full shape for TP
-    params -- other ranks' slices stay NaN), runs the degenerate-PG
-    ``megatron_to_hf`` (pure permutation), and extracts each output slot's
-    surviving positions. The slot list is cached after the first call (the
-    converter's output names are deterministic, so every rank's cache agrees
-    and the batched gather stays aligned)."""
-    spec = rec.spec
+    Scatters the delta into a NaN buffer of the LOCAL shard shape (exactly what
+    the real ``megatron_to_hf`` receives), runs the comm-stubbed probe -- real
+    group sizes, gathers synthesized locally, so the mapping executes its real
+    TP>1 code paths -- and extracts each output slot's surviving positions.
+    The slot list is cached after the first call (the converter's output names
+    are deterministic, so every rank's cache agrees and the batched gather
+    stays aligned)."""
     dtype_str = str(lval.dtype).replace("torch.", "")
+    assert lval.numel() == 0 or lval.is_floating_point(), (
+        f"{rec.megatron_name}: NaN sentinels require a floating-point param, got {lval.dtype}"
+    )
 
-    # The probe consumes the mcore-logical single-param shape. For expert params
-    # the engine-facing logical tensor prepends the ep dim; strip it for the
-    # probe buffer (dim 0 of the virtual tensor selects the expert, the probe
-    # sees one expert's ETP-full tensor).
-    is_expert_virtual = isinstance(place, BlockPlacement) and len(place.full_shape) == len(rec.param.shape) + 1
-    probe_shape = tuple(spec.full_shape[1:]) if is_expert_virtual else tuple(spec.full_shape)
-
-    buf = torch.full(probe_shape, float("nan"), dtype=lval.dtype, device=lval.device)
+    buf = torch.full(tuple(rec.param.shape), float("nan"), dtype=lval.dtype, device=lval.device)
     if lidx.numel():
-        g = translate_flat_indices(lidx, place)
-        if is_expert_virtual:
-            inner = 1
-            for x in probe_shape:
-                inner *= int(x)
-            g = g - int(place.global_offset[0]) * inner  # drop the ep-dim offset
-        buf.view(-1)[g] = lval
+        buf.view(-1)[lidx] = lval
 
     outs = rec.probe.megatron_to_hf(buf, rec.module)
 

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -15,7 +15,7 @@
 
 The delta engine consumes final HF-coordinate entries; everything mcore-specific
 lives here: enumerating parameters through :meth:`AutoBridge.get_conversion_tasks`,
-declaring each parameter's geometry as a :class:`ShardSpec`, and probing the
+routing each parameter's entries to its wire merge group, and probing the
 bridge's own ``megatron_to_hf`` converters with NaN sentinels to translate a
 shard-local delta into HF coordinates.
 
@@ -49,11 +49,11 @@ from __future__ import annotations
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import torch
 
-from verl.workers.engine.spec import BlockPlacement, ShardSpec
+from verl.workers.engine.spec import ShardSpec
 
 logger = logging.getLogger(__name__)
 
@@ -132,9 +132,10 @@ def make_probe(mapping, module):
             return out
 
         c.gather_from_tp_ranks = _gather_tp
-        # the probe sees ONE expert (the engine's virtual-ep tensor handles the
-        # expert dim); the hf name was bound with the GLOBAL expert id at task
-        # construction, so the ep fan-out reduces to the bound name.
+        # each rank's probe emits only its own local experts, under the hf name
+        # bound with the GLOBAL expert id at task construction; the engine
+        # merges entries over the etp x ep group, so the ep fan-out reduces to
+        # the bound name.
         c.gather_from_ep_ranks = lambda w, mod, name: {str(name): w}
         # mirrors the real helper's tail (unsqueeze(0) ... squeeze().unsqueeze(-1))
         c.gather_from_ep_ranks_scale = lambda w, mod, name: {str(name): w.unsqueeze(0).squeeze().unsqueeze(-1)}
@@ -164,22 +165,18 @@ class McoreParamExport:
     module: Any  # module handle megatron_to_hf reads config from
 
 
-def _mapping_partition_dim(mapping, param) -> Optional[int]:
-    """TP partition dim of ``param`` under ``mapping``: mcore convention keeps
-    it on the parameter (``tensor_model_parallel``/``partition_dim``); mappings
-    that gather (Column/Row/QKV/GatedMLP inner AutoMapping) follow it."""
-    if getattr(param, "tensor_model_parallel", False):
-        return int(getattr(param, "partition_dim", 0))
-    return None
-
-
 def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
     """Enumerate every local mcore parameter through the bridge's conversion
-    tasks and precompute its geometry declaration + form-B probe.
+    tasks and precompute its probe + wire routing.
 
-    The index is built once (parameter sets are static) and reused by both the
-    shard export and the delta entry hook. Order follows the bridge's task
-    enumeration, identical on every rank (lockstep requirement).
+    No shard geometry is hand-computed here: the comm-stubbed probe emits final
+    HF coordinates straight from the local shard, so the engine only needs to
+    know WHICH group's entries to merge per parameter (the spec's
+    ``gather_group``; ``full_shape`` is the nominal local shape) and that
+    replicated params contribute from rank 0 only. The index is built once
+    (parameter sets are static) and reused by both the shard export and the
+    delta entry hook. Order follows the bridge's task enumeration, identical on
+    every rank (lockstep requirement).
     """
     from megatron.core import parallel_state as mpu
 
@@ -190,12 +187,7 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
 
     tp_group = mpu.get_tensor_model_parallel_group()
     tp_world = torch.distributed.get_world_size(group=tp_group)
-    tp_rank = torch.distributed.get_rank(group=tp_group)
     ep_size = mpu.get_expert_model_parallel_world_size()
-    ep_rank = mpu.get_expert_model_parallel_rank() if ep_size > 1 else 0
-    etp_size = mpu.get_expert_tensor_parallel_world_size() if ep_size > 1 else 1
-    etp_rank = mpu.get_expert_tensor_parallel_rank() if ep_size > 1 else 0
-    etp_ep_group = mpu.get_expert_tensor_and_model_parallel_group() if ep_size > 1 else None
 
     tasks = bridge.get_conversion_tasks(megatron_model)
     index: list[McoreParamExport] = []
@@ -207,44 +199,21 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
             # parameter not owned by this rank (pp scope guard keeps this rare)
             continue
         module = task.megatron_module
-
-        is_expert = mapping.is_expert
-        pdim = _mapping_partition_dim(mapping, param)
-        if is_expert and pdim is None and etp_size > 1:
-            # mcore deliberately withholds tensor_model_parallel on expert
-            # weights (grouped-linear attr stamping in mcore's TE extensions),
-            # so for experts the layout rule is the primary source, not a
-            # fallback: fc1 = column-parallel dim 0, fc2 = row-parallel dim 1.
-            pdim = 0 if "linear_fc1" in name else 1
         local_shape = tuple(int(x) for x in param.shape)
 
-        if is_expert and ep_size > 1:
-            # one LOCAL expert tensor; the virtual logical tensor stacks the ep
-            # dim in front: [ep_size, *etp_full_shape]. The probe consumes the
-            # ETP-full single-expert shape (its ep gather is short-circuited and
-            # handled by the engine gather over etp_ep_group instead).
-            etp_full = list(local_shape)
-            inner_off = [0] * len(local_shape)
-            if etp_size > 1 and pdim is not None:
-                etp_full[pdim] *= etp_size
-                inner_off[pdim] = etp_rank * local_shape[pdim]
-            block = BlockPlacement(
-                (1, *local_shape),
-                (ep_rank, *inner_off),
-                (ep_size, *etp_full),
+        if mapping.is_expert and (ep_size > 1 or tp_world > 1):
+            # every rank holding a piece of this expert set contributes; the
+            # engine merges their probe entries over the joint etp x ep group.
+            spec = ShardSpec(
+                full_shape=local_shape,
+                place=0,
+                gather_group=mpu.get_expert_tensor_and_model_parallel_group(),
             )
-            spec = ShardSpec(full_shape=(ep_size, *etp_full), place=block, gather_group=etp_ep_group)
-        elif pdim is not None and tp_world > 1:
-            full = list(local_shape)
-            full[pdim] *= tp_world
-            offset = [0] * len(local_shape)
-            offset[pdim] = tp_rank * local_shape[pdim]
-            block = BlockPlacement(tuple(local_shape), tuple(offset), tuple(full))
-            spec = ShardSpec(full_shape=tuple(full), place=block, gather_group=tp_group)
+        elif getattr(param, "tensor_model_parallel", False) and tp_world > 1:
+            spec = ShardSpec(full_shape=local_shape, place=0, gather_group=tp_group)
         else:
-            # replicated across TP: single-slot geometry, engine's pg=None path
-            # (rank 0 consumes its own entry directly, replicas contribute later
-            # via lockstep zero counts -- ReplicatedMapping itself dedups too).
+            # replicated: engine's pg=None path (rank 0 consumes its own entry
+            # directly, replicas stay in lockstep via zero counts).
             spec = ShardSpec(full_shape=local_shape)
 
         index.append(

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -264,6 +264,19 @@ def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval
         f"{rec.megatron_name}: NaN sentinels require a floating-point param, got {lval.dtype}"
     )
 
+    cached = slot_cache.get(rec.megatron_name)
+    if lidx.numel() == 0 and cached is not None:
+        # empty delta: the slot table froze after the first probe, so the
+        # zero-count lockstep entry needs no probe run at all -- skip the
+        # buffer build, the transform and the full-output NaN scan.
+        return (
+            cached,
+            dtype_str,
+            torch.zeros(len(cached), dtype=torch.int64),
+            torch.empty(0, dtype=torch.int32, device=lval.device),
+            torch.empty(0, dtype=lval.dtype, device=lval.device),
+        )
+
     buf = torch.full(tuple(rec.param.shape), float("nan"), dtype=lval.dtype, device=lval.device)
     if lidx.numel():
         buf.view(-1)[lidx] = lval

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -28,6 +28,14 @@ into its TP slice yields HF tensors whose non-NaN survivors are exactly this
 rank's contributions in final HF coordinates.
 
 Scope (asserted in the exporter): TP + EP, PP=1, VPP=1, no LoRA.
+
+Safety boundary of the degenerate-PG trick: it relies on ``megatron_to_hf``
+using group state for COMMUNICATION only (gathers/broadcasts, and the ep-name
+fan-out that its ``ep_size == 1`` fast path bypasses); the post-gather
+transform is a pure permutation. A future mapping that let ``tp_size`` or
+``ep_rank`` into VALUE math would skew the probe silently -- rerun the D1
+bitwise probe (probe output vs real ``megatron_to_hf``, single GPU) as the
+regression oracle whenever Megatron-Bridge is upgraded.
 """
 
 from __future__ import annotations
@@ -68,19 +76,20 @@ def single_rank_pg_collection() -> SimpleNamespace:
 
 
 def _warm_lazy_mappings(mapping, module) -> None:
-    """Force AutoMapping's lazy inner mapping into existence BEFORE the probe is
-    copied: AutoMapping resolves its concrete Column/Row/Replicated delegate on
-    first use, snapshotting whatever process groups exist at that moment -- if
-    that first use happened inside the probe, the delegate would be born with
-    the REAL groups and gather for real (the qkv-bias double-size bug)."""
-    for obj in [mapping, *[v for v in vars(mapping).values() if hasattr(v, "megatron_to_hf")]]:
-        if hasattr(obj, "_detect_parallelism_type") and getattr(obj, "_mapping", None) is None and module is not None:
-            try:
-                t = obj._detect_parallelism_type(module)
-                obj._mapping = obj._get_or_create_mapping(t)
-                obj._detected_type = t
-            except Exception as e:  # pragma: no cover - defensive; probe falls back to real groups
-                logger.warning("could not warm lazy mapping %s: %s", type(obj).__name__, e)
+    """Force AutoMapping's lazy concrete delegate into existence: AutoMapping
+    resolves its Column/Row/Replicated delegate on first use, snapshotting
+    whatever process groups exist at that moment -- if that first use happened
+    inside the probe, the delegate would be born with the REAL groups and
+    gather for real (the qkv-bias double-size bug). Self-only on purpose:
+    ``_inject`` warms every child right before copying it, so each node of the
+    mapping tree is warmed exactly once."""
+    if hasattr(mapping, "_detect_parallelism_type") and getattr(mapping, "_mapping", None) is None and module is not None:
+        try:
+            t = mapping._detect_parallelism_type(module)
+            mapping._mapping = mapping._get_or_create_mapping(t)
+            mapping._detected_type = t
+        except Exception as e:  # pragma: no cover - defensive; probe falls back to real groups
+            logger.warning("could not warm lazy mapping %s: %s", type(mapping).__name__, e)
 
 
 def make_probe(mapping, module=None):
@@ -97,9 +106,11 @@ def make_probe(mapping, module=None):
 
     def _inject(m):
         c = copy.copy(m)
-        c.set_process_groups_from_pg_collection(pgs)
+        c.set_process_groups_from_pg_collection(pgs)  # sets only c's own groups
         for attr, value in list(vars(c).items()):
             if isinstance(value, MegatronParamMapping):
+                # warm BEFORE copying the child: the lazy delegate must exist so
+                # the child copy's vars() include it and the recursion reaches it.
                 _warm_lazy_mappings(value, module)
                 setattr(c, attr, _inject(value))
         return c

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -129,7 +129,7 @@ def _mapping_partition_dim(mapping, param) -> Optional[int]:
     return None
 
 
-def build_export_index(bridge, megatron_model, hf_path: Optional[str] = None) -> list[McoreParamExport]:
+def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
     """Enumerate every local mcore parameter through the bridge's conversion
     tasks and precompute its geometry declaration + form-B probe.
 
@@ -153,13 +153,7 @@ def build_export_index(bridge, megatron_model, hf_path: Optional[str] = None) ->
     etp_rank = mpu.get_expert_tensor_parallel_rank() if ep_size > 1 else 0
     etp_ep_group = mpu.get_expert_tensor_and_model_parallel_group() if ep_size > 1 else None
 
-    # hf_path is only needed when the bridge was built from a bare config (tests);
-    # the production engine builds it from_hf_pretrained and passes None.
-    tasks = (
-        bridge.get_conversion_tasks(megatron_model, hf_path=hf_path)
-        if hf_path
-        else bridge.get_conversion_tasks(megatron_model)
-    )
+    tasks = bridge.get_conversion_tasks(megatron_model)
     index: list[McoreParamExport] = []
     for task in tasks:
         mapping = task.mapping

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -83,6 +83,23 @@ class _ProbeGroup:
         )
 
 
+_NAN_POOL: dict = {}
+
+
+def _nan_block(shape, dtype, device) -> torch.Tensor:
+    """Read-only all-NaN placeholder for another rank's gather chunk, pooled by
+    (shape, dtype, device): the gather stub hands these out on every probe call
+    for every param, and they are only ever READ (the transforms are functional),
+    so one block per distinct shape serves the whole model for the run's
+    lifetime instead of a fresh cudaMalloc+fill per param per sync."""
+    key = (tuple(shape), dtype, str(device))
+    t = _NAN_POOL.get(key)
+    if t is None:
+        t = torch.full(tuple(shape), float("nan"), dtype=dtype, device=device)
+        _NAN_POOL[key] = t
+    return t
+
+
 def _warm_lazy_mappings(mapping, module) -> None:
     """Force AutoMapping's lazy concrete delegate into existence: AutoMapping
     resolves its Column/Row/Replicated delegate on first use, snapshotting
@@ -126,8 +143,11 @@ def make_probe(mapping, module):
         def _gather_tp(tensor, _c=c):
             # what a real all_gather over the tp group would produce, minus the
             # other ranks' data: our shard rides at its true rank index, every
-            # other chunk is NaN (those ranks export their own contributions).
-            out = [torch.full_like(tensor, float("nan")) for _ in range(_c.tp_size)]
+            # other chunk is a pooled read-only NaN block (those ranks export
+            # their own contributions; transforms never write into their inputs,
+            # which the TP>1 bitwise differential revalidates).
+            nan = _nan_block(tensor.shape, tensor.dtype, tensor.device)
+            out = [nan] * _c.tp_size
             out[_c.tp_rank] = tensor
             return out
 

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -170,12 +170,13 @@ def build_export_index(bridge, megatron_model, hf_path: Optional[str] = None) ->
             continue
         module = task.megatron_module
 
-        is_expert = bool(getattr(mapping, "is_expert", False)) or ".mlp.experts." in name
+        is_expert = mapping.is_expert
         pdim = _mapping_partition_dim(mapping, param)
         if is_expert and pdim is None and etp_size > 1:
-            # mcore expert weights do not always carry the standard
-            # tensor_model_parallel attribute; fall back to the layout rule
-            # (fc1 = column-parallel dim 0, fc2 = row-parallel dim 1).
+            # mcore deliberately withholds tensor_model_parallel on expert
+            # weights (grouped-linear attr stamping in mcore's TE extensions),
+            # so for experts the layout rule is the primary source, not a
+            # fallback: fc1 = column-parallel dim 0, fc2 = row-parallel dim 1.
             pdim = 0 if "linear_fc1" in name else 1
         local_shape = tuple(int(x) for x in param.shape)
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -838,6 +838,62 @@ class MegatronEngine(BaseEngine):
 
         return per_tensor_param, peft_config
 
+    def _mcore_export_index(self):
+        """Build (once) the per-parameter delta export index: geometry specs and
+        form-B probes derived from the bridge's conversion tasks. See
+        :mod:`verl.workers.engine.megatron.delta_export`."""
+        index = getattr(self, "_delta_export_index", None)
+        if index is None:
+            from .delta_export import build_export_index
+
+            assert not self.vanilla_bridge, (
+                "megatron delta_sharded is built on Megatron-Bridge param mappings; "
+                "the deprecated vanilla mbridge flavor is not supported"
+            )
+            assert self.peft_cls is None, "megatron delta_sharded does not support LoRA"
+            index = build_export_index(self.bridge, self.module)
+            self._delta_export_index = index
+            self._delta_export_by_name = {rec.megatron_name: rec for rec in index}
+            self._delta_slot_cache: dict = {}
+        return index
+
+    def get_per_tensor_param_shard(self, **kwargs):
+        """Yield each rank's *local* mcore shard ``(name, local_flat_bf16,
+        ShardSpec)`` -- the geometry comes from the Megatron-Bridge param
+        mappings (TP partition dims, EP virtual expert tensors). Pure export,
+        no side effects. TP+EP only (PP=1 asserted in the index builder)."""
+        load_megatron_model_to_gpu(self.module, load_grad=False)
+        index = self._mcore_export_index()
+
+        def _gen():
+            for rec in index:
+                local = rec.param.data
+                if local.is_floating_point() and local.dtype != torch.bfloat16:
+                    local = local.to(torch.bfloat16)
+                yield rec.megatron_name, local.reshape(-1), rec.spec
+
+        return _gen(), None
+
+    def _hf_delta_entry(self, name, spec, place, lidx, lval):
+        """mcore's per-param entry builder: probe the bridge's own converter
+        (degenerate-PG copy, pure transform) with NaN sentinels -- see
+        :func:`verl.workers.engine.megatron.delta_export.mcore_hf_delta_entry`."""
+        from .delta_export import mcore_hf_delta_entry
+
+        rec = self._delta_export_by_name[name]
+        return mcore_hf_delta_entry(rec, place, lidx, lval, self._delta_slot_cache)
+
+    def get_per_tensor_param_delta_shard(self, **kwargs):
+        """Yield the delta engine's steady payloads -- FINAL HF-coordinate entries
+        per mcore parameter (see the FSDP engine's method of the same name for the
+        contract; MegatronEngine extends BaseEngine directly, so the thin wrapper
+        is repeated here). Requires a prior :meth:`prime_delta_snapshots` call."""
+        from ..utils import hf_delta_export
+
+        self._delta_shard_snap = getattr(self, "_delta_shard_snap", {})
+        gen, _ = self.get_per_tensor_param_shard()
+        return hf_delta_export(gen, self._delta_shard_snap, self._hf_delta_entry), None
+
     def disable_adapter(self) -> ContextManager:
         return self.peft_cls.disable_adapter(self.module)
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -859,9 +859,9 @@ class MegatronEngine(BaseEngine):
 
     def get_per_tensor_param_shard(self, **kwargs):
         """Yield each rank's *local* mcore shard ``(name, local_flat_bf16,
-        ShardSpec)`` -- the geometry comes from the Megatron-Bridge param
-        mappings (TP partition dims, EP virtual expert tensors). Pure export,
-        no side effects. TP+EP only (PP=1 asserted in the index builder)."""
+        ShardSpec)`` -- the spec carries only the wire merge group (the
+        comm-stubbed probe owns all shard geometry). Pure export, no side
+        effects. TP+EP only (PP=1 asserted in the index builder)."""
         load_megatron_model_to_gpu(self.module, load_grad=False)
         index = self._mcore_export_index()
 
@@ -876,7 +876,8 @@ class MegatronEngine(BaseEngine):
 
     def _hf_delta_entry(self, name, spec, place, lidx, lval):
         """mcore's per-param entry builder: probe the bridge's own converter
-        (degenerate-PG copy, pure transform) with NaN sentinels -- see
+        (comm-stubbed copy -- real group sizes, gathers synthesized locally)
+        with NaN sentinels -- see
         :func:`verl.workers.engine.megatron.delta_export.mcore_hf_delta_entry`."""
         from .delta_export import mcore_hf_delta_entry
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -76,6 +76,13 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class MegatronEngine(BaseEngine):
+    # mcore keeps model-parallel-local params resident and moves large host
+    # buffers every step; pinning the whole delta snapshot set on top of that
+    # starves the node's cudaHostAlloc pool and surfaces as CUDA OOM in
+    # unrelated allocations (observed at 30B/235B) -- pageable is the safe
+    # default here.
+    delta_pin_snapshots = False
+
     def __init__(
         self,
         model_config: HFModelConfig,

--- a/verl/workers/engine/spec.py
+++ b/verl/workers/engine/spec.py
@@ -76,10 +76,11 @@ class ShardSpec:
     contributes: bool = True
     # Optional dim-0-separable converter: ``to_hf_chunk(dim0_start, segment)`` converts a
     # contiguous dim-0 segment ``full[dim0_start : dim0_start + segment.shape[0]]`` of the
-    # logical tensor to ``[(hf_name, hf_tensor)]``. When set on a block-converter spec the
-    # engine rebuilds and converts in bounded dim-0 segments instead of materializing the
-    # whole logical tensor on rank 0 (e.g. a fused expert stack: each segment is a run of
-    # whole experts and the converter only needs the segment plus its starting expert id).
+    # logical tensor to ``[(hf_name, hf_tensor)]``. Consumed by the SENDER-side NaN row
+    # probe (see the veomni backend's ``convert_row_to_hf``): each rank converts only its
+    # own touched dim-0 rows, so no rank ever materializes the whole logical tensor (e.g.
+    # a fused expert stack: each segment is a run of whole experts and the converter only
+    # needs the segment plus its starting expert id).
     to_hf_chunk: Optional[Callable[[int, torch.Tensor], list[tuple[str, torch.Tensor]]]] = None
     # Optional full slot enumeration for dim-0-separable converters: one
     # ``(hf_name, hf_shape)`` per converter output, in dim-0 order and matching

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -226,15 +226,21 @@ def hf_delta_export(gen, snaps: dict, entry_fn):
 def prime_delta_snapshots(gen, snaps: dict) -> None:
     """Pin each rank's current shards to CPU as the steady diff base. Run right
     after the seed's full-weight sync: weights do not move during the sync, so
-    the snapshots equal exactly what the rollout side received."""
+    the snapshots equal exactly what the rollout side received.
+
+    ``VERL_DELTA_PIN=0`` keeps the snapshots in pageable host memory: pinning a
+    whole shard set (cudaHostAlloc) competes with everything else that pins on
+    the node and its failure surfaces as a CUDA out-of-memory; pageable costs a
+    slower H2D on the diff read-back but cannot OOM the device."""
+    import os
+
     from verl.utils.device import is_cuda_available
 
+    pin = is_cuda_available and os.getenv("VERL_DELTA_PIN", "1") == "1"
     for name, local, _spec in gen:
         local = local.detach().contiguous().view(-1)
         snap = snaps.get(name)
         if snap is None or snap.numel() != local.numel():
-            # pinned host memory needs an accelerator context; degrade gracefully
-            # on CPU-only environments (unit tests) where pinning is meaningless.
-            snap = torch.empty_like(local, device="cpu", pin_memory=is_cuda_available)
+            snap = torch.empty_like(local, device="cpu", pin_memory=pin)
             snaps[name] = snap
         snap.copy_(local, non_blocking=True)

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -223,20 +223,16 @@ def hf_delta_export(gen, snaps: dict, entry_fn):
         yield (*entry_fn(name, spec, place, lidx, lval), pg)
 
 
-def prime_delta_snapshots(gen, snaps: dict) -> None:
-    """Pin each rank's current shards to CPU as the steady diff base. Run right
-    after the seed's full-weight sync: weights do not move during the sync, so
-    the snapshots equal exactly what the rollout side received.
+def prime_delta_snapshots(gen, snaps: dict, pin: bool) -> None:
+    """Snapshot each rank's current shards to CPU as the steady diff base. Run
+    right after the seed's full-weight sync: weights do not move during the
+    sync, so the snapshots equal exactly what the rollout side received.
 
-    ``VERL_DELTA_PIN=0`` keeps the snapshots in pageable host memory: pinning a
-    whole shard set (cudaHostAlloc) competes with everything else that pins on
-    the node and its failure surfaces as a CUDA out-of-memory; pageable costs a
-    slower H2D on the diff read-back but cannot OOM the device."""
-    import os
-
-    from verl.utils.device import is_cuda_available
-
-    pin = is_cuda_available and os.getenv("VERL_DELTA_PIN", "1") == "1"
+    ``pin`` selects pinned vs pageable host memory and is the ENGINE's call
+    (``BaseEngine.delta_pin_snapshots``): pinning a whole shard set
+    (cudaHostAlloc) competes with everything else that pins on the node and its
+    failure surfaces as a CUDA out-of-memory; pageable costs a slower H2D on
+    the diff read-back but cannot OOM the device."""
     for name, local, _spec in gen:
         local = local.detach().contiguous().view(-1)
         snap = snaps.get(name)

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -120,43 +120,46 @@ _VERIFY_STATS: dict = {"params": 0, "pieces": []}
 
 
 def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tensor, is_last: bool) -> None:
-    """State-equivalence sweep: the trainer streams its FULL current weights and
-    every ``copy_`` destination (the exact internal slice sglang's own
-    ``load_weights`` name-mapping resolves) is bit-compared against what the
-    server already holds BEFORE being overwritten. Zero mismatched elements
-    proves the server's delta-accumulated state was bit-identical to the
-    trainer's -- end to end, through sglang's own fusion/sharding mapping,
-    independent of generation or log-probs. Mismatches fail loud."""
+    """State-equivalence sweep, phrased as an IDEMPOTENCE check: replaying the
+    trainer's FULL current weights onto an in-sync server must be a no-op. For
+    each parameter we snapshot every ``copy_`` destination (the exact internal
+    slices sglang's own ``load_weights`` name-mapping resolves) BEFORE the
+    load, run the real load path -- including multi-stage loaders that first
+    write raw values and then transform in place (e.g. mamba's
+    ``A = -exp(A_log)`` composed loader) -- and bit-compare the post-load state
+    against the snapshot. Any changed element means the server's
+    delta-accumulated state disagreed with the trainer's; that fails loud.
+    Comparing per copy_ call instead would false-positive on every
+    transform-loaded param (raw-vs-transformed at each stage)."""
     orig_copy = torch.Tensor.copy_
 
-    def compare_then_copy_(self: torch.Tensor, src: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-        if isinstance(src, torch.Tensor) and src.is_floating_point() and self.shape == src.shape:
-            cast = src.to(self.dtype)
-            if self.dtype.is_floating_point and self.element_size() == 2:
-                diff = (self.view(torch.int16) != cast.view(torch.int16)).sum()
-            else:
-                diff = (self != cast).sum()
-            _VERIFY_STATS["pieces"].append(diff)  # stays on device; one sync at sweep end
-            return orig_copy(self, cast)
-        return orig_copy(self, src, *args, **kwargs)
+    by_param = _VERIFY_STATS.setdefault("by_param", {})
+    for p in params:
+        touched: dict = {}
 
-    torch.Tensor.copy_ = compare_then_copy_
-    try:
-        # one param at a time so mismatches attribute to a name (this is a
-        # diagnostic sweep; the extra per-param sync is irrelevant next to the
-        # wire transfer itself)
-        by_param = _VERIFY_STATS.setdefault("by_param", {})
-        for p in params:
-            start = len(_VERIFY_STATS["pieces"])
+        def snap_then_copy_(self: torch.Tensor, src: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+            key = (self.data_ptr(), self.numel(), self.dtype)
+            if key not in touched:
+                touched[key] = (self, self.detach().clone())
+            return orig_copy(self, src, *args, **kwargs)
+
+        torch.Tensor.copy_ = snap_then_copy_
+        try:
             _apply_dense(model, [p], values)
-            bad = sum(int(d.cpu()) for d in _VERIFY_STATS["pieces"][start:])
-            if bad:
-                by_param[p["name"]] = by_param.get(p["name"], 0) + bad
-    finally:
-        torch.Tensor.copy_ = orig_copy
+        finally:
+            torch.Tensor.copy_ = orig_copy
+        bad = 0
+        for dst, pre in touched.values():
+            if dst.is_floating_point() and dst.element_size() == 2:
+                bad += int((dst.view(torch.int16) != pre.view(torch.int16)).sum())
+            else:
+                bad += int((dst != pre).sum())
+        if bad:
+            by_param[p["name"]] = by_param.get(p["name"], 0) + bad
+        _VERIFY_STATS["pieces"].append(bad)
     _VERIFY_STATS["params"] += len(params)
     if is_last:
-        total = int(torch.stack([d.cpu() for d in _VERIFY_STATS["pieces"]]).sum()) if _VERIFY_STATS["pieces"] else 0
+        total = sum(_VERIFY_STATS["pieces"])
         n = _VERIFY_STATS["params"]
         _VERIFY_STATS["params"] = 0
         _VERIFY_STATS["pieces"] = []

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -142,7 +142,16 @@ def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tens
 
     torch.Tensor.copy_ = compare_then_copy_
     try:
-        _apply_dense(model, params, values)
+        # one param at a time so mismatches attribute to a name (this is a
+        # diagnostic sweep; the extra per-param sync is irrelevant next to the
+        # wire transfer itself)
+        by_param = _VERIFY_STATS.setdefault("by_param", {})
+        for p in params:
+            start = len(_VERIFY_STATS["pieces"])
+            _apply_dense(model, [p], values)
+            bad = sum(int(d.cpu()) for d in _VERIFY_STATS["pieces"][start:])
+            if bad:
+                by_param[p["name"]] = by_param.get(p["name"], 0) + bad
     finally:
         torch.Tensor.copy_ = orig_copy
     _VERIFY_STATS["params"] += len(params)
@@ -151,11 +160,14 @@ def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tens
         n = _VERIFY_STATS["params"]
         _VERIFY_STATS["params"] = 0
         _VERIFY_STATS["pieces"] = []
-        logger.warning("DELTA-VERIFY sweep: params=%d mismatch_elems=%d", n, total)
+        offenders = _VERIFY_STATS.pop("by_param", {})
+        top = sorted(offenders.items(), key=lambda kv: -kv[1])[:12]
+        logger.warning("DELTA-VERIFY sweep: params=%d mismatch_elems=%d offenders=%s", n, total, top)
         if total:
             raise RuntimeError(
                 f"delta state verification FAILED: {total} elements differ between the "
-                f"server's delta-accumulated weights and the trainer's full export"
+                f"server's delta-accumulated weights and the trainer's full export; "
+                f"top offenders: {top}"
             )
 
 

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -137,10 +137,10 @@ def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tens
     for p in params:
         touched: dict = {}
 
-        def snap_then_copy_(self: torch.Tensor, src: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        def snap_then_copy_(self: torch.Tensor, src: torch.Tensor, *args, _touched=touched, **kwargs) -> torch.Tensor:
             key = (self.data_ptr(), self.numel(), self.dtype)
-            if key not in touched:
-                touched[key] = (self, self.detach().clone())
+            if key not in _touched:
+                _touched[key] = (self, self.detach().clone())
             return orig_copy(self, src, *args, **kwargs)
 
         torch.Tensor.copy_ = snap_then_copy_

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -41,11 +41,14 @@ Register at server launch (verl config)::
 from __future__ import annotations
 
 import json
+import logging
 import math
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 # Cap on the densified tensors handed to one model.load_weights call, matching
 # SGLang's own delta-apply chunking default.
@@ -74,6 +77,9 @@ def apply_delta(model: torch.nn.Module, named_tensors: Iterable[tuple[str, torch
         )
 
     if spec["encoding"] == "dense":
+        if spec.get("verify"):
+            _verify_dense(model, spec["params"], values, bool(spec.get("is_last")))
+            return
         _apply_dense(model, spec["params"], values)
         return
 
@@ -108,6 +114,49 @@ def _apply_dense(model: torch.nn.Module, params: list[dict], values: torch.Tenso
         chunk_bytes += nbytes
     if chunk:
         model.load_weights(chunk)
+
+
+_VERIFY_STATS: dict = {"params": 0, "pieces": []}
+
+
+def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tensor, is_last: bool) -> None:
+    """State-equivalence sweep: the trainer streams its FULL current weights and
+    every ``copy_`` destination (the exact internal slice sglang's own
+    ``load_weights`` name-mapping resolves) is bit-compared against what the
+    server already holds BEFORE being overwritten. Zero mismatched elements
+    proves the server's delta-accumulated state was bit-identical to the
+    trainer's -- end to end, through sglang's own fusion/sharding mapping,
+    independent of generation or log-probs. Mismatches fail loud."""
+    orig_copy = torch.Tensor.copy_
+
+    def compare_then_copy_(self: torch.Tensor, src: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        if isinstance(src, torch.Tensor) and src.is_floating_point() and self.shape == src.shape:
+            cast = src.to(self.dtype)
+            if self.dtype.is_floating_point and self.element_size() == 2:
+                diff = (self.view(torch.int16) != cast.view(torch.int16)).sum()
+            else:
+                diff = (self != cast).sum()
+            _VERIFY_STATS["pieces"].append(diff)  # stays on device; one sync at sweep end
+            return orig_copy(self, cast)
+        return orig_copy(self, src, *args, **kwargs)
+
+    torch.Tensor.copy_ = compare_then_copy_
+    try:
+        _apply_dense(model, params, values)
+    finally:
+        torch.Tensor.copy_ = orig_copy
+    _VERIFY_STATS["params"] += len(params)
+    if is_last:
+        total = int(torch.stack([d.cpu() for d in _VERIFY_STATS["pieces"]]).sum()) if _VERIFY_STATS["pieces"] else 0
+        n = _VERIFY_STATS["params"]
+        _VERIFY_STATS["params"] = 0
+        _VERIFY_STATS["pieces"] = []
+        logger.warning("DELTA-VERIFY sweep: params=%d mismatch_elems=%d", n, total)
+        if total:
+            raise RuntimeError(
+                f"delta state verification FAILED: {total} elements differ between the "
+                f"server's delta-accumulated weights and the trainer's full export"
+            )
 
 
 def _decode_one(encoding: str, positions: torch.Tensor, values: torch.Tensor, p: dict) -> torch.Tensor:


### PR DESCRIPTION
### What does this PR do?

The mcore backend joins the sharded-delta contract (#7144). #7085 (veomni EP) is merged; this branch is rebased onto latest main, so the diff is the megatron/engine increment only. Everything rides Megatron-Bridge's own per-param machinery — no legacy converters, no hand-written index math:

- **Export index**: `AutoBridge.get_conversion_tasks` enumerates parameters; each becomes a `ShardSpec` (TP partition dims → `BlockPlacement` over the TP group; expert tensors → virtual `[ep, *etp]` blocks over the etp×ep group; replicated → the engine's rank-0 direct path). No hand-derived geometry: the engine only consumes `gather_group` + the replicated-rank0 rule.
- **Comm-stub probe**: each mapping's `megatron_to_hf` runs on a probe copy whose process groups are `_ProbeGroup`s (real `size()`/`rank()`, any collective raises) and whose gather helpers are stubbed to pure local semantics — NaN sentinels through the REAL converter code give final HF coordinates with zero collectives and zero converter forks. This keeps converters with real value math (Mamba's TP de-interleave, GQA fusions) bit-exact, which the earlier "degenerate world" probe could not.
- **Idempotence verify sweep** (`verify_every=K` engine kwarg): every K-th sync appends a full re-export in the same receive session; the rollout loader snapshots every `copy_` destination before its real load path, re-applies, and fails loud on any bitwise divergence — a production-grade end-to-end oracle that tolerates multi-stage loaders (e.g. sglang's composed A_log loader).
- **Perf**: shape-pooled NaN probe buffers (Opt-A) and an empty-delta short-circuit reusing the slot cache (Opt-B); snapshots default to pageable host memory on mcore (`delta_pin_snapshots = False` class attr — pinning whole shard sets surfaces as CUDA OOM at 30B/235B scale).

Scope: TP+EP+ETP, PP=1/VPP=1, no LoRA, Megatron-Bridge flavor only.

### Test

| check | result |
|---|---|
| D1 equivalence (tiny Qwen2, real bridge, 1 GPU) | probe entries == bitwise diff of the bridge's own full HF export, 22/22 HF tensors |
| **TP2 differential oracle** (`tests/special_distributed/test_mcore_probe_differential.py`) | real `megatron_to_hf` vs merged probe outputs, bitwise, on qwen2 / qwen3_moe / **nemotron_h (Mamba)** / falcon_h1 |
| **7B TP2** e2e | uw 3.8–4.9s steady; idempotence sweeps (v=2/4/6) zero mismatch |
| **30B-A3B TP1×EP8 + moe_grouped_gemm** | uw 14.5–17.6s steady (hand-written-converter baseline: 17.2–19.7s) |
| **235B-A22B TP4×EP16×PP1 + grouped_gemm** (16 trainer GPUs + TP16 rollout) | seed 107.6s/437.9GB; steady uw **23.6/23.7s**, payload ~20GB/step; same-shape NCCL full sync: **235.0–237.6s/step → delta is 8.2–9.7×**, seed < half one NCCL step |
| **hybrid-Mamba e2e** (NVIDIA-Nemotron-Nano-9B-v2, TP1 and TP2) | 6 steps + 3 full idempotence sweeps (3.39B elems each) zero mismatch; 50-step GRPO W&B pair mechanically green |
| Opt-A regression | comm-stub refactor cost +25–40% at 235B; pooled buffers recovered to 23.6/23.7s (baseline 24.3–29.5s) |
| Opt-B | empty-delta short-circuit validated 7B TP2 e2e + sweeps |
| CPU suites | tests/checkpoint_engine 32 passed |

### Additional Info


- Perf follow-ups (not this PR): closed-form index tables for the hottest mapping families (#7060), PP steady relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)