### PR TITLE
[rollout] fix: cap partial rollout resumes at the remaining response budget

### DIFF
--- a/tests/workers/rollout/test_llm_server_response_length_cap_on_cpu.py
+++ b/tests/workers/rollout/test_llm_server_response_length_cap_on_cpu.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cumulative response budget across partial rollout resumes.
+
+A resume re-sends ``prompt + everything generated so far`` as ``prompt_ids``. If the request
+carries no explicit limit, the server falls back to
+
+    min(response_length, prompt_length + response_length - len(prompt_ids))
+
+which charges already-generated tokens against the *prompt* budget and measures that budget with
+the configured ``prompt_length`` rather than this request's actual prompt length. Generation then
+runs to ``prompt_length + response_length - actual_prompt_length`` -- the overshoot is exactly the
+unused prompt budget, is decoded at the deepest KV positions, and is discarded by the agent loop's
+``[: response_length]`` slice. The ``max_model_len`` clamp does not bound it, because
+``max_model_len`` defaults to the model's ``max_position_embeddings``.
+
+``FakeRolloutServer`` below mirrors ``vLLMHttpServer.generate``'s cap arithmetic so these tests
+pin the behaviour the real servers implement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.workers.rollout import llm_server
+from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient
+from verl.workers.rollout.replica import TokenOutput
+
+PROMPT_LENGTH = 2048
+RESPONSE_LENGTH = 8192
+MAX_MODEL_LEN = 10241
+
+
+class FakeRolloutServer:
+    """Stand-in for the rollout server, reproducing its ``max_tokens`` resolution.
+
+    The model never emits EOS, so a request only ends when it exhausts the budget it was granted;
+    every ``abort_every`` tokens a weight sync aborts it, which is what drives the resume loop.
+    """
+
+    def __init__(self, abort_every: int):
+        self.abort_every = abort_every
+        self.grants: list[tuple[int, int]] = []
+
+    async def generate(self, request_id, *, prompt_ids, sampling_params, **kwargs):
+        # Requests cross a Ray boundary, so the server only ever mutates its own copy.
+        params = dict(sampling_params)
+
+        max_possible_tokens = MAX_MODEL_LEN - len(prompt_ids)
+        assert max_possible_tokens >= 1
+
+        if "max_tokens" in params:
+            max_tokens = params.pop("max_tokens")
+        elif "max_new_tokens" in params:
+            max_tokens = params.pop("max_new_tokens")
+        else:
+            max_tokens = min(RESPONSE_LENGTH, PROMPT_LENGTH + RESPONSE_LENGTH - len(prompt_ids))
+        max_tokens = max(1, min(max_tokens, max_possible_tokens))
+        self.grants.append((len(prompt_ids), max_tokens))
+
+        generated = min(max_tokens, self.abort_every)
+        return TokenOutput(
+            token_ids=[7] * generated,
+            log_probs=None,
+            stop_reason="length" if generated == max_tokens else "aborted",
+        )
+
+
+@pytest.fixture
+def server(monkeypatch: pytest.MonkeyPatch) -> FakeRolloutServer:
+    fake = FakeRolloutServer(abort_every=2000)
+    # ``super().generate`` binds to the class, so the base class has to be patched. An already
+    # bound method is not a descriptor, so it does not pick up the client as a second ``self``.
+    monkeypatch.setattr(llm_server.LLMServerClient, "generate", fake.generate)
+
+    real_sleep = asyncio.sleep
+
+    async def no_wait(_delay, *args, **kwargs):
+        return await real_sleep(0, *args, **kwargs)
+
+    # The resume loop backs off 1s between attempts; collapse it to keep the test fast.
+    monkeypatch.setattr(llm_server.asyncio, "sleep", no_wait)
+    return fake
+
+
+def _config(*, include_async_training: bool = True) -> Any:
+    config: dict[str, Any] = {"actor_rollout_ref": {"rollout": {"response_length": RESPONSE_LENGTH, "name": "vllm"}}}
+    if include_async_training:
+        config["async_training"] = {"partial_rollout": True}
+    return OmegaConf.create(config)
+
+
+async def _generate(config: Any, prompt_len: int, sampling_params: dict[str, Any]) -> TokenOutput:
+    client = FullyAsyncLLMServerClient(config=config, load_balancer_handle=None)
+    return await client.generate(
+        request_id="req-0",
+        prompt_ids=list(range(prompt_len)),
+        sampling_params=sampling_params,
+    )
+
+
+# A prompt far shorter than ``prompt_length`` leaves the most unused budget to leak into the
+# response; a prompt that fills ``prompt_length`` leaves none, which is why the pre-fix overshoot
+# went unnoticed in configs whose prompts are near the limit.
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prompt_len", [92, 136, PROMPT_LENGTH])
+async def test_resumes_never_exceed_response_length(server, prompt_len):
+    output = await _generate(_config(), prompt_len, {"temperature": 1.0})
+
+    assert len(output.token_ids) <= RESPONSE_LENGTH, (
+        f"generated {len(output.token_ids)} tokens against a {RESPONSE_LENGTH} budget; "
+        f"per-attempt grants were {server.grants}"
+    )
+    # A model that never emits EOS spends the budget exactly, and each attempt is granted only
+    # what the response still owes, so the grants sum to the budget.
+    assert len(output.token_ids) == RESPONSE_LENGTH
+    assert server.grants[0][1] == RESPONSE_LENGTH
+    assert sum(min(grant, server.abort_every) for _, grant in server.grants) == RESPONSE_LENGTH
+    assert output.stop_reason == "length"
+
+
+@pytest.mark.asyncio
+async def test_cap_holds_without_async_training_key(server):
+    """v1 async trainers install this client with a config that has no ``async_training`` key, so
+    ``should_retry`` stays True and the resume loop runs with no way to opt out."""
+    output = await _generate(_config(include_async_training=False), 136, {"temperature": 1.0})
+
+    assert len(output.token_ids) <= RESPONSE_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_caller_sampling_params_not_mutated(server):
+    """The per-attempt budget is written back into ``sampling_params``; the caller reuses that dict
+    across turns, so the rewrite must land on a copy."""
+    sampling_params = {"temperature": 1.0, "top_p": 0.9}
+
+    await _generate(_config(), 136, sampling_params)
+
+    assert sampling_params == {"temperature": 1.0, "top_p": 0.9}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit_key", ["max_tokens", "max_new_tokens"])
+async def test_explicit_caller_budget_wins(server, limit_key):
+    output = await _generate(_config(), 136, {"temperature": 1.0, limit_key: 500})
+
+    assert len(output.token_ids) <= 500
+
+
+@pytest.mark.asyncio
+async def test_config_without_rollout_section_is_tolerated(server):
+    """Lightweight callers and tests pass a config stub; the client must fall back to the server
+    default rather than raising."""
+    output = await _generate(SimpleNamespace(), 136, {"temperature": 1.0})
+
+    assert len(output.token_ids) > 0

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -319,6 +319,18 @@ class FullyAsyncLLMServerClient(LLMServerClient):
                 else:
                     raise
 
