### PR TITLE
[vllm] refactor: drop support for vLLM older than 0.18.0

### DIFF
--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -22,7 +22,7 @@ We recommend using the **FSDP / FSDP2** backend to investigate, research and pro
 
 2. Inference:
 
-For inference, vllm 0.8.3 and later versions have been tested for stability. We recommend turning on env var `VLLM_USE_V1=1` for optimal performance.
+For inference, vllm 0.18.0 and later versions are supported; older releases are no longer usable with verl.
 
 For SGLang, refer to the :doc:`SGLang Backend<../workers/sglang_worker>` for detailed installation and usage instructions. SGLang rollout is under extensive development and offers many advanced features and optimizations. We encourage users to report any issues or provide feedback via the `SGLang Issue Tracker <https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/issues/106>`_.
 

--- a/scripts/install_vllm_sglang_mcore.sh
+++ b/scripts/install_vllm_sglang_mcore.sh
@@ -9,7 +9,7 @@ echo "1. install inference frameworks and pytorch they need"
 if [ $USE_SGLANG -eq 1 ]; then
     pip install "sglang[all]==0.5.2" --no-cache-dir && pip install torch-memory-saver --no-cache-dir
 fi
-pip install --no-cache-dir "vllm==0.11.0"
+pip install --no-cache-dir "vllm==0.24.0"
 
 echo "2. install basic packages"
 pip install "transformers[hf_xet]>=4.51.0" accelerate datasets peft hf-transfer \
@@ -20,12 +20,11 @@ pip install "transformers[hf_xet]>=4.51.0" accelerate datasets peft hf-transfer 
 pip install "nvidia-ml-py>=12.560.30" "fastapi[standard]>=0.115.0" "optree>=0.13.0" "pydantic>=2.9" "grpcio>=1.62.1"
 
 
-echo "3. install FlashAttention and FlashInfer"
-# Install flash-attn-2.8.1 (cxx11abi=False)
-wget -nv https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.1/flash_attn-2.8.1+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl && \
-    pip install --no-cache-dir flash_attn-2.8.1+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl
-
-pip install --no-cache-dir flashinfer-python==0.3.1
+echo "3. install FlashAttention"
+# Built from source rather than a prebuilt wheel, which is pinned to one torch
+# release. FlashInfer is not installed here: vLLM pins the version it needs.
+export FLASH_ATTENTION_FORCE_BUILD="TRUE"
+pip install --no-build-isolation flash_attn==2.8.3
 
 
 if [ $USE_MEGATRON -eq 1 ]; then

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ PRIME_REQUIRES = []
 GEO_REQUIRES = ["mathruler", "torchvision", "qwen_vl_utils"]
 GPU_REQUIRES = ["liger-kernel", "flash-attn"]
 MATH_REQUIRES = ["math-verify"]  # Add math-verify as an optional dependency
