### PR TITLE
[ckpt, model] fix: validate model merger outputs

### DIFF
--- a/tests/model_merger/test_output_validation_on_cpu.py
+++ b/tests/model_merger/test_output_validation_on_cpu.py
@@ -1,0 +1,183 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, Qwen2Config
+
+from verl.model_merger import base_model_merger
+from verl.model_merger.base_model_merger import BaseModelMerger
+from verl.model_merger.output_validation import validate_hf_model_output
+
+
+class _TestModelMerger(BaseModelMerger):
+    def merge_and_save(self):
+        pass
+
+    def cleanup(self):
+        pass
+
+
+class _ConfigOnlyModel:
+    def to_empty(self, device):
+        return self
+
+    def can_generate(self):
+        return False
+
+    def save_pretrained(self, target_dir, state_dict):
+        with open(target_dir / "config.json", "w", encoding="utf-8") as f:
+            json.dump({"model_type": "test"}, f)
+
+
+class _ConfigOnlyAutoModel:
+    @classmethod
+    def from_config(cls, model_config, **kwargs):
+        return _ConfigOnlyModel()
+
+
+class _FakeTokenizer:
+    def save_pretrained(self, target_dir):
+        with open(target_dir / "tokenizer.json", "w", encoding="utf-8") as f:
+            json.dump({"version": "1.0"}, f)
+
+
+def test_save_rejects_tokenizer_only_output(monkeypatch, tmp_path):
+    merger = _TestModelMerger.__new__(_TestModelMerger)
+    merger.config = SimpleNamespace(target_dir=tmp_path, trust_remote_code=False, local_dir=None)
+    merger.hf_model_config_path = tmp_path
+    merger.model_config = SimpleNamespace()
+
+    monkeypatch.setattr(merger, "get_transformers_auto_model_class", lambda: _ConfigOnlyAutoModel)
+    monkeypatch.setattr(base_model_merger, "drop_tied_target_keys", lambda *args: None)
+    monkeypatch.setattr(base_model_merger, "hf_processor", lambda *args, **kwargs: None)
+    monkeypatch.setattr(base_model_merger, "hf_tokenizer", lambda *args, **kwargs: _FakeTokenizer())
+
+    with pytest.raises(RuntimeError, match="no complete model weights"):
+        merger.save_hf_model_and_tokenizer({"weight": torch.ones(1)})
+
+
+def test_save_accepts_actual_hf_model_output(monkeypatch, tmp_path):
+    model_config = Qwen2Config(
+        vocab_size=32,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+    )
+    source_model = AutoModelForCausalLM.from_config(model_config)
+
+    merger = _TestModelMerger.__new__(_TestModelMerger)
+    merger.config = SimpleNamespace(target_dir=tmp_path, trust_remote_code=False, local_dir=None)
+    merger.hf_model_config_path = tmp_path
+    merger.model_config = model_config
+
+    monkeypatch.setattr(merger, "get_transformers_auto_model_class", lambda: AutoModelForCausalLM)
+    monkeypatch.setattr(merger, "patch_model_generation_config", lambda model: model)
+    monkeypatch.setattr(base_model_merger, "hf_processor", lambda *args, **kwargs: None)
+    monkeypatch.setattr(base_model_merger, "hf_tokenizer", lambda *args, **kwargs: None)
+
+    merger.save_hf_model_and_tokenizer(source_model.state_dict())
+
+    assert (tmp_path / "config.json").is_file()
+    assert (tmp_path / "model.safetensors").is_file()
+
+
+@pytest.mark.parametrize("weight_name", ("model.safetensors", "pytorch_model.bin"))
+def test_validate_hf_model_output_accepts_single_weight_file(tmp_path, weight_name):
+    (tmp_path / "config.json").write_text('{"model_type": "test"}', encoding="utf-8")
+    (tmp_path / weight_name).write_bytes(b"weights")
+
+    validate_hf_model_output(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("index_name", "shard_names"),
+    (
+        ("model.safetensors.index.json", ("model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors")),
+        ("pytorch_model.bin.index.json", ("pytorch_model-00001-of-00002.bin", "pytorch_model-00002-of-00002.bin")),
+    ),
+)
+def test_validate_hf_model_output_accepts_complete_sharded_weights(tmp_path, index_name, shard_names):
+    (tmp_path / "config.json").write_text('{"model_type": "test"}', encoding="utf-8")
+    weight_map = {f"layer.{index}.weight": shard_name for index, shard_name in enumerate(shard_names)}
+    (tmp_path / index_name).write_text(json.dumps({"weight_map": weight_map}), encoding="utf-8")
+    for shard_name in shard_names:
+        (tmp_path / shard_name).write_bytes(b"weights")
+
+    validate_hf_model_output(tmp_path)
+
+
+def test_validate_hf_model_output_rejects_missing_shard(tmp_path):
+    (tmp_path / "config.json").write_text('{"model_type": "test"}', encoding="utf-8")
+    index = {
+        "weight_map": {
+            "layer.0.weight": "model-00001-of-00002.safetensors",
+            "layer.1.weight": "model-00002-of-00002.safetensors",
+        }
+    }
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+    (tmp_path / "model-00001-of-00002.safetensors").write_bytes(b"weights")
+
+    with pytest.raises(RuntimeError, match="model-00002-of-00002.safetensors"):
+        validate_hf_model_output(tmp_path)
+
+
+def test_validate_hf_model_output_accepts_single_file_with_stale_index(tmp_path):
+    (tmp_path / "config.json").write_text('{"model_type": "test"}', encoding="utf-8")
+    (tmp_path / "pytorch_model.bin").write_bytes(b"weights")
+    index = {"weight_map": {"layer.0.weight": "model-00001-of-00001.safetensors"}}
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+
+    validate_hf_model_output(tmp_path)
+
+
+def test_validate_hf_model_output_rejects_escaping_shard_path(tmp_path):
+    target_dir = tmp_path / "output"
+    target_dir.mkdir()
+    (target_dir / "config.json").write_text('{"model_type": "test"}', encoding="utf-8")
+    (tmp_path / "external.safetensors").write_bytes(b"weights")
+    index = {"weight_map": {"layer.0.weight": "../external.safetensors"}}
+    (target_dir / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unsafe shard paths"):
+        validate_hf_model_output(target_dir)
+
+
+def test_validate_hf_model_output_rejects_non_string_shard_name(tmp_path):
+    (tmp_path / "config.json").write_text('{"model_type": "test"}', encoding="utf-8")
+    index = {"weight_map": {"layer.0.weight": []}}
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="invalid shard names"):
+        validate_hf_model_output(tmp_path)
+
+
+def test_validate_hf_model_output_rejects_missing_config(tmp_path):
+    (tmp_path / "model.safetensors").write_bytes(b"weights")
+
+    with pytest.raises(RuntimeError, match="missing or empty config.json"):
+        validate_hf_model_output(tmp_path)
+
+
+def test_validate_hf_model_output_rejects_empty_weight_file(tmp_path):
+    (tmp_path / "config.json").write_text('{"model_type": "test"}', encoding="utf-8")
+    (tmp_path / "model.safetensors").touch()
+
+    with pytest.raises(RuntimeError, match="no complete model weights"):
+        validate_hf_model_output(tmp_path)

