### PR TITLE
[rollout] fix: decode per-turn LLM tokens in traces

### DIFF
--- a/docs/advance/rollout_trace.rst
+++ b/docs/advance/rollout_trace.rst
@@ -18,6 +18,8 @@ Trace Parameter Configuration
 - ``actor_rollout_ref.rollout.trace.token2text=True`` # To show decoded text in trace view
 - ``actor_rollout_ref.rollout.trace.max_samples_per_step_per_worker=N`` # Limit traces per worker (optional)
 
+When ``token2text`` is enabled, ``prompt_text`` and ``response_text`` are added to the traced output for both the complete agent loop and each per-turn LLM generation call. The token ids remain available in the trace.
+
 Limiting Trace Volume
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -95,7 +97,7 @@ After executing the training, on the project page, you can see the WEAVE sidebar
 
 Each Trace project corresponds to a trajectory. You can filter and select the trajectories you need to view by step, sample_index, rollout_n, and experiment_name.
 
-After enabling token2text, prompt_text and response_text will be automatically added to the output of ToolAgentLoop.run, making it convenient to view the input and output content.
+After enabling token2text, ``prompt_text`` and ``response_text`` are automatically added to the outputs of ``ToolAgentLoop.run`` and each ``LLMServerClient.generate`` call, making it convenient to inspect complete trajectories and individual turns.
 
 .. image:: https://github.com/eric-haibin-lin/verl-community/blob/main/docs/weave_trace_list.png?raw=true
 
@@ -136,7 +138,7 @@ For example, searching for ``"tags.step = '1'"`` can display all trajectories of
 
 Opening one of the trajectories allows you to view each function call process within it.
 
-After enabling token2text, prompt_text and response_text will be automatically added to the output of ToolAgentLoop.run, making it convenient to view the content.
+After enabling token2text, ``prompt_text`` and ``response_text`` are automatically added to the outputs of ``ToolAgentLoop.run`` and each ``LLMServerClient.generate`` call, making it convenient to inspect complete trajectories and individual turns.
 
 .. image:: https://github.com/eric-haibin-lin/verl-community/blob/main/docs/mlflow_trace_view.png?raw=true
 

--- a/tests/utils/test_rollout_trace_on_cpu.py
+++ b/tests/utils/test_rollout_trace_on_cpu.py
@@ -18,6 +18,7 @@ import types
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
 
 from verl.utils.rollout_trace import RolloutTraceConfig, rollout_trace_attr, rollout_trace_op
 
@@ -67,6 +68,17 @@ def mock_trackio_client():
         yield mock_trackio
 
 
+@pytest.fixture
+def mock_mlflow_client():
+    """Mocks the mlflow module, yielding the mock module and active span."""
+    mock_mlflow = MagicMock()
+    mock_span = MagicMock()
+    mock_mlflow.start_span.return_value.__enter__.return_value = mock_span
+
+    with patch.dict(sys.modules, {"mlflow": mock_mlflow}):
+        yield mock_mlflow, mock_span
+
+
 class TracedClass:
     @rollout_trace_op
     # @weave.op
@@ -109,6 +121,24 @@ class ChatTraceClass:
         }
 
 
+class GeneratedTokenOutput(BaseModel):
+    token_ids: list[int]
+
+
+class FakeTokenizer:
+    def decode(self, token_ids):
+        return "decoded:" + ",".join(str(token_id) for token_id in token_ids)
+
+
+class LLMGenerateTraceClass:
+    def __init__(self):
+        self.tokenizer = FakeTokenizer()
+
+    @rollout_trace_op
+    async def generate(self, *, prompt_ids):
+        return GeneratedTokenOutput(token_ids=[3, 4])
+
+
 async def test_rollout_trace_on_untraced_class():
     """Tests that the decorator works correctly when no backend is configured."""
     instance = UntracedClass()
@@ -132,6 +162,30 @@ async def test_rollout_trace_with_tracer(mock_weave_client):
 
     mock_call = mock_weave_client.create_call.return_value
     mock_weave_client.finish_call.assert_called_once_with(mock_call, output=result)