-VLLM_REQUIRES = ["tensordict>=0.8.0,<=0.10.0,!=0.9.0", "vllm>=0.8.5,<=0.12.0"]
+VLLM_REQUIRES = ["tensordict>=0.8.0,<=0.10.0,!=0.9.0", "vllm>=0.18.0"]
 TRTLLM_REQUIRES = ["tensorrt-llm>=1.2.0rc6"]
 SGLANG_REQUIRES = [
     "tensordict>=0.8.0,<=0.10.0,!=0.9.0",

--- a/verl/third_party/vllm/__init__.py
+++ b/verl/third_party/vllm/__init__.py
@@ -36,29 +36,25 @@ if package_version is None:
     if not is_sglang_available():
         raise ValueError(
             f"vllm version {package_version} not supported and SGLang also not Found. Currently supported "
-            f"vllm versions are 0.7.0+"
+            f"vllm versions are 0.18.0+"
         )
 elif is_npu_available:
     # sleep_mode=2 is not supported on vllm-ascend for now, will remove this restriction when this ability is ready.
     VLLM_SLEEP_LEVEL = 1
     from vllm import LLM
     from vllm.distributed import parallel_state
-elif vs.parse(package_version) >= vs.parse("0.7.0"):
+elif vs.parse(package_version) >= vs.parse("0.18.0"):
     vllm_version = package_version
-    if vs.parse(package_version) >= vs.parse("0.8.5"):
-        VLLM_SLEEP_LEVEL = 2
+    VLLM_SLEEP_LEVEL = 2
     from vllm import LLM
     from vllm.distributed import parallel_state
 else:
-    if vs.parse(package_version) in [vs.parse("0.5.4"), vs.parse("0.6.3")]:
-        raise ValueError(
-            f"vLLM version {package_version} support has been removed. vLLM 0.5.4 and 0.6.3 are no longer "
-            f"supported. Please use vLLM 0.7.0 or later."
-        )
+    # An unusable vLLM is tolerated when SGLang can serve as the backend instead,
+    # matching the branch above for a missing vLLM.
     if not is_sglang_available():
         raise ValueError(
             f"vllm version {package_version} not supported and SGLang also not Found. Currently supported "
-            f"vllm versions are 0.7.0+"
+            f"vllm versions are 0.18.0+"
         )
 
 __all__ = ["LLM", "parallel_state"]

--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -79,19 +79,8 @@ def apply_npu_vllm_patches() -> None:
     if not is_torch_npu_available(check_device=False):
         return
 
-    import vllm
-    from packaging import version
+    # Disable flash_attn in RotaryEmbedding (NPU)
+    from vllm.model_executor.layers.fused_moe import FusedMoE
 
-    _VLLM_VERSION = version.parse(vllm.__version__)
-    if _VLLM_VERSION >= version.parse("0.13.0") and _VLLM_VERSION <= version.parse("0.14.0"):
-        # Disable flash_attn in RotaryEmbedding (NPU) when VLLM >= 0.13
-        from vllm.model_executor.layers.fused_moe import FusedMoE
-
-        patch_vllm013_rotary_emb()
-        _patch_legacy_fused_moe_weight_loader(FusedMoE)
-    elif _VLLM_VERSION >= version.parse("0.18.0"):
-        # Disable flash_attn in RotaryEmbedding (NPU) when VLLM >= 0.18
-        from vllm.model_executor.layers.fused_moe import FusedMoE
-
-        patch_vllm013_rotary_emb()
-        _patch_legacy_fused_moe_weight_loader(FusedMoE)
+    patch_vllm013_rotary_emb()
+    _patch_legacy_fused_moe_weight_loader(FusedMoE)

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -277,11 +277,6 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
     is_mxfp8_npu = is_mxfp8_vllm_ascend(quant_config)
     if is_mxfp8_npu:
         import torch_npu
-    # vLLM v0.11-v0.12 renamed weight_scale_inv → weight_scale in process_weights_after_loading,
-    # so load_weights expects "_scale" suffix. v0.14+ keeps weight_scale_inv, so expects "_scale_inv".
-    vllm_ver = _get_vllm_version()
-    _use_scale_not_scale_inv = version.parse("0.11.0") <= vllm_ver < version.parse("0.14.0")
-
     for k, v in weights:
         if not is_fp8_weight(k, model):
             yield (k, v)
@@ -307,10 +302,7 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
         # Yield the quantized weight
         yield (k, param_lp)
 
-        # Yield the scale with appropriate naming based on vLLM version
         if is_mxfp8_npu:
-            yield (k + "_scale", param_scale)
-        elif _use_scale_not_scale_inv and "expert" not in k:
             yield (k + "_scale", param_scale)
         else:
             yield (k + "_scale_inv", param_scale)
@@ -410,125 +402,8 @@ def _make_process_weights_after_loading_for_vllm20(original_fn):
     return _patched_process_weights_after_loading
 
 
-def process_weights_after_loading_for_vllm10(self, layer) -> None:
-    """This function is used to process the weights after loading for a Linear layer, it is used for vllm v0.10
-
-    Compared to the original process_weights_after_loading in vllm, we just avoid creation of
-    new torch.nn.Parameter objects, because that removes the weight_loader attribute which we need for refit.
-    """
-    logger.debug("Applying patch process_weights_after_loading")
-    try:
-        from vllm.model_executor.parameter import (
-            BlockQuantScaleParameter,
-            ModelWeightParameter,
-        )
-    except Exception:
-        print("error")
-    from torch.nn import Parameter
-
-    def _create_param_from_subclass_attributes(custom_param):
-        param = Parameter(custom_param.data, requires_grad=False)
-        base_param_dir = dir(torch.nn.Parameter)
-        custom_param_dir = dir(custom_param)
-        # Find the attributes that are unique to the custom parameter
-        custom_attributes = [
-            attr for attr in custom_param_dir if attr not in base_param_dir and not attr.startswith("__")
-        ]
-        # Set the custom attributes into the base parameter object
-        for attr in custom_attributes:
-            setattr(param, attr, getattr(custom_param, attr))
-
-        param.subclass_type = type(custom_param)
-        return param
-
-    assert self.block_quant and self.quant_config.is_checkpoint_fp8_serialized
-    assert self.quant_config.activation_scheme == "dynamic"
-    weight = layer.weight.data
-    weight_scale_inv = layer.weight_scale_inv.data
-    weight = self._maybe_pad_weight(weight)
-
-    layer.weight = _create_param_from_subclass_attributes(
-        ModelWeightParameter(
-            data=weight,
-            output_dim=0,
-            input_dim=1,
-            weight_loader=layer.weight.weight_loader,
-        )
-    )
-    layer.weight_scale_inv = _create_param_from_subclass_attributes(
-        BlockQuantScaleParameter(
-            data=weight_scale_inv,
-            output_dim=0,
-            input_dim=1,
-            weight_loader=layer.weight_scale_inv.weight_loader,
-        )
-    )
-
-
-def process_weights_after_loading_for_vllm11(self, layer) -> None:
-    """This function is used to process the weights after loading for a Linear layer, it is used for vllm 0.11
-
-    Compared to the original process_weights_after_loading in vllm, we just avoid creation of
-    new torch.nn.Parameter objects, because that removes the weight_loader attribute which we need for refit.
-    """
-    from torch.nn import Parameter
-    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-        maybe_post_process_fp8_weight_block,
-        process_fp8_weight_block_strategy,
-    )
-    from vllm.model_executor.parameter import (
-        BlockQuantScaleParameter,
-        ModelWeightParameter,
-    )
-
-    assert self.block_quant and self.quant_config.is_checkpoint_fp8_serialized
-    assert self.quant_config.activation_scheme == "dynamic"
-
-    def _create_param_from_subclass_attributes(custom_param):
-        param = Parameter(custom_param.data, requires_grad=False)
-        base_param_dir = dir(torch.nn.Parameter)
-        custom_param_dir = dir(custom_param)
-        # Find the attributes that are unique to the custom parameter
-        custom_attributes = [
-            attr for attr in custom_param_dir if attr not in base_param_dir and not attr.startswith("__")
-        ]
-        # Set the custom attributes into the base parameter object
-        for attr in custom_attributes:
-            setattr(param, attr, getattr(custom_param, attr))
-
-        param.subclass_type = type(custom_param)
-        return param
-
-    weight_scale = layer.weight_scale_inv if hasattr(layer, "weight_scale_inv") else layer.weight_scale
-    weight, weight_scale = process_fp8_weight_block_strategy(layer.weight, weight_scale)
-
-    layer.weight = _create_param_from_subclass_attributes(
-        ModelWeightParameter(
-            data=weight.data,
-            output_dim=0,
-            input_dim=1,
-            weight_loader=layer.weight.weight_loader,
-        )
-    )
-    layer.weight_scale = _create_param_from_subclass_attributes(
-        BlockQuantScaleParameter(
-            data=weight_scale.data,
-            output_dim=0,
-            input_dim=1,
-            weight_loader=layer.weight_scale_inv.weight_loader,
-        )
-    )
-
-    del layer.weight_scale_inv
-
-    if _get_vllm_version() == version.parse("0.11.0"):
-        maybe_post_process_fp8_weight_block(layer, self.cutlass_block_fp8_supported)
-    else:
-        maybe_post_process_fp8_weight_block(layer)
-
-
 def process_weights_after_loading_for_vllm14(self, layer) -> None:
