### PR TITLE
[trainer] feat: add opt-in rollout-vs-actor probs diagnostic for bypass mode

### DIFF
--- a/docs/algo/rollout_corr.md
+++ b/docs/algo/rollout_corr.md
@@ -2,7 +2,7 @@
 
 **Author:** [Yingru Li](https://richardli.xyz/)
 
-Last updated: 10/30/2025.
+Last updated: 07/29/2026.
 
 ---
 
@@ -281,6 +281,32 @@ Threshold specification for rejection sampling.
 - **K1 KL modes (`*k1`)**: Use `"lower_upper"` strings (e.g. `"0.7_1.3"`). Supplying a float implies only the upper bound; the lower bound defaults to its reciprocal.
 - **K2/K3 KL modes (`*k2`/`*k3`)**: Supply positive upper bounds (float or numeric string).
 - Set to `null` to disable thresholds entirely (only valid when `rollout_rs` is null).
+
+### `debug_rollout_actor_probs` (bool)
+
+Opt-in diagnostic for **bypass mode** (`bypass_mode: true`), default `false`.
+
+In bypass mode the trainer sets `old_log_probs = rollout_log_probs` and never recomputes the actor
+policy π_θ, so the rollout-vs-actor consistency metrics — the Pearson correlation
+`training/rollout_actor_probs_pearson_corr` and `training/rollout_probs_diff_{max,mean,std}` — are
+**not emitted**. These metrics are among the most useful async-RL diagnostics because they directly
+measure the training/inference (off-policy) gap and catch precision/tokenizer/temperature drift that
+KL magnitude alone can miss.
+
+When set to `true`, the trainer runs **one extra no-grad inference forward** per step to recompute
+π_θ purely for observability and feeds it to `calculate_debug_metrics`. The training computation is
+untouched, so results are byte-identical whether or not this is enabled — the only cost is the extra
+inference forward (roughly what the non-bypass path already pays every step).
+
+Requirements and notes:
+
+- Requires `actor_rollout_ref.rollout.calculate_log_probs: true` so that `rollout_log_probs` is
+  available; otherwise the diagnostic logs a one-time warning and is skipped.
+- The recompute divides logits by `actor_rollout_ref.rollout.temperature`, which matches vLLM's
+  default `logprobs_mode: processed_logprobs` (log-probs taken after the logits processors,
+  temperature included). The correlation is therefore meaningful at any temperature. If you override
+  `logprobs_mode` to a `raw_*` variant, the two sides are scaled differently and the reported
+  correlation partly reflects that mismatch.
 
 ## Understanding the Framework: Components and Combinations
 

--- a/tests/utils/debug/test_metrics.py
+++ b/tests/utils/debug/test_metrics.py
@@ -11,12 +11,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import unittest
 
 import torch
 
 from verl.protocol import DataProto
 from verl.utils.debug.metrics import calculate_debug_metrics
+
+DEBUG_METRIC_KEYS = {
+    "training/rollout_probs_diff_valid",
+    "training/rollout_probs_diff_max",
+    "training/rollout_probs_diff_mean",
+    "training/rollout_probs_diff_std",
+    "training/rollout_actor_probs_pearson_corr",
+}
+
+
+def _make_data(rollout_log_probs, old_log_probs, mask):
+    rollout_log_probs = torch.tensor(rollout_log_probs, dtype=torch.float32)
+    old_log_probs = torch.tensor(old_log_probs, dtype=torch.float32)
+    mask = torch.tensor(mask)
+    return DataProto.from_dict(
+        {
+            "rollout_log_probs": rollout_log_probs,
+            "old_log_probs": old_log_probs,
+            "response_mask": mask,
+            "responses": torch.zeros_like(rollout_log_probs),
+        }
+    )
 
 
 class TestMetrics(unittest.TestCase):
@@ -42,6 +65,32 @@ class TestMetrics(unittest.TestCase):
         metrics = calculate_debug_metrics(data)
         print(metrics)
         assert metrics["training/rollout_probs_diff_valid"] == 1
+        # all five debug metrics must be emitted, including the Pearson correlation
+        assert DEBUG_METRIC_KEYS.issubset(metrics.keys())
+
+    def test_pearson_corr_perfectly_correlated(self):
+        # identical rollout/actor log-probs => probs are identical => correlation == 1.0
+        log_probs = [[-0.1, -0.5, -1.0, -2.0]]
+        data = _make_data(log_probs, log_probs, [[1, 1, 1, 1]])
+        metrics = calculate_debug_metrics(data)
+        assert metrics["training/rollout_probs_diff_valid"] == 1
+        self.assertAlmostEqual(metrics["training/rollout_actor_probs_pearson_corr"], 1.0, places=4)
+
+    def test_pearson_corr_anti_correlated(self):
+        # probs [0.1,0.2,0.3,0.4] vs [0.4,0.3,0.2,0.1] are perfectly anti-correlated => -1.0
+        rollout = [[math.log(p) for p in (0.1, 0.2, 0.3, 0.4)]]
+        actor = [[math.log(p) for p in (0.4, 0.3, 0.2, 0.1)]]
+        data = _make_data(rollout, actor, [[1, 1, 1, 1]])
+        metrics = calculate_debug_metrics(data)
+        self.assertAlmostEqual(metrics["training/rollout_actor_probs_pearson_corr"], -1.0, places=4)
+
+    def test_empty_mask_returns_nan(self):
+        # no valid tokens => valid flag 0 and nan statistics (guards against div-by-zero)
+        log_probs = [[-0.1, -0.5, -1.0, -2.0]]
+        data = _make_data(log_probs, log_probs, [[0, 0, 0, 0]])
+        metrics = calculate_debug_metrics(data)
+        assert metrics["training/rollout_probs_diff_valid"] == 0
+        assert math.isnan(metrics["training/rollout_actor_probs_pearson_corr"])
 
 
 if __name__ == "__main__":

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -856,6 +856,7 @@ algorithm:
     bypass_mode: false
     loss_type: ppo_clip
     rollout_is_batch_normalize: false
+    debug_rollout_actor_probs: false
   _target_: verl.trainer.config.AlgoConfig
   gamma: 1.0
   lam: 1.0

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -778,6 +778,7 @@ algorithm:
     bypass_mode: false
     loss_type: ppo_clip
     rollout_is_batch_normalize: false
+    debug_rollout_actor_probs: false
   _target_: verl.trainer.config.AlgoConfig
   gamma: 1.0
   lam: 1.0

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -794,6 +794,7 @@ algorithm:
     bypass_mode: false
     loss_type: ppo_clip
     rollout_is_batch_normalize: false
+    debug_rollout_actor_probs: false
   _target_: verl.trainer.config.AlgoConfig
   gamma: 1.0
   lam: 1.0

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -792,6 +792,7 @@ algorithm:
     bypass_mode: false
     loss_type: ppo_clip
     rollout_is_batch_normalize: false
+    debug_rollout_actor_probs: false
   _target_: verl.trainer.config.AlgoConfig
   gamma: 1.0
   lam: 1.0

--- a/verl/trainer/config/algorithm.py
+++ b/verl/trainer/config/algorithm.py
@@ -137,6 +137,15 @@ class RolloutCorrectionConfig(BaseConfig):
               L = -E[min(r*A, clip(r)*A)] where r = π_current / π_rollout
             Default: "ppo_clip"
 
+        debug_rollout_actor_probs (bool): Opt-in diagnostic, only honored in bypass mode
+            (bypass_mode=True). Bypass mode never recomputes the actor policy π_θ, so the
+            rollout-vs-actor consistency metrics emitted by ``calculate_debug_metrics``
+            (``training/rollout_actor_probs_pearson_corr`` and ``training/rollout_probs_diff_*``)
+            are unavailable. When True, the trainer runs one extra no-grad inference forward per
+            step purely for observability; the training computation is unchanged.
+            Requires actor_rollout_ref.rollout.calculate_log_probs=True.
+            Default: False
+
     Example:
         # Create with defaults
         config = RolloutCorrectionConfig()
@@ -182,6 +191,10 @@ class RolloutCorrectionConfig(BaseConfig):
     rollout_rs_threshold: Optional[str | float] = None
     bypass_mode: bool = False
     loss_type: str = "ppo_clip"
+    # Opt-in diagnostic (bypass mode only): recompute the actor policy π_θ via one extra no-grad
+    # inference forward to emit rollout-vs-actor consistency metrics (Pearson correlation and
+    # rollout_probs_diff_*). Training math is unchanged. Requires rollout.calculate_log_probs=True.
+    debug_rollout_actor_probs: bool = False
 
     @classmethod
     def decoupled_token_is(cls, threshold: float = 2.0) -> "RolloutCorrectionConfig":

--- a/verl/trainer/config/algorithm/rollout_correction.yaml
+++ b/verl/trainer/config/algorithm/rollout_correction.yaml
@@ -26,3 +26,9 @@ loss_type: ppo_clip
 
 # Batch normalize IS weights: false = raw weights, true = normalize to mean=1.0
 rollout_is_batch_normalize: false
+
+# Opt-in diagnostic for bypass mode (bypass_mode=true): recompute the actor policy π_θ via one
+# extra no-grad inference forward to emit rollout-vs-actor consistency metrics (Pearson
+# correlation and rollout_probs_diff_*). Training math is unchanged.
+# Requires actor_rollout_ref.rollout.calculate_log_probs=true.
+debug_rollout_actor_probs: false

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1489,6 +1489,7 @@ class PPOTrainer(ABC):
         rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
         bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
         if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
+            self._maybe_debug_rollout_actor_probs(batch, metrics, rollout_corr_config)
             data = tq.kv_batch_get(
                 keys=batch.keys, partition_id=batch.partition_id, select_fields=["rollout_log_probs"]
             )
@@ -1540,6 +1541,54 @@ class PPOTrainer(ABC):
             metrics.update(calculate_debug_metrics(data))
 
         return batch
+
+    def _maybe_debug_rollout_actor_probs(self, batch: KVBatchMeta, metrics: dict, rollout_corr_config) -> None:
+        """Opt-in bypass-mode diagnostic: recompute π_θ to emit rollout-vs-actor consistency metrics.
+
+        Bypass mode sets ``old_log_probs = rollout_log_probs`` and never recomputes the actor policy
+        π_θ, so the metrics produced by ``calculate_debug_metrics`` (Pearson correlation between the
+        rollout and actor probabilities, plus ``rollout_probs_diff_*``) are unavailable by default.
+
+        When ``algorithm.rollout_correction.debug_rollout_actor_probs`` is enabled, run one extra
+        no-grad inference forward (``compute_log_prob``) purely for observability and feed the result
+        to ``calculate_debug_metrics``. The training computation (``old_log_probs = rollout_log_probs``)
+        is left untouched, so training results are byte-identical whether or not this is enabled.
+        """
+        if not (rollout_corr_config and rollout_corr_config.get("debug_rollout_actor_probs", False)):
+            return
+        if not self.config.actor_rollout_ref.rollout.calculate_log_probs:
+            if not getattr(self, "_debug_rollout_actor_probs_warned", False):
+                logger.warning(
+                    "algorithm.rollout_correction.debug_rollout_actor_probs=True requires "
+                    "actor_rollout_ref.rollout.calculate_log_probs=True to access rollout_log_probs; "
+                    "skipping the rollout-vs-actor diagnostic."
+                )
+                self._debug_rollout_actor_probs_warned = True
+            return
+
+        # Recompute π_θ via a no-grad inference forward. Snapshot/restore extra_info so the bypass
+        # path's downstream stages are unaffected by the diagnostic's flags.
+        saved_extra_info = dict(batch.extra_info)
+        try:
+            batch.extra_info.update(
+                {
+                    "calculate_entropy": False,
+                    "compute_loss": False,
+                    "temperature": self.config.actor_rollout_ref.rollout.temperature,
+                }
+            )
+            self.actor_rollout_wg.compute_log_prob(batch)
+            dbg = tq.kv_batch_get(
+                keys=batch.keys,
+                partition_id=batch.partition_id,
+                select_fields=["log_probs", "response_mask", "responses", "rollout_log_probs"],
+            )
+        finally:
+            batch.extra_info.clear()
+            batch.extra_info.update(saved_extra_info)
+
+        dbg["old_log_probs"] = response_from_nested(dbg.pop("log_probs"), dbg["response_mask"])
+        metrics.update(calculate_debug_metrics(DataProto(batch=dbg.to_padded_tensor())))
 
     def _compute_ref_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Compute the reference log prob of the batch."""


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in diagnostic that restores the rollout-vs-actor consistency metrics in **bypass mode**.

In bypass mode (`algorithm.rollout_correction.bypass_mode=true`) the trainer sets `old_log_probs = rollout_log_probs` and never recomputes the actor policy π_θ, so `calculate_debug_metrics` is never invoked and `training/rollout_actor_probs_pearson_corr` / `training/rollout_probs_diff_{max,mean,std}` are simply absent from the metrics. These are among the most useful async-RL diagnostics — they directly measure the training/inference gap and catch precision, tokenizer, and temperature drift that KL magnitude alone can miss. This is most acute for `PPOTrainerSeparateAsync`, which force-sets `bypass_mode = True` (`verl/trainer/ppo/v1/trainer_separate_async.py:70`) — i.e. the configuration with the *largest* expected train/infer gap currently has zero visibility into it.

The new flag `algorithm.rollout_correction.debug_rollout_actor_probs` (default `false`) makes the bypass branch of `_compute_old_log_prob` run **one extra no-grad `compute_log_prob` forward** purely for observability and feed the recomputed π_θ to the existing `calculate_debug_metrics`. `old_log_probs` is still set from `rollout_log_probs`, so the training computation is untouched and results are identical whether or not the diagnostic is enabled. The only cost is the extra inference forward — roughly what the non-bypass path already pays every step — and it lands inside the existing `marked_timer("old_log_prob")`, so it shows up in `timing_s/old_log_prob` rather than hiding.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - [`is:pr is:open bypass_mode`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+bypass_mode) → only #4930 (bypass mode config *timing*), unrelated.
  - [`is:pr is:open pearson`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+pearson) → only #4252, discussed below.
  - [`is:issue rollout_probs_diff`](https://github.com/verl-project/verl/issues?q=rollout_probs_diff) → no open issue requesting this.

  **Not a duplicate of #4252** ("use unscaled logits for accurate pearson correlation metric"). That PR changes *how* the existing metric is computed for the non-bypass path, by plumbing an unscaled `log_probs_for_metrics` through the actors. This PR does not touch the metric computation at all — it makes the existing, unmodified `calculate_debug_metrics` reachable from a code path where it currently never runs. The two are orthogonal and would not conflict. Worth noting for reviewers: #4252's premise (vLLM returns unscaled log-probs) was true when its issue #4162 was filed, but #4755 later added `rollout.logprobs_mode` defaulting to `processed_logprobs`, which makes vLLM's log-probs temperature-scaled and consistent with the actor recompute. #4162 is now closed.

- [x] Format the PR title as `[{modules}] {type}: {description}` → `[trainer] feat: add opt-in rollout-vs-actor probs diagnostic for bypass mode`

### Test

**Unit tests** — `tests/utils/debug/test_metrics.py` (picked up by `gpu_unit_tests.yml`):
**Smoke tests** -- run the separate async workflow and confirmed pcc chart showing up in mlflow.

```bash
pytest -s tests/utils/debug/test_metrics.py
# 4 passed
```

Three cases added, covering the metric this PR surfaces: identical rollout/actor log-probs → correlation `1.0`; perfectly anti-correlated probabilities → `-1.0`; all-False mask → `valid=0` and `nan` statistics. The existing `test_calculate_debug_metrics` now also asserts that all five debug metric keys are emitted.

**Honest scoping of the test coverage:** these tests exercise `calculate_debug_metrics`, which this PR does not modify. The new code path itself — `PPOTrainer._maybe_debug_rollout_actor_probs` — is not unit-tested, because reaching it requires a live `actor_rollout_wg` worker group and a TransferQueue partition; there is no existing fixture in the repo for driving `_compute_old_log_prob` in isolation. It was instead validated by GPU smoke test (below). Happy to add a mock-based test if a reviewer prefers.

**GPU smoke test** — ran an end-to-end bypass-mode job with the flag enabled and confirmed `training/rollout_actor_probs_pearson_corr` is emitted and charts correctly, where it was previously absent.

**Lint / repo checks** — `ruff check`, `ruff format --check`, `scripts/generate_trainer_config.sh` (regenerates byte-identical), `check_docstrings`, `check_docs_time_info`, `check_license`, `validate_structure` all pass.

### API and Usage Example

New config field, defaults to `false`, so existing configs are unaffected:

```yaml
algorithm:
  rollout_correction:
    bypass_mode: true
    debug_rollout_actor_probs: true   # NEW: opt-in diagnostic
actor_rollout_ref:
  rollout:
    calculate_log_probs: true         # required (already required by bypass mode)
```

Or from the CLI:

```bash
python3 -m verl.trainer.main_ppo \
    algorithm.rollout_correction.bypass_mode=true \
    algorithm.rollout_correction.debug_rollout_actor_probs=true \
    actor_rollout_ref.rollout.calculate_log_probs=true \
    ...
```

Emitted metrics (identical to what the decoupled path already logs):

```
training/rollout_actor_probs_pearson_corr
training/rollout_probs_diff_valid
training/rollout_probs_diff_{max,mean,std}
```

### Design & Code Changes

- **`verl/trainer/ppo/v1/trainer_base.py`** — new `PPOTrainer._maybe_debug_rollout_actor_probs()`, called at the top of the bypass branch of `_compute_old_log_prob()`, *before* `old_log_probs` is written. It snapshots and restores `batch.extra_info` around the call so the diagnostic's flags (`calculate_entropy=False`, `compute_loss=False`, `temperature`) can't leak into downstream stages, then reads back `log_probs` / `response_mask` / `responses` / `rollout_log_probs` and hands them to `calculate_debug_metrics`. It deliberately does **not** write `old_log_probs` back to the TransferQueue — bypass semantics are preserved.
- **`verl/trainer/config/algorithm.py`** — `RolloutCorrectionConfig.debug_rollout_actor_probs: bool = False`, documented in the class docstring.
- **`verl/trainer/config/algorithm/rollout_correction.yaml`** + the four regenerated `_generated_*_trainer.yaml`.
- **`docs/algo/rollout_corr.md`** — documents the flag, its one-forward-pass cost, the `calculate_log_probs` requirement, and how the recompute's temperature scaling lines up with `rollout.logprobs_mode`.
- **`tests/utils/debug/test_metrics.py`** — the three cases described above.

**Points I'd like reviewer input on:**

1. **Scope: v1 trainer only.** The same gap exists in `verl/trainer/ppo/ray_trainer.py:1550` and `verl/experimental/separation/ray_trainer.py:510`. I kept this to `v1/trainer_base.py` because that's the path `PPOTrainerSeparateAsync` uses and the one I could validate on hardware. Happy to extend to the others in this PR or a follow-up.
2. **Why an extra forward** rather than reusing the π_θ that `_update_actor`'s first micro-batch already computes? That would be free, but it only covers part of the batch (so the metric would not be comparable to the decoupled path's) and would mean reaching into the minibatch training loop. The extra forward keeps the metric's semantics *exactly* identical to what non-bypass mode reports.
3. **No warning when `debug_rollout_actor_probs=true` but `bypass_mode=false`** — the flag is currently just ignored. I can add a config-time warning if that's preferred.
4. **The `calculate_log_probs` guard is arguably unreachable.** The bypass path reads `rollout_log_probs` unconditionally two lines later, so if `calculate_log_probs` were `false`, bypass mode is already broken. The warn-and-skip is defensive; an `assert` (or dropping it) may be cleaner. Open to either.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: the new trainer method requires a live worker group + TransferQueue and has no existing test harness; validated by GPU smoke test instead. See the Test section.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] If your PR is related to the `recipe` submodule — N/A.

---

**AI assistance disclosure:** This change was developed with AI assistance (GitHub Copilot and Claude). Per [`CLAUDE.md`](https://github.com/verl-project/verl/blob/main/CLAUDE.md), I have reviewed every changed line, understand the change end-to-end, and ran the tests and the GPU smoke test reported above myself.
<img width="574" height="667" alt="Screenshot 2026-07-29 at 4 39 34 PM" src="https://github.com/user-attachments/assets/8bb84ce0-8926-40a3-b8c0-3bf80f8b9e8e" />
