### PR TITLE
[trainer] feat: support decouple ppo for v1 separate_async

### DIFF
--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -169,6 +169,8 @@ def _parse_rollout_rs_thresholds(
                 raise ValueError(f"Invalid numeric threshold '{spec}' for option '{option}'.") from exc
             if lower <= 0 or upper <= 0:
                 raise ValueError(f"Thresholds for option '{option}' must be positive, got {spec}.")
+            if lower > upper:
+                raise ValueError(f"Thresholds for option '{option}' must be lower <= upper, got {spec}.")
             thresholds[option] = {
                 "lower": lower,
                 "upper": upper,

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -138,6 +138,8 @@ class PPOTrainer(ABC):
         self._rollout_moe_lb_metrics_accumulator = RolloutMoELoadBalanceMetricsAccumulator(
             model_config=self.config.actor_rollout_ref.model
         )
+        # track mini-batch index within a parameter_sync_step cycle for Decoupled PPO
+        self.local_trigger_step = 0
 
     def _build_replay_buffer(self) -> ReplayBuffer:
         """Instantiate the replay buffer (or a user-provided custom sampler).
@@ -520,7 +522,8 @@ class PPOTrainer(ABC):
         combined_keys: list = []
         combined_tags: list = []
         combined_partition_id = "train"
-        for _ in range(self.parameter_sync_step):
+        for trigger_idx in range(self.parameter_sync_step):
+            self.local_trigger_step = trigger_idx
             iter_metrics: dict = {}
             batch = self._step_once(iter_metrics, timing_raw, sample_batch_size)
             sample_count = sum(not tag.get("is_padding", False) for tag in batch.tags)

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -19,11 +19,14 @@ import ray
 from omegaconf import DictConfig
 
 from verl.checkpoint_engine import CheckpointEngineManager
-from verl.trainer.ppo.utils import need_reward_model
+from verl.trainer.ppo.utils import Role, need_reward_model
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient, LLMServerManager
+from transfer_queue import KVBatchMeta
+from verl.experimental.separation.engine_workers import DetachActorWorker
+from verl.trainer.ppo.v1.utils import MetricsAggregator
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -66,8 +69,18 @@ class PPOTrainerSeparateAsync(PPOTrainer):
 
         super().__init__(config)
 
-        # TODO: Support Decoupled PPO: https://arxiv.org/abs/2505.24298
-        self.config.algorithm.rollout_correction.bypass_mode = True
+        # track mini-batch index within a parameter_sync_step cycle for Decoupled PPO
+        self.local_trigger_step = 1
+
+    def _init_resource_pool_mgr(self):
+        super()._init_resource_pool_mgr()
+        # Replace ActorRolloutRefWorker with DetachActorWorker to get CPU save/restore
+        # capability needed for Decoupled PPO when parameter_sync_step > 1.
+        # The base class adds exactly one of ActorRolloutRef or ActorRollout to the mapping.
+        if Role.ActorRolloutRef in self.role_worker_mapping:
+            self.role_worker_mapping[Role.ActorRolloutRef] = ray.remote(DetachActorWorker)
+        elif Role.ActorRollout in self.role_worker_mapping:
+            self.role_worker_mapping[Role.ActorRollout] = ray.remote(DetachActorWorker)
 
     def _setup(self):
         super()._setup()
@@ -90,6 +103,63 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         # hybrid engine is in rollout mode after initialization
         self.current_mode = HybridEngineMode.ROLLOUT
         self.add_replicas_to_balancer()
+
+    def step(self, metrics: dict, timing_raw: dict) -> KVBatchMeta:
+        """Override step() to track local_trigger_step for Decoupled PPO weight management."""
+        train_batch_size = self.config.data.train_batch_size
+        assert train_batch_size % self.parameter_sync_step == 0, (
+            f"train_batch_size ({train_batch_size}) must be divisible by "
+            f"parameter_sync_step ({self.parameter_sync_step})"
+        )
+        sample_batch_size = train_batch_size // self.parameter_sync_step
+
+        self._add_batch_to_generate()
+
+        metrics_aggregator = MetricsAggregator()
+        combined_keys: list = []
+        combined_tags: list = []
+        combined_partition_id = "train"
+        for trigger_idx in range(self.parameter_sync_step):
+            self.local_trigger_step = trigger_idx + 1  # 1-indexed for _compute_old_log_prob
+            iter_metrics: dict = {}
+            batch = self._step_once(iter_metrics, timing_raw, sample_batch_size)
+            sample_count = sum(not tag.get("is_padding", False) for tag in batch.tags)
+            metrics_aggregator.add_step_metrics(iter_metrics, sample_count=sample_count)
+            # Strip padding entries added by _balance_batch → upsample_batch_to_divisible_size;
+            # they have no TQ data and would cause shape mismatches downstream (e.g., in
+            # _compute_metrics). Only real (non-padding) entries are combined.
+            combined_keys.extend(key for key, tag in zip(batch.keys, batch.tags) if not tag.get("is_padding", False))
+            combined_tags.extend(tag for tag in batch.tags if not tag.get("is_padding", False))
+            combined_partition_id = batch.partition_id
+
+        metrics.update(metrics_aggregator.get_aggregated_metrics())
+        return KVBatchMeta(partition_id=combined_partition_id, keys=combined_keys, tags=combined_tags)
+
+    def _compute_old_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+        """Version-aware old_log_probs computation for Decoupled PPO.
+
+        In bypass mode, delegates to the base class (copies rollout_log_probs directly).
+        In Decoupled mode, uses save_model_to_cpu / restore_model_from_cpu to ensure
+        all mini-batches within a parameter_sync_step cycle use the same stable π_old.
+
+        - local_trigger_step == 1: Current weights are π_old → save to CPU, compute directly.
+        - local_trigger_step >= 2: Save current weights → restore π_old → compute → restore current.
+        """
+        rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
+        bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+        if bypass_recomputing_logprobs:
+            return super()._compute_old_log_prob(batch, metrics)
+
+        if self.local_trigger_step == 1:
+            self.actor_rollout_wg.save_model_to_cpu(1)
+            return super()._compute_old_log_prob(batch, metrics)
+        else:
+            self.actor_rollout_wg.save_model_to_cpu(self.local_trigger_step)
+            self.actor_rollout_wg.restore_model_from_cpu(1)
+            result = super()._compute_old_log_prob(batch, metrics)
+            self.actor_rollout_wg.restore_model_from_cpu(self.local_trigger_step)
+            self.actor_rollout_wg.clear_cpu_model(self.local_trigger_step)
+            return result
 
     def get_llm_client(self):
         # get server client from standalone rollout

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -17,16 +17,15 @@ from enum import Enum
 
 import ray
 from omegaconf import DictConfig
+from transfer_queue import KVBatchMeta
 
 from verl.checkpoint_engine import CheckpointEngineManager
+from verl.experimental.separation.engine_workers import DetachActorWorker
 from verl.trainer.ppo.utils import Role, need_reward_model
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient, LLMServerManager
-from transfer_queue import KVBatchMeta
-from verl.experimental.separation.engine_workers import DetachActorWorker
-from verl.trainer.ppo.v1.utils import MetricsAggregator
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -69,9 +68,6 @@ class PPOTrainerSeparateAsync(PPOTrainer):
 
         super().__init__(config)
 
-        # track mini-batch index within a parameter_sync_step cycle for Decoupled PPO
-        self.local_trigger_step = 1
-
     def _init_resource_pool_mgr(self):
         super()._init_resource_pool_mgr()
         # Replace ActorRolloutRefWorker with DetachActorWorker to get CPU save/restore
@@ -104,37 +100,6 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         self.current_mode = HybridEngineMode.ROLLOUT
         self.add_replicas_to_balancer()
 
-    def step(self, metrics: dict, timing_raw: dict) -> KVBatchMeta:
-        """Override step() to track local_trigger_step for Decoupled PPO weight management."""
-        train_batch_size = self.config.data.train_batch_size
-        assert train_batch_size % self.parameter_sync_step == 0, (
-            f"train_batch_size ({train_batch_size}) must be divisible by "
-            f"parameter_sync_step ({self.parameter_sync_step})"
-        )
-        sample_batch_size = train_batch_size // self.parameter_sync_step
-
-        self._add_batch_to_generate()
-
-        metrics_aggregator = MetricsAggregator()
-        combined_keys: list = []
-        combined_tags: list = []
-        combined_partition_id = "train"
-        for trigger_idx in range(self.parameter_sync_step):
-            self.local_trigger_step = trigger_idx + 1  # 1-indexed for _compute_old_log_prob
-            iter_metrics: dict = {}
-            batch = self._step_once(iter_metrics, timing_raw, sample_batch_size)
-            sample_count = sum(not tag.get("is_padding", False) for tag in batch.tags)
-            metrics_aggregator.add_step_metrics(iter_metrics, sample_count=sample_count)
-            # Strip padding entries added by _balance_batch → upsample_batch_to_divisible_size;
-            # they have no TQ data and would cause shape mismatches downstream (e.g., in
-            # _compute_metrics). Only real (non-padding) entries are combined.
-            combined_keys.extend(key for key, tag in zip(batch.keys, batch.tags) if not tag.get("is_padding", False))
-            combined_tags.extend(tag for tag in batch.tags if not tag.get("is_padding", False))
-            combined_partition_id = batch.partition_id
-
-        metrics.update(metrics_aggregator.get_aggregated_metrics())
-        return KVBatchMeta(partition_id=combined_partition_id, keys=combined_keys, tags=combined_tags)
-
     def _compute_old_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Version-aware old_log_probs computation for Decoupled PPO.
 
@@ -142,20 +107,20 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         In Decoupled mode, uses save_model_to_cpu / restore_model_from_cpu to ensure
         all mini-batches within a parameter_sync_step cycle use the same stable π_old.
 
-        - local_trigger_step == 1: Current weights are π_old → save to CPU, compute directly.
-        - local_trigger_step >= 2: Save current weights → restore π_old → compute → restore current.
+        - local_trigger_step == 0: Current weights are π_old → save to CPU, compute directly.
+        - local_trigger_step >= 1: Save current weights → restore π_old → compute → restore current.
         """
         rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
         bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
         if bypass_recomputing_logprobs:
             return super()._compute_old_log_prob(batch, metrics)
 
-        if self.local_trigger_step == 1:
-            self.actor_rollout_wg.save_model_to_cpu(1)
+        if self.local_trigger_step == 0:
+            self.actor_rollout_wg.save_model_to_cpu(0)
             return super()._compute_old_log_prob(batch, metrics)
         else:
             self.actor_rollout_wg.save_model_to_cpu(self.local_trigger_step)
-            self.actor_rollout_wg.restore_model_from_cpu(1)
+            self.actor_rollout_wg.restore_model_from_cpu(0)
             result = super()._compute_old_log_prob(batch, metrics)
             self.actor_rollout_wg.restore_model_from_cpu(self.local_trigger_step)
             self.actor_rollout_wg.clear_cpu_model(self.local_trigger_step)


### PR DESCRIPTION
### What does this PR do?

as the title

test result （mimo 7b， dapo dataset）

<img width="1741" height="467" alt="image" src="https://github.com/user-attachments/assets/e4c68ee8-7269-4b82-b191-f31ed180d919" />
<img width="1744" height="477" alt="image" src="https://github.com/user-attachments/assets/af19b154-55d6-4f54-be32-f1b0a145a7dc" />
<img width="1740" height="464" alt="image" src="https://github.com/user-attachments/assets/da334d50-9eed-4477-ae97-b2b0a438884e" />


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