-    """This function is used to process the weights after loading for a Linear layer, it is used for vllm v0.14-v0.19.
+    """This function is used to process the weights after loading for a Linear layer, it is used for vllm v0.18-v0.19.
 
     Compared to the original process_weights_after_loading in vllm, we just avoid creation of
     new torch.nn.Parameter objects, because that removes the weight_loader attribute which we need for refit.
@@ -587,140 +462,6 @@ def process_weights_after_loading_for_vllm14(self, layer) -> None:
         layer.input_scale = None
 
     maybe_post_process_fp8_weight_block(layer)
-
-
-def process_weights_after_loading_moe_for_vllm10(self, layer) -> None:
-    """This function is used to process the weights after loading for a FusedMoE layer, it is used for vllm v0.10"""
-    from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import is_rocm_aiter_moe_enabled
-    from vllm.model_executor.layers.quantization.fp8 import _is_col_major, _swap_w13_to_w31
-    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-        get_col_major_tma_aligned_tensor,
-        requant_weight_ue8m0_inplace,
-    )
-    from vllm.utils.deep_gemm import is_blackwell_deep_gemm_used
-
-    self.rocm_aiter_moe_enabled = is_rocm_aiter_moe_enabled()
-    assert self.quant_config.activation_scheme == "dynamic"
-    if self.flashinfer_moe_enabled:
-        w13_weight = _swap_w13_to_w31(layer.w13_weight.data)
-        w13_weight_scale_inv = _swap_w13_to_w31(layer.w13_weight_scale_inv.data)
-        w2_weight = layer.w2_weight.data
-        w2_weight_scale_inv = layer.w2_weight_scale_inv.data
-    else:
-        w13_weight = layer.w13_weight.data
-        w13_weight_scale_inv = layer.w13_weight_scale_inv.data
-        w2_weight = layer.w2_weight
-        w2_weight_scale_inv = layer.w2_weight_scale_inv
-
-    from torch.nn import Parameter
-
-    def _create_param_from_subclass_attributes(custom_data, custom_weight):
-        param = Parameter(custom_data, requires_grad=False)
-        base_param_dir = dir(torch.nn.Parameter)
-        custom_weight_dir = dir(custom_weight)
-        # Find the attributes that are unique to the custom parameter
-        custom_attributes = [
-            attr for attr in custom_weight_dir if attr not in base_param_dir and not attr.startswith("__")
-        ]
-        # Set the custom attributes into the base parameter object
-        for attr in custom_attributes:
-            setattr(param, attr, getattr(custom_weight, attr))
-
-        return param
-
-    layer.w13_weight = _create_param_from_subclass_attributes(w13_weight, layer.w13_weight)
-    layer.w13_weight_scale_inv = _create_param_from_subclass_attributes(
-        w13_weight_scale_inv, layer.w13_weight_scale_inv
-    )
-    layer.w2_weight = _create_param_from_subclass_attributes(w2_weight, layer.w2_weight)
-    layer.w2_weight_scale_inv = _create_param_from_subclass_attributes(w2_weight_scale_inv, layer.w2_weight_scale_inv)
-
-    # DeepGemm scales need to be transposed and aligned.  We try to do
-    # it ahead of time for performance reasons.
-    if self.allow_deep_gemm and not is_blackwell_deep_gemm_used():
-        # Lazy import to avoid CUDA initialization problems.
-        if _is_col_major(layer.w13_weight_scale_inv):
-            layer.w13_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w13_weight_scale_inv).contiguous()
-        if _is_col_major(layer.w2_weight_scale_inv):
-            layer.w2_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w2_weight_scale_inv).contiguous()
-
-    if is_blackwell_deep_gemm_used():
-        assert layer.weight_block_size is not None
-        # Re-quantise the expert weights so their scales are UE8M0.
-        block_sz = tuple(layer.weight_block_size)
-        requant_weight_ue8m0_inplace(
-            layer.w13_weight.data,
-            layer.w13_weight_scale_inv.data,
-            block_sz,
-        )
-        requant_weight_ue8m0_inplace(
-            layer.w2_weight.data,
-            layer.w2_weight_scale_inv.data,
-            block_sz,
-        )
-
-        if _is_col_major(layer.w13_weight_scale_inv):
-            layer.w13_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w13_weight_scale_inv).contiguous()
-        if _is_col_major(layer.w2_weight_scale_inv):
-            layer.w2_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w2_weight_scale_inv).contiguous()
-
-
-def process_weights_after_loading_moe_for_vllm11(self, layer) -> None:
-    """This function is used to process the weights after loading for a FusedMoE layer, it is used for vllm 0.11"""
-    from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-        swap_w13_to_w31,
-    )
-    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-        expert_weight_is_col_major,
-        requant_weight_ue8m0_inplace,
-    )
-    from vllm.utils.deep_gemm import (
-        get_col_major_tma_aligned_tensor,
-        is_deep_gemm_e8m0_used,
-    )
-
-    try:
-        from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import is_rocm_aiter_moe_enabled
-
-        self.rocm_aiter_moe_enabled = is_rocm_aiter_moe_enabled()
-    except ImportError:
-        from vllm._aiter_ops import rocm_aiter_ops
-
-        self.rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
-
-    assert self.block_quant and self.quant_config.is_checkpoint_fp8_serialized
-    assert self.quant_config.activation_scheme == "dynamic"
-
-    if self.flashinfer_moe_backend is not None:
-        layer.w13_weight.data = swap_w13_to_w31(layer.w13_weight.data)
-        layer.w13_weight_scale_inv.data = swap_w13_to_w31(layer.w13_weight_scale_inv.data)
-
-    if self.allow_deep_gemm and not is_deep_gemm_e8m0_used():
-        if expert_weight_is_col_major(layer.w13_weight_scale_inv):
-            layer.w13_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w13_weight_scale_inv)
-        if expert_weight_is_col_major(layer.w2_weight_scale_inv):
-            layer.w2_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w2_weight_scale_inv)
-
-    if is_deep_gemm_e8m0_used():
-        assert layer.weight_block_size is not None
-        # Re-quantise the expert weights so their scales are UE8M0.
-        block_sz = tuple(layer.weight_block_size)
-        requant_weight_ue8m0_inplace(
-            layer.w13_weight.data,
-            layer.w13_weight_scale_inv.data,
-            block_sz,
-        )
-        requant_weight_ue8m0_inplace(
-            layer.w2_weight.data,
-            layer.w2_weight_scale_inv.data,
-            block_sz,
-        )
-
-        # Ensure column-major TMA alignment expected by DeepGEMM.
-        if expert_weight_is_col_major(layer.w13_weight_scale_inv):
-            layer.w13_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w13_weight_scale_inv)
-        if expert_weight_is_col_major(layer.w2_weight_scale_inv):
-            layer.w2_weight_scale_inv = get_col_major_tma_aligned_tensor(layer.w2_weight_scale_inv)
 
 
 def process_weights_after_loading_moe_for_vllm14(self, layer) -> None:
