### PR TITLE
[ckpt] fix: clean up local checkpoints after load

### DIFF
--- a/tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py
+++ b/tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py
@@ -137,3 +137,44 @@ class TestCheckpointCleanupLogic:
         manager.register_checkpoint(ckpt_300, 1)
         assert not os.path.exists(ckpt_200)
         assert manager.previous_saved_paths == [ckpt_300]
+
+    def test_cleanup_after_load_removes_checkpoint_on_rank_zero(self, manager, monkeypatch):
+        """The opt-in cleanup removes the role checkpoint only after all ranks finish loading."""
+        checkpoint_path = self._create_checkpoint_dir(100)
+        events = []
+        remove_checkpoint = manager.remove_previous_save_local_path
+
+        def record_remove(path):
+            events.append("remove")
+            remove_checkpoint(path)
+
+        monkeypatch.setattr("torch.distributed.barrier", lambda: events.append("barrier"))
+        monkeypatch.setattr(manager, "remove_previous_save_local_path", record_remove)
+
+        manager._cleanup_local_checkpoint_after_load(checkpoint_path, enabled=True)
+
+        assert not os.path.exists(checkpoint_path)
+        assert events == ["barrier", "remove", "barrier"]
+
+    def test_cleanup_after_load_is_rank_zero_only(self, manager, monkeypatch):
+        """Nonzero ranks synchronize but never race rank zero to delete the shared directory."""
+        checkpoint_path = self._create_checkpoint_dir(100)
+        manager.rank = 1
+        barriers = []
+        monkeypatch.setattr("torch.distributed.barrier", lambda: barriers.append("barrier"))
+
+        manager._cleanup_local_checkpoint_after_load(checkpoint_path, enabled=True)
+
+        assert os.path.exists(checkpoint_path)
+        assert barriers == ["barrier", "barrier"]
+
+    def test_cleanup_after_load_disabled_preserves_checkpoint(self, manager, monkeypatch):
+        """Disabled cleanup keeps the checkpoint and preserves the existing load barrier."""
+        checkpoint_path = self._create_checkpoint_dir(100)
+        barriers = []
+        monkeypatch.setattr("torch.distributed.barrier", lambda: barriers.append("barrier"))
+
+        manager._cleanup_local_checkpoint_after_load(checkpoint_path, enabled=False)
+
+        assert os.path.exists(checkpoint_path)
+        assert barriers == ["barrier"]

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -163,6 +163,16 @@ class BaseCheckpointManager:
                 continue
             shutil.rmtree(abs_path, ignore_errors=True)
 
+    def _cleanup_local_checkpoint_after_load(self, local_path: str, enabled: bool) -> None:
+        """Synchronize checkpoint loading and optionally remove the shared local directory."""
+        torch.distributed.barrier()
+        if not enabled:
+            return
+
+        if self.rank == 0:
+            self.remove_previous_save_local_path(local_path)
+        torch.distributed.barrier()
+
     def ensure_checkpoint_capacity(self, max_ckpt_to_keep: int):
         """
         Remove old checkpoints to make room for a new one, keeping a safety buffer.

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -29,7 +29,7 @@ from transformers import GenerationConfig, PreTrainedTokenizer, ProcessorMixin
 from transformers.dynamic_module_utils import custom_object_save
 
 from verl.utils.device import is_cuda_available
-from verl.utils.fs import copy_to_local, is_non_local, local_mkdir_safe
+from verl.utils.fs import copy_to_local, local_mkdir_safe
 from verl.utils.fsdp_utils import fsdp_version, get_fsdp_full_state_dict, get_fsdp_state_ctx
 from verl.utils.logger import log_with_rank
 from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq
@@ -219,20 +219,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                 self.lr_scheduler.load_state_dict(lr_scheduler_state_dict)
                 log_with_rank(f"Loaded lr_scheduler from {remote_extra_state_path}", rank=self.rank, logger=logger)
 
-        if self.rank == 0 and del_local_after_load:
-            try:
-                os.remove(local_model_path) if is_non_local(local_model_path) else None
-                os.remove(local_optim_path) if is_non_local(local_optim_path) else None
-                os.remove(local_extra_state_path) if is_non_local(local_extra_state_path) else None
-            except Exception as e:
-                log_with_rank(
-                    f"remove local resume ckpt file after loading failed, exception {e} will be ignored",
-                    rank=self.rank,
-                    logger=logger,
-                )
-
-        # wait for everyone to load checkpoints
-        torch.distributed.barrier()
+        self._cleanup_local_checkpoint_after_load(local_path, enabled=del_local_after_load)
 
     def save_checkpoint(self, local_path: str, hdfs_path: str = None, global_step: int = 0, max_ckpt_to_keep=None):
         """

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -30,7 +30,7 @@ from packaging import version
 from transformers import GenerationConfig
 
 from verl.utils.device import get_device_name, get_torch_device
