### PR TITLE
[algo, cfg] feat: add token-sum loss aggregation

### DIFF
--- a/tests/trainer/ppo/test_loss_aggregation_on_cpu.py
+++ b/tests/trainer/ppo/test_loss_aggregation_on_cpu.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU coverage for loss aggregation modes."""
+
+import pytest
+import torch
+
+from verl.trainer.ppo.core_algos import agg_loss
+
+
+def test_token_sum_masks_tokens_and_scales_for_dp():
+    loss_mat = torch.tensor([[1.0, 2.0, 30.0], [4.0, 50.0, 6.0]])
+    loss_mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 0.0, 1.0]])
+
+    loss = agg_loss(loss_mat, loss_mask, loss_agg_mode="token-sum", dp_size=4)
+
+    assert loss.item() == pytest.approx((1.0 + 2.0 + 4.0 + 6.0) * 4)
+
+
+@pytest.mark.parametrize("num_micro_batches", [1, 2, 4])
+def test_token_sum_is_microbatch_invariant(num_micro_batches):
+    loss_mat = torch.arange(1, 25, dtype=torch.float32).reshape(8, 3)
+    loss_mask = torch.tensor([[1.0, 1.0, 0.0]] * 8)
+    step = loss_mat.shape[0] // num_micro_batches
+
+    accumulated = sum(
+        agg_loss(loss_mat[i : i + step], loss_mask[i : i + step], loss_agg_mode="token-sum")
+        for i in range(0, loss_mat.shape[0], step)
+    )
+    whole = agg_loss(loss_mat, loss_mask, loss_agg_mode="token-sum")
+
+    torch.testing.assert_close(accumulated, whole)
+
+
+@pytest.mark.parametrize("dp_size", [2, 4])
+def test_token_sum_matches_global_sum_after_fsdp_mean_reduction(dp_size):
+    loss_mat = torch.arange(1, 25, dtype=torch.float32).reshape(8, 3)
+    loss_mask = torch.tensor([[1.0, 1.0, 0.0]] * 8)
+    rank_step = loss_mat.shape[0] // dp_size
+
+    rank_losses = [
+        agg_loss(
+            loss_mat[i : i + rank_step],
+            loss_mask[i : i + rank_step],
+            loss_agg_mode="token-sum",
+            dp_size=dp_size,
+        )
+        for i in range(0, loss_mat.shape[0], rank_step)
+    ]
+    fsdp_reduced = torch.stack(rank_losses).mean()
+    global_sum = agg_loss(loss_mat, loss_mask, loss_agg_mode="token-sum")
+
+    torch.testing.assert_close(fsdp_reduced, global_sum)

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -78,7 +78,7 @@ policy_loss:
 # Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C
 clip_ratio_c: 3.0
 
-# Loss aggregation mode: "token-mean", "seq-mean-token-sum", "seq-mean-token-mean", or "seq-mean-token-sum-norm"
+# Loss aggregation mode: "token-mean", "token-sum", "seq-mean-token-sum", "seq-mean-token-mean", or "seq-mean-token-sum-norm"
 loss_agg_mode: token-mean
 
 # Scale factor for "seq-mean-token-sum-norm" loss aggregation mode.
@@ -332,4 +332,3 @@ qat:
 
   # Path to vLLM quantization config JSON file
   quantization_config_path: null
-

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1171,6 +1171,11 @@ def agg_loss(
                 raise ValueError("(global) batch_num_tokens is required when dp_size > 1")
             batch_num_tokens = loss_mask.sum()
         loss = verl_F.masked_sum(loss_mat, loss_mask) / batch_num_tokens * dp_size
+    elif loss_agg_mode == "token-sum":
+        # DDP/FSDP average gradients across data-parallel ranks. Scaling each
+        # rank's local token sum by dp_size makes the reduced gradient equal to
+        # the sum over all valid tokens in the global batch.
+        loss = verl_F.masked_sum(loss_mat, loss_mask) * dp_size
     elif loss_agg_mode in ["seq-mean-token-sum", "seq-mean-token-sum-norm"]:
         seq_losses = torch.sum(loss_mat * loss_mask, dim=-1)  # token-sum
         seq_mask = (torch.sum(loss_mask, dim=-1) > 0).float()  # exclude fully masked sequences

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -119,7 +119,7 @@ class ActorConfig(BaseConfig):
         clip_ratio_high (float): Upper bound for PPO clipping ratio.
         policy_loss (PolicyLossConfig): Configuration for policy loss computation.
         clip_ratio_c (float): Clipping ratio for critic loss.
-        loss_agg_mode (str): Loss aggregation mode. Options: 'token-mean', 'sample-mean'.
+        loss_agg_mode (str): Loss aggregation mode, including 'token-mean', 'token-sum', and sequence modes.
         loss_scale_factor (Optional[int]): Scale factor for 'seq-mean-token-sum-norm' loss aggregation mode.
             If None, uses response_length. Set to a constant to ensure consistent normalization.
         entropy_coeff (float): Entropy coefficient for regularization.
@@ -212,6 +212,7 @@ class ActorConfig(BaseConfig):
 
         valid_loss_agg_modes = [
             "token-mean",
+            "token-sum",
             "seq-mean-token-sum",
             "seq-mean-token-mean",
             "seq-mean-token-sum-norm",


### PR DESCRIPTION
### What does this PR do?

Adds `token-sum` as a loss aggregation mode. The masked local token sum is scaled by the data-parallel world size so that DDP/FSDP mean-reduced gradients equal the global token sum.

This narrows the original mixed scope of #7197 to one reviewable feature. The importance-sampling/DRO and standard-PPO changes have been split into separate PRs.

This is not a duplicate of another open PR: the [open-PR search for token-sum loss aggregation](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22token+sum%22+%22loss+aggregation%22) identified this existing PR as the implementation being split.

AI assistance disclosure: OpenAI Codex was used to split the original commit, organize focused tests, run checks, and update this PR. The human submitter must review every changed line and rerun the focused tests in a working PyTorch environment before merge.

### Checklist Before Starting

- [x] Search for similar PRs. Query: [token-sum loss aggregation](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22token+sum%22+%22loss+aggregation%22)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `pre-commit run --all-files --show-diff-on-failure --color=always` — passed.
- `python -m pytest -q tests/trainer/ppo/test_loss_aggregation_on_cpu.py tests/workers/config/test_actor_config_on_cpu.py` — blocked before collection because the current Python environment does not have pytest installed. The available system PyTorch is also unusable because `libnvshmem_host.so.3` is missing.

### API and Usage Example

```bash
actor_rollout_ref.actor.loss_agg_mode=token-sum
```

### Design & Code Changes

- Add masked token-sum aggregation with data-parallel scaling.
- Accept `token-sum` in actor configuration validation and document it in the actor config.
- Add CPU tests for masking, microbatch invariance, and simulated FSDP mean reduction.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). The actor configuration reference is updated inline.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Focused CPU tests were added to the existing test suite; local execution is blocked as described above.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).