### PR TITLE
[rollout, vllm, hardware]fix: add IPC check before invoking ipc_collect in BucketedWeightReceiver

### DIFF
--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -27,7 +27,7 @@ import torch
 import zmq
 from torch.multiprocessing.reductions import reduce_tensor
 
-from verl.utils.device import get_device_id, get_device_name, get_torch_device
+from verl.utils.device import get_device_id, get_device_name, get_torch_device, is_support_ipc
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -212,7 +212,8 @@ class BucketedWeightSender:
             del self.shm
             self.shm = None
         gc.collect()
-        get_torch_device().ipc_collect()
+        if is_support_ipc():
+            get_torch_device().ipc_collect()
         get_torch_device().empty_cache()
 
     def _direct_send_large_weight(self, name: str, weight: torch.Tensor):
@@ -331,5 +332,6 @@ class BucketedWeightReceiver:
             del self.shm
             self.shm = None
         gc.collect()
-        get_torch_device().ipc_collect()
+        if is_support_ipc():
+            get_torch_device().ipc_collect()
         get_torch_device().empty_cache()


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

fix the runtime error when some device did not support IPC during bucketed weight receiver.
The solution will utilize the abstract device method to check the IPC before trigger

similar IPC check used during [SHM](https://github.com/verl-project/verl/blob/main/verl/workers/rollout/vllm_rollout/vllm_rollout.py#L156). so, this is needed too.
/home/sdp/lun/verl/verl/workers/rollout/vllm_rollout/vllm_rollout.py

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- https://github.com/verl-project/verl/pulls?q=is%3Apr+ipc_collect+is%3Aopen
- [x ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
--
to put the log of A100 before convert to Ready PR.

The 5 skipped are TestBucketedWeightTransferSHM — those only run on non-CUDA accelerators (NPU). All 8 CUDA/IPC tests pass including test_large_weight which exercises the _cleanup() path with the PR fix.

Image: verlai/verl:vllm017.latest (torch 2.10 + vllm 0.17.0 — properly )
Branch: bucketed_weight_transfer_enable_ipc_check (PR branch)
GPUs: GPU 1 + GPU 2 (A100 80GB each, passed via UUID)
Test: pytest tests/utils/test_bucketed_weight_transfer.py — the official test file for this exact PR
[/workspace/verl/examples/grpo_trainer/run_qwen3_4b_fsdp.sh log](https://gist.github.com/kahlun/e6c97a47b9e3668fbf1eaf8e857adf0d)

--

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
