### PR TITLE
[misc] fix: handle large timeout results

### DIFF
--- a/tests/utils/test_timeout_decorator_cpu.py
+++ b/tests/utils/test_timeout_decorator_cpu.py
@@ -24,6 +24,19 @@ from verl.utils.py_functional import timeout_limit as timeout
 # --- Test Task Functions ---
 TEST_TIMEOUT_SECONDS = 1.5  # Timeout duration for tests
 LONG_TASK_DURATION = TEST_TIMEOUT_SECONDS + 0.5  # Duration slightly longer than timeout
+LARGE_RESULT_SIZE = 4 * 1024 * 1024
+DESERIALIZATION_TIMEOUT_SECONDS = 0.5
+DESERIALIZATION_DELAY_SECONDS = DESERIALIZATION_TIMEOUT_SECONDS + 0.25
+
+
+def rebuild_slow_result():
+    time.sleep(DESERIALIZATION_DELAY_SECONDS)
+    return "slow_result"
+
+
+class SlowResult:
+    def __reduce__(self):
+        return rebuild_slow_result, ()
 
 
 @timeout(seconds=TEST_TIMEOUT_SECONDS)  # Keep global decorator for mp tests
@@ -31,6 +44,16 @@ def quick_task(x):
     """A task that completes quickly."""
     time.sleep(0.1)
     return "quick_ok"
+
+
+@timeout(seconds=TEST_TIMEOUT_SECONDS)
+def large_result_task():
+    return b"x" * LARGE_RESULT_SIZE
+
+
+@timeout(seconds=DESERIALIZATION_TIMEOUT_SECONDS)
+def slow_deserialization_task():
+    return SlowResult()
 
 
 @timeout(seconds=TEST_TIMEOUT_SECONDS)  # Keep global decorator for mp tests
@@ -99,6 +122,21 @@ def test_quick_task():  # Renamed from test_multiprocessing_quick_task
     # Call the globally decorated function directly
     result = quick_task(1)
     assert result == "quick_ok"  # Use pytest assert
+
+
+def test_large_result():
+    result = large_result_task()
+
+    assert len(result) == LARGE_RESULT_SIZE
+    assert result[:1] == b"x"
+    assert result[-1:] == b"x"
+
+
+def test_result_deserialization_respects_timeout():
+    with pytest.raises(TimeoutError) as excinfo:
+        slow_deserialization_task()
+
+    assert f"timed out after {DESERIALIZATION_TIMEOUT_SECONDS} seconds" in str(excinfo.value)
 
 
 def test_slow_task_timeout():  # Renamed from test_multiprocessing_slow_task_timeout

--- a/verl/utils/py_functional.py
+++ b/verl/utils/py_functional.py
@@ -20,6 +20,7 @@ import multiprocessing
 import os
 import queue  # Import the queue module for exception type hint
 import signal
+import time
 from contextlib import contextmanager
 from functools import wraps
 from types import SimpleNamespace
@@ -110,35 +111,59 @@ def timeout_limit(seconds: float, use_signals: bool = False):
                 q = multiprocessing.Queue(maxsize=1)
                 process = multiprocessing.Process(target=_mp_target_wrapper, args=(func, q, args, kwargs))
                 process.start()
-                process.join(timeout=seconds)
+                deadline = time.monotonic() + seconds
 
-                if process.is_alive():
-                    process.terminate()
-                    process.join(timeout=0.5)  # Give it a moment to terminate
+                def terminate_process():
                     if process.is_alive():
-                        print(f"Warning: Process {process.pid} did not terminate gracefully after timeout.")
-                    # Update function name in error message if needed (optional but good practice)
-                    raise TimeoutError(f"Function {func.__name__} timed out after {seconds} seconds (multiprocessing)!")
+                        process.terminate()
+                        process.join(timeout=0.5)  # Give it a moment to terminate
+                        if process.is_alive():
+                            print(f"Warning: Process {process.pid} did not terminate gracefully after timeout.")
 
                 try:
