### PR TITLE
  [rollout] feat: support MXFP8 rollout quantization

### DIFF
--- a/tests/utils/test_sglang_mxfp8_utils.py
+++ b/tests/utils/test_sglang_mxfp8_utils.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import torch
+
+from verl.utils.sglang import sglang_mxfp8_utils as mxfp8
+
+
+async def _collect(async_iterable):
+    return [item async for item in async_iterable]
+
+
+def test_get_mxfp8_quant_config_returns_expected_fields():
+    config = mxfp8.get_mxfp8_quant_config()
+
+    assert config["activation_scheme"] == "dynamic"
+    assert config["fmt"] == "e4m3"
+    assert config["quant_method"] == "mxfp8"
+    assert config["weight_block_size"] == [1, 32]
+    assert config["scale_fmt"] == "ue8m0"
+    # Mirrors the FP8 hardcode: exactly these five fields, no module skip lists.
+    assert set(config) == {"activation_scheme", "fmt", "quant_method", "weight_block_size", "scale_fmt"}
+
+
+def test_should_quantize_param_matches_fp8_policy():
+    # SGLangMXFP8QuantizerHelper reuses the base FP8 should_quantize_param, so the
+    # selection policy here mirrors verl/utils/fp8_utils.py (name-based, no shape check).
+    helper = mxfp8.SGLangMXFP8QuantizerHelper(mxfp8.get_mxfp8_quant_config())
+    quantizable = torch.empty(8, 64, dtype=torch.bfloat16)
+
+    assert helper.should_quantize_param("model.layers.0.self_attn.q_proj.weight", quantizable)
+    assert helper.should_quantize_param("model.layers.0.mlp.gate_proj.weight", quantizable)
+    assert not helper.should_quantize_param("model.layers.0.mlp.gate.weight", quantizable)
+    assert not helper.should_quantize_param("model.layers.0.input_layernorm.weight", quantizable)
+    assert not helper.should_quantize_param("model.embed_tokens.weight", quantizable)
+    assert not helper.should_quantize_param("model.layers.0.self_attn.q_proj.bias", quantizable)
+
+
+def test_quant_weights_by_name_emits_mxfp8_scale_tensor(monkeypatch):
+    def fake_quantize(tensor_2d):
+        qweight = torch.zeros(tensor_2d.shape, dtype=torch.uint8)
+        scale = torch.ones((tensor_2d.shape[0], tensor_2d.shape[1] // 32), dtype=torch.uint8)
+        return qweight, scale
+
+    monkeypatch.setattr(mxfp8, "_quantize_with_sglang", fake_quantize)
+
+    helper = mxfp8.SGLangMXFP8QuantizerHelper(mxfp8.get_mxfp8_quant_config())
+    weights = [
+        ("model.layers.0.self_attn.q_proj.weight", torch.randn(2, 64, dtype=torch.bfloat16)),
+        ("model.layers.0.input_layernorm.weight", torch.randn(64, dtype=torch.bfloat16)),
+    ]
+
+    result = asyncio.run(_collect(helper.quant_weights_by_name(weights)))
+
+    assert [name for name, _ in result] == [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.q_proj.weight_scale_inv",
+        "model.layers.0.input_layernorm.weight",
+    ]
+    assert result[0][1].shape == torch.Size([2, 64])
+    assert result[1][1].shape == torch.Size([2, 2])
+    assert result[1][1].dtype == torch.uint8
+    assert result[2][1] is weights[1][1]

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -449,7 +449,8 @@ prometheus:
   # Specify served_model_name to avoid displaying overly long model paths in Grafana
   served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
 
-# type of quantization in vllm, currently support fp8 and torchao
+# type of quantization in inference engine.
+# vLLM supports fp8 and torchao; SGLang supports fp8 and mxfp8.
 quantization: null
 
 # extra quantization information serialized in a config file, e.g. torchao_config.json

--- a/verl/utils/sglang/sglang_mxfp8_utils.py
+++ b/verl/utils/sglang/sglang_mxfp8_utils.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from typing import Any
+
+import torch
+
+from verl.utils.fp8_utils import FP8QuantizerHelper
+from verl.workers.rollout.utils import ensure_async_iterator
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+TARGET_MXFP8_BLOCK_SIZE = [1, 32]
+# Mirror the FP8 hardcode (activation_scheme / fmt / quant_method / weight_block_size),
+# plus scale_fmt for the MXFP8 UE8M0 scales.
+MXFP8_BLOCK_QUANT_KWARGS: dict[str, Any] = {
+    "activation_scheme": "dynamic",
+    "fmt": "e4m3",
+    "quant_method": "mxfp8",
+    "weight_block_size": TARGET_MXFP8_BLOCK_SIZE,
+    "scale_fmt": "ue8m0",
+}
+
+
+def get_mxfp8_quant_config() -> dict[str, Any]:
+    return dict(MXFP8_BLOCK_QUANT_KWARGS)
+
+
+def _quantize_with_sglang(tensor_2d: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    # SGLang's triton MXFP8 helper: FP8 E4M3 weights + UE8M0 (uint8) scales grouped
+    # along the input dim in chunks of 32, in SGLang's swizzle-free layout.
+    from sglang.srt.layers.quantization.fp8_utils import mxfp8_group_quantize
+
+    return mxfp8_group_quantize(tensor_2d)
+
+
+class SGLangMXFP8QuantizerHelper(FP8QuantizerHelper):
+    """Quantize SGLang rollout weights to MXFP8."""
+
+    def should_quantize_param(self, param_name, tensor=None):
+        # Keep the optional tensor argument for MXFP8 callers while intentionally
+        # using the same name-based selection policy as the upstream FP8 helper.
+        return super().should_quantize_param(param_name)
+
+    async def quant_weights_by_name(self, weights, dtype=torch.bfloat16):
+        if isinstance(self.quant_config, dict):
+            weight_block_size = self.quant_config.get("weight_block_size")
+        else:
+            weight_block_size = getattr(self.quant_config, "weight_block_size", None)
+
+        if weight_block_size is None:
+            raise ValueError("weight_block_size not found in quant_config")
+
+        async for param_name, tensor in ensure_async_iterator(weights):
+            if not self.should_quantize_param(param_name, tensor):
+                yield (param_name, tensor)
+                continue
+
+            if (
+                torch.distributed.is_available()
+                and torch.distributed.is_initialized()
+                and torch.distributed.get_rank() == 0
+            ):
+                logger.debug(f"Quantizing to MXFP8: {param_name}")
+
+            # Do not silently fall back to bf16 on failure: an MXFP8-configured
+            # rollout engine cannot consume an unquantized weight in this slot.
+            tensor_2d = tensor.to(dtype).reshape(-1, tensor.shape[-1]).contiguous()
+            param_lp, param_scale = _quantize_with_sglang(tensor_2d)
+            scale = param_scale.view(
+                *tensor.shape[:-1],
+                tensor.shape[-1] // TARGET_MXFP8_BLOCK_SIZE[1],
+            ).contiguous()
+
+            yield (param_name, param_lp.view_as(tensor))
+            yield (param_name + "_scale_inv", scale)
+
+            del tensor_2d, param_lp, param_scale, scale

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -289,8 +289,17 @@ class SGLangHttpServer:
                     "sglang>=0.5.5 is required for FP8 quantization"
                 )
                 fp8_block_quant_kwargs = build_sglang_fp8_quant_config(self.model_config.hf_config)
+            elif quantization == "mxfp8":
+                from verl.utils.sglang.sglang_mxfp8_utils import get_mxfp8_quant_config
+
+                mxfp8_block_quant_kwargs = get_mxfp8_quant_config()
             else:
-                raise ValueError(f"Currently only support fp8 quantization, got: {quantization}")
+                raise ValueError(f"Currently only support fp8 and mxfp8 quantization, got: {quantization}")
+        quantization_config = None
+        if quantization == "fp8":
+            quantization_config = fp8_block_quant_kwargs
+        elif quantization == "mxfp8":
+            quantization_config = mxfp8_block_quant_kwargs
         infer_tp = self.config.tensor_model_parallel_size * self.config.data_parallel_size
         args = {
             "model_path": self.model_config.local_path,
@@ -314,8 +323,8 @@ class SGLangHttpServer:
             "skip_tokenizer_init": self.config.skip_tokenizer_init,
             "skip_server_warmup": True,
             "quantization": quantization,
-            "json_model_override_args": json.dumps({"quantization_config": fp8_block_quant_kwargs})
-            if quantization == "fp8"
+            "json_model_override_args": json.dumps({"quantization_config": quantization_config})
+            if quantization_config is not None
             else json.dumps({}),
             "custom_weight_loader": custom_weight_loader or None,
             **engine_kwargs,

--- a/verl/workers/rollout/sglang_rollout/http_server_engine.py
+++ b/verl/workers/rollout/sglang_rollout/http_server_engine.py
@@ -387,6 +387,22 @@ class HttpServerAdapter(EngineBase):
             },
         )
 
+    def post_process_weights(
+        self,
+        restore_weights_before_load: bool = False,
+        post_process_quantization: bool = False,
+        post_load_weights: bool = False,
+    ) -> dict[str, Any]:
+        """Run SGLang's post-update weight processing hooks."""
+        return self._make_request(
+            "post_process_weights",
+            {
+                "restore_weights_before_load": restore_weights_before_load,
+                "post_process_quantization": post_process_quantization,
+                "post_load_weights": post_load_weights,
+            },
+        )
+
     def shutdown(self) -> None:
         """Shutdown the HTTP server and clean up resources.
 
@@ -771,6 +787,22 @@ class AsyncHttpServerAdapter(HttpServerAdapter):
                 "serialized_named_tensors": serialized_named_tensors,
                 "load_format": load_format,
                 "flush_cache": flush_cache,
+            },
+        )
+
+    async def post_process_weights(
+        self,
+        restore_weights_before_load: bool = False,
+        post_process_quantization: bool = False,
+        post_load_weights: bool = False,
+    ) -> dict[str, Any]:
+        """Run SGLang's post-update weight processing hooks asynchronously."""
+        return await self._make_async_request(
+            "post_process_weights",
+            {
+                "restore_weights_before_load": restore_weights_before_load,
+                "post_process_quantization": post_process_quantization,
+                "post_load_weights": post_load_weights,
             },
         )
 

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -127,6 +127,10 @@ class ServerAdapter(BaseRollout):
             )
             fp8_block_quant_kwargs = build_sglang_fp8_quant_config(self.model_config.hf_config)
             self.model_config.hf_config.quantization_config = fp8_block_quant_kwargs
