### PR TITLE
[megatron] fix: preserve generation config during merge

### DIFF
--- a/tests/model_merger/test_output_validation_on_cpu.py
+++ b/tests/model_merger/test_output_validation_on_cpu.py
@@ -117,7 +117,7 @@ def test_save_generation_config_preserves_pretrained_values(tmp_path):
     assert saved_config.max_new_tokens == 4096
 
 
-def test_save_generation_config_allows_missing_file(tmp_path):
+def test_save_generation_config_allows_missing_file(capsys, tmp_path):
     source_dir = tmp_path / "source"
     target_dir = tmp_path / "target"
     source_dir.mkdir()
@@ -130,6 +130,33 @@ def test_save_generation_config_allows_missing_file(tmp_path):
     merger.save_generation_config(target_dir)
 
     assert not stale_config_path.exists()
+    assert capsys.readouterr().out == ""
+
+
+def test_load_generation_config_warns_when_file_is_missing(capsys, tmp_path):
+    merger = _TestModelMerger.__new__(_TestModelMerger)
+    merger.hf_model_config_path = tmp_path
+
+    assert merger.load_generation_config() is None
+    assert f"Warning: Generation config file not found in {tmp_path}" in capsys.readouterr().out
+
+
+def test_save_generation_config_rejects_invalid_source(tmp_path):
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+    (source_dir / "generation_config.json").write_text("{invalid", encoding="utf-8")
+    stale_config_path = target_dir / "generation_config.json"
+    stale_config_path.write_text('{"eos_token_id": 0}', encoding="utf-8")
+
+    merger = _TestModelMerger.__new__(_TestModelMerger)
+    merger.hf_model_config_path = source_dir
+
+    with pytest.raises(OSError, match="not a valid JSON file"):
+        merger.save_generation_config(target_dir)
+
+    assert stale_config_path.is_file()
 
 
 @pytest.mark.parametrize("weight_name", ("model.safetensors", "pytorch_model.bin"))

--- a/tests/model_merger/test_output_validation_on_cpu.py
+++ b/tests/model_merger/test_output_validation_on_cpu.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from transformers import AutoModelForCausalLM, Qwen2Config
+from transformers import AutoModelForCausalLM, GenerationConfig, Qwen2Config
 
 from verl.model_merger import base_model_merger
 from verl.model_merger.base_model_merger import BaseModelMerger
@@ -96,6 +96,40 @@ def test_save_accepts_actual_hf_model_output(monkeypatch, tmp_path):
 
     assert (tmp_path / "config.json").is_file()
     assert (tmp_path / "model.safetensors").is_file()
+
+
+def test_save_generation_config_preserves_pretrained_values(tmp_path):
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+    GenerationConfig(
+        eos_token_id=[151643, 151645],
+        max_new_tokens=4096,
+    ).save_pretrained(source_dir)
+
+    merger = _TestModelMerger.__new__(_TestModelMerger)
+    merger.hf_model_config_path = source_dir
+    merger.save_generation_config(target_dir)
+
+    saved_config = GenerationConfig.from_pretrained(target_dir)
+    assert saved_config.eos_token_id == [151643, 151645]
+    assert saved_config.max_new_tokens == 4096
+
+
+def test_save_generation_config_allows_missing_file(tmp_path):
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+    source_dir.mkdir()
+    target_dir.mkdir()
+    stale_config_path = target_dir / "generation_config.json"
+    stale_config_path.write_text('{"eos_token_id": 0}', encoding="utf-8")
+
+    merger = _TestModelMerger.__new__(_TestModelMerger)
+    merger.hf_model_config_path = source_dir
+    merger.save_generation_config(target_dir)
+
+    assert not stale_config_path.exists()
 
 
 @pytest.mark.parametrize("weight_name", ("model.safetensors", "pytorch_model.bin"))

--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -245,20 +245,21 @@ class BaseModelMerger(ABC):
                 model.generation_config = generation_config
         return model
 
-    def load_generation_config(self):
+    def load_generation_config(self, warn_if_missing: bool = True):
         """Load the generation config stored alongside the pretrained model config."""
-        try:
-            return GenerationConfig.from_pretrained(self.hf_model_config_path)
-        except OSError:
-            print(
-                f"Warning: Generation config file not found in {self.hf_model_config_path}, using a "
-                f"generation config created from the model config."
-            )
+        generation_config_path = os.path.join(self.hf_model_config_path, "generation_config.json")
+        if not os.path.isfile(generation_config_path):
+            if warn_if_missing:
+                print(
+                    f"Warning: Generation config file not found in {self.hf_model_config_path}, using a "
+                    f"generation config created from the model config."
+                )
             return None
+        return GenerationConfig.from_pretrained(self.hf_model_config_path)
 
     def save_generation_config(self, target_dir):
         """Preserve the pretrained generation config in a merged model directory."""
-        generation_config = self.load_generation_config()
+        generation_config = self.load_generation_config(warn_if_missing=False)
         if generation_config is not None:
             generation_config.save_pretrained(target_dir)
         else:

--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -240,14 +240,31 @@ class BaseModelMerger(ABC):
         This function patch the generation_config created from model config to the pretrained model.
         """
         if model.can_generate():
-            try:
-                model.generation_config = GenerationConfig.from_pretrained(self.hf_model_config_path)
-            except OSError:
-                print(
-                    f"Warning: Generation config file not found in {self.hf_model_config_path}, using a "
-                    f"generation config created from the model config."
-                )
+            generation_config = self.load_generation_config()
+            if generation_config is not None:
+                model.generation_config = generation_config
         return model
+
+    def load_generation_config(self):
+        """Load the generation config stored alongside the pretrained model config."""
+        try:
+            return GenerationConfig.from_pretrained(self.hf_model_config_path)
+        except OSError:
+            print(
+                f"Warning: Generation config file not found in {self.hf_model_config_path}, using a "
+                f"generation config created from the model config."
+            )
+            return None
+
+    def save_generation_config(self, target_dir):
+        """Preserve the pretrained generation config in a merged model directory."""
+        generation_config = self.load_generation_config()
+        if generation_config is not None:
+            generation_config.save_pretrained(target_dir)
+        else:
+            stale_config_path = os.path.join(target_dir, "generation_config.json")
+            if os.path.isfile(stale_config_path):
+                os.remove(stale_config_path)
 
     def _load_lora_train_meta(self) -> Optional[dict[str, object]]:
         if not self.config.local_dir:

--- a/verl/model_merger/megatron_model_merger.py
+++ b/verl/model_merger/megatron_model_merger.py
@@ -479,6 +479,7 @@ class MegatronModelMerger(BaseModelMerger):
             print(f"model saved to {target_dir} with {numel=}")
 
             self.model_config.save_pretrained(self.config.target_dir)
+            self.save_generation_config(self.config.target_dir)
 
             processor = hf_processor(self.hf_model_config_path, trust_remote_code=self.config.trust_remote_code)
             tokenizer = hf_tokenizer(self.hf_model_config_path, trust_remote_code=self.config.trust_remote_code)
@@ -506,7 +507,7 @@ class MegatronModelMerger(BaseModelMerger):
             self._validate_state_dict(merged_state_dict)
         elif self.config.operation == "merge":
             self.save_hf_model_and_tokenizer(merged_state_dict)
-            if self.config.hf_upload:
+            if self.config.hf_upload and self.rank == 0:
                 self.upload_to_huggingface()
         else:
             raise ValueError(f"Unknown operation: {self.config.operation}")


### PR DESCRIPTION
### What does this PR do?

Fixes #7198.

Also fixes #7226: under distributed Megatron merge, every rank previously entered the optional Hugging Face upload branch and could upload the same merged checkpoint concurrently. The upload is now restricted to rank 0.

The distributed Megatron merger now preserves the independent pretrained `generation_config.json` in merged Hugging Face outputs. This prevents generation settings that are absent from `config.json`, such as multiple EOS token IDs, from being lost.

The change reuses a common loader with the existing FSDP merger behavior and removes a stale target `generation_config.json` when the source has none. Missing generation configuration remains a supported fallback, while an existing but malformed `generation_config.json` now propagates its parsing error instead of being silently treated as absent. This fail-closed behavior is intentional because silently dropping a corrupt generation configuration can change generation behavior without a visible failure.

This is not a duplicate of #1277: that PR fixed the FSDP/legacy merger path. The distributed Megatron merger was added later and did not call the generation-config preservation logic.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+generation_config+megatron
- [x] Searched for related issues: https://github.com/verl-project/verl/issues?q=generation_config+megatron
- [x] PR title follows the required module/type format.

### Test

```text
PYTHONPATH=. .venv/bin/pytest -q tests/model_merger/test_output_validation_on_cpu.py
14 passed

.venv/bin/ruff check verl/model_merger/base_model_merger.py verl/model_merger/megatron_model_merger.py tests/model_merger/test_output_validation_on_cpu.py
All checks passed!

.venv/bin/ruff format --check verl/model_merger/base_model_merger.py verl/model_merger/megatron_model_merger.py tests/model_merger/test_output_validation_on_cpu.py
3 files already formatted

python -m py_compile <three changed Python files>
passed
```

The unit tests cover preserving a multi-EOS configuration, removing stale target configuration when the source has no independent generation config, and rejecting a malformed source generation config. A full multi-GPU Megatron merge was not run locally.

### API and Usage Example

No API or CLI change. Existing Megatron merge commands produce the additional `generation_config.json` artifact when it exists in the source checkpoint metadata.

### Design & Code Changes

- Extract loading and saving of pretrained generation configuration into `BaseModelMerger`.
- Save that configuration from the distributed Megatron merger.
- Treat a missing generation config as an allowed fallback, but surface malformed existing configuration.
- Restrict optional Hugging Face upload to rank 0, fixing #7226.
- Add CPU unit coverage for multi-EOS preservation, missing-source cleanup, and malformed-source rejection.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Ran targeted Ruff and unit tests listed above.
- [ ] Human submitter has completed final line-by-line review.
- [x] No documentation update is required because behavior is corrective and the CLI is unchanged.
- [x] Added unit tests.
- [ ] Request CI only after human review.

### AI assistance disclosure

AI assistance was used for code-path investigation, patch preparation, tests, and initial review. This PR is intentionally opened as a draft and must remain draft until the human submitter reviews every changed line and can defend the change end-to-end.