-                    success, result_or_exc = q.get(timeout=0.1)  # Small timeout for queue read
+                    while True:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            terminate_process()
+                            raise TimeoutError(
+                                f"Function {func.__name__} timed out after {seconds} seconds (multiprocessing)!"
+                            )
+
+                        try:
+                            success, result_or_exc = q.get(timeout=min(0.1, remaining))
+                            break
+                        except queue.Empty as err:
+                            if process.is_alive():
+                                continue
+
+                            process.join()
+                            exitcode = process.exitcode
+                            if exitcode is not None and exitcode != 0:
+                                raise RuntimeError(
+                                    f"Child process exited with error (exitcode: {exitcode}) before returning result."
+                                ) from err
+                            raise TimeoutError(
+                                f"Operation timed out or process finished unexpectedly without result "
+                                f"(exitcode: {exitcode})."
+                            ) from err
+
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        terminate_process()
+                        raise TimeoutError(
+                            f"Function {func.__name__} timed out after {seconds} seconds (multiprocessing)!"
+                        )
+
+                    process.join(timeout=remaining)
+                    if process.is_alive():
+                        terminate_process()
+                        raise TimeoutError(
+                            f"Function {func.__name__} timed out after {seconds} seconds (multiprocessing)!"
+                        )
+
                     if success:
                         return result_or_exc
-                    else:
-                        raise result_or_exc  # Reraise exception from child
-                except queue.Empty as err:
-                    exitcode = process.exitcode
-                    if exitcode is not None and exitcode != 0:
-                        raise RuntimeError(
-                            f"Child process exited with error (exitcode: {exitcode}) before returning result."
-                        ) from err
-                    else:
-                        # Should have timed out if queue is empty after join unless process died unexpectedly
-                        # Update function name in error message if needed (optional but good practice)
-                        raise TimeoutError(
-                            f"Operation timed out or process finished unexpectedly without result "
-                            f"(exitcode: {exitcode})."
-                        ) from err
+                    raise result_or_exc  # Reraise exception from child
                 finally:
                     q.close()
                     q.join_thread()


### PR DESCRIPTION
### What does this PR do?

Fixes false multiprocessing timeouts when decorated functions return values larger than the queue pipe buffer. The parent now drains the result queue before joining the child, keeps one deadline across result delivery and process exit, and rejects results whose deserialization completes after the deadline.

This does not duplicate an existing PR; the open-PR searches for [`timeout_limit large result`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+timeout_limit+large+result) and related multiprocessing queue deadlock terms returned no matching implementation.

AI assistance: Codex was used to help implement the code.

### Checklist Before Starting

- [x] Search for similar PRs. Query: [`timeout_limit large result`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+timeout_limit+large+result)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
python -c 'import pathlib, sys, types, pytest
root = pathlib.Path("verl").resolve()
verl = types.ModuleType("verl"); verl.__path__ = [str(root)]
utils = types.ModuleType("verl.utils"); utils.__path__ = [str(root / "utils")]
metric = types.ModuleType("verl.utils.metric"); metric.Metric = type("Metric", (), {})
sys.modules.update({"verl": verl, "verl.utils": utils, "verl.utils.metric": metric})
raise SystemExit(pytest.main(["tests/utils/test_timeout_decorator_cpu.py", "-q"]))'
# 8 passed, 1 skipped

uvx --with hydra-core pre-commit run --files verl/utils/py_functional.py tests/utils/test_timeout_decorator_cpu.py
# all hooks passed

git diff --check origin/main...HEAD
# exited successfully
```

### API and Usage Example

No API changes.

### Design & Code Changes

- Read multiprocessing results while the child is alive so large queue payloads can be drained.
- Preserve existing timeout and child-crash error behavior with a monotonic deadline.
- Add regression coverage for a 4 MiB result and result deserialization that crosses the deadline.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). No user-facing API or configuration changed.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. The existing CPU timeout test module now covers large results and deadline-crossing deserialization.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [ ] If this PR is related to the `recipe` submodule, update the reference to the submodule commit. Not applicable.