+        elif self.config.get("quantization", None) == "mxfp8":
+            from verl.utils.sglang.sglang_mxfp8_utils import get_mxfp8_quant_config
+
+            self.model_config.hf_config.quantization_config = get_mxfp8_quant_config()
         self._engine: AsyncHttpServerAdapter = None
 
         rank = int(os.environ["RANK"])
@@ -343,12 +347,22 @@ class ServerAdapter(BaseRollout):
                 await self._engine.load_lora_adapter_from_tensor(req)
         else:
             update_weights_bucket_bytes = int(self.config.checkpoint_engine.update_weights_bucket_megabytes) << 20
+
             if self.config.get("quantization", None) == "fp8":
                 from verl.utils.sglang.sglang_fp8_utils import SGLangFP8QuantizerHelper
 
                 logger.info("Convert bf16 weights to fp8 format before loading")
                 fp8_quantizer_helper = SGLangFP8QuantizerHelper(self.model_config.hf_config.quantization_config)
                 weights = fp8_quantizer_helper.quant_weights_by_name(
+                    weights,
+                    dtype=self.model_config.hf_config.dtype,
+                )
+            elif self.config.get("quantization", None) == "mxfp8":
+                from verl.utils.sglang.sglang_mxfp8_utils import SGLangMXFP8QuantizerHelper
+
+                logger.info("Convert bf16 weights to mxfp8 format before loading")
+                mxfp8_quantizer_helper = SGLangMXFP8QuantizerHelper(self.model_config.hf_config.quantization_config)
+                weights = mxfp8_quantizer_helper.quant_weights_by_name(
                     weights,
                     dtype=self.model_config.hf_config.dtype,
                 )