--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -26,6 +26,8 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForTokenClas
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq
 
+from .output_validation import validate_hf_model_output
+
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
 
@@ -415,6 +417,8 @@ class BaseModelMerger(ABC):
         if tokenizer is not None:
             print(f"Saving tokenizer to {self.config.target_dir}")
             tokenizer.save_pretrained(self.config.target_dir)
+
+        validate_hf_model_output(self.config.target_dir)
 
     def upload_to_huggingface(self):
         import requests

--- a/verl/model_merger/megatron_model_merger.py
+++ b/verl/model_merger/megatron_model_merger.py
@@ -47,6 +47,7 @@ from verl.utils.megatron_utils import get_model
 from verl.utils.tokenizer import hf_processor, hf_tokenizer
 
 from .base_model_merger import BaseModelMerger, ModelMergerConfig
+from .output_validation import validate_hf_model_output
 
 
 @contextmanager
@@ -487,6 +488,8 @@ class MegatronModelMerger(BaseModelMerger):
             if tokenizer is not None:
                 print(f"Saving tokenizer to {self.config.target_dir}")
                 tokenizer.save_pretrained(self.config.target_dir)
+
+            validate_hf_model_output(self.config.target_dir)
 
     def merge_and_save(self):
         from verl.utils.megatron_utils import get_model_dist_checkpoint_path

