### PR TITLE
[misc] fix: enforce HDFS copy timeout

### DIFF
--- a/tests/utils/test_hdfs_io_on_cpu.py
+++ b/tests/utils/test_hdfs_io_on_cpu.py
@@ -1,0 +1,106 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shlex
+import signal
+import sys
+import time
+
+import pytest
+
+from verl.utils import hdfs_io
+
+
+def _process_exists(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_for_process_exit(pid, timeout=2):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _process_exists(pid):
+            return True
+        time.sleep(0.01)
+    return not _process_exists(pid)
+
+
+def test_hdfs_copy_forwards_timeout(monkeypatch):
+    command = "hdfs dfs -put -f /tmp/source hdfs://cluster/dest"
+    calls = []
+
+    def fail_command(cmd, timeout=None):
+        calls.append((cmd, timeout))
+        return -1
+
+    monkeypatch.setattr(hdfs_io, "_HDFS_BIN_PATH", "hdfs")
+    monkeypatch.setattr(hdfs_io, "_run_cmd", fail_command)
+
+    copied = hdfs_io.copy("/tmp/source", "hdfs://cluster/dest", timeout=3, dirs_exist_ok=True)
+
+    assert copied is False
+    assert calls == [(command, 3)]
+
+
+def test_run_cmd_returns_completed_process_exit_code():
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote('raise SystemExit(7)')}"
+
+    assert hdfs_io._run_cmd(command, timeout=5) == 7
+
+
+@pytest.mark.skipif(os.name != "posix", reason="HDFS command execution requires POSIX")
+def test_run_cmd_timeout_terminates_process_group(tmp_path):
+    pid_file = tmp_path / "child.pid"
+    child_code = f"import os, time; open({str(pid_file)!r}, 'w').write(str(os.getpid())); time.sleep(10)"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(child_code)} & wait"
+    child_pid = None
+
+    try:
+        result = hdfs_io._run_cmd(command, timeout=1)
+        child_pid = int(pid_file.read_text())
+        child_exited = _wait_for_process_exit(child_pid)
+    finally:
+        if child_pid is not None and _process_exists(child_pid):
+            os.kill(child_pid, signal.SIGKILL)
+
+    assert result == -1
+    assert child_exited
+
+
+@pytest.mark.skipif(os.name != "posix", reason="HDFS command execution requires POSIX")
+def test_run_cmd_interrupt_terminates_process_group(monkeypatch):
+    class InterruptingProcess:
+        pid = 123
+        wait_calls = 0
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise KeyboardInterrupt
+            return -signal.SIGKILL
+
+    process = InterruptingProcess()
+    killed_groups = []
+    monkeypatch.setattr(hdfs_io.subprocess, "Popen", lambda *args, **kwargs: process)
+    monkeypatch.setattr(hdfs_io.os, "killpg", lambda pid, sig: killed_groups.append((pid, sig)))
+
+    with pytest.raises(KeyboardInterrupt):
+        hdfs_io._run_cmd("hdfs dfs -ls /", timeout=5)
+
+    assert killed_groups == [(process.pid, signal.SIGKILL)]
+    assert process.wait_calls == 2

--- a/verl/utils/hdfs_io.py
+++ b/verl/utils/hdfs_io.py
@@ -15,6 +15,8 @@
 import logging
 import os
 import shutil
+import signal
+import subprocess
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_SFT_LOGGING_LEVEL", "WARN"))
@@ -102,7 +104,7 @@ def copy(src: str, dst: str, **kwargs) -> bool:
         # TODO(haibin.lin):
         # - handle SameFileError for hdfs files(?)
         # - return file destination for hdfs files
-        return _copy(src, dst)
+        return _copy(src, dst, timeout=kwargs.get("timeout"))
     else:
         if os.path.isdir(src):
             return shutil.copytree(src, dst, **kwargs)
@@ -110,7 +112,7 @@ def copy(src: str, dst: str, **kwargs) -> bool:
             return shutil.copy(src, dst, **kwargs)
 
 
-def _copy(from_path: str, to_path: str, timeout: int = None) -> bool:
+def _copy(from_path: str, to_path: str, timeout: float | None = None) -> bool:
     if to_path.startswith("hdfs"):
         if from_path.startswith("hdfs"):
             returncode = _run_cmd(_hdfs_cmd(f"-cp -f {from_path} {to_path}"), timeout=timeout)
@@ -137,8 +139,28 @@ def _copy(from_path: str, to_path: str, timeout: int = None) -> bool:
     return returncode == 0
 
 
-def _run_cmd(cmd: str, timeout=None):
-    return os.system(cmd)
+def _terminate_process_tree(process: subprocess.Popen) -> None:
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    else:
+        process.kill()
+    process.wait()
+
+
+def _run_cmd(cmd: str, timeout: float | None = None) -> int:
+    process = subprocess.Popen(cmd, shell=True, start_new_session=os.name == "posix")
+    try:
+        return process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _terminate_process_tree(process)
+        logger.warning("HDFS command timed out after %s seconds: %s", timeout, cmd)
+        return -1
+    except BaseException:
+        _terminate_process_tree(process)
+        raise
 
 
 def _hdfs_cmd(cmd: str) -> str:


### PR DESCRIPTION
### What does this PR do?

Honor the existing `timeout` keyword for HDFS copies. HDFS commands now run in an isolated process group on POSIX systems; timeout and interruption paths terminate the process tree and wait for cleanup so a failed copy cannot continue modifying its destination in the background.

Timed-out copies log a warning and return `False`. Local filesystem copy behavior is unchanged.

Add CPU regression coverage for timeout forwarding, completed-command exit codes, process-tree termination, and interruption cleanup.

AI assistance: Codex was used to help implement the code.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+hdfs+copy+timeout
- [x] No open PR was found that implements this HDFS copy timeout behavior.
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[misc] fix: enforce HDFS copy timeout`

### Test

- CPU tests for `tests/utils/test_fs_on_cpu.py` and `tests/utils/test_hdfs_io_on_cpu.py`, executed with minimal package-import stubs because the local lightweight environment does not include Ray: `7 passed in 1.06s`
- `uvx --with hydra-core pre-commit run --files verl/utils/hdfs_io.py tests/utils/test_hdfs_io_on_cpu.py`: all hooks passed
- `ruff check`, `ruff format --check`, `compileall`, and `git diff --check`: passed

### API and Usage Example

No API or configuration changes. The existing keyword now bounds HDFS command execution:

```python
copied = hdfs_io.copy(local_path, hdfs_path, timeout=60)
```

The result is `False` when the command exceeds 60 seconds.

### Design & Code Changes

- Forward `timeout` from the public HDFS copy branch to `_copy()`.
- Replace timeout-ignoring `os.system()` execution with managed subprocess execution.
- Start POSIX commands in a new session and terminate the process group on timeout or interruption.
- Preserve the existing boolean copy result and local filesystem behavior.
- Add HDFS-independent CPU tests, including a real child-process cleanup check.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied pre-commit checks to all changed files.
- [x] No documentation update is required because this fixes an existing keyword without changing the API.
- [x] Added unit tests in a `test_*_on_cpu.py` file discovered by `cpu_unit_tests.yml`.
- [ ] Request CI in the project CI channel.
- [x] This PR is not related to the `recipe` submodule.