-from verl.utils.fs import is_non_local, local_mkdir_safe
+from verl.utils.fs import local_mkdir_safe
 from verl.utils.logger import log_with_rank
 from verl.utils.megatron.dist_checkpointing import load_dist_checkpointing, save_dist_checkpointing
 from verl.utils.megatron_utils import (
@@ -760,15 +760,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             log_with_rank(f"Loaded RNG states from {local_path}", rank=self.rank, logger=logger)
         log_with_rank(f"Loaded Megatron-FSDP checkpoint from {local_path}", rank=self.rank, logger=logger)
 
-        if del_local_after_load:
-            try:
-                os.remove(local_path) if is_non_local(local_path) else None
-            except Exception as e:
-                log_with_rank(
-                    f"remove local resume ckpt file after loading failed, exception {e} will be ignored",
-                    rank=self.rank,
-                    logger=logger,
-                )
+        self._cleanup_local_checkpoint_after_load(local_path, enabled=del_local_after_load)
 
     def _save_megatron_fsdp_checkpoint(self, dist_checkpoint_path: str):
         """Save a Megatron-FSDP (DTensor) checkpoint.
@@ -974,15 +966,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             self.load_rng_states(loaded_extra["rng_state"])
             log_with_rank(f"Loaded RNG states from {extra_dist_path}", rank=self.rank, logger=logger)
 
-        if del_local_after_load:
-            try:
-                os.remove(local_path) if is_non_local(local_path) else None
-            except Exception as e:
-                log_with_rank(
-                    f"remove local resume ckpt file after loading failed, exception {e} will be ignored",
-                    rank=self.rank,
-                    logger=logger,
-                )
+        self._cleanup_local_checkpoint_after_load(local_path, enabled=del_local_after_load)
 
     # -- Save ------------------------------------------------------------------
 


### PR DESCRIPTION
### What does this PR do?

Fix `del_local_after_load` for FSDP and Megatron checkpoints. All ranks now finish loading before rank 0 removes the shared role checkpoint directory, followed by a second synchronization so no rank races with cleanup. Disabled cleanup continues to preserve the checkpoint.

Add CPU regression coverage for cleanup ordering, rank-zero-only deletion, and the disabled path.

AI assistance: Codex was used to help implement the code.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+checkpoint+cleanup+after+load
- [x] No open PR was found that implements this checkpoint cleanup behavior.
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[ckpt] fix: clean up local checkpoints after load`

### Test

- Stubbed CPU execution of `tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py`: `8 passed in 0.04s`
- `uvx --with hydra-core pre-commit run --files tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py verl/utils/checkpoint/checkpoint_manager.py verl/utils/checkpoint/fsdp_checkpoint_manager.py verl/utils/checkpoint/megatron_checkpoint_manager.py`: all hooks passed
- `git diff --check`: passed

### API and Usage Example

No API or configuration changes. Setting the existing `trainer.del_local_ckpt_after_load=true` option now removes the loaded local role checkpoint directory after distributed loading completes.

### Design & Code Changes

- Add a shared checkpoint cleanup helper that synchronizes before deletion, deletes only on rank 0, and synchronizes after deletion.
- Use the helper in FSDP, Megatron, and Megatron-FSDP checkpoint loading paths.
- Replace ineffective per-file cleanup checks with role-directory cleanup.
- Add CPU regression tests for enabled, nonzero-rank, and disabled behavior.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied pre-commit checks to all changed files.
- [x] No documentation update is required because this fixes existing configuration behavior without changing the API.
- [x] Added unit tests to an existing `test_*_on_cpu.py` file discovered by `cpu_unit_tests.yml`.
- [ ] Request CI in the project CI channel.
- [x] This PR is not related to the `recipe` submodule.