+
+
+async def test_token2text_decodes_llm_generate_input_and_output(mock_mlflow_client):
+    """Per-turn LLM traces decode prompt input ids and generated output ids."""
+    _, mock_span = mock_mlflow_client
+    RolloutTraceConfig.init(
+        project_name="my-project",
+        experiment_name="my-experiment",
+        backend="mlflow",
+        token2text=True,
+    )
+
+    instance = LLMGenerateTraceClass()
+    result = await instance.generate(prompt_ids=[1, 2])
+
+    assert result == GeneratedTokenOutput(token_ids=[3, 4])
+    mock_span.set_inputs.assert_called_once_with({"prompt_ids": [1, 2]})
+    mock_span.set_outputs.assert_called_once_with(
+        {
+            "token_ids": [3, 4],
+            "prompt_text": "decoded:1,2",
+            "response_text": "decoded:3,4",
+        }
+    )
 
 
 async def test_rollout_trace_with_exception(mock_weave_client):

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -547,6 +547,10 @@ class AgentLoopWorker:
             self.model_config.tokenizer.chat_template = self.model_config.custom_chat_template
 
         trace_config = self.rollout_config.trace
+        if trace_config.get("token2text", False):
+            # rollout_trace_op runs on the LLM client, so provide the tokenizer
+            # needed to decode each generate call's prompt and response tokens.
+            self.llm_client.tokenizer = self.tokenizer
         RolloutTraceConfig.init(
             self.rollout_config.trace.project_name,
             self.rollout_config.trace.experiment_name,

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -315,6 +315,52 @@ def _current_trace_attributes():
     return {**(_trace_attributes.get() or {})}
 
 
+def _trace_field(value, field_name):
+    if isinstance(value, dict):
+        return value.get(field_name)
+    return getattr(value, field_name, None)
+
+
+def _trace_output_copy(output):
+    if isinstance(output, BaseModel):
+        return output.model_dump()
+    if isinstance(output, dict):
+        return dict(output)
+    if hasattr(output, "__dict__"):
+        return dict(vars(output))
+    return None
+
+
+async def _add_token2text(instance, inputs, output):
+    tokenizer = getattr(instance, "tokenizer", None)
+    decode = getattr(tokenizer, "decode", None)
+    if not callable(decode):
+        return output
+
+    # Agent-loop outputs contain prompt_ids/response_ids, while per-turn
+    # LLMServerClient.generate calls receive prompt_ids and return token_ids.
+    prompt_ids = _trace_field(output, "prompt_ids")
+    if prompt_ids is None:
+        prompt_ids = inputs.get("prompt_ids")
+    response_ids = _trace_field(output, "response_ids")
+    if response_ids is None:
+        response_ids = _trace_field(output, "token_ids")
+
+    if prompt_ids is None and response_ids is None:
+        return output
+
+    output_copy = _trace_output_copy(output)
+    if output_copy is None:
+        return output
+
+    loop = get_event_loop()
+    if prompt_ids is not None:
+        output_copy["prompt_text"] = await loop.run_in_executor(None, decode, prompt_ids)
+    if response_ids is not None:
+        output_copy["response_text"] = await loop.run_in_executor(None, decode, response_ids)
+    return output_copy
+
+
 def rollout_trace_op(func):
     @functools.wraps(func)
     async def async_wrapper(self, *args, **kwargs):
@@ -332,26 +378,6 @@ def rollout_trace_op(func):
         inputs = dict(bound_args.arguments)
         del inputs["self"]
 
-        async def add_token2text(self, result):
-            if hasattr(result, "prompt_ids") and hasattr(self, "tokenizer") and hasattr(self.tokenizer, "decode"):
-                # Use model_dump() for Pydantic models to get a proper copy,
-                # otherwise vars() returns a reference to internal __dict__ which
-                # can cause serialization issues with MLflow
-                if isinstance(result, BaseModel):
-                    _result = result.model_dump()
-                else:
-                    _result = dict(vars(result))
-                loop = get_event_loop()
-                if hasattr(result, "prompt_ids"):
-                    prompt_text = await loop.run_in_executor(None, self.tokenizer.decode, result.prompt_ids)
-                    _result["prompt_text"] = prompt_text
-
-                if hasattr(result, "response_ids"):
-                    response_text = await loop.run_in_executor(None, self.tokenizer.decode, result.response_ids)
-                    _result["response_text"] = response_text
-                return _result
-            return result
-
         if backend == "weave":
             tracer = RolloutTraceConfig.get_client()
 
@@ -361,7 +387,7 @@ def rollout_trace_op(func):
                 result = await func(self, *args, **kwargs)
 
                 if enable_token2text:
-                    _result = await add_token2text(self, result)
+                    _result = await _add_token2text(self, inputs, result)
                     tracer.finish_call(call, output=_result)
                 else:
                     tracer.finish_call(call, output=result)
@@ -378,7 +404,7 @@ def rollout_trace_op(func):
                 span.set_inputs(inputs)
                 result = await func(self, *args, **kwargs)
                 if enable_token2text:
-                    _result = await add_token2text(self, result)
+                    _result = await _add_token2text(self, inputs, result)
                     span.set_outputs(_result)
                 else:
                     span.set_outputs(result)
@@ -388,7 +414,7 @@ def rollout_trace_op(func):
             try:
                 result = await func(self, *args, **kwargs)
                 if enable_token2text:
-                    _result = await add_token2text(self, result)
+                    _result = await _add_token2text(self, inputs, result)
                     _log_trackio_trace(func.__qualname__, inputs, output=_result)
                 else:
                     _log_trackio_trace(func.__qualname__, inputs, output=result)


### PR DESCRIPTION
### What does this PR do?

Fixes #3515.

When rollout tracing is configured with `token2text=True`, per-turn `LLMServerClient.generate` spans currently omit `prompt_text` and `response_text`. This PR makes those decoded fields available for MLflow, Weave, and Trackio while keeping the existing configuration and decorator API unchanged.

#### Root cause

The existing decoder only looks for `prompt_ids` / `response_ids` on the traced function's output and requires a tokenizer on the decorated object. In the async agentic RL path, `LLMServerClient.generate` instead receives `prompt_ids` as an input and returns `TokenOutput.token_ids`, and the client does not own the AgentLoop tokenizer.

#### Changes

- Decode `input.prompt_ids` into `prompt_text` when prompt ids are not present on the output.
- Decode `output.token_ids` into `response_text` when `response_ids` are not present.
- Preserve the existing `output.prompt_ids` / `output.response_ids` behavior for full agent-loop traces.
- Provide the AgentLoop tokenizer to the LLM client only when `token2text` is enabled.
- Copy Pydantic, dictionary, and object outputs before adding decoded fields, leaving the returned model result unchanged.
- Add an MLflow-focused CPU unit test and update the rollout trace documentation.

#### Why this is not a duplicate

- Exact issue search: [open PRs mentioning #3515](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+3515+in%3Abody)
- Keyword search: [open token2text PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+token2text+prompt_text+response_text)
- PR #5588 addressed the same gap but is closed and unmerged. It introduced a general configurable field-mapping API and a global tokenizer fallback. This PR takes a narrower approach for the established rollout fields, without adding public API or global tokenizer state.

#### AI assistance disclosure

OpenAI Codex assisted with implementation, tests, validation, and PR drafting. The human submitter reviewed every changed line, understands the change end-to-end, and confirmed the targeted tests pass. The commit also includes an `Assisted-by: OpenAI Codex` trailer.

### Checklist Before Starting

- [x] Searched for similar PRs; query links are included above.
- [x] Formatted the title as `[{modules}] {type}: {description}`.

### Test

```text
python -m pytest -q --asyncio-mode=auto \
  tests/utils/test_rollout_trace_on_cpu.py \
  tests/workers/rollout/test_llm_server_routed_experts_on_cpu.py \
  tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py

25 passed, 2 skipped
```

The two skipped tests are the opt-in real Weave and MLflow integration tests, which require external backend configuration.

```text
pre-commit run --all-files --show-diff-on-failure --color=never

All hooks passed, including Ruff, Ruff format, mypy, generated trainer config verification, repository sanity checks, and compileall.
```

```text
uv pip check

All installed packages are compatible.
```

### API and Usage Example

There is no public API or configuration change. Existing configuration now also decodes each per-turn generation span:

```yaml
actor_rollout_ref:
  rollout:
    trace:
      backend: mlflow
      token2text: true
```

Each traced `LLMServerClient.generate` output includes `prompt_text` and `response_text` in addition to the original token fields.

### Design & Code Changes

The token-to-text helper now resolves the existing output fields first, then falls back to the per-turn generation field layout (`input.prompt_ids` and `output.token_ids`). `AgentLoopWorker` supplies its tokenizer to the local LLM client only when decoding is enabled. All tracing backends continue to use the same shared conversion path.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [x] Applied the full pre-commit checks.
- [x] Updated the documentation.
- [x] Added a CPU unit test to the existing rollout-trace test file, which is already collected by the CPU workflow; no workflow path change is needed.
- [ ] Request CI in the community channel once this draft is ready for CI.
- [x] Recipe submodule update is not applicable.