@@ -831,23 +572,9 @@ def apply_vllm_fp8_patches():
         fp8_state.vllm_patches.extend([patcher1, patcher2])
         return
 
-    # Linear patch: v0.14+ keeps weight_scale_inv, v0.11-v0.12 renames to weight_scale
-    if vllm_ver >= version.parse("0.14.0"):
-        linear_patch_fn = process_weights_after_loading_for_vllm14
-    elif vllm_ver >= version.parse("0.11.0"):
-        linear_patch_fn = process_weights_after_loading_for_vllm11
-    else:
-        linear_patch_fn = process_weights_after_loading_for_vllm10
-    patcher1 = patch(func1_path, linear_patch_fn)
+    patcher1 = patch(func1_path, process_weights_after_loading_for_vllm14)
     patcher1.start()
 
-    # MoE patch
-    if vllm_ver >= version.parse("0.14.0"):
-        moe_patch_fn = process_weights_after_loading_moe_for_vllm14
-    elif vllm_ver >= version.parse("0.11.0"):
-        moe_patch_fn = process_weights_after_loading_moe_for_vllm11
-    else:
-        moe_patch_fn = process_weights_after_loading_moe_for_vllm10
-    patcher2 = patch(func2_path, moe_patch_fn)
+    patcher2 = patch(func2_path, process_weights_after_loading_moe_for_vllm14)
     patcher2.start()
     fp8_state.vllm_patches.extend([patcher1, patcher2])

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -29,10 +29,12 @@ from vllm import SamplingParams
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.cli.serve import run_headless
 from vllm.entrypoints.openai.api_server import build_app, init_app_state
