### PR TITLE
[fsdp, model] feat: support full-rank VLM modules with LoRA

### DIFF
--- a/docs/advance/ppo_lora.rst
+++ b/docs/advance/ppo_lora.rst
@@ -1,7 +1,7 @@
 RL(HF) algorithms with LoRA Support
 ===========================================
 
-Last updated: 02/03/2026.
+Last updated: 07/29/2026.
 
 We support LoRA (Low-Rank Adaptation) for reinforcement learning algorithms such as PPO, GRPO, and others.
 
@@ -45,6 +45,11 @@ FSDP Backend Usage Guide
 - `actor_rollout_ref.model.lora.merge`: bool, whether to merge LoRA adapters into the base model weights before transferring to the rollout engine (vLLM or SGLang).
    If True, LoRA adapters are merged into base weights and full merged weights are synced. If False, only LoRA adapter deltas are transferred natively.
    For SGLang, ``merge=True`` is currently required. Native adapter loading (``merge=False``) for SGLang is planned.
+- `actor_rollout_ref.model.modules_to_save`: list of module names to train fully and save with the PEFT adapter.
+   This is useful for VLM projectors or aligners that should remain fully trainable while the other target modules use LoRA.
+   Modules listed here are excluded from LoRA injection by PEFT. Because rollout engines cannot apply arbitrary full-rank
+   modules as LoRA deltas, verl automatically merges LoRA and synchronizes full weights when this option is set. This is
+   more expensive than native LoRA delta synchronization, so keep the listed modules small.
 
 5. Recommend options:
 

--- a/examples/tuning/lora/run_qwen2_5_vl_7b_fsdp.sh
+++ b/examples/tuning/lora/run_qwen2_5_vl_7b_fsdp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # GRPO + LoRA | vision | vLLM rollout | FSDP training | NVIDIA GPUs
-# LoRA freezes the vision tower by excluding `.*visual.*` modules.
+# LoRA freezes the vision tower while fully training its multimodal projector.
 
 set -xeuo pipefail
 