--- a/verl/model_merger/output_validation.py
+++ b/verl/model_merger/output_validation.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path, PurePosixPath
+
+_CONFIG_NAME = "config.json"
+_WEIGHT_NAMES = ("model.safetensors", "pytorch_model.bin")
+_WEIGHT_INDEX_NAMES = ("model.safetensors.index.json", "pytorch_model.bin.index.json")
+
+
+def _is_nonempty_file(path: Path) -> bool:
+    return path.is_file() and path.stat().st_size > 0
+
+
+def _safe_shard_path(target_dir: Path, shard_name: str) -> Path | None:
+    shard_path = PurePosixPath(shard_name)
+    if shard_path.is_absolute() or not shard_path.parts or ".." in shard_path.parts:
+        return None
+    return target_dir.joinpath(*shard_path.parts)
+
+
+def validate_hf_model_output(target_dir: str | Path) -> None:
+    """Raise when a model merger output is not a complete Hugging Face model."""
+    target_dir = Path(target_dir)
+    errors = []
+
+    config_path = target_dir / _CONFIG_NAME
+    if not _is_nonempty_file(config_path):
+        errors.append(f"missing or empty {_CONFIG_NAME}")
+    else:
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+            if not isinstance(config, dict):
+                errors.append(f"{_CONFIG_NAME} must contain a JSON object")
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            errors.append(f"invalid {_CONFIG_NAME}: {exc}")
+
+    has_complete_weights = any(_is_nonempty_file(target_dir / name) for name in _WEIGHT_NAMES)
+    index_errors = []
+    for index_name in _WEIGHT_INDEX_NAMES:
+        index_path = target_dir / index_name
+        if not index_path.exists():
+            continue
+
+        try:
+            index = json.loads(index_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            index_errors.append(f"invalid {index_name}: {exc}")
+            continue
+
+        weight_map = index.get("weight_map") if isinstance(index, dict) else None
+        if not isinstance(weight_map, dict) or not weight_map:
+            index_errors.append(f"{index_name} has no non-empty weight_map")
+            continue
+
+        shard_names = list(weight_map.values())
+        if not all(isinstance(name, str) and name for name in shard_names):
+            index_errors.append(f"{index_name} contains invalid shard names")
+            continue
+
+        shard_names = set(shard_names)
+        shard_paths = {name: _safe_shard_path(target_dir, name) for name in shard_names}
+        unsafe_shards = sorted(name for name, path in shard_paths.items() if path is None)
+        if unsafe_shards:
+            index_errors.append(f"{index_name} contains unsafe shard paths: {unsafe_shards}")
+            continue
+
+        missing_shards = sorted(name for name, path in shard_paths.items() if not _is_nonempty_file(path))
+        if missing_shards:
+            index_errors.append(f"{index_name} references missing or empty shards: {missing_shards}")
+            continue
+
+        has_complete_weights = True
+
+    if not has_complete_weights:
+        errors.extend(index_errors)
+        expected = ", ".join((*_WEIGHT_NAMES, *_WEIGHT_INDEX_NAMES))
+        errors.append(f"no complete model weights; expected one of: {expected}")
+
+    if errors:
+        details = "; ".join(errors)
+        raise RuntimeError(f"Incomplete Hugging Face model output at {target_dir}: {details}")


### PR DESCRIPTION
### What does this PR do?

Fixes #7191.

`verl.model_merger` currently has no terminal filesystem-level check after model serialization. A standard Transformers model normally writes its weights, but the merger supports pluggable/custom model implementations and multiple save paths, so callers have no explicit final postcondition for a complete Hugging Face artifact.

This PR makes that success contract explicit by validating:

- after the common FSDP/single-process save path;
- on Megatron rank 0 after all distributed shards and metadata are written.

The check requires a parseable `config.json` plus either a non-empty standard weight file or a complete standard sharded-weight index. Incomplete outputs raise an actionable `RuntimeError` before upload. The validator does not load model tensors. Parameter merging, key conversion, dtype, sharding, LoRA behavior, CLI arguments, and public function signatures are unchanged.

AI assistance was used for repository inspection, test scaffolding, implementation support, and preparation of this description. I reviewed every changed line, reproduced the missing postcondition on unpatched `main`, and ran the tests listed below.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+model+merger+output+validation
- [x] Title: `[ckpt, model] fix: validate model merger outputs`
- [x] No open PR references #7191.

This does not duplicate #7068, which fixes exported key conversion, or #4770, which handles PEFT keys and LoRA metadata. Neither validates the completed full-model output.

### Test

```bash
pytest -q tests/model_merger/test_output_validation_on_cpu.py
```

```text
12 passed
```

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

```text
All hooks passed
```

Additional Linux CPU integration validation:

- Reproduced the missing postcondition on unpatched `main` with a normal-returning custom `save_pretrained()` implementation.
- Verified that the patched path fails with an actionable error.
- Merged a tiny world-size-1 Qwen2 FSDP checkpoint through `python -m verl.model_merger merge --backend fsdp`.
- Loaded the merged output with Transformers and completed a forward pass with logits shape `[1, 2, 16]`.

### API and Usage Example

No CLI or function signature changes. A merger invocation whose final directory does not satisfy the filesystem-level output contract now exits non-zero with:

```text
Incomplete Hugging Face model output at <target_dir>: <missing or invalid files>
```

### Design & Code Changes

- Add `validate_hf_model_output()` with no new runtime dependency.
- Validate standard single-file and sharded Hugging Face weight layouts.
- Reject missing or empty config/weights, malformed indexes, missing shards, and lexical shard paths outside the target directory.
- Add CPU tests for both accepted and rejected layouts, including a real `save_pretrained()` output.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Ran complete pre-commit checks.
- [x] No documentation update is required because this is an error-path correctness fix with no API change.
- [x] Added CPU tests discoverable by `cpu_unit_tests.yml` through the `test_*_on_cpu.py` pattern.
- [x] Requested CI after the PR was opened.