+from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
 from vllm.inputs import TokensPrompt
 from vllm.lora.request import LoRARequest
 from vllm.outputs import RequestOutput
 from vllm.usage.usage_lib import UsageContext
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from verl.plugin.platform import get_platform
@@ -63,27 +65,9 @@ from verl.workers.rollout.vllm_rollout.utils import (
 )
 
 _VLLM_VERSION = version.parse(vllm.__version__)
-_RESET_PREFIX_CACHE_KWARGS = {}
-if _VLLM_VERSION >= version.parse("0.13.0"):
-    _RESET_PREFIX_CACHE_KWARGS["reset_connector"] = True
 
-
-if _VLLM_VERSION > version.parse("0.11.0"):
-    from vllm.utils.argparse_utils import FlexibleArgumentParser
-
-    if _VLLM_VERSION == version.parse("0.12.0"):
-        from vllm.entrypoints.harmony_utils import get_encoding
-
-    elif _VLLM_VERSION >= version.parse("0.13.0"):
-        from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
-
-    else:
-        get_encoding = None
-
-    if get_encoding is not None and os.getenv("VERL_USE_GPT_OSS", "0") == "1":
-        get_encoding()
-else:
-    from vllm.utils import FlexibleArgumentParser
+if os.getenv("VERL_USE_GPT_OSS", "0") == "1":
+    get_encoding()
 
 
 logger = logging.getLogger(__file__)