@@ -364,6 +378,9 @@ class ServerAdapter(BaseRollout):
                 )
 
         if self._engine is not None and self._is_server_tp_leader():
+            if self.config.get("quantization", None) == "mxfp8":
+                logger.info("Post-process SGLang MXFP8 weights after loading")
+                await self._engine.post_process_weights(post_process_quantization=True)
             await self._engine.flush_cache()
             if global_steps is not None:
                 await self.server_actor.set_global_steps.remote(global_steps)


### PR DESCRIPTION
### What does this PR do?

This PR adds MXFP8 rollout weight quantization support for the SGLang backend.

  When `actor_rollout_ref.rollout.quantization=mxfp8` is enabled, verl dynamically quantizes updated higher-precision rollout weights into MXFP8 on the SGLang side. Selected linear and MoE expert weights are converted to FP8 E4M3 weights with UE8M0 inverse scales using a `[1, 32]` microscaling block size.
  
  The default rollout behavior is unchanged. MXFP8-specific imports, weight conversion, and post-processing are only activated when quantization=mxfp8.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [mxfp8](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+mxfp8)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`


### API and Usage Example

  Enable MXFP8 rollout through the configuration:
```
  actor_rollout_ref:
    rollout:
      name: sglang
      quantization: mxfp8
```

Install the required SGLang branch before running the MXFP8 recipe:
```
  pip install "sglang @ git+https://github.com/sgl-project/sglang.git@sglang-miles-v0.5.12-final#subdirectory=python"
```
  The complete Qwen3-30B-A3B example is provided by the recipe submodule under:
```
  low_precision/run_dapo_qwen3_moe_30b_mxfp8e2e.sh
```

### Experiment
- Recipe: DAPO recipe and DAPO dataset
- Model: Qwen3-30B-A3B 
- Setup: Training with Megatron, inference with sglang
- Token-level IS with C= 2

<img width="2214" height="1100" alt="image" src="https://github.com/user-attachments/assets/48a2d506-254f-4149-ac7d-15654b306b7e" />

verl-recipe PR: [verl-recipe/pull/127](https://github.com/verl-project/verl-recipe/pull/127)


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