+    def _configured_response_length(self) -> Optional[int]:
+        """Per-response token budget from the rollout config, or ``None`` when unavailable.
+
+        Tests and lightweight callers may pass a config stub without the rollout section; in that
+        case the resume loop keeps its previous behaviour of deferring to the server default.
+        """
+        rollout_config = getattr(getattr(self.config, "actor_rollout_ref", None), "rollout", None)
+        response_length = getattr(rollout_config, "response_length", None)
+        if isinstance(response_length, int) and response_length > 0:
+            return response_length
+        return None
+
     @rollout_trace_op
     async def generate(
         self,
@@ -354,6 +366,22 @@ class FullyAsyncLLMServerClient(LLMServerClient):
         elif "max_new_tokens" in sampling_params:
             limit_key = "max_new_tokens"
         original_max_tokens = sampling_params.get(limit_key) if limit_key else None
+
+        # The budget below is rewritten on every attempt, and the caller reuses its dict across
+        # turns, so never mutate the caller's copy.
+        sampling_params = dict(sampling_params)
+
+        if original_max_tokens is None:
+            # Without an explicit limit each attempt falls back to the server-side default, which is
+            # derived from len(prompt_ids) and is only correct on the first attempt: a resume passes
+            # prompt + tokens generated so far, so the default charges generated tokens against the
+            # *prompt* budget and re-permits close to a full response_length every time. Pin the
+            # cumulative budget here instead, which also makes the bookkeeping in step 3 effective.
+            response_length = self._configured_response_length()
+            if response_length is not None:
+                limit_key = "max_tokens"
+                original_max_tokens = response_length
+                sampling_params[limit_key] = response_length
 
         final_output = TokenOutput(
             token_ids=[],


### PR DESCRIPTION
### What does this PR do?

**Summary:** when a partial rollout is aborted and resumed, the total number of generated tokens can go past `response_length`. The extra tokens are slow to generate, and they are thrown away afterwards. This PR makes the resume path count the tokens it has already generated, so the total stays inside `response_length`.

#### The problem, step by step

**1. Agent loops do not set a token limit.**

`sampling_params` is built in `agent_loop.py:590` and `agent_loop_tq.py:64`. Neither one sets `max_tokens` or `max_new_tokens`.

**2. So the server uses its default formula** (`vllm_async_server.py:564`):

```python
max_tokens = min(
    self.config.response_length,
    self.config.prompt_length + self.config.response_length - len(prompt_ids),
)
```

This formula assumes that `prompt_ids` contains only the prompt. That is true for the first request.

**3. But a resume sends prompt + generated tokens.**

`FullyAsyncLLMServerClient.generate` calls the server with `prompt_ids + final_output.token_ids` (`llm_server.py:369`). This is correct — the engine needs them to continue the sequence. But now `len(prompt_ids)` is larger than the prompt.

**4. Two mistakes happen at the same time.**

- Generated tokens are subtracted from a budget that means *prompt* tokens.
- `self.config.prompt_length` is the configured *maximum* prompt size, not the real prompt size of this request.

These two mistakes do not cancel each other. The result is a limit based on the model window (`prompt_length + response_length`) instead of the remaining budget (`response_length - already_generated`).

**5. The `max_model_len` clamp does not stop it.**

`max_model_len` is `null` by default, and then becomes the model's `max_position_embeddings` (`vllm_async_server.py:954-955`). It is only checked as an upper bound. So it is usually much larger than `prompt_length + response_length`.

#### How large is the error?

The total generated length can reach:

```
prompt_length + response_length - actual_prompt_length
```

So the extra amount is exactly the **unused part of the prompt budget**:

```
overshoot = prompt_length - actual_prompt_length
```

This means:

- Short prompts → large overshoot.
- A prompt that fills `prompt_length` → no overshoot at all.

Example with `prompt_length=2048`, `response_length=8192`, real prompt = 136 tokens, `max_model_len=10241`:

| | `len(prompt_ids)` | limit the server gives | correct limit |
| --- | --- | --- | --- |
| first request | 136 | `min(8192, 2048+8192−136)` = **8192** | 8192 ✅ |
| resume after 6000 tokens | 6136 | `min(8192, 2048+8192−6136)` = **4104** | 8192−6000 = **2192** ❌ |

The resume is allowed 4104 more tokens instead of 2192. The response reaches 10104 tokens instead of 8192.

#### Why this wastes time

Decoding cost grows with sequence length, because every step reads the KV cache of all earlier tokens. The extra tokens sit at positions 8192–10104, so they are the slowest tokens in the whole request. They are then dropped by the `[: response_length]` slice in the agent loop. Maximum cost, zero benefit.

#### The fix already exists, but never runs

`llm_server.py` already tracks the remaining budget across resumes. But that code is inside `if original_max_tokens is not None`. When the caller sets no limit key — which is always true for agent loops — `original_max_tokens` is `None`, so the block never runs. This PR gives it a value, so it starts working.

#### Which setups are affected

This does **not** require `partial_rollout`. `trainer_colocate_async.py:34` and `trainer_separate_async.py:131` also install this client. Their config has no `async_training` key, so `should_retry` at `llm_server.py:412` stays `True`. There is no way to turn it off.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [`is:pr max_tokens response_length`](https://github.com/verl-project/verl/issues?q=repo%3Averl-project%2Fverl+is%3Apr+max_tokens+response_length), [`partial_rollout response_length`](https://github.com/verl-project/verl/issues?q=repo%3Averl-project%2Fverl+partial_rollout+response_length)
- [x] Format the PR title as `[{modules}] {type}: {description}`

I searched the open PRs that touch `max_tokens`, `response_length`, or partial rollout. No open PR changes `llm_server.py` or the resume path, so this is not a duplicate.

### Test

New file: `tests/workers/rollout/test_llm_server_response_length_cap_on_cpu.py`.

It runs the real `FullyAsyncLLMServerClient`. Only the server is replaced by a fake one, and that fake copies the exact `max_tokens` logic of `vLLMHttpServer.generate`. The file name ends with `_on_cpu.py`, so `cpu_unit_tests.yml` collects it automatically.

```bash
pytest -s -x --asyncio-mode=auto tests/workers/rollout/test_llm_server_response_length_cap_on_cpu.py
```

**Result on this branch: 8 passed.**

**Result on the parent commit: 3 of 8 fail.**

```
AssertionError: generated 10104 tokens against a 8192 budget; per-attempt grants were
  [(136, 8192), (2136, 8104), (4136, 6104), (6136, 4104), (8136, 2104), (10136, 104)]

AssertionError: generated 10148 tokens against a 8192 budget; per-attempt grants were
  [(92, 8192), (2092, 8148), (4092, 6148), (6092, 4148), (8092, 2148), (10092, 148)]
```

Each pair above is `(len(prompt_ids), limit given)`. With the fix, the limits become:

```
[(136, 8192), (2136, 6192), (4136, 4192), (6136, 2192), (8136, 192)]
```

Every attempt now receives exactly what is still left. The sum is 8192.

I also re-ran the existing test for this code, `tests/workers/rollout/test_llm_server_routed_experts_on_cpu.py` (it covers routing merge across resumes, for all three backend formats). All tests still pass.

`pre-commit run --files <changed files> --show-diff-on-failure` passes on all hooks.

**Not tested:** I did not run a GPU end-to-end job. The bug is integer arithmetic on `len(prompt_ids)`, and the test above runs the real client against an exact copy of the server formula.

### API and Usage Example

No API change.

Behaviour change: if the caller sets no `max_tokens` or `max_new_tokens`, the **total** across all resumes is now limited by `response_length`. Before, each attempt got a new limit from the server formula. A limit set by the caller still has priority.

```python
# Unchanged: an explicit limit wins.
await client.generate(request_id=..., prompt_ids=..., sampling_params={"max_tokens": 512})

# Changed: with no limit key, the total across all resumes is now bounded by
# actor_rollout_ref.rollout.response_length, instead of by the model window.
await client.generate(request_id=..., prompt_ids=..., sampling_params={"temperature": 1.0})
```

### Design & Code Changes

**`verl/workers/rollout/llm_server.py`**

- If the caller sets no limit key, use the configured `response_length` as the total budget. This activates the existing per-attempt tracking at the end of the loop.
- Copy `sampling_params` first. That tracking code writes the remaining budget back into the dict, and the caller re-uses the same dict across turns, so the write must not escape.
- Read the config through a small helper that returns `None` if the rollout section is missing. Callers that pass a config stub (the existing CPU tests do this) keep the old behaviour.

**`tests/workers/rollout/test_llm_server_response_length_cap_on_cpu.py`** — new file.

**Why I did not change the vLLM and SGLang formula**

The formula is wrong for resumed sequences. But the term `prompt_length + response_length - len(prompt_ids)` is currently the *only* thing that limits the total across resumes. If it were replaced by `min(response_length, max_model_len - len(prompt_ids))` without the client-side budget, every resume would start again with a full `response_length`, which is worse. After this PR, the formula is only a fallback for callers that send no limit at all.

**Not included in this PR**

The same problem also exists in `tool_agent_loop.py`. It adds earlier turns and tool responses into `prompt_ids`, and then hits the same server formula. No resume is needed for this. Its `len(response_mask) >= response_length` checks only stop the loop *after* a too-long turn was already generated. The fix would be a per-turn limit of `response_length - len(response_mask)`. I kept this PR to the resume path only, so it stays small and easy to review. I am happy to add the multi-turn part here if maintainers prefer.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed — no config or API change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows). Covered by `cpu_unit_tests.yml` through the `*_on_cpu.py` pattern.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [ ] `recipe` submodule update — not needed.

---

AI assistance was used in preparing this change: the analysis, the patch, and the test were produced with Claude Code. I have read through the full diff and can speak to the change end-to-end.