@@ -267,8 +251,6 @@ class vLLMHttpServer:
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
         if self.config.get("limit_images", None):  # support for multi-image data
             engine_kwargs["limit_mm_per_prompt"] = {"image": self.config.get("limit_images")}
-        if self.config.cudagraph_capture_sizes and _VLLM_VERSION <= version.parse("0.11.0"):
-            engine_kwargs["cuda_graph_sizes"] = self.config.cudagraph_capture_sizes
 
         self._preprocess_engine_kwargs(engine_kwargs)
 
@@ -299,7 +281,7 @@ class vLLMHttpServer:
                 dcp_size,
             )
             compilation_config["cudagraph_mode"] = "PIECEWISE"
-        if self.config.cudagraph_capture_sizes and _VLLM_VERSION > version.parse("0.11.0"):
+        if self.config.cudagraph_capture_sizes:
             compilation_config["cudagraph_capture_sizes"] = self.config.cudagraph_capture_sizes
 
         compilation_config = json.dumps(compilation_config)
@@ -334,9 +316,7 @@ class vLLMHttpServer:
         profiler_args = build_vllm_profiler_args(
             self.profiler_controller.config, self.profiler_controller.tool_config, self.replica_rank
         )
-        if _VLLM_VERSION >= version.parse("0.13.0"):
-            # vLLM >= 0.13.0 supports profiler config via CLI args; env vars still work but will be deprecated
-            args.update(profiler_args)
+        args.update(profiler_args)
 
         if self.config.prometheus.enable:
             if self.config.prometheus.served_model_name:
@@ -796,7 +776,7 @@ class vLLMHttpServer:
             # processes across all DP shards (unlike collective_rpc which only reaches
             # TP workers within a single shard).
             await self.engine.wake_up(tags=tags or self._get_wake_up_tags())
-            await self.engine.reset_prefix_cache(**_RESET_PREFIX_CACHE_KWARGS)
+            await self.engine.reset_prefix_cache(reset_connector=True)
         elif self.rollout_mode == RolloutMode.COLOCATED:
             # Directly call engine to wake up without sync weights.
             await self.engine.wake_up(tags=self._get_wake_up_tags())
@@ -804,7 +784,7 @@ class vLLMHttpServer:
             # (e.g. MooncakeStoreConnector) whose entries were computed
             # against the previous weights. No-op success when no connector
             # is configured (vLLM scheduler treats it as such).
