### PR TITLE
[vllm] chore: remove unused get_device_uuid from vllm rollout

### DIFF
--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -25,7 +25,6 @@ from typing import Any, Literal, Optional, get_args
 import torch
 from vllm.outputs import RequestOutput
 
-from verl.plugin.platform import get_platform
 from verl.utils.device import is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
@@ -77,24 +76,6 @@ def set_death_signal():
     libc.prctl(1, signal.SIGKILL)
     if os.getppid() == 1:
         os.kill(os.getpid(), signal.SIGKILL)
-
-
-def get_device_uuid(device_id: int) -> str:
-    from vllm.platforms import current_platform
-
-    # Convert torch.npu.current_device to its corresponding ASCEND_RT_VISIBLE_DEVICES.
-    if is_npu_available:
-        if os.getenv("ASCEND_RT_VISIBLE_DEVICES") is not None:
-            npu_visible_devices = os.environ["ASCEND_RT_VISIBLE_DEVICES"].split(",")
-            assert device_id < len(npu_visible_devices), f"device_id {device_id} must less than {npu_visible_devices}"
-            return "NPU-" + npu_visible_devices[device_id]
-        else:
-            return f"NPU-{device_id}"
-    else:
-        try:
-            return current_platform.get_device_uuid(device_id)
-        except Exception:
-            return get_platform().get_device_uuid(device_id=device_id)
 
 
 def get_vllm_max_lora_rank(lora_rank: int):

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -38,11 +38,10 @@ from torch.distributed.device_mesh import DeviceMesh
 
 from verl import DataProto
 from verl.third_party.vllm import VLLM_SLEEP_LEVEL, get_version
-from verl.utils.device import get_device_id, is_support_ipc
+from verl.utils.device import is_support_ipc
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
 from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
-from verl.workers.rollout.vllm_rollout.utils import get_device_uuid
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -140,7 +139,6 @@ class ServerAdapter(BaseRollout):
         else:
             self.sleep_level = VLLM_SLEEP_LEVEL
 
-        self.device_uuid = get_device_uuid(get_device_id())
         # Use replica_rank + node-local rank to form ZMQ handle instead of GPU UUID,
         # because CheckpointEngineWorker and vLLM worker may see different GPU UUIDs
         # when CUDA_VISIBLE_DEVICES differs between processes (common on ROCm/AMD).


### PR DESCRIPTION
Delete the useless code.