@@ -56,6 +56,7 @@ MODEL=(
     actor_rollout_ref.model.lora_alpha=${lora_alpha}
     actor_rollout_ref.model.target_modules=all-linear
     actor_rollout_ref.model.exclude_modules='.*visual.*'
+    actor_rollout_ref.model.modules_to_save='["visual.merger"]'
 )
 
 ACTOR=(

--- a/tests/utils/test_normalize_peft_param_name_on_cpu.py
+++ b/tests/utils/test_normalize_peft_param_name_on_cpu.py
@@ -12,12 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import nullcontext
+from types import SimpleNamespace
+
 import pytest
 import torch
 from peft import LoraConfig, get_peft_model
-from transformers import AutoModelForCausalLM, Qwen3Config
+from peft.utils.save_and_load import get_peft_model_state_dict
+from transformers import (
+    AutoModelForCausalLM,
+    Qwen2_5_VLConfig,
+    Qwen2_5_VLForConditionalGeneration,
+    Qwen2_5_VLVisionConfig,
+    Qwen3Config,
+)
 
+import verl.workers.engine.fsdp.transformer_impl as fsdp_transformer_impl
 from verl.utils.fsdp_utils import normalize_peft_param_name
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
 
 
 def create_base_model():
@@ -145,6 +157,121 @@ def test_normalize_peft_param_name_tensor_shapes_match(base_model, peft_model):
         base_shape = base_state_dict[key].shape
         peft_shape = normalized_peft_state_dict[key].shape
         assert base_shape == peft_shape, f"Shape mismatch for {key}: base={base_shape}, peft={peft_shape}"
+
+
+def test_normalize_peft_param_name_uses_active_modules_to_save():
+    """Test that full-weight sync uses the trainable modules_to_save copy."""
+    base_model = create_base_model()
+    lora_config = LoraConfig(
+        r=8,
+        lora_alpha=16,
+        target_modules="all-linear",
+        modules_to_save=["lm_head"],
+        lora_dropout=0.0,
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+    peft_model = get_peft_model(base_model, lora_config)
+    lm_head = peft_model.base_model.model.lm_head
+
+    with torch.no_grad():
+        lm_head.original_module.weight.zero_()
+        lm_head.modules_to_save["default"].weight.fill_(1.0)
+
+    normalized = normalize_peft_param_name(peft_model.state_dict())
+
+    assert set(normalized) == set(create_base_model().state_dict())
+    assert torch.all(normalized["lm_head.weight"] == 1.0)
+    assert not any("modules_to_save" in key or "original_module" in key for key in normalized)
+
+
+def test_fsdp_exporter_streams_active_modules_to_save(monkeypatch):
+    """Test that the merged FSDP export returns full weights without PEFT metadata."""
+    peft_model = get_peft_model(
+        create_base_model(),
+        LoraConfig(
+            r=8,
+            lora_alpha=16,
+            target_modules="all-linear",
+            modules_to_save=["lm_head"],
+            lora_dropout=0.0,
+            bias="none",
+            task_type="CAUSAL_LM",
+        ),
+    )
+    lm_head = peft_model.base_model.model.lm_head
+    with torch.no_grad():
+        lm_head.original_module.weight.zero_()
+        lm_head.modules_to_save["default"].weight.fill_(1.0)
+
+    engine = object.__new__(FSDPEngine)
+    engine.module = peft_model
+    engine.model_config = SimpleNamespace(should_merge_lora=True)
+    engine._uses_fsdp2_cpu_offload_policy = True
+    engine._is_offload_param = False
+
+    monkeypatch.setattr(fsdp_transformer_impl, "merged_lora_context", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fsdp_transformer_impl, "get_device_id", lambda: 0)
+    monkeypatch.setattr(fsdp_transformer_impl, "log_gpu_memory_usage", lambda *_args, **_kwargs: None)
+
+    per_tensor_param, peft_config = engine.get_per_tensor_param()
+    exported = dict(per_tensor_param)
+
+    assert peft_config is None
+    assert torch.all(exported["lm_head.weight"] == 1.0)
+    assert not any("modules_to_save" in key or "original_module" in key for key in exported)
+
+
+def test_vlm_projector_modules_to_save_semantics():
+    """Test that a VLM projector is fully trainable, saved, and excluded from LoRA."""
+    vision_config = Qwen2_5_VLVisionConfig(
+        depth=1,
+        hidden_size=16,
+        intermediate_size=32,
+        num_heads=2,
+        out_hidden_size=16,
+        patch_size=14,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+    )
+    config = Qwen2_5_VLConfig(
+        vision_config=vision_config,
+        text_config={
+            "model_type": "qwen2",
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "vocab_size": 128,
+        },
+        bos_token_id=1,
+        eos_token_id=2,
+        image_token_id=3,
+        video_token_id=4,
+        vision_start_token_id=5,
+        vision_end_token_id=6,
+    )
+    base_model = Qwen2_5_VLForConditionalGeneration(config)
+    peft_model = get_peft_model(
+        base_model,
+        LoraConfig(
+            r=2,
+            target_modules="all-linear",
+            exclude_modules=".*visual.*",
+            modules_to_save=["visual.merger"],
+            task_type="CAUSAL_LM",
+        ),
+    )
+
+    trainable_names = [name for name, param in peft_model.named_parameters() if param.requires_grad]
+    trainable_projector = [name for name in trainable_names if "visual.merger" in name]
+    adapter_state = get_peft_model_state_dict(peft_model, save_embedding_layers=False)
+
+    assert trainable_projector
+    assert all("modules_to_save.default" in name for name in trainable_projector)
+    assert not any("visual" in name and "lora_" in name for name in trainable_names)
+    assert any("visual.merger" in key for key in adapter_state)
 
 
 def test_normalize_peft_param_name_empty_dict():

--- a/tests/workers/config/test_model_config_on_cpu.py
+++ b/tests/workers/config/test_model_config_on_cpu.py
@@ -94,3 +94,18 @@ class TestHFModelConfigCPU:
         merged_config = OmegaConf.merge(base_config, invalid_cli_config)
         with pytest.raises(TypeError):
             OmegaConf.to_object(merged_config)
+
+    @pytest.mark.parametrize(
+        ("lora", "modules_to_save", "expected"),
+        [
+            ({"merge": False}, None, False),
+            ({"merge": True}, None, True),
+            ({"merge": False}, ["visual.merger"], True),
+        ],
+    )
+    def test_should_merge_lora(self, lora, modules_to_save, expected):
+        model_config = object.__new__(HFModelConfig)
+        object.__setattr__(model_config, "lora", lora)
+        object.__setattr__(model_config, "modules_to_save", modules_to_save)
+
+        assert model_config.should_merge_lora is expected

--- a/tests/workers/rollout/rollout_sglang/test_lora_merge_mode_on_cpu.py
+++ b/tests/workers/rollout/rollout_sglang/test_lora_merge_mode_on_cpu.py
@@ -38,6 +38,11 @@ class _StubModelConfig:
 
     lora_rank: int = 0
     lora: dict[str, Any] = field(default_factory=dict)
+    modules_to_save: list[str] | None = None
+
+    @property
+    def should_merge_lora(self) -> bool:
+        return self.lora.get("merge", False) or bool(self.modules_to_save)
 
 
 class TestLoraServedAsAdapter:
@@ -56,6 +61,10 @@ class TestLoraServedAsAdapter:
 
     def test_fsdp_adapter(self):
         assert lora_served_as_adapter(_StubModelConfig(lora_rank=8)) is True
+
+    def test_fsdp_modules_to_save_uses_merged_weights(self):
+        config = _StubModelConfig(lora_rank=8, modules_to_save=["visual.merger"])
+        assert lora_served_as_adapter(config) is False
 
     def test_merge_absent_defaults_to_adapter(self):
         assert lora_served_as_adapter(_StubModelConfig(lora_rank=8, lora={})) is True

--- a/tests/workers/rollout/rollout_sglang/test_lora_sleep_level.py
+++ b/tests/workers/rollout/rollout_sglang/test_lora_sleep_level.py
@@ -38,6 +38,11 @@ class _StubModelConfig:
 
     lora_rank: int = 0
     lora: dict[str, Any] = field(default_factory=dict)
+    modules_to_save: list[str] | None = None
+
+    @property
+    def should_merge_lora(self) -> bool:
+        return self.lora.get("merge", False) or bool(self.modules_to_save)
 
 
 @dataclass
@@ -64,7 +69,7 @@ class _LoraAsAdapterMixin:
     def lora_as_adapter(self) -> bool:
         return (
             self.model_config.lora_rank > 0 or self.model_config.lora.get("rank", 0) > 0
-        ) and not self.model_config.lora.get("merge", False)
+        ) and not self.model_config.should_merge_lora
 
 
 class _FakeServer(_LoraAsAdapterMixin):
@@ -99,6 +104,10 @@ class TestLoraAsAdapter:
 
     def test_lora_rank_in_dict_with_merge(self):
         server = _FakeServer(_StubModelConfig(lora_rank=0, lora={"rank": 16, "merge": True}))
+        assert server.lora_as_adapter is False
+
+    def test_modules_to_save_uses_merged_weights(self):
+        server = _FakeServer(_StubModelConfig(lora_rank=8, modules_to_save=["visual.merger"]))
         assert server.lora_as_adapter is False
 
 
@@ -187,19 +196,24 @@ class TestSGLangHttpServerSleepTags:
 
 
 class TestActorRolloutRefWorkerPeftMerge:
-    """Test that ActorRolloutRefWorker reads peft_merge from model.lora.merge."""
+    """Test that ActorRolloutRefWorker uses the shared full-sync decision."""
 
     def test_merge_true(self):
         mc = _StubModelConfig(lora_rank=8, lora={"merge": True})
-        peft_merge = mc.lora.get("merge", False)
+        peft_merge = mc.should_merge_lora
         assert peft_merge is True
 
     def test_merge_false(self):
         mc = _StubModelConfig(lora_rank=8, lora={"merge": False})
-        peft_merge = mc.lora.get("merge", False)
+        peft_merge = mc.should_merge_lora
         assert peft_merge is False
 
     def test_merge_absent_defaults_false(self):
         mc = _StubModelConfig(lora_rank=8, lora={})
-        peft_merge = mc.lora.get("merge", False)
+        peft_merge = mc.should_merge_lora
         assert peft_merge is False
+
+    def test_modules_to_save_enables_full_sync(self):
+        mc = _StubModelConfig(lora_rank=8, modules_to_save=["visual.merger"])
+        peft_merge = mc.should_merge_lora
+        assert peft_merge is True

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -456,6 +456,7 @@ actor_rollout_ref:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false
@@ -715,6 +716,7 @@ critic:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -402,6 +402,7 @@ actor_rollout_ref:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false
@@ -613,6 +614,7 @@ critic:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -407,6 +407,7 @@ actor_rollout_ref:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false
@@ -629,6 +630,7 @@ critic:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -412,6 +412,7 @@ actor_rollout_ref:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false
@@ -636,6 +637,7 @@ critic:
     lora_alpha: 16
     target_modules: all-linear
     exclude_modules: null
+    modules_to_save: null
     lora_adapter_path: null
     use_liger: false
     use_fused_kernels: false

--- a/verl/trainer/config/model/hf_model.yaml
+++ b/verl/trainer/config/model/hf_model.yaml
@@ -51,6 +51,9 @@ target_modules: all-linear
 # Exclude modules from LoRA adaptation
 exclude_modules: null
 
+# Modules to train fully and save alongside the LoRA adapter
+modules_to_save: null
+
 # Path to pre-trained LoRA adapter to load for continued training
 lora_adapter_path: null
 

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -192,7 +192,7 @@ def validate_config(
     lora_rank = lora_config.get("rank", 0)
     if lora_rank <= 0:
         lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
-    if lora_config.get("merge", False):
+    if lora_config.get("merge", False) or config.actor_rollout_ref.model.get("modules_to_save"):
         lora_rank = 0
     if lora_rank > 0 and config.actor_rollout_ref.rollout.name == "vllm":
         from verl.workers.rollout.vllm_rollout.utils import get_vllm_max_lora_rank

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -18,6 +18,7 @@ import json
 import logging
 import math
 import os
+import re
 from abc import ABC
 from collections import OrderedDict
 from contextlib import contextmanager, nullcontext
@@ -845,20 +846,23 @@ def normalize_peft_param_name(params: dict) -> dict:
     For example,
         base_model.model.model.embed_tokens.weight -> model.embed_tokens.weight
         base_model.model.model.layers.0.self_attn.q_proj.base_layer.weight -> model.layers.0.self_attn.q_proj.weight
+        base_model.model.visual.merger.modules_to_save.default.weight -> visual.merger.weight
     and remove params such as base_model.model.model.layers.0.self_attn.q_proj.lora_A.default.weight,
-    base_model.model.model.layers.0.self_attn.q_proj.lora_B.default.weight
+    base_model.model.model.layers.0.self_attn.q_proj.lora_B.default.weight, and frozen
+    ``original_module`` copies created by PEFT ``modules_to_save`` wrappers.
     """
 
     def _normalize_peft_name(name: str) -> str:
-        return name.replace("base_model.model.", "").replace("base_model.", "").replace(".base_layer", "")
+        name = name.replace("base_model.model.", "").replace("base_model.", "").replace(".base_layer", "")
+        return re.sub(r"\.modules_to_save\.[^.]+(?=\.|$)", "", name)
 
-    def _is_lora_key(name: str) -> bool:
+    def _is_adapter_key(name: str) -> bool:
         # catch typical PEFT keys
-        return ("lora_" in name) or (".adapter_" in name)
+        return ("lora_" in name) or (".adapter_" in name) or (".original_module." in name)
 
     params = [(_normalize_peft_name(k), v) for k, v in params.items()]
-    # strip any residual LoRA tensors
-    params = {k: v for k, v in params if not _is_lora_key(k)}
+    # strip adapter tensors and frozen copies while retaining active modules_to_save
+    params = {k: v for k, v in params if not _is_adapter_key(k)}
     return params
 
 

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -127,6 +127,7 @@ class HFModelConfig(BaseConfig):
     target_parameters: Optional[list[str]] = None  # for lora adapter on nn.Parameter
 
     exclude_modules: Optional[str] = None
+    modules_to_save: Optional[list[str]] = None
 
     # megatron lora config
     lora: dict[str, Any] = field(default_factory=dict)
@@ -144,6 +145,11 @@ class HFModelConfig(BaseConfig):
     architectures: Optional[list[str]] = None
 
     mtp: MtpConfig = field(default_factory=MtpConfig)
+
+    @property
+    def should_merge_lora(self) -> bool:
+        """Whether rollout synchronization needs full merged model weights."""
+        return self.lora.get("merge", False) or bool(self.modules_to_save)
 
     def __post_init__(self):
         import_external_libs(self.external_lib)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -340,6 +340,7 @@ class FSDPEngine(BaseEngine):
                 "target_modules": convert_to_regular_types(self.model_config.target_modules),
                 "target_parameters": convert_to_regular_types(self.model_config.target_parameters),
                 "exclude_modules": convert_to_regular_types(self.model_config.exclude_modules),
+                "modules_to_save": convert_to_regular_types(self.model_config.modules_to_save),
                 "bias": "none",
             }
             module = get_peft_model(module, LoraConfig(**lora_config))
@@ -935,13 +936,14 @@ class FSDPEngine(BaseEngine):
 
         log_gpu_memory_usage("After load_fsdp_model_to_gpu", logger=logger)
 
-        peft_config = None
-        merge_lora = self.model_config.lora.get("merge", False)
-
         peft_model = getattr(self.module, "_fsdp_wrapped_module", self.module)
+        peft_config = peft_model.peft_config.get("default", None) if hasattr(peft_model, "peft_config") else None
+        # PEFT modules_to_save are full-rank parameters, not LoRA deltas. Rollout
+        # engines therefore need the merged full weights to receive their updates.
+        merge_lora = self.model_config.should_merge_lora
+
         if hasattr(peft_model, "peft_config"):  # LoRA
             if not merge_lora:
-                peft_config = peft_model.peft_config.get("default", None)
                 params = collect_lora_params(
                     module=self.module,
                     layered_summon=layered_summon,

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -666,7 +666,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             # used for LoRA (base_sync_done is unused in merge-only mode but kept for Phase 2 adapter path)
             self.base_sync_done: bool = "dummy" not in self.config.rollout.load_format
             self.layered_summon = self.config.rollout.get("layered_summon", False)
-            self.peft_merge: bool = model_config.lora.get("merge", False)
+            self.peft_merge: bool = model_config.should_merge_lora
 
         # 4. build checkpoint engine
         if "actor" in self.role:
@@ -725,9 +725,10 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
            - after update_weights: rollout should be in wake_up mode.
         2. For async training with disaggregated trainer and rollout, send_weights only by checkpoint engine.
 
-        LoRA handling: when model.lora.merge=True (peft_merge), LoRA is merged into
-        base weights before sync. The engine returns full HF-keyed params with
-        peft_config=None, so the rollout receives a standard weight update.
+        LoRA handling: when model.should_merge_lora is true (explicit merge or
+        modules_to_save), LoRA is merged into base weights before sync. The engine
+        returns full HF-keyed params with peft_config=None, so the rollout receives
+        a standard weight update.
 
         Args:
             global_steps: Current global training step count, passed to rollout for logging/tracking.

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -33,13 +33,13 @@ def lora_served_as_adapter(model_config) -> bool:
     runs set ``model.lora.rank`` (dict) while fsdp runs set the flat ``model.lora_rank``,
     so both must be checked to detect that LoRA is enabled at all.
 
-    With ``model.lora.merge=True`` the trainer merges the adapter into the base weights
-    and pushes a full HF-keyed weight update (``peft_config=None``), so no adapter is ever
-    loaded into SGLang: the engine must not be launched with ``enable_lora`` and requests
-    must not carry a ``lora_path``.
+    When ``model.should_merge_lora`` is true, the trainer pushes a full HF-keyed weight
+    update (``peft_config=None``). This covers explicit ``model.lora.merge=True`` as well
+    as PEFT ``modules_to_save``, whose full-rank updates cannot be represented by LoRA
+    deltas. In either case, SGLang must not launch or generate with an adapter.
     """
     lora_enabled = model_config.lora_rank > 0 or model_config.lora.get("rank", 0) > 0
-    return lora_enabled and not model_config.lora.get("merge", False)
+    return lora_enabled and not model_config.should_merge_lora
 
 
 def broadcast_pyobj(

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -207,7 +207,7 @@ class vLLMHttpServer:
     def lora_as_adapter(self) -> bool:
         return (
             self.model_config.lora_rank > 0 or self.model_config.lora.get("rank", 0) > 0
-        ) and not self.model_config.lora.get("merge", False)
+        ) and not self.model_config.should_merge_lora
 
     async def collective_rpc(
         self,
@@ -374,7 +374,7 @@ class vLLMHttpServer:
                 self.model_config.lora_rank
             )  # FIXME: fallback to lora_rank for now, we should unify lora settings.
 
-        if self.model_config.lora.get("merge", False):
+        if self.model_config.should_merge_lora:
             lora_rank = 0
 
         if lora_rank > 0:


### PR DESCRIPTION
### What does this PR do?

Adds PEFT `modules_to_save` semantics to the FSDP Hugging Face model path so a VLM can combine language-model LoRA with fully trainable non-LoRA submodules such as a multimodal projector.

- exposes `actor_rollout_ref.model.modules_to_save` and passes it to `LoraConfig`;
- keeps configured submodules fully trainable and included in PEFT adapter checkpoints while `exclude_modules` prevents LoRA injection into them;
- normalizes PEFT `modules_to_save` wrappers for full-weight synchronization, selecting the active trainable copy and excluding the frozen `original_module` copy;
- automatically uses merged full-weight rollout synchronization when `modules_to_save` is configured, because these updates cannot be represented as LoRA deltas;
- routes both vLLM and SGLang adapter decisions through the shared full-sync semantics;
- updates the Qwen2.5-VL FSDP LoRA example and documentation.

Related context: #1346 requests finer VLM freezing and training control. This PR does not implement arbitrary freeze patterns; it provides the PEFT-native full-rank-submodule contract needed for the common projector-plus-LoRA setup.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+modules_to_save
  - Not a duplicate of #6320, which adds generic full-parameter freeze patterns across engines.
  - Not a duplicate of #6670, which adds Megatron and vLLM tower-connector LoRA support.
  - Integrated with #7234, which centralized the SGLang merge-vs-adapter decision after this PR was opened.
- [x] Format the PR title as required by CI.

### Test

Validated at head `22e03805976e196481db64147ed5e044465390c1` on current `main` at `ddfbf4ea01b27ab47ac9de50514a9c9dcb631e7a`.

```bash
PYTHONPATH=. python -m pytest -q \
  tests/utils/test_normalize_peft_param_name_on_cpu.py \
  tests/workers/config/test_model_config_on_cpu.py::TestHFModelConfigCPU::test_should_merge_lora \
  tests/workers/rollout/rollout_sglang/test_lora_sleep_level.py \
  tests/workers/rollout/rollout_sglang/test_lora_merge_mode_on_cpu.py \
  tests/workers/test_engine_workers_lora_sync.py
# 57 passed, 2 warnings in 8.07s

pre-commit run --all-files --show-diff-on-failure --color=always
# Ruff, Ruff format, Mypy, generated configs, all repository-local sanity hooks,
# and compileall passed.

bash scripts/generate_trainer_config.sh
# All good

git diff --check origin/main...HEAD
# passed
```

The focused suite now includes an exporter-level CPU/mock regression that calls `FSDPEngine.get_per_tensor_param()`, verifies the active `modules_to_save` weight is present in the rollout-facing full-weight stream, and verifies `peft_config is None`.

No accelerator-specific code is introduced. Unit coverage is CPU-only; no GPU or NPU training job was run. The change does not alter numerical kernels or loss formulas.

### API and Usage Example

```yaml
actor_rollout_ref:
  model:
    lora_rank: 64
    target_modules: all-linear
    exclude_modules: ".*visual.*"
    modules_to_save:
      - visual.merger
```

Semantics:

- `target_modules`: modules receiving LoRA adapters;
- `exclude_modules`: modules excluded from LoRA injection;
- `modules_to_save`: modules trained and saved at full rank.

### Design & Code Changes

The implementation follows the native PEFT `modules_to_save` contract, also used by LLaMA-Factory and SWIFT. PEFT wraps each saved module with a frozen `original_module` and an active trainable adapter copy. verl full-weight sync therefore discards the frozen copy, unwraps the active key, and sends merged full weights whenever arbitrary full-rank submodules are present.

After syncing with current `main`, SGLang retains the centralized `lora_served_as_adapter()` helper added by #7234. The helper now delegates the full-sync decision to `HFModelConfig.should_merge_lora`, so both explicit `model.lora.merge=True` and `modules_to_save` disable adapter serving consistently across launch, generation, and sleep paths.

The current diff is 225 additions and 30 deletions across 18 files; 171 additions are tests, and 8 additions are generated configuration entries.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Run the full pre-commit wrapper successfully.
- [x] Add or update documentation.
- [x] Add focused CPU tests, including the FSDP exporter contract and rollout synchronization semantics.
- [x] Request project CI after human review.
- [x] Recipe submodule update is not applicable.

### AI assistance disclosure

AI assistance was used for implementation, prior-art comparison, conflict-resolution analysis, and test execution. The human submitter requested the original publication and this branch-maintenance update. Project CI and maintainer review remain external gates.