-            await self.engine.reset_prefix_cache(**_RESET_PREFIX_CACHE_KWARGS)
+            await self.engine.reset_prefix_cache(reset_connector=True)
         elif self.rollout_mode == RolloutMode.STANDALONE:
             logger.info("skip wake_up in standalone mode")
 
@@ -825,12 +805,10 @@ class vLLMHttpServer:
             # (e.g. MooncakeStoreConnector) whose entries were computed
             # against the previous model weights. With no connector it
             # is a no-op success, so we can pass it unconditionally.
-            await self.engine.reset_prefix_cache(**_RESET_PREFIX_CACHE_KWARGS)
+            await self.engine.reset_prefix_cache(reset_connector=True)
 
-            if _VLLM_VERSION >= version.parse("0.9.0"):
-                await self.engine.reset_mm_cache()
-            if _VLLM_VERSION >= version.parse("0.16.0"):
-                await self.engine.reset_encoder_cache()
+            await self.engine.reset_mm_cache()
+            await self.engine.reset_encoder_cache()
 
     async def release_kv_cache(self):
         """Release only kv_cache GPU memory, keeping model weights intact.
@@ -887,50 +865,23 @@ class vLLMHttpServer:
                 - request_ids: List of aborted request IDs
         """
         try:
-            if _VLLM_VERSION >= version.parse("0.12.0"):
-                # Snapshot request IDs before pausing for reporting
-                request_ids = list(self.engine.output_processor.request_states.keys())
+            # Snapshot request IDs before pausing for reporting
+            request_ids = list(self.engine.output_processor.request_states.keys())
 
-                # pause_generation with wait_for_inflight_requests=False will:
-                # 1. Set engine to paused state (blocks new generate calls)
-                # 2. Abort all in-flight requests
-                # 3. Wait for requests to drain
-                # 4. Clear prefix and mm caches if clear_cache=True.
-                #    EngineCore._reset_caches defaults reset_connector=True
-                #    on this path, so any attached external KV store (e.g.
-                #    MooncakeStoreConnector) is invalidated along with the
-                #    local prefix cache — RL-correct hard-reset at every
-                #    weight update boundary, no extra kwargs needed.
-                await self.engine.pause_generation(
-                    wait_for_inflight_requests=False,
-                    clear_cache=reset_prefix_cache,
-                )
-            else:
-                # Take an atomic snapshot to avoid race conditions with the vLLM engine thread
-                request_states_snapshot = list(self.engine.output_processor.request_states.items())
-                request_ids = [req_id for req_id, _ in request_states_snapshot]
-
-                if not request_ids:
-                    return {"aborted_count": 0, "request_ids": []}
-
-                # For each request, create an abort output and put it to its queue
-                # This allows the generator to receive the aborted result
-                from vllm.v1.engine import FinishReason
-
-                for _, req_state in request_states_snapshot:
-                    request_output = req_state.make_request_output(
-                        [], pooling_output=None, finish_reason=FinishReason.ABORT, stop_reason=None
-                    )
-                    req_state.queue.put(request_output)
-
-                # Abort requests in the output processor and engine core
-                self.engine.output_processor.abort_requests(request_ids)
-                await self.engine.engine_core.abort_requests_async(request_ids)
-
-                # Try to reset prefix cache to ensure clean state
-                if reset_prefix_cache:
-                    await self.clear_kv_cache()
-                    logger.info("Prefix cache reset after abort")
+            # pause_generation with wait_for_inflight_requests=False will:
+            # 1. Set engine to paused state (blocks new generate calls)
+            # 2. Abort all in-flight requests
+            # 3. Wait for requests to drain
+            # 4. Clear prefix and mm caches if clear_cache=True.
+            #    EngineCore._reset_caches defaults reset_connector=True
+            #    on this path, so any attached external KV store (e.g.
+            #    MooncakeStoreConnector) is invalidated along with the
+            #    local prefix cache — RL-correct hard-reset at every
+            #    weight update boundary, no extra kwargs needed.
+            await self.engine.pause_generation(
+                wait_for_inflight_requests=False,
+                clear_cache=reset_prefix_cache,
+            )
 
             logger.info(f"Aborted {len(request_ids)} requests: {request_ids}")
             return {"aborted_count": len(request_ids), "request_ids": request_ids}
@@ -940,15 +891,10 @@ class vLLMHttpServer:
             return {"aborted_count": 0, "request_ids": [], "error": str(e)}
 
     async def resume_generation(self):
-        """Resume generation after abort_all_requests (pause_generation).
-
-        Only effective on vLLM >= 0.12.0 where pause_generation is used.
-        No-op on older versions.
-        """
+        """Resume generation after abort_all_requests (pause_generation)."""
         if self.node_rank != 0:
             return
-        if _VLLM_VERSION >= version.parse("0.12.0"):
-            await self.engine.resume_generation()
+        await self.engine.resume_generation()
 
     async def abort_request(self, request_id: str, reset_prefix_cache: bool = True) -> dict[str, Any]:
         """Abort a specific generation request.
@@ -1151,8 +1097,7 @@ class vLLMHttpServer:
         else:
             sleep_level = 2
         await self.engine.sleep(level=sleep_level)
-        if _VLLM_VERSION >= version.parse("0.17.0"):
-            await self.engine.reset_encoder_cache()
+        await self.engine.reset_encoder_cache()
 
 
 class vLLMReplica(RolloutReplica):
@@ -1176,8 +1121,6 @@ class vLLMReplica(RolloutReplica):
         assert len(self.workers) == self.world_size, (
             f"worker number {len(self.workers)} not equal to world size {self.world_size}"
         )
-
-        self._validate_launch_requirements()
 
         # get (node_id, CUDA_VISIBLE_DEVICES) of all workers
         worker_infos = await asyncio.gather(
@@ -1311,15 +1254,6 @@ class vLLMReplica(RolloutReplica):
     # -----------------------------------------------------------------------
     # Hook methods for subclass overrides
     # -----------------------------------------------------------------------
-
-    def _validate_launch_requirements(self) -> None:
-        """Validate requirements before launching. Override in subclasses."""
-        # NOTE: We always use MP Executor backend whether it's single-node or multi-node.
-        # For multi-node without DP (e.g TP=16), need vllm>=0.11.1, https://github.com/vllm-project/vllm/pull/23691
-        if self.config.data_parallel_size == 1 and self.nnodes > 1:
-            assert _VLLM_VERSION >= version.parse("0.11.1"), (
-                "For multi-node MP Executor, either (1) set data_parallel_size > 1 or (2) upgrade vLLM to >= 0.11.1"
-            )
 
     def _get_server_name_prefix(self) -> str:
         """Return the Ray actor name prefix (e.g. 'vllm_')."""

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -33,11 +33,10 @@ from typing import Any, Generator, Optional
 
 import ray
 import torch
-from packaging import version as vs
 from torch.distributed.device_mesh import DeviceMesh
 
 from verl import DataProto
-from verl.third_party.vllm import VLLM_SLEEP_LEVEL, get_version
+from verl.third_party.vllm import VLLM_SLEEP_LEVEL
 from verl.utils.device import is_support_ipc
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
@@ -45,16 +44,6 @@ from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedW
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
-
-
-def _check_vllm_version_for_sleep_level():
-    # https://github.com/vllm-project/vllm/issues/25171
-    minver = "0.11.0"
-    current_version = get_version("vllm")
-    if not current_version:
-        logger.warning("Could not determine vLLM version, assuming an older version for sleep_level configuration.")
-        return False
-    return vs.parse(current_version) >= vs.parse(minver)
 
 
 class ServerAdapter(BaseRollout):
@@ -133,7 +122,7 @@ class ServerAdapter(BaseRollout):
         else:
             self._has_server = self.rollout_rank == 0
 
-        if config.layered_summon or (config.expert_parallel_size > 1 and not _check_vllm_version_for_sleep_level()):
+        if config.layered_summon:
             logger.warning("Setting the sleep level to 1 may cause a memory overflow.")
             self.sleep_level = 1
         else:


### PR DESCRIPTION

Raises the minimum supported vLLM to 0.18.0 and removes every compatibility
branch at or below that version, across `verl/workers/rollout/vllm_rollout/`,
`verl/utils/vllm/`, and `verl/third_party/vllm/`.
