### PR TITLE
 [doc, hardware, worker, trainer] feat: add SFT support for TPU using TorchTitan engine 

### DIFF
--- a/docs/hardware/multi_chip_support.rst
+++ b/docs/hardware/multi_chip_support.rst
@@ -22,6 +22,7 @@ Hardware Support
 
 - NVIDIA GPU (CUDA)
 - Huawei Ascend NPU
+- Google TPU
 
 **Via verl-hardware-plugin (reference implementations):**
 
@@ -79,6 +80,7 @@ Architecture Overview
     |  |  PlatformRegistry                                        |      |
     |  |    ├─ "nvidia"    → PlatformCUDA      (built-in)         |      |
     |  |    ├─ "huawei"    → PlatformNPU       (built-in)         |      |
+    |  |    ├─ "tpu"       → PlatformTPU       (built-in)         |      |
     |  |    ├─ "intel"     → PlatformXPU       (plugin)           |      |
     |  |    ├─ "cambricon" → PlatformMLU       (plugin)           |      |
     |  |    └─ "metax"     → PlatformMetaX     (plugin)           |      |

--- a/examples/tpu/sft/run_qwen3_0_6b_torchtitan.sh
+++ b/examples/tpu/sft/run_qwen3_0_6b_torchtitan.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# TorchTitan | SFT Training | Qwen3-0.6B | TPU v6e-4 Local VM
+#
+# Hardware Setup:
+#   1 Slice of TPU v6e-4 (1 physical host VM, 4 TPU chips total).
+#   
+# Parallelism Config:
+#   TP (Tensor Parallel) = 2
+#   DP (Data Parallel / FSDP) = 2
+#   PP (Pipeline Parallel) = 1
+#   Total Chips = TP * DP * PP = 2 * 2 * 1 = 4 chips.
+
+set -xeuo pipefail
+
+export RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS=1
+export VERL_PLATFORM=tpu
+export RAY_OVERRIDE_JOB_RUNTIME_ENV=1
+export PYTHONUNBUFFERED=1
+
+# Disable XLA HLO fusion passes for stable TPU compiler execution
+export XLA_FLAGS="--xla_disable_hlo_passes=instruction-fusion,fusion-merger,multi-output-fusion,horizontal-fusion"
+
+# Project and Experiment details
+project_name='GRPO_TPU_SFT'
+exp_name='SFT-Qwen3-0.6B-tpu-torchtitan-v6e4'
+
+# Paths (overridable via env vars; supports HuggingFace model ID or local path)
+MODEL_PATH="${MODEL_PATH:-assets/hf/Qwen3-0.6B}"
+TRAIN_FILE="${TRAIN_FILE:-gsm8k_sft/train.parquet}"
+TEST_FILE="${TEST_FILE:-gsm8k_sft/test.parquet}"
+
+# JAX/XLA Memory Preallocation and Launch Barrier Configuration
+export LIBTPU_INIT_ARGS="--xla_tpu_use_enhanced_launch_barrier=false --xla_tpu_scoped_vmem_limit_kib=65536"
+
+# TPU Node topology configs
+export NNODES_TRAINER=1       # 1 physical VM host
+export N_CHIPS_TRAINER=4      # 4 TPU chips per VM host
+
+# Launch Ray SFT Trainer
+# We use the SFT Trainer Ray entrypoint to orchestrate across TPU VMs
+python3 -m verl.trainer.sft_trainer_ray \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.val_max_samples=32 \
+    data.train_batch_size=16 \
+    data.micro_batch_size_per_gpu=2 \
+    data.pad_mode=tpu_binned_pack \
+    data.truncation=error \
+    data.use_dynamic_bsz=False \
+    data.max_length=2048 \
+    data.max_token_len_per_gpu=2048 \
+    data.ignore_input_ids_mismatch=True \
+    model.use_remove_padding=False \
+    engine=torchtitan \
+    model=hf_model \
+    model.path="${MODEL_PATH}" \
+    optim=torchtitan \
+    optim.lr=1e-5 \
+    optim.lr_warmup_steps_ratio=0.2 \
+    optim.weight_decay=0.1 \
+    optim.betas="[0.9,0.95]" \
+    optim.clip_grad=1.0 \
+    optim.min_lr_factor=0.1 \
+    optim.decay_type=cosine \
+    trainer.total_training_steps=8 \
+    engine.tensor_parallel_size=2 \
+    engine.pipeline_parallel_size=1 \
+    engine.context_parallel_size=1 \
+    engine.data_parallel_shard_size=2 \
+    engine.use_torch_compile=False \
+    engine.attn_type=varlen \
+    engine.max_seq_len=2048 \
+    trainer.test_freq=after_each_epoch \
+    trainer.save_freq=-1 \
+    trainer.logger="['console']" \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}" \
+    trainer.total_epochs=2 \
+    trainer.resume_mode=disable \
+    trainer.nnodes="${NNODES_TRAINER}" \
+    trainer.n_gpus_per_node="${N_CHIPS_TRAINER}" \
+    "$@"

--- a/tests/special_sanity/check_device_api_usage.py
+++ b/tests/special_sanity/check_device_api_usage.py
@@ -29,6 +29,7 @@ CUDA_KEYWORD_CHECK_WHITELIST = [
     "verl/plugin/platform/platform_base.py",  # docstring mentions torch.cuda
     "verl/plugin/platform/platform_cuda.py",  # CUDA platform implementation
     "verl/plugin/platform/platform_rocm.py",  # ROCm platform reuses torch.cuda via hipify
+    "verl/plugin/platform/platform_tpu.py",  # TPU platform overrides platform_cuda behaviors
     "verl/plugin/platform/platform_manager.py",  # platform auto-detection probes torch.cuda
     "verl/utils/profiler/nvtx_profile.py",  # appear in NsightSystemsProfiler
     "verl/utils/profiler/torch_profile.py",  # appear in TorchProfiler

--- a/tests/special_sanity/check_example_naming.py
+++ b/tests/special_sanity/check_example_naming.py
@@ -78,6 +78,7 @@ ALLOWED_BACKENDS = (
     "mindspeed",
     "automodel",
     "veomni",
+    "torchtitan",
 )
 
 # Directories whose scripts have their own conventions and are exempt from

--- a/tests/special_sanity/check_license.py
+++ b/tests/special_sanity/check_license.py
@@ -32,6 +32,7 @@ license_head_huawei = "Copyright (c) 2025 Huawei Technologies Co., Ltd. All Righ
 license_head_huawei_26 = "Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved."
 license_head_nvidia = "Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved."
 license_head_baai = "Copyright (c) 2026 BAAI. All rights reserved."
+license_head_google_baai = "Copyright 2024-2025 BAAI and Google LLC"
 license_headers = [
     license_head_bytedance,
     license_head_bytedance_25,
@@ -48,6 +49,7 @@ license_headers = [
     license_head_huawei_26,
     license_head_nvidia,
     license_head_baai,
+    license_head_google_baai,
 ]
 
 

--- a/verl/plugin/platform/platform_manager.py
+++ b/verl/plugin/platform/platform_manager.py
@@ -172,3 +172,4 @@ def set_platform(platform: PlatformBase) -> None:
 from .platform_cuda import PlatformCUDA  # noqa: E402, F401
 from .platform_npu import PlatformNPU  # noqa: E402, F401
 from .platform_rocm import PlatformROCm  # noqa: E402, F401
+from .platform_tpu import PlatformTPU  # noqa: E402, F401

--- a/verl/plugin/platform/platform_tpu.py
+++ b/verl/plugin/platform/platform_tpu.py
@@ -1,0 +1,295 @@
+# Copyright 2024-2025 BAAI and Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Google TPU platform implementation.
+
+TPU with PyTorch/XLA (torch_tpu) reuses the ``torch.cuda.*`` API surface, so most of
+``PlatformCUDA`` works unchanged. This class subclasses ``PlatformCUDA`` and overrides
+device-specific environment configuration, resource options, and memory management proxies.
+"""
+
+import logging
+import os
+from typing import Any
+
+import ray
+import torch
+
+from .platform_cuda import PlatformCUDA
+from .platform_manager import PlatformRegistry, get_platform
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Communication port defaults for TPU distributed slice builder meshes
+ROLLOUT_BASE_PORT = 8070
+TRAINER_BASE_PORT = 8471
+
+# TPU Chip HBM capacities in bytes
+HBM_BYTES_TPU_V5P = 95 * 1024 * 1024 * 1024  # 95 GB
+HBM_BYTES_TPU_V6E = 32 * 1024 * 1024 * 1024  # 32 GB
+HBM_BYTES_TPU_V7X = 192 * 1024 * 1024 * 1024  # 192 GB
+
+
+def get_tpu_chip_hbm_bytes() -> int:
+    """Detects the TPU chip generation from Ray node labels or environment variables and returns its HBM capacity."""
+    tpu_type = ""
+
+    # Query Ray cluster node labels for TPU resource type
+    try:
+        if ray.is_initialized():
+            tpu_nodes = [node for node in ray.nodes() if "TPU" in node.get("Resources", {}) and node.get("Alive")]
+            if tpu_nodes:
+                labels = tpu_nodes[0].get("Labels", {})
+                tpu_type = (labels.get("ray.io/accelerator-type") or labels.get("ray.io/tpu-pod-type") or "").lower()
+    except Exception as e:
+        logger.debug(f"Unable to query Ray node labels for TPU chip type: {e}")
+
+    # Fallback to environment variables
+    if not tpu_type:
+        tpu_type = (
+            os.environ.get("TPU_ACCELERATOR_TYPE")
+            or os.environ.get("ACCELERATOR_TYPE")
+            or os.environ.get("TPU_TYPE")
+            or ""
+        ).lower()
+
+    if "v5p" in tpu_type:
+        return HBM_BYTES_TPU_V5P
+    elif "v6e" in tpu_type:
+        return HBM_BYTES_TPU_V6E
+    elif "v7x" in tpu_type:
+        return HBM_BYTES_TPU_V7X
+    else:
+        logger.warning(f"Unable to determine TPU chip HBM bytes for tpu_type='{tpu_type}'. Returning -1.")
+        return -1
+
+
+# Enforce static compilation graph for torch.compile on TPU
+try:
+    _orig_compile = torch.compile
+
+    def patched_compile(*args, **kwargs):
+        if get_platform().device_name == "tpu":
+            kwargs["dynamic"] = False
+        return _orig_compile(*args, **kwargs)
+
+    torch.compile = patched_compile
+except Exception as e:
+    logger.warning(f"Failed to patch torch.compile for TPU: {e}")
+
+
+class DummyTpuDeviceModule:
+    """Fallback device module for CPU-only nodes and driver processes.
+
+    Provides no-op implementations for torch.tpu APIs on processes where torch_tpu is not imported
+    or no TPU devices are attached.
+    """
+
+    def is_available(self) -> bool:
+        return False
+
+    def set_device(self, device_index: Any) -> None:
+        pass
+
+    def current_device(self) -> int:
+        return 0
+
+    def device_count(self) -> int:
+        return 0
+
+    def synchronize(self) -> None:
+        pass
+
+    def manual_seed(self, seed: int) -> None:
+        torch.manual_seed(seed)
+
+    def manual_seed_all(self, seed: int) -> None:
+        torch.manual_seed(seed)
+
+
+class TPUDeviceModuleProxy:
+    """Proxy wrapper for torch.tpu to emulate PyTorch CUDA memory management APIs.
+
+    Provides default fallback implementations for CUDA memory tracking methods
+    (e.g., memory_reserved, memory_allocated, get_device_properties) that are called throughout verl's codebase
+    but not natively provided by torch_tpu.
+    """
+
+    def __init__(self, original_module):
+        self.__dict__["_original_module"] = original_module
+
+    def __getattr__(self, name):
+        if name == "set_device":
+            return self.set_device
+        elif name in ("memory_reserved", "memory_allocated", "max_memory_reserved", "max_memory_allocated"):
+            return lambda *args, **kwargs: 0
+        elif name in ("reset_peak_memory_stats", "reset_accumulated_memory_stats"):
+            return lambda *args, **kwargs: None
+        elif name == "empty_cache":
+            return self.empty_cache
+        elif name == "get_device_properties":
+            hbm_bytes = get_tpu_chip_hbm_bytes()
+            return lambda device_index=None: type("DeviceProps", (), {"total_memory": hbm_bytes})()
+        elif name == "mem_get_info":
+            hbm_bytes = get_tpu_chip_hbm_bytes()
+            return lambda *args, **kwargs: (hbm_bytes, hbm_bytes)
+        return getattr(self._original_module, name)
+
+    def set_device(self, device_index: Any) -> None:
+        pass
+
+    def empty_cache(self) -> None:
+        if hasattr(self._original_module, "_clear_cache"):
+            try:
+                self._original_module._clear_cache()
+            except Exception as e:
+                logger.warning(f"Failed to clear TPU cache: {e}")
+
+
+@PlatformRegistry.register(platform="tpu")
+class PlatformTPU(PlatformCUDA):
+    """Platform backend for Google TPUs (subclasses PlatformCUDA for API compatibility)."""
+
+    @property
+    def vendor_name(self) -> str:
+        return "google"
+
+    @property
+    def device_name(self) -> str:
+        return "tpu"
+
+    @property
+    def device_module(self):
+        original_tpu = getattr(torch, "tpu", DummyTpuDeviceModule())
+        return TPUDeviceModuleProxy(original_tpu)
+
+    def current_device(self) -> int:
+        return self.device_module.current_device()
+
+    def device_count(self) -> int:
+        return self.device_module.device_count()
+
+    def set_device(self, device_index: int) -> None:
+        self.device_module.set_device(device_index)
+
+    def synchronize(self, device_index: int | None = None) -> None:
+        self.device_module.synchronize()
+
+    def manual_seed(self, seed: int) -> None:
+        torch.manual_seed(seed)
+
+    def manual_seed_all(self, seed: int) -> None:
+        self.device_module.manual_seed_all(seed)
+
+    def is_available(self) -> bool:
+        if hasattr(torch, "tpu"):
+            try:
+                return torch.tpu.is_available()
+            except Exception as e:
+                logger.warning(f"torch.tpu.is_available() check failed: {e}")
+        return False
+
+    def is_platform_available(self, use_smi_check=False) -> bool:
+        if os.environ.get("VERL_PLATFORM") == "tpu":
+            return True
+        if "TPU_NAME" in os.environ or "TPU_VISIBLE_DEVICES" in os.environ:
+            return True
+        return False
+
+    def ray_resource_name(self) -> str:
+        return "TPU"
+
+    def ray_resource_options(self, num_gpus: float) -> dict[str, Any]:
+        tpu_chips = int(num_gpus)
+        return {"resources": {"TPU": tpu_chips}} if tpu_chips >= 1 else {}
+
+    def communication_backend_name(self) -> str:
+        return "tpu_dist"
+
+    def ray_noset_envvars(self) -> list[str]:
+        return super().ray_noset_envvars() + [
+            "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
+        ]
+
+    def get_tpu_env_vars(
+        self,
+        rank: int,
+        world_size: int,
+        local_rank: int,
+        local_world_size: int,
+        name_prefix: str,
+        pgs: list,
+    ) -> dict[str, str]:
+        """Generates TPU-specific distributed environment variables for PJRT mesh initialization."""
+        node_ip_map = {node["NodeID"]: node["NodeManagerAddress"] for node in ray.nodes()}
+        pg_ips = []
+        for pg in pgs:
+            specs = ray._private.state.state.placement_group_table(pg.id)
+            node_id = specs["bundles_to_node_id"][0]
+            pg_ips.append(node_ip_map[node_id])
+
+        is_rollout = "rollout" in name_prefix.lower()
+        base_port = ROLLOUT_BASE_PORT if is_rollout else TRAINER_BASE_PORT
+
+        sb_addresses = []
+        for ip in pg_ips:
+            for lr in range(local_world_size):
+                sb_addresses.append(f"{ip}:{base_port + lr}")
+
+        env_vars = {
+            "TORCH_TPU_SLICEBUILDER_ADDRESSES": ",".join(sb_addresses),
+            "TPU_PROCESS_ADDRESSES": ",".join(sb_addresses),
+            "TPU_PROCESS_PORT": str(base_port + local_rank),
+            "CLOUD_TPU_TASK_ID": str(rank // local_world_size),
+            "TPU_WORKER_HOSTNAMES": ",".join(pg_ips),
+            "TPU_VISIBLE_CHIPS": str(local_rank),
+        }
+
+        # Apply TPU topology and host bounds based on TPU pod type or world size
+        tpu_nodes = [node for node in ray.nodes() if "TPU" in node.get("Resources", {}) and node.get("Alive")]
+        tpu_type = tpu_nodes[0].get("Labels", {}).get("ray.io/tpu-pod-type", "") if tpu_nodes else ""
+
+        if tpu_type == "v6e-32":
+            topo = "4,8,1"
+        elif tpu_type == "v6e-8":
+            topo = "2,4,1"
+        elif tpu_type == "v6e-4":
+            topo = "2,2,1"
+        else:
+            topo = (
+                "4,8,1"
+                if world_size == 32
+                else ("2,4,1" if world_size == 8 else ("2,2,1" if world_size == 4 else "1,1,1"))
+            )
+
+        env_vars.update(
+            {
+                "TORCH_TPU_TOPOLOGY": topo,
+                "TPU_HOST_BOUNDS": topo,
+                "TPU_CHIPS_PER_HOST_BOUNDS": "1,1,1",
+                "CHIPS_PER_HOST": "4",
+            }
+        )
+
+        if is_rollout:
+            env_vars.update(
+                {
+                    "SKIP_JAX_PRECOMPILE": "1",
+                    "VLLM_ENABLE_V1_MULTIPROCESSING": "1",
+                }
+            )
+            if world_size > 1:
+                env_vars["TPU_MULTIHOST_BACKEND"] = "ray"
+
+        return env_vars

--- a/verl/plugin/platform/platform_tpu_workarounds.py
+++ b/verl/plugin/platform/platform_tpu_workarounds.py
@@ -71,7 +71,13 @@ def patch_ray_worker():
         def patched_func(self, resource_name, resource_regex):
             try:
                 return original_func(self, resource_name, resource_regex)
-            except IndexError:
+            except IndexError as e:
+                import traceback
+
+                print(
+                    f"[patch_ray_worker] Intercepted Ray accelerator lookup IndexError for resource '{resource_name}': {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 return []
 
         ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource = patched_func

--- a/verl/plugin/platform/platform_tpu_workarounds.py
+++ b/verl/plugin/platform/platform_tpu_workarounds.py
@@ -1,0 +1,194 @@
+# Copyright 2024-2025 BAAI and Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Platform-specific utilities and Ray cluster integration workarounds for Google TPU execution."""
+
+import logging
+import os
+
+import ray
+import ray._private.worker
+import torch
+
+from verl.plugin.platform import get_platform
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Default concurrency and CPU allocation for Ray TaskRunner actor on TPU worker nodes
+DEFAULT_TASK_RUNNER_CPUS = 10
+DEFAULT_TASK_RUNNER_CONCURRENCY = 100
+
+
+def convert_tensors_to_scalars(val):
+    """Recursively converts TPU tensors in metrics dictionaries to Python scalars or CPU structures.
+
+    Directly moving a TPU scalar tensor with a special PJRT allocator to the CPU driver process
+    via `.cpu()` can trigger allocator assertion errors in containerized multi-host setups.
+    Calling `.item()` on singleton tensors or converting non-scalar tensors safely avoids driver process crashes.
+    """
+    if isinstance(val, torch.Tensor):
+        if val.numel() == 1:
+            return val.item()
+        else:
+            try:
+                return val.detach().cpu()
+            except Exception:
+                return val.tolist()
+    elif isinstance(val, dict):
+        return {k: convert_tensors_to_scalars(v) for k, v in val.items()}
+    elif isinstance(val, list):
+        return [convert_tensors_to_scalars(v) for v in val]
+    elif isinstance(val, tuple):
+        return tuple(convert_tensors_to_scalars(v) for v in val)
+    elif hasattr(val, "aggregate"):
+        try:
+            return val.aggregate()
+        except Exception:
+            return val
+    return val
+
+
+def patch_ray_worker():
+    """Patches Ray worker resource lookup to handle containerized TPU device index bounds in GKE.
+
+    In containerized GKE environments where TPU chips are isolated per pod, Raylet physical accelerator
+    lookups can raise an `IndexError` when querying host-level accelerator indices.
+    """
+    try:
+        original_func = ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource
+
+        def patched_func(self, resource_name, resource_regex):
+            try:
+                return original_func(self, resource_name, resource_regex)
+            except IndexError:
+                return []
+
+        ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource = patched_func
+    except Exception as e:
+        logger.warning(f"Failed to apply Ray worker accelerator patch: {e}")
+
+
+def aggregate_sft_metrics_tpu(metrics):
+    """Aggregates metrics returned by multi-host data-parallel training workers on the CPU driver.
+
+    Under distributed TorchTitan training across multiple data-parallel ranks, worker metrics can be
+    returned as lists of dictionaries or dictionaries of rank-specific tensors. This helper computes
+    their average cleanly.
+    """
+    if isinstance(metrics, list):
+        aggregated_metrics = {}
+        if len(metrics) > 0:
+            keys = metrics[0].keys()
+            for k in keys:
+                vals = [m[k] for m in metrics if k in m]
+                if len(vals) > 0:
+                    try:
+                        vals_tensor = torch.tensor(vals, dtype=torch.float32)
+                        aggregated_metrics[k] = torch.mean(vals_tensor).item()
+                    except Exception:
+                        aggregated_metrics[k] = vals[0]
+        return aggregated_metrics
+    elif isinstance(metrics, dict):
+        aggregated_metrics = {}
+        for k, v in metrics.items():
+            if isinstance(v, list) or (hasattr(v, "shape") and len(v.shape) > 0):
+                try:
+                    aggregated_metrics[k] = torch.tensor(v, dtype=torch.float32).mean().item()
+                except Exception:
+                    if isinstance(v, list) and len(v) > 0:
+                        aggregated_metrics[k] = v[0]
+                    else:
+                        aggregated_metrics[k] = v
+            else:
+                aggregated_metrics[k] = v
+        return aggregated_metrics
+    else:
+        raise TypeError(f"Unexpected metrics structure type: {type(metrics)}")
+
+
+def extract_validation_loss(metrics) -> float:
+    """Extracts scalar validation loss value from worker metrics dictionary or list."""
+    if isinstance(metrics, list):
+        valid_losses = [m["loss"] for m in metrics if "loss" in m]
+        return sum(valid_losses) / len(valid_losses) if valid_losses else 0.0
+    elif isinstance(metrics, dict):
+        if "loss" in metrics:
+            v = metrics["loss"]
+            if isinstance(v, list) or (hasattr(v, "shape") and len(v.shape) > 0):
+                return torch.tensor(v, dtype=torch.float32).mean().item()
+            return float(v)
+    elif isinstance(metrics, int | float):
+        return float(metrics)
+    return float(metrics)
+
+
+def get_ray_init_kwargs() -> dict:
+    """Returns Ray initialization arguments including runtime environment hooks for TPU workers."""
+    env_vars = {}
+    if "PYTHONPATH" in os.environ:
+        env_vars["PYTHONPATH"] = os.environ["PYTHONPATH"]
+    if "VERL_PLATFORM" in os.environ:
+        env_vars["VERL_PLATFORM"] = os.environ["VERL_PLATFORM"]
+    return {
+        "runtime_env": {
+            "worker_process_setup_hook": patch_ray_worker,
+            "env_vars": env_vars,
+        }
+    }
+
+
+def run_trainer_on_tpu(trainer_cls, config):
+    """Executes the SFT/PPO trainer inside a remote Ray TaskRunner actor on TPU worker nodes.
+
+    The Ray driver process runs on the head/CPU node where TPU devices are not present.
+    Wrapping trainer initialization inside a remote actor ensures that PJRT client initialization
+    and device setup run directly on TPU worker nodes.
+    """
+
+    @ray.remote(num_cpus=DEFAULT_TASK_RUNNER_CPUS, max_concurrency=DEFAULT_TASK_RUNNER_CONCURRENCY)
+    class TaskRunner:
+        def run(self, config):
+            trainer = trainer_cls(config=config)
+            trainer.fit()
+
+    runner = TaskRunner.remote()
+    ray.get(runner.run.remote(config))
+
+
+def get_platform_worker_env_vars(
+    resource_pool,
+    rank: int,
+    world_size: int,
+    local_rank: int,
+    local_world_size: int,
+    name_prefix: str,
+    device_name: str,
+) -> dict:
+    """Generates platform-specific environment variables for worker nodes."""
+    env_vars = {}
+    if "VERL_PLATFORM" in os.environ:
+        env_vars["VERL_PLATFORM"] = os.environ["VERL_PLATFORM"]
+    for var in get_platform().ray_noset_envvars():
+        env_vars[var] = "1"
+    pgs = resource_pool.get_placement_groups(device_name=device_name)
+    tpu_env = get_platform().get_tpu_env_vars(
+        rank=rank,
+        world_size=world_size,
+        local_rank=local_rank,
+        local_world_size=local_world_size,
+        name_prefix=name_prefix,
+        pgs=pgs,
+    )
+    env_vars.update(tpu_env)
+    return env_vars

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -276,9 +276,17 @@ class Worker(WorkerHelper):
             # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set,
             # so we need to set local rank when the flag is set.
             device_name = get_resource_name()
-            local_rank = ray.get_runtime_context().get_accelerator_ids()[device_name][0]
-            os.environ["LOCAL_RANK"] = local_rank
-            get_torch_device().set_device(int(local_rank))
+            if device_name == "TPU":
+                local_rank = os.environ.get("TPU_VISIBLE_CHIPS", "0")
+            else:
+                local_rank = ray.get_runtime_context().get_accelerator_ids()[device_name][0]
+
+            os.environ["LOCAL_RANK"] = str(local_rank)
+
+            # Avoid eager device initialization for non-TPU engine workers (e.g. CheckpointEngineWorker)
+            # which could lock TPU chips unnecessarily.
+            if self.__class__.__name__ != "CheckpointEngineWorker" or device_name != "TPU":
+                get_torch_device().set_device(int(local_rank))
 
     def _configure_with_store(self, store: dict):
         """

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -26,6 +26,7 @@ from ray.util.placement_group import PlacementGroup, placement_group
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy, PlacementGroupSchedulingStrategy
 
 from verl.plugin.platform import get_platform
+from verl.plugin.platform.platform_tpu_workarounds import get_platform_worker_env_vars
 from verl.protocol import DataProto, _padding_size_key
 from verl.single_controller.base import ClassWithInitArgs, ResourcePool, Worker, WorkerGroup
 from verl.single_controller.base.decorator import MAGIC_ATTR, Dispatch
@@ -120,6 +121,8 @@ class RayResourcePool(ResourcePool):
         detached=False,
         accelerator_type: Optional[str] = None,
     ) -> None:
+        if get_platform().device_name == "tpu":
+            max_colocate_count = 1
         super().__init__(process_on_nodes, max_colocate_count)
         self.use_gpu = use_gpu
         # print(f"in RayProcessDispatchConfiguration: name_prefix = {name_prefix}")
@@ -146,8 +149,8 @@ class RayResourcePool(ResourcePool):
         bundle = {"CPU": self.max_colocate_count}
         if self.use_gpu:
             bundle[device_name] = 1
-            if self.accelerator_type is not None:
-                bundle[self.accelerator_type] = 1e-4
+        if self.accelerator_type is not None:
+            bundle[self.accelerator_type] = 1e-4
         pg_scheme = [[bundle.copy() for _ in range(process_count)] for process_count in self._store]
 
         lifetime = "detached" if self.detached else None
@@ -192,6 +195,10 @@ class ResourcePoolManager:
     max_colocate_count: int = 3
     resource_pool_dict: dict[str, RayResourcePool] = field(default_factory=dict)
 
+    def __post_init__(self):
+        if get_platform().device_name == "tpu":
+            self.max_colocate_count = 1
+
     def create_resource_pool(self):
         """Create Ray resource pools for distributed training.
 
@@ -226,9 +233,9 @@ class ResourcePoolManager:
     def _check_resource_available(self):
         """Check if the resource pool can be satisfied in this ray cluster."""
         node_available_resources = ray._private.state.available_resources_per_node()
+        device_name = get_platform().ray_resource_name()
         node_available_gpus = {
-            node: node_info.get("GPU", 0) if "GPU" in node_info else node_info.get("NPU", 0)
-            for node, node_info in node_available_resources.items()
+            node: node_info.get(device_name, 0) for node, node_info in node_available_resources.items()
         }
 
         # check total required gpus can be satisfied
@@ -638,6 +645,16 @@ class RayWorkerGroup(WorkerGroup):
             "MASTER_ADDR": self._master_addr,
             "MASTER_PORT": self._master_port,
         }
+        platform_env = get_platform_worker_env_vars(
+            resource_pool=resource_pool,
+            rank=rank,
+            world_size=world_size,
+            local_rank=local_rank,
+            local_world_size=local_world_size,
+            name_prefix=self.name_prefix,
+            device_name=self.device_name,
+        )
+        env_vars.update(platform_env)
         if worker_env is not None:
             logging.debug(f"Appending ray class env, origin: {env_vars}, customized env: {worker_env}")
             conflict_env_vars = set(env_vars.keys()) & set(worker_env.keys())

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -32,6 +32,13 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
+from verl.plugin.platform import get_platform
+from verl.plugin.platform.platform_tpu_workarounds import (
+    aggregate_sft_metrics_tpu,
+    extract_validation_loss,
+    get_ray_init_kwargs,
+    run_trainer_on_tpu,
+)
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler, OrchestrationMode
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -279,6 +286,7 @@ class SFTTrainer:
             "use_remove_padding": self.config.model.use_remove_padding,
             "use_dynamic_bsz": self.config.data.use_dynamic_bsz,
             "max_token_len_per_gpu": self.config.data.max_token_len_per_gpu,
+            "max_length": self.config.data.max_length,
             "micro_batch_size_per_gpu": self.config.data.micro_batch_size_per_gpu,
             "temperature": 1.0,
             "global_batch_size": self.global_batch_size,
@@ -338,13 +346,15 @@ class SFTTrainer:
                     self.training_client.stop_profile()
 
                 metrics = tu.get(output, "metrics")
+                if get_platform().device_name == "tpu":
+                    metrics = aggregate_sft_metrics_tpu(metrics)
 
                 # TODO: we can actual accumulate metrics for N steps and perform aggregate metrics
                 metrics["train/loss"] = metrics.pop("loss")
-                metrics["train/grad_norm"] = metrics.pop("grad_norm")
-                metrics["train/lr"] = metrics.pop("lr")
-                metrics["train/mfu"] = metrics.pop("mfu")
-                metrics["train/global_tokens"] = torch.sum(torch.tensor(batch_seqlens, device=self.device_name)).item()
+                metrics["train/grad_norm"] = metrics.pop("grad_norm", 0.0)
+                metrics["train/lr"] = metrics.pop("lr", 0.0)
+                metrics["train/mfu"] = metrics.pop("mfu", 0.0)
+                metrics["train/global_tokens"] = sum(batch_seqlens)
                 total_tokens += metrics["train/global_tokens"]
                 metrics["train/total_tokens(B)"] = total_tokens / 1e9
                 tracking.log(data=metrics, step=global_step)
@@ -362,9 +372,14 @@ class SFTTrainer:
                         output = self.training_client.infer_batch(val_data)
                         output = output.get()
                         metrics = tu.get(output, "metrics")
-                        val_losses.append(metrics["loss"])
+                        val_loss_val = extract_validation_loss(metrics)
+                        val_losses.append(val_loss_val)
 
-                    val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
+                    if len(val_losses) > 0:
+                        val_loss = torch.mean(torch.tensor(val_losses, dtype=torch.float32))
+                    else:
+                        logger.warning("val_losses is empty. Check if val_max_samples is too small.")
+                        val_loss = torch.tensor(0.0)
 
                     metric = {"val/loss": val_loss.detach().item()}
                     tracking.log(data=metric, step=global_step)
@@ -380,9 +395,14 @@ class SFTTrainer:
 
 
 def run_sft(config):
-    ray.init()
-    trainer = SFTTrainer(config=config)
-    trainer.fit()
+    ray_init_kwargs = get_ray_init_kwargs()
+    ray.init(**ray_init_kwargs)
+
+    if get_platform().device_name == "tpu":
+        run_trainer_on_tpu(SFTTrainer, config)
+    else:
+        trainer = SFTTrainer(config=config)
+        trainer.fit()
 
 
 @hydra.main(config_path="config", config_name="sft_trainer_engine", version_base=None)

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -27,6 +27,7 @@ class DatasetPadMode(str, Enum):
     RIGHT = "right"
     LEFT_RIGHT = "left_right"
     NO_PADDING = "no_padding"
+    TPU_BINNED_PACK = "tpu_binned_pack"
 
 
 class SFTTensorCollator:
@@ -40,7 +41,7 @@ class SFTTensorCollator:
         self.pad_mode = pad_mode
 
     def __call__(self, batch: list[dict[str, any]]) -> dict[str, any]:
-        if self.pad_mode == DatasetPadMode.NO_PADDING:
+        if self.pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK]:
             return self.collate_variable_batch(batch)
         elif self.pad_mode in [DatasetPadMode.RIGHT, DatasetPadMode.LEFT_RIGHT]:
             from torch.utils.data import default_collate

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -93,8 +93,8 @@ class MultiTurnSFTDataset(Dataset):
         # Set defaults and extract parameters from config if provided
         config = config or {}
         self.pad_mode = config.get("pad_mode", "right")
-        assert self.pad_mode in ["right", "no_padding"], (
-            f"Expect pad_mode to be 'right' or 'no_padding'. Got {self.pad_mode}"
+        assert self.pad_mode in ["right", "no_padding", "tpu_binned_pack"], (
+            f"Expect pad_mode to be 'right', 'no_padding', or 'tpu_binned_pack'. Got {self.pad_mode}"
         )
         self.truncation = config.get("truncation", "error")
         # for right padding
@@ -401,7 +401,7 @@ class MultiTurnSFTDataset(Dataset):
             if len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
-        elif self.pad_mode == DatasetPadMode.NO_PADDING:
+        elif self.pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK]:
             if sequence_length > self.max_length and self.truncation == "error":
                 raise ValueError(f"{sequence_length=} is larger than {self.max_length=}")
             # truncate input_ids if it is longer than max_length

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -23,6 +23,7 @@ import ray
 import torch.distributed
 from torch.distributed import TCPStore
 
+from verl.plugin.platform import get_platform
 from verl.utils.device import get_device_name, get_nccl_backend, get_resource_name, get_torch_device, is_npu_available
 from verl.utils.net_utils import is_ipv6
 
@@ -34,6 +35,11 @@ def set_numa_affinity():
 
     initialized = False
     try:
+        device_name = get_resource_name()
+        # NUMA affinity via pynvml is NVIDIA GPU-specific; return early on TPU.
+        if device_name == "TPU":
+            return
+
         libnuma = ctypes.CDLL("libnuma.so")
         if libnuma.numa_available() < 0:
             return
@@ -83,6 +89,10 @@ def initialize_global_process_group_ray(timeout_second=None, backend=None):
     # in current ray environment, LOCAL_RANK is always zero.
 
     import torch.distributed
+
+    # On TPU platforms, import torch_tpu to register the TPU communication backend with torch.distributed.
+    if get_platform().device_name == "tpu":
+        pass
 
     timeout = timedelta(seconds=timeout_second) if timeout_second is not None else None
     backend = backend or f"cpu:gloo,{get_device_name()}:{get_nccl_backend()}"

--- a/verl/workers/engine/torchtitan/tpu_utils.py
+++ b/verl/workers/engine/torchtitan/tpu_utils.py
@@ -1,0 +1,631 @@
+# Copyright 2024-2025 BAAI and Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TPU sequence packing utilities, attention monkey patches, and memory layout helpers."""
+
+import logging
+import os
+from typing import Any
+
+import torch
+import torch.distributed
+import torch.nn.functional as F
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData
+
+import verl.utils.torch_functional as verl_F
+from verl.utils import tensordict_utils as tu
+from verl.utils.torch_functional import logprobs_from_logits
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Default sequence packing constants
+DEFAULT_MAX_BIN_LEN = 1024
+DEFAULT_MAX_PROMPT_LEN = 512
+DEFAULT_MAX_RESPONSE_LEN = 512
+SEQUENCE_ALIGNMENT_MULTIPLE = 128
+
+
+def slice_metadata_item(data: TensorDict, k: str, i: int, batch_size: int, attn_mask: torch.Tensor = None):
+    """Slices a metadata item from a TensorDict for the i-th batch element."""
+    val = data.get(k, None)
+    if val is None:
+        return None
+    if isinstance(val, NonTensorData):
+        val = val.data
+
+    # Handle NestedTensor or structures with offsets
+    if getattr(val, "is_nested", False) or hasattr(val, "offsets"):
+        try:
+            return val.unbind()[i]
+        except Exception:
+            try:
+                return val[i]
+            except Exception:
+                pass
+
+    # Slice prompts and responses to exact active lengths if standard padded 2D tensors
+    if k == "prompts" and isinstance(val, torch.Tensor) and not getattr(val, "is_nested", False):
+        if attn_mask is not None and val.ndim >= 2:
+            prompt_len_active = int(attn_mask[i, : val.shape[-1]].sum().item())
+            return val[i, :prompt_len_active]
+        elif val.ndim >= 2:
+            return val[i]
+    elif k == "responses" and isinstance(val, torch.Tensor) and not getattr(val, "is_nested", False):
+        if attn_mask is not None and val.ndim >= 2:
+            prompt_val = data.get("prompts", None)
+            if isinstance(prompt_val, NonTensorData):
+                prompt_val = prompt_val.data
+            prompt_len_i = 0
+            if getattr(prompt_val, "is_nested", False) or hasattr(prompt_val, "offsets"):
+                prompt_len_i = prompt_val.unbind()[i].shape[-1]
+            elif isinstance(prompt_val, torch.Tensor) and prompt_val.ndim >= 2:
+                prompt_len_i = int(attn_mask[i, : prompt_val.shape[-1]].sum().item())
+
+            resp_mask = attn_mask[i, prompt_len_i : prompt_len_i + val.shape[-1]]
+            response_len_active = int(resp_mask.sum().item())
+            return val[i, :response_len_active]
+        elif val.ndim >= 2:
+            return val[i]
+
+    # Handle standard PyTorch Tensor
+    if isinstance(val, torch.Tensor):
+        if val.ndim > 0 and val.shape[0] == batch_size:
+            return val[i]
+        return val
+
+    # Handle list or tuple
+    if isinstance(val, list | tuple) and len(val) == batch_size:
+        return val[i]
+
+    raw_val = tu.get_non_tensor_data(data=data, key=k, default=None)
+    if isinstance(raw_val, NonTensorData):
+        raw_val = raw_val.data
+    if getattr(raw_val, "is_nested", False) or hasattr(raw_val, "offsets"):
+        try:
+            return raw_val.unbind()[i]
+        except Exception:
+            try:
+                return raw_val[i]
+            except Exception:
+                pass
+    if isinstance(raw_val, list | tuple) and len(raw_val) == batch_size:
+        return raw_val[i]
+    return raw_val
+
+
+def tpu_binned_pack_tensordict(
+    data: TensorDict, max_bin_len: int = DEFAULT_MAX_BIN_LEN
+) -> tuple[list[TensorDict], list[list[int]]]:
+    """Packs variable-length sequence data into static micro-batches of shape [1, max_bin_len].
+
+    On Google TPU execution, variable-length sequence shapes trigger dynamic graph recompilations.
+    This host-side CPU sequence packer bins active sequence tokens into static micro-batches of
+    shape [1, max_bin_len] to eliminate recompilation overhead.
+    """
+    data = data.cpu()
+    batch_size = data.batch_size[0]
+
+    attention_mask_key = "attention_mask" if "attention_mask" in data.keys() else "loss_mask"
+    attn_mask = data[attention_mask_key]
+
+    active_lengths = [int(attn_mask[i].sum().item()) for i in range(batch_size)]
+
+    keys_to_pack = []
+    keys_to_preserve = []
+
+    sequence_keys = {
+        "input_ids",
+        "position_ids",
+        "attention_mask",
+        "loss_mask",
+        "labels",
+        "log_prob",
+        "log_probs",
+        "old_log_prob",
+        "old_log_probs",
+        "ref_log_prob",
+        "advantages",
+        "returns",
+        "values",
+        "response_mask",
+        "rollout_is_weights",
+    }
+
+    for k, v in data.items():
+        if isinstance(v, torch.Tensor) and v.dim() >= 2 and v.shape[0] == batch_size:
+            if k in sequence_keys:
+                keys_to_pack.append(k)
+                continue
+        keys_to_preserve.append(k)
+
+    sliced_sequences = []
+    for i in range(batch_size):
+        length = active_lengths[i]
+
+        seq_data = {}
+        for k in keys_to_pack:
+            val = data[k]
+            if getattr(val, "is_nested", False):
+                seq_tensor = val.unbind()[i]
+                if seq_tensor.dim() == 1:
+                    seq_data[k] = seq_tensor[:length]
+                else:
+                    seq_data[k] = seq_tensor[..., :length]
+            else:
+                if val.dim() == 2:
+                    seq_data[k] = val[i, :length]
+                else:
+                    seq_data[k] = val[i, ..., :length]
+
+        metadata_dict = {}
+        for k in keys_to_preserve:
+            metadata_dict[k] = slice_metadata_item(data, k, i, batch_size, attn_mask=attn_mask)
+
+        sliced_sequences.append(
+            {
+                "seq_data": seq_data,
+                "metadata": metadata_dict,
+                "length": length,
+                "original_idx": i,
+            }
+        )
+
+    # Sort sequences descending by length for dense bin-packing
+    sorted_seqs = sorted(sliced_sequences, key=lambda s: s["length"], reverse=True)
+
+    bins: list[list[dict]] = []
+    bin_lengths: list[int] = []
+
+    for seq in sorted_seqs:
+        seq_len_active = seq["length"]
+        if seq_len_active == 0:
+            continue
+        assert seq_len_active <= max_bin_len, f"Sequence length {seq_len_active} exceeds max_bin_len {max_bin_len}"
+
+        placed = False
+        for i, current_len in enumerate(bin_lengths):
+            if current_len + seq_len_active <= max_bin_len:
+                bins[i].append(seq)
+                bin_lengths[i] += seq_len_active
+                placed = True
+                break
+
+        if not placed:
+            bins.append([seq])
+            bin_lengths.append(seq_len_active)
+
+    logger.debug(f"TPU Binned Packer: input batch_size={batch_size}, total bins={len(bins)}")
+    packed_micro_batches = []
+    batch_idx_list = []
+    for bin_idx, (bin_seqs, active_len) in enumerate(zip(bins, bin_lengths, strict=False)):
+        batch_idx_list.append([seq["original_idx"] for seq in bin_seqs])
+        logger.debug(f"Bin #{bin_idx}: {len(bin_seqs)} sequences, active tokens={active_len}/{max_bin_len}")
+
+        concatenated_td = {}
+        for k in keys_to_pack:
+            first_seq = bin_seqs[0]["seq_data"][k]
+            concat_dim = -1 if first_seq.dim() > 1 else 0
+            concatenated_td[k] = torch.cat([seq["seq_data"][k] for seq in bin_seqs], dim=concat_dim)
+
+        slack_len = max_bin_len - active_len
+        offsets = [0]
+        curr = 0
+        for seq in bin_seqs:
+            curr += seq["length"]
+            offsets.append(curr)
+
+        if slack_len > 0:
+            offsets.append(max_bin_len)
+            for k in keys_to_pack:
+                val = concatenated_td[k]
+                pad_val = 0
+                if k == "input_ids":
+                    pad_val = int(tu.get_non_tensor_data(data=data, key="pad_token_id", default=0))
+
+                if val.dim() == 1:
+                    pad_tensor = torch.full((slack_len,), pad_val, dtype=val.dtype)
+                    concatenated_td[k] = torch.cat([val, pad_tensor], dim=0)
+                else:
+                    pad_shape = list(val.shape)
+                    pad_shape[-1] = slack_len
+                    pad_tensor = torch.full(pad_shape, pad_val, dtype=val.dtype)
+                    concatenated_td[k] = torch.cat([val, pad_tensor], dim=-1)
+
+        cu_seqlens = torch.tensor(offsets, dtype=torch.int32)
+        positions = torch.arange(max_bin_len)
+        seq_indices = (positions.unsqueeze(1) >= cu_seqlens.unsqueeze(0)).sum(dim=1) - 1
+        same_seq_mask = seq_indices.unsqueeze(1) == seq_indices.unsqueeze(0)
+        causal_mask = positions.unsqueeze(1) >= positions.unsqueeze(0)
+
+        padding_seq_idx = (len(cu_seqlens) - 2) if slack_len > 0 else (len(cu_seqlens) - 1)
+        tpu_num_seqs_val = padding_seq_idx
+
+        non_pad_mask = seq_indices < padding_seq_idx
+
+        attention_mask = same_seq_mask & causal_mask & non_pad_mask.unsqueeze(1)
+        attention_mask = attention_mask.unsqueeze(0).unsqueeze(0)
+
+        mb_td = TensorDict({k: v.unsqueeze(0) for k, v in concatenated_td.items()}, batch_size=[1])
+
+        mb_td["tpu_custom_attention_mask"] = attention_mask
+        mb_td["tpu_cu_seqlens"] = NonTensorData([cu_seqlens])
+        mb_td["tpu_num_seqs"] = NonTensorData([tpu_num_seqs_val])
+
+        for k in keys_to_preserve:
+            vals = [seq["metadata"][k] for seq in bin_seqs]
+            if k in ["prompts", "responses"]:
+                mb_td[k] = NonTensorData(vals)
+            elif all(isinstance(v, torch.Tensor) for v in vals):
+                shapes = [v.shape for v in vals]
+                if all(s == shapes[0] for s in shapes):
+                    stacked = torch.stack(vals, dim=0)
+                    mb_td[k] = stacked.unsqueeze(0)
+                else:
+                    mb_td[k] = NonTensorData(vals)
+            else:
+                mb_td[k] = NonTensorData(vals)
+
+        packed_micro_batches.append(mb_td)
+
+    return packed_micro_batches, batch_idx_list
+
+
+def prepare_tpu_binned_pack_micro_batches(data: TensorDict) -> tuple[list[TensorDict], list[list[int]]]:
+    """Prepares static sequence-packed micro-batches synchronized across data-parallel ranks on TPU."""
+    max_length = tu.get_non_tensor_data(data=data, key="max_length", default=None)
+    if max_length is not None:
+        max_bin_len = max_length
+    else:
+        max_token_len = tu.get_non_tensor_data(data=data, key="max_token_len_per_gpu", default=None)
+        if max_token_len is not None:
+            max_bin_len = max_token_len
+        else:
+            max_prompt_length = tu.get_non_tensor_data(
+                data=data, key="max_prompt_length", default=DEFAULT_MAX_PROMPT_LEN
+            )
+            max_response_length = tu.get_non_tensor_data(
+                data=data, key="max_response_length", default=DEFAULT_MAX_RESPONSE_LEN
+            )
+            max_bin_len = max_prompt_length + max_response_length
+
+    micro_batches, batch_idx_list = tpu_binned_pack_tensordict(data=data, max_bin_len=max_bin_len)
+
+    num_bins = len(micro_batches)
+    if torch.distributed.is_initialized():
+        num_bins_tensor = torch.tensor([num_bins], dtype=torch.int32)
+        torch.distributed.all_reduce(num_bins_tensor, op=torch.distributed.ReduceOp.MAX)
+        global_max_bins = num_bins_tensor.item()
+    else:
+        global_max_bins = num_bins
+
+    mbsz = tu.get_non_tensor_data(data=data, key="micro_batch_size_per_gpu", default=1)
+    if global_max_bins % mbsz != 0:
+        global_max_bins = ((global_max_bins // mbsz) + 1) * mbsz
+
+    if num_bins < global_max_bins:
+        last_batch = micro_batches[-1]
+        last_indices = batch_idx_list[-1]
+        for _ in range(global_max_bins - num_bins):
+            dummy_batch = last_batch.clone()
+            if "loss_mask" in dummy_batch.keys():
+                dummy_batch["loss_mask"] = torch.zeros_like(dummy_batch["loss_mask"])
+            micro_batches.append(dummy_batch)
+            batch_idx_list.append([-1] * len(last_indices))
+
+    if mbsz > 1:
+        grouped_batches = []
+        grouped_idx_list = []
+        for idx in range(0, len(micro_batches), mbsz):
+            batch_slice = micro_batches[idx : idx + mbsz]
+            idx_slice = batch_idx_list[idx : idx + mbsz]
+
+            keys_to_pop = []
+            for k in list(batch_slice[0].keys()):
+                if k in ("tpu_cu_seqlens", "tpu_num_seqs"):
+                    keys_to_pop.append(k)
+                    continue
+
+                all_tensors = True
+                shapes = []
+                for mb in batch_slice:
+                    v = mb.get(k, None)
+                    if v is None or not isinstance(v, torch.Tensor) or isinstance(v, NonTensorData):
+                        all_tensors = False
+                        break
+                    shapes.append(v.shape)
+
+                if not all_tensors:
+                    keys_to_pop.append(k)
+                else:
+                    first_shape_suffix = shapes[0][1:]
+                    for sh in shapes[1:]:
+                        if sh[1:] != first_shape_suffix:
+                            keys_to_pop.append(k)
+                            break
+
+            combined_metadata = {}
+            for k in keys_to_pop:
+                combined_list = []
+                for mb in batch_slice:
+                    mb_val = mb.pop(k, None)
+                    if mb_val is not None:
+                        if isinstance(mb_val, NonTensorData):
+                            raw = mb_val.data
+                            if isinstance(raw, list | tuple):
+                                combined_list.extend(raw)
+                            else:
+                                combined_list.append(raw)
+                        else:
+                            if isinstance(mb_val, list | tuple):
+                                combined_list.extend(mb_val)
+                            else:
+                                combined_list.append(mb_val)
+                combined_metadata[k] = combined_list
+
+            grouped_td = torch.cat(batch_slice, dim=0)
+
+            for k, combined_list in combined_metadata.items():
+                if len(combined_list) > 0:
+                    grouped_td[k] = NonTensorData(combined_list)
+
+            grouped_batches.append(grouped_td)
+            grouped_idx_list.append([i for sub in idx_slice for i in sub])
+        micro_batches = grouped_batches
+        batch_idx_list = grouped_idx_list
+
+    return micro_batches, batch_idx_list
+
+
+def prepare_tpu_packed_outputs(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    micro_batch: TensorDict,
+    temperature: float,
+    calculate_entropy: bool,
+    entropy_checkpointing: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Reconstructs log_probs and entropy NestedTensors from sliced active tokens under TPU static sequence packing."""
+    mbsz = logits.shape[0]
+
+    cu_seqlens_list = micro_batch["tpu_cu_seqlens"]
+    if hasattr(cu_seqlens_list, "data"):
+        cu_seqlens_list = cu_seqlens_list.data
+    if not isinstance(cu_seqlens_list, list | tuple):
+        cu_seqlens_list = [cu_seqlens_list]
+
+    num_seqs_list = micro_batch["tpu_num_seqs"]
+    if hasattr(num_seqs_list, "data"):
+        num_seqs_list = num_seqs_list.data
+    if not isinstance(num_seqs_list, list | tuple):
+        num_seqs_list = [num_seqs_list]
+
+    log_probs_all_rows = []
+    entropy_all_rows = []
+    combined_offsets = [0]
+    current_offset = 0
+
+    for row_idx in range(mbsz):
+        cu_seqlens = cu_seqlens_list[row_idx]
+        if hasattr(cu_seqlens, "data"):
+            cu_seqlens = cu_seqlens.data
+        if isinstance(cu_seqlens, list):
+            cu_seqlens = (
+                cu_seqlens[0] if len(cu_seqlens) > 0 else torch.tensor([0, DEFAULT_MAX_BIN_LEN], dtype=torch.int32)
+            )
+        if hasattr(cu_seqlens, "data"):
+            cu_seqlens = cu_seqlens.data
+        if not isinstance(cu_seqlens, torch.Tensor):
+            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
+
+        num_seqs = num_seqs_list[row_idx]
+        if hasattr(num_seqs, "data"):
+            num_seqs = num_seqs.data
+        if isinstance(num_seqs, list):
+            num_seqs = num_seqs[0] if len(num_seqs) > 0 else 1
+        if hasattr(num_seqs, "data"):
+            num_seqs = num_seqs.data
+
+        cu_seqlens_active = cu_seqlens[: num_seqs + 1]
+        active_len = int(cu_seqlens_active[-1].item())
+
+        logits_rmpad = logits[row_idx, :active_len, :] / temperature
+        labels_rmpad = labels[row_idx, :active_len]
+
+        log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=labels_rmpad)
+        log_probs_all_rows.append(log_probs_rmpad)
+
+        if calculate_entropy:
+            if not entropy_checkpointing:
+                entropy_rmpad = verl_F.entropy_from_logits(logits_rmpad)
+            else:
+                entropy_rmpad = torch.utils.checkpoint.checkpoint(verl_F.entropy_from_logits, logits_rmpad)
+            entropy_all_rows.append(entropy_rmpad)
+
+        for i in range(1, len(cu_seqlens_active)):
+            combined_offsets.append(current_offset + int(cu_seqlens_active[i].item()))
+        current_offset += active_len
+
+    log_probs_flat_cat = torch.cat(log_probs_all_rows, dim=0)
+    cu_seqlens_combined = torch.tensor(combined_offsets, dtype=torch.int32, device=log_probs_flat_cat.device)
+
+    log_probs = torch.nested.nested_tensor_from_jagged(log_probs_flat_cat, cu_seqlens_combined)
+
+    entropy = None
+    if calculate_entropy:
+        entropy_flat_cat = torch.cat(entropy_all_rows, dim=0)
+        entropy = torch.nested.nested_tensor_from_jagged(entropy_flat_cat, cu_seqlens_combined)
+
+    return log_probs, entropy
+
+
+def monkey_patch_varlen_attention_tpu():
+    """Patches TorchTitan's VarlenAttention forward method to use native scaled_dot_product_attention on TPU."""
+    try:
+        from torchtitan.models.common.attention import VarlenAttention
+
+        def tpu_varlen_forward(self, xq, xk, xv, *, attention_masks, scale=None, **kwargs):
+            if attention_masks.dim() == 4:
+                mask = attention_masks.to(torch.bool)
+            elif hasattr(attention_masks, "cu_seq_q"):
+                total_tokens = xq.shape[1]
+                cu_seqs = attention_masks.cu_seq_q
+
+                positions = torch.arange(total_tokens, device=xq.device)
+                seq_indices = (positions.unsqueeze(1) >= cu_seqs.unsqueeze(0)).sum(dim=1) - 1
+                same_seq_mask = seq_indices.unsqueeze(1) == seq_indices.unsqueeze(0)
+                causal_mask = positions.unsqueeze(1) >= positions.unsqueeze(0)
+
+                mask = same_seq_mask & causal_mask
+                mask = mask.unsqueeze(0).unsqueeze(0)
+            else:
+                seq_len = xq.shape[1]
+                positions = torch.arange(seq_len, device=xq.device)
+                causal_mask = (positions.unsqueeze(1) >= positions.unsqueeze(0)).unsqueeze(0).unsqueeze(0)
+
+                padding_mask = attention_masks.unsqueeze(1).unsqueeze(2).to(torch.bool)
+                mask = causal_mask & padding_mask
+
+            q = xq.transpose(1, 2)
+            k = xk.transpose(1, 2)
+            v = xv.transpose(1, 2)
+
+            if q.shape[1] != k.shape[1]:
+                num_repeat = q.shape[1] // k.shape[1]
+                k = k.repeat_interleave(num_repeat, dim=1)
+                v = v.repeat_interleave(num_repeat, dim=1)
+
+            attn_out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, scale=scale)
+            return attn_out.transpose(1, 2)
+
+        VarlenAttention.forward = tpu_varlen_forward
+        logger.info("Successfully patched VarlenAttention.forward for TPU execution.")
+    except Exception as e:
+        logger.warning(f"Failed to patch VarlenAttention: {e}")
+
+
+def compute_global_batch_num_tokens(data: TensorDict, dp_group, tp_size: int) -> Any:
+    """Computes global batch token count for loss normalization on TPU.
+
+    On TPU, performing CPU-side all-reduce for loss normalization avoids graph desynchronization
+    and JIT compilation lockups across ranks.
+    """
+    batch_num_tokens = data["loss_mask"].sum().cpu()
+    if torch.distributed.is_initialized():
+        torch.distributed.all_reduce(batch_num_tokens, op=torch.distributed.ReduceOp.SUM)
+        batch_num_tokens = batch_num_tokens / tp_size
+    return batch_num_tokens.item()
+
+
+def synchronize_tpu_loss(loss: torch.Tensor):
+    """Materializes forward graph loss without blocking to split XLA forward and backward compilation passes."""
+    try:
+        from torch_tpu._internal.sync import synchronize
+
+        synchronize(loss, wait=False)
+    except ImportError:
+        pass
+
+
+def compute_tpu_max_seq_len(input_ids: torch.Tensor) -> int:
+    """Rounds up sequence length to a multiple of 128 to ensure memory stride alignment on TPU."""
+    offsets = input_ids.offsets()
+    offsets_tpu = torch.empty(offsets.shape, dtype=offsets.dtype, device=offsets.device)
+    offsets_tpu.copy_(offsets)
+    max_seq_len = int(max(offsets_tpu.cpu().diff()))
+    max_seq_len = (
+        (max_seq_len + SEQUENCE_ALIGNMENT_MULTIPLE - 1) // SEQUENCE_ALIGNMENT_MULTIPLE
+    ) * SEQUENCE_ALIGNMENT_MULTIPLE
+    return max_seq_len
+
+
+def reconstruct_tpu_packed_metadata_tensors(micro_batch: TensorDict, device_id: Any):
+    """Reconstructs nested prompts/responses tensors on device from host NonTensorData lists."""
+    for k in ["prompts", "responses"]:
+        if k in micro_batch.keys():
+            val = micro_batch[k]
+            if isinstance(val, NonTensorData):
+                val = val.data
+            if isinstance(val, list):
+                flat_vals = [v.values() if getattr(v, "is_nested", False) else v for v in val]
+                flat_vals = [f.to(device_id) for f in flat_vals]
+                nested_val = torch.nested.as_nested_tensor(flat_vals, layout=torch.jagged)
+                micro_batch._tensordict[k] = nested_val
+
+
+def unwrap_metadata(val):
+    """Recursively unwraps metadata values (lists, single-element tensors) to standard Python types."""
+    if isinstance(val, list):
+        if len(val) > 0:
+            return unwrap_metadata(val[0])
+        return None
+    if isinstance(val, torch.Tensor):
+        if val.numel() == 1:
+            return val.item()
+        elif val.numel() > 1:
+            return val.flatten()[0].item()
+    return val
+
+
+def prepare_tpu_model_outputs_if_packed(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    micro_batch: TensorDict,
+    temperature: float,
+    calculate_entropy: bool,
+    entropy_checkpointing: bool,
+):
+    """If the micro-batch uses TPU static sequence packing, reconstructs log_probs and entropy NestedTensors."""
+    if "tpu_custom_attention_mask" in micro_batch.keys():
+        log_probs, entropy = prepare_tpu_packed_outputs(
+            logits=logits,
+            labels=labels,
+            micro_batch=micro_batch,
+            temperature=temperature,
+            calculate_entropy=calculate_entropy,
+            entropy_checkpointing=entropy_checkpointing,
+        )
+        return log_probs, entropy
+    return None
+
+
+def safe_to_padded_tensor(nt: Any, padding: Any = 0, output_size: Any = None) -> torch.Tensor:
+    """Safely converts a NestedTensor to a padded dense tensor on TPU.
+
+    PyTorch TPU currently lacks native C++ kernel support for `aten::_jagged_to_padded_dense_forward`.
+    Falling back to `unbind()` + tensor slice assignment avoids operator runtime errors on TPU.
+    """
+    if not getattr(nt, "is_nested", False):
+        return nt
+    try:
+        return torch.nested.to_padded_tensor(nt, padding=padding, output_size=output_size)
+    except Exception:
+        tensors = nt.unbind()
+        if not tensors:
+            return torch.empty(output_size, device=nt.device, dtype=nt.dtype)
+        if output_size is not None and len(output_size) == 3:
+            out = torch.full(output_size, padding, device=tensors[0].device, dtype=tensors[0].dtype)
+            for i, t in enumerate(tensors):
+                out[i, :, : t.shape[-1]] = t
+        elif output_size is not None:
+            out = torch.full(output_size, padding, device=tensors[0].device, dtype=tensors[0].dtype)
+            for i, t in enumerate(tensors):
+                out[i, : t.shape[-1]] = t
+        else:
+            batch_size = len(tensors)
+            max_len = max(t.shape[-1] for t in tensors)
+            out = torch.full((batch_size, max_len), padding, device=tensors[0].device, dtype=tensors[0].dtype)
+            for i, t in enumerate(tensors):
+                out[i, : t.shape[-1]] = t
+        return out

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -854,7 +854,9 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
         device_name = get_device_name()
         micro_batch = micro_batch.to(get_device_id())
 
-        reconstruct_tpu_packed_metadata_tensors(micro_batch, get_device_id())
+        # Guard TPU-specific packed metadata reconstruction to run only on TPU devices
+        if device_name == "tpu":
+            reconstruct_tpu_packed_metadata_tensors(micro_batch, get_device_id())
 
         input_ids, extra_inputs, extra_kwargs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
 

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -30,15 +30,15 @@ from torch.distributed.tensor import DTensor
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
-from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
-from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
+from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.config import ActivationCheckpointConfig, CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed import utils as dist_utils
-from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.train import Trainer
 
 import verl.utils.torch_functional as verl_F
+from verl.plugin.platform import get_platform
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
@@ -53,6 +53,17 @@ from verl.utils.fsdp_utils import (
 from verl.utils.model import extract_multi_modal_inputs
 from verl.utils.torch_functional import logprobs_from_logits
 from verl.workers.config import HFModelConfig, TorchtitanEngineConfig, TorchtitanOptimizerConfig
+from verl.workers.engine.torchtitan.tpu_utils import (
+    compute_global_batch_num_tokens,
+    compute_tpu_max_seq_len,
+    monkey_patch_varlen_attention_tpu,
+    prepare_tpu_binned_pack_micro_batches,
+    prepare_tpu_model_outputs_if_packed,
+    reconstruct_tpu_packed_metadata_tensors,
+    safe_to_padded_tensor,
+    synchronize_tpu_loss,
+    unwrap_metadata,
+)
 from verl.workers.engine.torchtitan.utils import (
     NoOpDataLoader,
     derive_torchtitan_name_and_flavor,
@@ -68,6 +79,9 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 device_name = get_device_name()
+
+if device_name == "tpu":
+    monkey_patch_varlen_attention_tpu()
 
 
 class TorchTitanEngine(BaseEngine):
@@ -110,19 +124,17 @@ class TorchTitanEngine(BaseEngine):
         model_module = importlib.import_module(f"torchtitan.models.{torchtitan_name}")
         model_spec = model_module.model_registry(torchtitan_flavor, attn_backend=self.engine_config.attn_type)
 
+        # Use foreach optimizer implementation on TPU.
+        impl = "foreach" if get_platform().device_name == "tpu" else "fused"
+
         optimizer = OptimizersContainer.Config(
-            param_groups=[
-                ParamGroupConfig(
-                    pattern=r".*",
-                    optimizer_name=self.optimizer_config.name,
-                    optimizer_kwargs={
-                        "lr": self.optimizer_config.lr,
-                        "eps": self.optimizer_config.eps,
-                        "betas": (self.optimizer_config.betas[0], self.optimizer_config.betas[1]),
-                        "weight_decay": self.optimizer_config.weight_decay,
-                    },
-                )
-            ],
+            name=self.optimizer_config.name,
+            lr=self.optimizer_config.lr,
+            eps=self.optimizer_config.eps,
+            beta1=self.optimizer_config.betas[0],
+            beta2=self.optimizer_config.betas[1],
+            weight_decay=self.optimizer_config.weight_decay,
+            implementation=impl,
         )
 
         total_steps = self.optimizer_config.total_training_steps
@@ -143,7 +155,6 @@ class TorchTitanEngine(BaseEngine):
             pipeline_parallel_degree=self.engine_config.pipeline_parallel_size,
             context_parallel_degree=self.engine_config.context_parallel_size,
             expert_parallel_degree=self.engine_config.expert_parallel_size,
-            spmd_backend=self.engine_config.spmd_backend,
         )
         checkpoint = CheckpointManager.Config(
             enable=True,
@@ -151,7 +162,12 @@ class TorchTitanEngine(BaseEngine):
             initial_load_model_only=True,
             initial_load_path=model_config.path,
         )
-        compile_config = CompileConfig(enable=self.engine_config.use_torch_compile)
+        # Set compile backend to 'tpu' when running on TPU.
+        compile_config = CompileConfig(
+            enable=self.engine_config.use_torch_compile,
+            backend="tpu" if device_name == "tpu" else "inductor",
+        )
+
         training_kwargs = {}
         if self.engine_config.max_seq_len is not None:
             training_kwargs["seq_len"] = self.engine_config.max_seq_len
@@ -166,9 +182,9 @@ class TorchTitanEngine(BaseEngine):
         # so spmd.assert_type() raises "no current mesh". Set activation_checkpoint="none"
         # (or enable torch.compile, which recomputes in-graph) in that configuration.
         activation_checkpoint = {
-            "selective": SelectiveAC.Config,
-            "full": FullAC.Config,
-            "none": lambda: None,
+            "selective": lambda: ActivationCheckpointConfig(mode="selective"),
+            "full": lambda: ActivationCheckpointConfig(mode="full"),
+            "none": lambda: ActivationCheckpointConfig(mode="none"),
         }[self.engine_config.activation_checkpoint]()
 
         # Construct Torchtitan's Trainer.Config
@@ -191,6 +207,9 @@ class TorchTitanEngine(BaseEngine):
         self.trainer = Trainer(self.config)
 
         self._init_device_mesh()
+
+        if get_device_name() == "tpu" and torch.distributed.is_initialized():
+            torch.distributed.barrier()
 
         # Re-enable FSDP's gradient division for verl's loss scaling.
         # TorchTitan disables gradient division by default (for global token normalization),
@@ -337,20 +356,28 @@ class TorchTitanEngine(BaseEngine):
     def forward_backward_batch(self, data: TensorDict, loss_function: Callable, forward_only=False):
         """Perform forward and optionally backward pass on a batch."""
         tu.assign_non_tensor(data, sp_size=self.engine_config.tensor_parallel_size)
-
-        # Compute num_tokens in global batch for loss normalization
-        batch_num_tokens = data["loss_mask"].sum().to(get_device_id())
         dp_group = self.get_data_parallel_group()
-        if dp_group is not None:
-            torch.distributed.all_reduce(batch_num_tokens, op=torch.distributed.ReduceOp.SUM, group=dp_group)
-        tu.assign_non_tensor(data, batch_num_tokens=batch_num_tokens.item())
+        is_tpu = get_device_name() == "tpu"
+
+        if is_tpu:
+            batch_num_tokens = compute_global_batch_num_tokens(data, dp_group, self.engine_config.tensor_parallel_size)
+        else:
+            batch_num_tokens = data["loss_mask"].sum().to(get_device_id())
+            if dp_group is not None:
+                torch.distributed.all_reduce(batch_num_tokens, op=torch.distributed.ReduceOp.SUM, group=dp_group)
+            batch_num_tokens = batch_num_tokens if batch_num_tokens.device.type == "tpu" else batch_num_tokens.item()
+        tu.assign_non_tensor(data, batch_num_tokens=batch_num_tokens)
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())
 
-        micro_batches, indices = prepare_micro_batches(
-            data=data,
-            dp_group=self.get_data_parallel_group(),
-            same_micro_num_in_dp=True,
-        )
+        pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
+        if is_tpu and pad_mode == DatasetPadMode.NO_PADDING:
+            micro_batches, indices = prepare_tpu_binned_pack_micro_batches(data)
+        else:
+            micro_batches, indices = prepare_micro_batches(
+                data=data,
+                dp_group=self.get_data_parallel_group(),
+                same_micro_num_in_dp=True,
+            )
 
         output_lst = []
 
@@ -362,6 +389,8 @@ class TorchTitanEngine(BaseEngine):
             with self.trainer.train_context(), ctx:
                 loss, output = self.forward_step(micro_batch, loss_function=loss_function, forward_only=forward_only)
                 if not forward_only:
+                    if get_device_name() == "tpu":
+                        synchronize_tpu_loss(loss)
                     loss.backward()
             output_lst.append(output)
 
@@ -595,21 +624,60 @@ class EngineTrainModeCtx(BaseEngineCtx):
         super().__exit__(exc_type, exc_value, traceback)
 
 
-@EngineRegistry.register(model_type="language_model", backend=["torchtitan"], device=["cuda", "npu"])
+@EngineRegistry.register(model_type="language_model", backend=["torchtitan"], device=["cuda", "npu", "tpu"])
 class TorchTitanEngineWithLMHead(TorchTitanEngine):
     """TorchTitan engine implementation for language models with LM head."""
 
     def prepare_model_inputs(self, micro_batch: TensorDict):
+        if "tpu_custom_attention_mask" in micro_batch.keys():
+            # Packed TPU format
+            input_ids = micro_batch["input_ids"]
+            position_ids = micro_batch["position_ids"]
+            labels = torch.roll(input_ids, shifts=-1, dims=1)
+            labels[:, -1] = -100
+            attention_mask = micro_batch["tpu_custom_attention_mask"]
+            extra_inputs = {"positions": position_ids}
+            extra_kwargs = {"attention_masks": attention_mask}
+            output_args = {"labels": labels}
+
+            # Send to TPU device and ensure contiguous
+            device = self.trainer.device
+            input_ids = input_ids.to(device).contiguous()
+            extra_inputs = {
+                k: v.to(device).contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_inputs.items()
+            }
+            extra_kwargs = {
+                k: v.to(device).contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_kwargs.items()
+            }
+            output_args = {
+                k: v.to(device).contiguous() if isinstance(v, torch.Tensor) else v for k, v in output_args.items()
+            }
+
+            return input_ids, extra_inputs, extra_kwargs, output_args
+
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         pad_mode = tu.get_non_tensor_data(data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-        assert pad_mode == DatasetPadMode.NO_PADDING, f"pad_mode {pad_mode} not supported"
+        assert pad_mode in (
+            DatasetPadMode.NO_PADDING,
+            DatasetPadMode.RIGHT,
+            DatasetPadMode.TPU_BINNED_PACK,
+            "tpu_binned_pack",
+        ), f"pad_mode {pad_mode} not supported"
 
         multi_modal_inputs = extract_multi_modal_inputs(micro_batch.get("multi_modal_inputs", []))
         input_ids = micro_batch["input_ids"]
         position_ids = micro_batch["position_ids"]
         output_args = {}
 
-        if use_remove_padding:
+        if pad_mode == DatasetPadMode.RIGHT:
+            # For static/pre-padded RIGHT padding format, no nested/jagged tensor mechanics are needed.
+            # Shifting input_ids by -1 yields target labels.
+            labels = torch.roll(input_ids, shifts=-1, dims=1)
+            labels[:, -1] = -100  # Mask out the last wrapped label token
+            attention_mask = micro_batch["attention_mask"]
+            if position_ids.dim() == 3:
+                position_ids = position_ids.transpose(0, 1)
+        elif use_remove_padding:
             input_ids = input_ids.values().unsqueeze(0)
             if position_ids.dim() == 3:
                 position_ids = position_ids.values().unsqueeze(1)
@@ -627,27 +695,26 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
             loss_mask = micro_batch["loss_mask"]
             pad_token_id = tu.get_non_tensor_data(data=micro_batch, key="pad_token_id", default=0)
             batch_size = micro_batch.batch_size[0]
-            max_seq_len = max(input_ids.offsets().diff())
+            if self.engine_config.max_seq_len is not None:
+                max_seq_len = self.engine_config.max_seq_len
+            elif input_ids.device.type == "tpu":
+                max_seq_len = compute_tpu_max_seq_len(input_ids)
+            else:
+                max_seq_len = max(input_ids.offsets().diff())
 
             labels = torch.roll(input_ids.values(), shifts=-1, dims=0)
-            input_ids = torch.nested.to_padded_tensor(
-                input_ids, padding=pad_token_id, output_size=(batch_size, max_seq_len)
-            )
+            input_ids = safe_to_padded_tensor(input_ids, padding=pad_token_id, output_size=(batch_size, max_seq_len))
 
             if position_ids.dim() == 3:
-                position_ids = torch.nested.to_padded_tensor(
+                position_ids = safe_to_padded_tensor(
                     position_ids, padding=0, output_size=(batch_size, 4, max_seq_len)
                 ).transpose(0, 1)
             else:
-                position_ids = torch.nested.to_padded_tensor(
-                    position_ids, padding=0, output_size=(batch_size, max_seq_len)
-                )
+                position_ids = safe_to_padded_tensor(position_ids, padding=0, output_size=(batch_size, max_seq_len))
 
             attention_mask_list = [torch.ones_like(t, dtype=torch.int32) for t in loss_mask]
             attention_mask = torch.nested.as_nested_tensor(attention_mask_list, layout=torch.jagged)
-            attention_mask = torch.nested.to_padded_tensor(
-                attention_mask, padding=0, output_size=(batch_size, max_seq_len)
-            )
+            attention_mask = safe_to_padded_tensor(attention_mask, padding=0, output_size=(batch_size, max_seq_len))
 
         extra_inputs = {
             "positions": position_ids,
@@ -669,68 +736,113 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
         # TODO(jessicazhong): multimodal is not yet supported for Torchtitan engine
         extra_inputs.update(multi_modal_inputs)
         output_args["labels"] = labels
+
+        # Ensure all model inputs and kwargs are contiguous on TPU.
+        if input_ids.device.type == "tpu":
+            input_ids = input_ids.contiguous()
+            extra_inputs = {k: v.contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_inputs.items()}
+            extra_kwargs = {k: v.contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_kwargs.items()}
+
         return input_ids, extra_inputs, extra_kwargs, output_args
 
     def prepare_model_outputs(self, logits, output_args, micro_batch: TensorDict):
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
+        use_remove_padding = unwrap_metadata(use_remove_padding)
+
         pad_mode = tu.get_non_tensor_data(data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-        assert pad_mode == DatasetPadMode.NO_PADDING, f"pad_mode {pad_mode} not supported"
+        pad_mode = unwrap_metadata(pad_mode)
+        assert pad_mode in (
+            DatasetPadMode.NO_PADDING,
+            DatasetPadMode.RIGHT,
+            DatasetPadMode.TPU_BINNED_PACK,
+            "tpu_binned_pack",
+        ), f"pad_mode {pad_mode} not supported"
 
         temperature = micro_batch["temperature"]
+        temperature = unwrap_metadata(temperature)
+
         calculate_entropy = tu.get_non_tensor_data(data=micro_batch, key="calculate_entropy", default=False)
+        calculate_entropy = unwrap_metadata(calculate_entropy)
+
         labels = output_args["labels"]
         model_output = {}
 
-        input_ids = micro_batch["input_ids"]
-        cu_seqlens = input_ids.offsets()
-        if use_remove_padding:
-            labels = labels.squeeze(0)
-            logits_rmpad = logits.squeeze(0)
-            # PyTorch's autograd doesn't allow in-place modification of views when gradients need to flow back
-            logits_rmpad = logits_rmpad / temperature
+        tpu_outputs = prepare_tpu_model_outputs_if_packed(
+            logits=logits,
+            labels=labels,
+            micro_batch=micro_batch,
+            temperature=temperature,
+            calculate_entropy=calculate_entropy,
+            entropy_checkpointing=self.engine_config.entropy_checkpointing,
+        )
 
-            inplace_backward = True
-            if calculate_entropy:
-                inplace_backward = False
-            log_probs = logprobs_from_logits(
-                logits=logits_rmpad,
-                labels=labels,
-                inplace_backward=inplace_backward,
-            )
-
-            if calculate_entropy:
-                if not self.engine_config.entropy_checkpointing:
-                    if self.engine_config.entropy_from_logits_with_chunking:
-                        entropy_rmpad = self.compute_entropy_from_logits(
-                            logits_rmpad,
-                            chunk_size=self.engine_config.entropy_from_logits_chunk_size,
-                        )  # ((total_nnz / sp) + pad)
-                    else:
-                        entropy_rmpad = self.compute_entropy_from_logits(logits_rmpad)
-                else:
-                    entropy_rmpad = torch.utils.checkpoint.checkpoint(self.compute_entropy_from_logits, logits_rmpad)
-
-            log_probs = torch.nested.nested_tensor_from_jagged(log_probs.squeeze(0), cu_seqlens)
-            if calculate_entropy:
-                entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
-        else:
-            logits.div_(temperature)
+        if tpu_outputs is not None:
+            log_probs, entropy = tpu_outputs
+        elif pad_mode == DatasetPadMode.RIGHT:
+            logits = logits / temperature
             if calculate_entropy:
                 if not self.engine_config.entropy_checkpointing:
                     entropy = verl_F.entropy_from_logits(logits)
                 else:
                     entropy = torch.utils.checkpoint.checkpoint(verl_F.entropy_from_logits, logits)
 
-            seq_lengths = cu_seqlens.diff()
-            starts = torch.zeros_like(seq_lengths, dtype=torch.int64)
-            logits = torch.nested.narrow(logits, 1, starts, seq_lengths, layout=torch.jagged)
-            logits_rmpad = torch.cat([t for t in logits.unbind()])
-            log_probs = logprobs_from_logits(logits=logits_rmpad, labels=output_args["labels"])
-            log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
-            if calculate_entropy:
-                entropy = torch.nested.narrow(entropy, 1, starts, seq_lengths, layout=torch.jagged)
-                entropy_rmpad = torch.cat([t for t in entropy.unbind()])
-                entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
+            log_probs = logprobs_from_logits(logits=logits, labels=labels)
+        else:
+            input_ids = micro_batch["input_ids"]
+            if hasattr(input_ids, "offsets"):
+                cu_seqlens = input_ids.offsets()
+            else:
+                cu_seqlens = micro_batch["tpu_cu_seqlens"].squeeze(0)
+            if use_remove_padding:
+                labels = labels.squeeze(0)
+                logits_rmpad = logits.squeeze(0)
+                # PyTorch's autograd doesn't allow in-place modification of views when gradients need to flow back
+                logits_rmpad = logits_rmpad / temperature
+
+                inplace_backward = True
+                if calculate_entropy:
+                    inplace_backward = False
+                log_probs = logprobs_from_logits(
+                    logits=logits_rmpad,
+                    labels=labels,
+                    inplace_backward=inplace_backward,
+                )
+
+                if calculate_entropy:
+                    if not self.engine_config.entropy_checkpointing:
+                        if self.engine_config.entropy_from_logits_with_chunking:
+                            entropy_rmpad = self.compute_entropy_from_logits(
+                                logits_rmpad,
+                                chunk_size=self.engine_config.entropy_from_logits_chunk_size,
+                            )  # ((total_nnz / sp) + pad)
+                        else:
+                            entropy_rmpad = self.compute_entropy_from_logits(logits_rmpad)
+                    else:
+                        entropy_rmpad = torch.utils.checkpoint.checkpoint(
+                            self.compute_entropy_from_logits, logits_rmpad
+                        )
+
+                log_probs = torch.nested.nested_tensor_from_jagged(log_probs.squeeze(0), cu_seqlens)
+                if calculate_entropy:
+                    entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
+            else:
+                logits = logits / temperature
+                if calculate_entropy:
+                    if not self.engine_config.entropy_checkpointing:
+                        entropy = verl_F.entropy_from_logits(logits)
+                    else:
+                        entropy = torch.utils.checkpoint.checkpoint(verl_F.entropy_from_logits, logits)
+
+                seq_lengths = cu_seqlens.diff()
+                starts = torch.zeros_like(seq_lengths, dtype=torch.int64)
+                logits = torch.nested.narrow(logits, 1, starts, seq_lengths, layout=torch.jagged)
+                logits_rmpad = torch.cat([t for t in logits.unbind()])
+                log_probs = logprobs_from_logits(logits=logits_rmpad, labels=output_args["labels"])
+                log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
+                if calculate_entropy:
+                    entropy = torch.nested.narrow(entropy, 1, starts, seq_lengths, layout=torch.jagged)
+                    entropy_rmpad = torch.cat([t for t in entropy.unbind()])
+                    entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
 
         model_output["log_probs"] = log_probs
         if calculate_entropy:
@@ -741,6 +853,9 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
     def forward_step(self, micro_batch: TensorDict, loss_function, forward_only):
         device_name = get_device_name()
         micro_batch = micro_batch.to(get_device_id())
+
+        reconstruct_tpu_packed_metadata_tensors(micro_batch, get_device_id())
+
         input_ids, extra_inputs, extra_kwargs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
 
         with torch.autocast(device_type=device_name, dtype=torch.bfloat16):

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -106,7 +106,9 @@ def postprocess_batch_func(output_lst, indices, data: TensorDict):
 
     use_dynamic_bsz = tu.get_non_tensor_data(data=data, key="use_dynamic_bsz", default=True)
     pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-    assert pad_mode == DatasetPadMode.NO_PADDING, "postprocess_batch_func only support NO_PADDING pad_mode"
+    assert pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"], (
+        "postprocess_batch_func only support NO_PADDING or TPU_BINNED_PACK pad_mode"
+    )
 
     # losses_reduced is a list of dict containing outputs for each micro-batch
     # reorder entropy and outputs. Return None for other pp ranks
@@ -129,7 +131,7 @@ def postprocess_batch_func(output_lst, indices, data: TensorDict):
 
     # concat results from micro batches
     for key, val in model_output.items():
-        if pad_mode == DatasetPadMode.NO_PADDING:
+        if pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"]:
             tensors = [tensor for nt in model_output[key] for tensor in nt.unbind()]
             model_output[key] = torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
         else:

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -28,6 +28,7 @@ from tensordict import NonTensorData, TensorDict
 from torch.distributed.device_mesh import init_device_mesh
 
 from verl.checkpoint_engine import CheckpointEngineRegistry
+from verl.plugin.platform.platform_tpu_workarounds import convert_tensors_to_scalars
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
 from verl.trainer.distillation import distillation_ppo_loss, is_distillation_enabled
@@ -191,11 +192,20 @@ class TrainingWorker(Worker, DistProfilerExtension):
         # perform all gather in dp group to ensure that it's correct.
         # Here each metric in metrics can be a list (micro-batch metrics) or a singleton
         # we should always sum the loss of each micro-batch as we scale by global_bsz/global_token
-        loss = torch.sum(torch.tensor(output.pop("loss"), device=self.device_name))
         dp_group = self.engine.get_data_parallel_group()
-        if dp_group is not None:
-            torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
-        loss = loss.item()
+
+        if self.device_name == "tpu":
+            # Avoid eager distributed TPU/Gloo collectives outside JIT execution graphs.
+            # Convert all metrics to CPU scalars and return them directly;
+            # the driver (sft_trainer_ray.py) collects and averages metrics across ranks on CPU.
+            loss = torch.sum(torch.tensor(output.pop("loss"), device="cpu")).item()
+            target_group = None
+        else:
+            loss = torch.sum(torch.tensor(output.pop("loss"), device=self.device_name))
+            if dp_group is not None:
+                torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
+            loss = loss.item()
+            target_group = dp_group
 
         # For grad_norm, we do not perform all reduce because it is already been done when clipping grad
         grad_norm = metrics.pop("grad_norm", None)
@@ -204,8 +214,14 @@ class TrainingWorker(Worker, DistProfilerExtension):
         lr = metrics.pop("lr", None)
 
         # For other metrics, we perform all gather in dp group (only if DP > 1)
-        if dp_group is not None:
-            final_metrics = allgather_dict_into_dict(data=metrics, group=dp_group)
+        if self.device_name == "tpu":
+            # Convert device-bound TPU tensors in the metrics dict to standard Python scalars.
+            metrics = convert_tensors_to_scalars(metrics)
+
+        if self.device_name == "tpu":
+            final_metrics = metrics
+        elif target_group is not None:
+            final_metrics = allgather_dict_into_dict(data=metrics, group=target_group)
         else:
             final_metrics = metrics
         final_metrics["loss"] = loss
@@ -232,6 +248,9 @@ class TrainingWorker(Worker, DistProfilerExtension):
             final_metrics["mfu"] = estimated_flops / promised_flops / torch.distributed.get_world_size()
             if forward_only:
                 final_metrics["mfu"] /= 3.0
+        if self.device_name == "tpu":
+            # Convert any tensors in final_metrics to scalars/cpu before moving to cpu inside TensorDict
+            final_metrics = convert_tensors_to_scalars(final_metrics)
         # model outputs
         model_output = output.pop("model_output", {})
         # We only return final_metrics
@@ -320,13 +339,16 @@ class TrainingWorker(Worker, DistProfilerExtension):
                     for key, val in output.items():
                         # flattn dp and micro batch
                         if isinstance(val, list):
-                            output[key] = (
-                                Metric.aggregate_dp(val)
-                                if isinstance(val[0], Metric)
-                                else list(chain.from_iterable(val))
-                            )
+                            if isinstance(val[0], Metric):
+                                output[key] = Metric.aggregate_dp(val)
+                            elif isinstance(val[0], list | tuple):
+                                output[key] = list(chain.from_iterable(val))
+                            else:
+                                output[key] = sum(val) / len(val) if isinstance(val[0], int | float) else val[0]
                     append_to_dict(metrics, output)
 
+                if self.device_name == "tpu":
+                    metrics = convert_tensors_to_scalars(metrics)
                 output = tu.get_tensordict(tensor_dict={}, non_tensor_dict={"metrics": metrics}).cpu()
             else:
                 output = None

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -19,51 +19,135 @@ from tensordict import TensorDict
 from verl.trainer.ppo.core_algos import agg_loss, compute_value_loss, get_policy_loss_fn, kl_penalty
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
+from verl.utils.device import get_device_name
 from verl.utils.metric import AggregationType, Metric
 from verl.utils.torch_functional import masked_mean, masked_sum
 from verl.workers.config import ActorConfig, CriticConfig
 from verl.workers.utils.padding import no_padding_2_padding
+from verl.workers.utils.tpu_static_packing import (
+    flatten_tpu_loss_mask,
+    select_and_pad_tpu_data,
+    unpack_tpu_packed_data,
+)
+
+
+class DummyConfig:
+    """Fallback configuration object when config is passed as None during SFT loss evaluation."""
+
+    def __init__(self):
+        self.global_batch_info = {}
+        self.loss_scale_factor = None
+        self.loss_agg_mode = "token-mean"
 
 
 def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
+    """Compute Supervised Fine-Tuning (SFT) loss for actor model.
+
+    Supports both padded (RIGHT) and packed/nested sequence representations,
+    including static sequence packing for Google TPU v6e.
+
+    Args:
+        config (ActorConfig): Configuration object for actor training.
+        model_output (dict): Model forward outputs containing 'log_probs'.
+        data (TensorDict): Data batch containing token IDs, masks, and metadata.
+        dp_group: Data parallel process group (optional).
+
+    Returns:
+        tuple[torch.Tensor, dict]: Computed SFT loss and empty metrics dict.
+    """
+    is_tpu = get_device_name() == "tpu"
+    if is_tpu:
+        # TPU: Unpack sequence data if TPU static sequence packing is enabled
+        data = unpack_tpu_packed_data(data)
+
     pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-    dp_size = data["dp_size"]
-    batch_num_tokens = data["batch_num_tokens"]
+
+    dp_size = tu.get_non_tensor_data(data=data, key="dp_size", default=1)
+    batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
 
     log_prob = model_output["log_probs"]
 
-    if pad_mode == DatasetPadMode.NO_PADDING:
+    if pad_mode in (DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"):
         # log_prob and loss mask are nested tensors of shape [bsz, j1]
         # for each sample, loss mask shape is [1, prompt_length + response_length]
         loss_mask = data["loss_mask"]
 
-        log_prob_flatten = log_prob.values()
-        loss_mask_flatten = loss_mask.values()
+        if is_tpu and pad_mode in (DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"):
+            # TPU: flatten loss mask to align with TPU binned static packed log_probs
+            log_prob_flatten = log_prob.values()
+            loss_mask = flatten_tpu_loss_mask(loss_mask, data, log_prob_flatten)
 
-        # left-shift the loss mask by one token to align with log_prob
-        loss_mask_flatten = torch.roll(loss_mask_flatten, shifts=-1, dims=0)
+        log_prob = no_padding_2_padding(log_prob, data)
 
-        # NOTE: loss is averaged over all tokens in the batch across all data parallel groups,
-        # For FSDP backend, the loss is directly used for backward; while for Megatron backend,
-        # the loss should be scaled by `num_microbatches` for pp schedule.
-        loss = -masked_sum(log_prob_flatten, loss_mask_flatten) / batch_num_tokens * dp_size
+        # construct global batch info
+        if config is None:
+            config = DummyConfig()
+
+        config.global_batch_info["dp_size"] = dp_size
+        config.global_batch_info["batch_num_tokens"] = batch_num_tokens
+        config.global_batch_info["global_batch_size"] = data["global_batch_size"]
+        config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
+
+        mask_key = "response_mask" if "response_mask" in data.keys() else "loss_mask"
+        if is_tpu:
+            # TPU: select and pad tensors with fixed target shape to avoid dynamic shape recompilation
+            padded_dict = select_and_pad_tpu_data(data, mask_key, target_tensor=log_prob)
+            response_mask = padded_dict[mask_key].to(bool)
+        else:
+            response_mask = data[mask_key].to(bool)
+
+        # Bypass zero-sequence length empty tensor backward pass issues
+        if log_prob.shape[1] == 0:
+            log_prob = torch.zeros(
+                (log_prob.shape[0], 1), device=log_prob.device, dtype=log_prob.dtype, requires_grad=True
+            )
+            response_mask = torch.zeros((response_mask.shape[0], 1), device=response_mask.device, dtype=torch.bool)
+
+        loss = agg_loss(
+            loss_mat=-log_prob, loss_mask=response_mask, loss_agg_mode=config.loss_agg_mode, **config.global_batch_info
+        )
+    elif pad_mode == DatasetPadMode.RIGHT:
+        if "response_mask" in data.keys():
+            mask = data["response_mask"].to(bool)
+            mask[:, -1] = False
+        else:
+            mask = data["loss_mask"].to(bool)
+            mask = torch.cat([mask[:, 1:], torch.zeros_like(mask[:, :1])], dim=1)
+        loss = -masked_sum(log_prob, mask) / batch_num_tokens * dp_size
     else:
-        response_mask = data["response_mask"].to(bool)
-        loss = -masked_sum(log_prob, response_mask) / batch_num_tokens * dp_size
+        raise ValueError(f"Unsupported pad_mode: {pad_mode}")
 
     return loss, {}
 
 
 def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
-    """Computes ppo loss from model output (log_prob, entropy, values, etc. ) and old_log_probs from data."""
+    """Compute PPO policy gradient loss, entropy bonus, and KL divergence penalty.
+
+    Args:
+        config (ActorConfig): Configuration object for actor training.
+        model_output (dict): Model forward outputs containing 'log_probs' and optional 'entropy'.
+        data (TensorDict): Data batch containing old log probs, advantages, masks, and metadata.
+        dp_group: Data parallel process group (optional).
+
+    Returns:
+        tuple[torch.Tensor, dict]: Total policy loss and metric dictionary containing policy metrics,
+            entropy loss, and KL loss tracking.
+    """
+    is_tpu = get_device_name() == "tpu"
+    if is_tpu:
+        # TPU: Unpack sequence data if TPU static sequence packing is enabled
+        data = unpack_tpu_packed_data(data)
+
     log_prob = no_padding_2_padding(model_output["log_probs"], data)
     entropy = model_output.get("entropy", None)
     if entropy is not None:
         entropy = no_padding_2_padding(entropy, data)
 
     # global batch info for loss aggregation
-    config.global_batch_info["dp_size"] = data["dp_size"]
-    config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
+    dp_size = tu.get_non_tensor_data(data=data, key="dp_size", default=1)
+    batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
+    config.global_batch_info["dp_size"] = dp_size
+    config.global_batch_info["batch_num_tokens"] = batch_num_tokens
     config.global_batch_info["global_batch_size"] = data["global_batch_size"]
     config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
 
@@ -71,8 +155,8 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     # normalize using dp_size/global_bsz/global_token; in this case, metric aggregation should be SUM
     # to reflect the mean loss over the global batch
     if (
-        data["dp_size"] > 1
-        or data["batch_num_tokens"] is not None
+        dp_size > 1
+        or batch_num_tokens is not None
         or data["global_batch_size"] is not None
         or config.loss_scale_factor is not None
     ):
@@ -88,7 +172,12 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         fields.append("rollout_is_weights")
     if "ref_log_prob" in data:
         fields.append("ref_log_prob")
-    data = data.select(*fields).to_padded_tensor()
+
+    if is_tpu:
+        # TPU: select and pad tensors with fixed target shape to avoid dynamic shape recompilation
+        data = select_and_pad_tpu_data(data, *fields, target_tensor=log_prob)
+    else:
+        data = data.select(*fields).to_padded_tensor()
 
     response_mask = data["response_mask"].to(bool)
     # compute policy loss
@@ -139,24 +228,30 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
         policy_loss += kl_loss * config.kl_loss_coef
         metrics["kl_loss"] = Metric(value=kl_loss, aggregation=metric_aggregation)
-        metrics["kl_coef"] = config.kl_loss_coef
+        metrics["kl_coef"] = Metric(value=config.kl_loss_coef, aggregation=metric_aggregation)
 
     return policy_loss, metrics
 
 
 def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=None):
-    """value loss
+    """Compute critic value function loss with optional value clipping.
 
     Args:
-        config: CriticConfig
-        model_output: model output from the model
-        data: the input to the model
-        dp_group: data paralle group
+        config (CriticConfig): Configuration object for critic training.
+        model_output (dict): Model forward outputs containing predicted 'values'.
+        data (TensorDict): Data batch containing target returns, old values, and masks.
+        dp_group: Data parallel process group (optional).
 
     Returns:
-        value loss
+        tuple[torch.Tensor, dict]: Value function loss and metric dictionary containing vf_loss,
+            vf_clipfrac, and mean predicted values.
     """
-    vpreds = no_padding_2_padding(model_output["values"], data)  # (bsz, response_length)
+    is_tpu = get_device_name() == "tpu"
+    if is_tpu:
+        # TPU: Unpack sequence data if TPU static sequence packing is enabled
+        data = unpack_tpu_packed_data(data)
+
+    vpreds = no_padding_2_padding(model_output["values"], data)
 
     # Normalize the value loss over the global mini-batch (dp_size / batch_num_tokens /
     # global_batch_size) instead of the local micro-batch, so the accumulated critic gradient is
@@ -177,8 +272,13 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
     else:
         metric_aggregation = AggregationType.MEAN
 
-    # select fields and convert to padded tensor
-    data = data.select("values", "returns", "response_mask").to_padded_tensor()
+    if is_tpu:
+        # TPU: select and pad tensors with fixed target shape to avoid dynamic shape recompilation
+        data = select_and_pad_tpu_data(data, "values", "returns", "response_mask")
+    else:
+        # select fields and convert to padded tensor
+        data = data.select("values", "returns", "response_mask").to_padded_tensor()
+
     values = data["values"]
     returns = data["returns"]
     response_mask = data["response_mask"].to(bool)

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -15,9 +15,11 @@
 import torch
 import torch.nn.functional as F
 from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData
 
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
+from verl.utils.device import get_device_name
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
@@ -96,6 +98,116 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
     return data
 
 
+def get_packed_sequence_offsets_and_lens(
+    tensor: torch.Tensor, data: TensorDict, values: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Extract and compute sequence offsets, response lengths, and maximum response length from packed sequences.
+
+    Handles both TPU static binned packing and PyTorch nested/jagged tensor representations.
+
+    Args:
+        tensor (torch.Tensor): The input token or sequence tensor (nested/jagged or dense).
+        data (TensorDict): Data batch containing prompts, responses, or mask attributes.
+        values (torch.Tensor): Reference value tensor used to infer target device and dtypes.
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor, int]:
+            - sequence_offsets (torch.Tensor): Cumulative sequence end offsets.
+            - response_lens (torch.Tensor): Length of the response section for each sequence.
+            - max_response_len (int): Maximum response length across the batch.
+    """
+    is_tpu = get_device_name() == "tpu" or "tpu_custom_attention_mask" in data.keys()
+    if is_tpu and not (getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets")):
+        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
+
+        return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
+
+    if "prompts" in data.keys() and "responses" in data.keys():
+        prompt_ids = data["prompts"]
+        response_ids = data["responses"]
+
+        if isinstance(prompt_ids, NonTensorData):
+            prompt_ids = prompt_ids.data
+        if isinstance(response_ids, NonTensorData):
+            response_ids = response_ids.data
+    else:
+        prompt_ids = None
+        response_ids = None
+
+    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
+    if isinstance(max_response_len, list | tuple):
+        max_response_len = max(max_response_len) if len(max_response_len) > 0 else -1
+
+    if getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets"):
+        sequence_offsets = tensor.offsets()[1:].to(device=values.device)
+        sequence_lens = tensor.offsets().diff().to(device=values.device)
+
+        if response_ids is not None and (getattr(response_ids, "is_nested", False) or hasattr(response_ids, "offsets")):
+            response_lens = response_ids.offsets().diff().to(device=values.device)
+        elif response_ids is not None and isinstance(response_ids, list | tuple):
+            response_lens = torch.tensor(
+                [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+                device=values.device,
+                dtype=torch.int64,
+            )
+        elif response_ids is not None and isinstance(response_ids, torch.Tensor) and response_ids.ndim >= 2:
+            if "response_mask" in data.keys():
+                response_lens = data["response_mask"].sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = torch.tensor(
+                    [response_ids.shape[1]] * response_ids.shape[0], device=values.device, dtype=torch.int64
+                )
+        else:
+            mask_key = (
+                "response_mask"
+                if "response_mask" in data.keys()
+                else ("loss_mask" if "loss_mask" in data.keys() else None)
+            )
+            if mask_key is not None:
+                mask_val = data[mask_key]
+                if getattr(mask_val, "is_nested", False) or hasattr(mask_val, "offsets"):
+                    response_lens = torch.tensor(
+                        [int(x.sum().item()) for x in mask_val],
+                        device=values.device,
+                        dtype=torch.int64,
+                    )
+                else:
+                    response_lens = mask_val.sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = sequence_lens // 2
+
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+    elif prompt_ids is not None and (getattr(prompt_ids, "is_nested", False) or hasattr(prompt_ids, "offsets")):
+        prompt_lens = prompt_ids.offsets().diff().to(device=values.device)
+        response_lens = response_ids.offsets().diff().to(device=values.device)
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    elif prompt_ids is not None and isinstance(prompt_ids, list | tuple):
+        prompt_lens = torch.tensor(
+            [p.shape[-1] if hasattr(p, "shape") else len(p) for p in prompt_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        response_lens = torch.tensor(
+            [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    else:
+        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
+
+        return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
+
+    return sequence_offsets, response_lens, max_response_len
+
+
 def no_padding_2_padding(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor:
     """Slice response from unpad model output.
 
@@ -108,36 +220,26 @@ def no_padding_2_padding(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor
     Returns:
         tensor: sliced response tensor of shape [bsz, max_response_len, *]
     """
-    values = tensor.values() if tensor.is_nested else tensor
-    prompt_ids = data["prompts"]
-    response_ids = data["responses"]
-
-    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
-
-    if prompt_ids.is_nested:
-        prompt_lens = prompt_ids.offsets().diff()
-        response_lens = response_ids.offsets().diff()
-        if max_response_len < 0:
-            max_response_len = response_lens.max().item()
-    else:
-        attention_mask = data["attention_mask"]
-        assert not attention_mask.is_nested
-        prompt_lens = attention_mask[:, : prompt_ids.shape[1]].sum(dim=1)
-        response_lens = attention_mask[:, prompt_ids.shape[1] :].sum(dim=1)
-        max_response_len = response_ids.shape[1]
-
-    sequence_lens = prompt_lens + response_lens
-    sequence_offsets = sequence_lens.cumsum(dim=0)
-    assert sequence_offsets[-1].item() == values.shape[0]
-    assert not prompt_lens.eq(0).any(), f"seq_offset - resp_len - 1 assumes prompt_len > 0. Got {prompt_lens}"
+    values = tensor.values() if getattr(tensor, "is_nested", False) else tensor
+    sequence_offsets, response_lens, max_response_len = get_packed_sequence_offsets_and_lens(tensor, data, values)
 
     response_list = []
     # Skip padding dimensions after sequence dimensions, if any.
     skip_padding = (0, 0) * (values.ndim - 1)
+    prev_offset = 0
     for resp_len, seq_offset in zip(response_lens, sequence_offsets, strict=True):
-        pad_size = max_response_len - resp_len
-        # left-shift model output by one token for log_probs/values
-        response_list.append(F.pad(values[seq_offset - resp_len - 1 : seq_offset - 1], (*skip_padding, 0, pad_size)))
+        resp_len_item = int(resp_len.item()) if isinstance(resp_len, torch.Tensor) else int(resp_len)
+        seq_offset_item = int(seq_offset.item()) if isinstance(seq_offset, torch.Tensor) else int(seq_offset)
+        pad_size = max(0, max_response_len - resp_len_item)
+
+        start_idx = seq_offset_item - resp_len_item - 1
+        end_idx = seq_offset_item - 1
+        if start_idx < prev_offset:
+            start_idx = seq_offset_item - resp_len_item
+            end_idx = seq_offset_item
+
+        response_list.append(F.pad(values[start_idx:end_idx], (*skip_padding, 0, pad_size)))
+        prev_offset = seq_offset_item
 
     output = torch.stack(response_list, dim=0)
     return output

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -20,6 +20,7 @@ from tensordict.tensorclass import NonTensorData
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
 from verl.utils.device import get_device_name
+from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
@@ -118,8 +119,6 @@ def get_packed_sequence_offsets_and_lens(
     """
     is_tpu = get_device_name() == "tpu" or "tpu_custom_attention_mask" in data.keys()
     if is_tpu and not (getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets")):
-        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
-
         return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
 
     if "prompts" in data.keys() and "responses" in data.keys():
@@ -201,8 +200,6 @@ def get_packed_sequence_offsets_and_lens(
         sequence_lens = prompt_lens + response_lens
         sequence_offsets = sequence_lens.cumsum(dim=0)
     else:
-        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
-
         return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
 
     return sequence_offsets, response_lens, max_response_len

--- a/verl/workers/utils/tpu_static_packing.py
+++ b/verl/workers/utils/tpu_static_packing.py
@@ -1,0 +1,405 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData
+
+from verl.utils import tensordict_utils as tu
+
+
+def unpack_tpu_packed_data(data: TensorDict) -> TensorDict:
+    """Reconstruct NestedTensors from packed flat sequence keys on TPU.
+
+    In TPU binned sequence packing, standard sequence keys (like old_log_probs,
+    advantages, response_mask) are packed into 2D flat tensors. Reconstructing them
+    as device NestedTensors using cu_seqlens ensures they can be correctly
+    padded/sliced to [batch_size, max_response_len].
+    """
+    if "tpu_custom_attention_mask" not in data.keys():
+        return data
+
+    input_ids = data["input_ids"]
+    mbsz = input_ids.shape[0]
+
+    cu_seqlens_list = data["tpu_cu_seqlens"]
+    if hasattr(cu_seqlens_list, "data"):
+        cu_seqlens_list = cu_seqlens_list.data
+    if not isinstance(cu_seqlens_list, list | tuple):
+        cu_seqlens_list = [cu_seqlens_list]
+
+    num_seqs_list = data["tpu_num_seqs"]
+    if hasattr(num_seqs_list, "data"):
+        num_seqs_list = num_seqs_list.data
+    if not isinstance(num_seqs_list, list | tuple):
+        num_seqs_list = [num_seqs_list]
+
+    # Include "loss_mask" in the unpack keys list to unpack SFT training loss mask correctly.
+    sequence_keys_to_unpack = [
+        "old_log_probs",
+        "advantages",
+        "response_mask",
+        "values",
+        "returns",
+        "ref_log_prob",
+        "rollout_is_weights",
+        "loss_mask",
+    ]
+
+    for k in sequence_keys_to_unpack:
+        if k in data.keys():
+            val = data[k]
+            if isinstance(val, torch.Tensor) and not getattr(val, "is_nested", False):
+                cumulative_offset = 0
+                combined_cu_seqlens = [0]
+                combined_val_rmpad_list = []
+
+                for row_idx in range(mbsz):
+                    cu_seqlens_row = cu_seqlens_list[row_idx]
+                    num_seqs_row = num_seqs_list[row_idx]
+
+                    if isinstance(cu_seqlens_row, list):
+                        cu_seqlens_row = cu_seqlens_row[0]
+                    if not isinstance(cu_seqlens_row, torch.Tensor):
+                        cu_seqlens_row = torch.tensor(cu_seqlens_row, dtype=torch.int32)
+
+                    cu_seqlens_active = cu_seqlens_row[: num_seqs_row + 1]
+                    active_len = int(cu_seqlens_active[-1].item())
+
+                    if val.dim() >= 2:
+                        val_row = val[row_idx, :active_len]
+                    else:
+                        val_row = val[:active_len]
+
+                    combined_val_rmpad_list.append(val_row)
+
+                    row_offsets = cu_seqlens_active[1:] - cu_seqlens_active[0] + cumulative_offset
+                    combined_cu_seqlens.extend(row_offsets.tolist())
+                    cumulative_offset += active_len
+
+                combined_val_rmpad = torch.cat(combined_val_rmpad_list, dim=0).to(val.device)
+                combined_cu_seqlens_tensor = torch.tensor(combined_cu_seqlens, dtype=torch.int32, device=val.device)
+                nested_val = torch.nested.nested_tensor_from_jagged(combined_val_rmpad, combined_cu_seqlens_tensor)
+                data._tensordict[k] = nested_val
+
+    return data
+
+
+def nested_to_padded_tpu(val: torch.Tensor, fill_val=0.0) -> torch.Tensor:
+    """Safely converts a PyTorch NestedTensor to a padded 2D dense tensor on TPU."""
+    if not isinstance(val, torch.Tensor) or not getattr(val, "is_nested", False):
+        return val
+    try:
+        return val.to_padded_tensor(fill_val)
+    except Exception:
+        values = val.values()
+        offsets = val.offsets()
+        bsz = offsets.shape[0] - 1
+        lens = offsets.diff().tolist()
+        max_len = max(lens) if len(lens) > 0 else 0
+        out = torch.full(
+            (bsz, max_len, *values.shape[1:]), fill_value=fill_val, dtype=values.dtype, device=values.device
+        )
+        for i in range(bsz):
+            st, en = int(offsets[i]), int(offsets[i + 1])
+            row_data = values[st:en]
+            row_len = min(en - st, row_data.shape[0])
+            if row_len > 0:
+                out[i, :row_len] = row_data[:row_len]
+        return out
+
+
+def pad_to_2d_tensor(val, target_len=-1, fill_val=0.0, target_tensor=None):
+    """Pads standard and nested tensors to 2D dense tensors of target length."""
+    if val is None:
+        return None
+    if isinstance(val, torch.Tensor):
+        val = nested_to_padded_tpu(val, fill_val)
+        if val.ndim == 1:
+            val = val.unsqueeze(0)
+    elif isinstance(val, list | tuple):
+        t_list = []
+        for x in val:
+            if isinstance(x, torch.Tensor):
+                x = nested_to_padded_tpu(x, fill_val)
+                if x.ndim == 0:
+                    x = x.unsqueeze(0)
+                elif x.ndim > 1:
+                    x = x.flatten()
+            else:
+                x = torch.as_tensor(x)
+                if x.ndim == 0:
+                    x = x.unsqueeze(0)
+            t_list.append(x)
+
+        if len(t_list) > 0:
+            max_item_len = max(t.shape[0] for t in t_list)
+            if target_len > 0:
+                max_item_len = max(max_item_len, target_len)
+            aligned = []
+            for t in t_list:
+                if t.shape[0] < max_item_len:
+                    pad = torch.full((max_item_len - t.shape[0],), fill_value=fill_val, dtype=t.dtype, device=t.device)
+                    t = torch.cat([t, pad], dim=0)
+                elif t.shape[0] > max_item_len:
+                    t = t[:max_item_len]
+                aligned.append(t)
+            val = torch.stack(aligned, dim=0)
+        else:
+            val = torch.empty((0, target_len if target_len > 0 else 0))
+    else:
+        val = torch.as_tensor(val)
+        if val.ndim == 1:
+            val = val.unsqueeze(0)
+
+    if isinstance(val, torch.Tensor):
+        val = nested_to_padded_tpu(val, fill_val)
+    if isinstance(target_tensor, torch.Tensor):
+        target_tensor = nested_to_padded_tpu(target_tensor, 0.0)
+
+    if isinstance(val, torch.Tensor) and val.ndim >= 2:
+        if target_len > 0:
+            curr_len = int(val.shape[1])
+            if curr_len < target_len:
+                pad_shape = list(val.shape)
+                pad_shape[1] = target_len - curr_len
+                pad = torch.full(pad_shape, fill_value=fill_val, dtype=val.dtype, device=val.device)
+                val = torch.cat([val, pad], dim=1)
+            elif curr_len > target_len:
+                val = val[:, :target_len]
+
+    if target_tensor is not None and isinstance(target_tensor, torch.Tensor) and isinstance(val, torch.Tensor):
+        if val.device != target_tensor.device or val.dtype != target_tensor.dtype:
+            if not val.dtype.is_floating_point and target_tensor.dtype.is_floating_point:
+                val = val.to(device=target_tensor.device, dtype=target_tensor.dtype)
+            else:
+                val = val.to(device=target_tensor.device)
+        val_s0, target_s0 = int(val.shape[0]), int(target_tensor.shape[0])
+        val_s1, target_s1 = int(val.shape[1]), int(target_tensor.shape[1])
+        if (val_s0, val_s1) != (target_s0, target_s1):
+            if val_s0 != target_s0:
+                if val_s0 < target_s0:
+                    rep = (target_s0 + val_s0 - 1) // max(1, val_s0)
+                    val = val.repeat(rep, 1)[:target_s0]
+                else:
+                    val = val[:target_s0]
+            if val_s1 != target_s1:
+                if val_s1 < target_s1:
+                    pad_shape = list(val.shape)
+                    pad_shape[1] = target_s1 - val_s1
+                    pad = torch.full(pad_shape, fill_value=fill_val, dtype=val.dtype, device=val.device)
+                    val = torch.cat([val, pad], dim=1)
+                else:
+                    val = val[:, :target_s1]
+    return val
+
+
+def select_and_pad_tpu_data(data: TensorDict, *fields, target_tensor=None) -> dict:
+    """Select and pad TensorDict fields on TPU."""
+    from verl.workers.utils.padding import no_padding_2_padding  # Avoid circular import with padding.py
+
+    is_tpu_packed = "tpu_custom_attention_mask" in data.keys()
+    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
+    if isinstance(max_response_len, list | tuple):
+        max_response_len = max(max_response_len) if len(max_response_len) > 0 else -1
+
+    padded_dict = {}
+    for k in fields:
+        if k not in data.keys():
+            continue
+        val = data[k]
+        if isinstance(val, NonTensorData):
+            val = val.data
+
+        fill_val = (
+            1.0
+            if k == "rollout_is_weights"
+            else (True if k == "response_mask" and getattr(val, "dtype", None) == torch.bool else 0.0)
+        )
+
+        padded = None
+        if is_tpu_packed:
+            if isinstance(val, list | tuple):
+                try:
+                    val_t = torch.as_tensor(val)
+                    padded = no_padding_2_padding(val_t, data)
+                except Exception:
+                    pass
+            if padded is None:
+                try:
+                    padded = no_padding_2_padding(val, data)
+                except Exception:
+                    pass
+
+        padded = pad_to_2d_tensor(
+            padded if padded is not None else val,
+            target_len=max_response_len,
+            fill_val=fill_val,
+            target_tensor=target_tensor,
+        )
+        padded_dict[k] = padded
+
+    return padded_dict
+
+
+def flatten_tpu_loss_mask(loss_mask: torch.Tensor, data: TensorDict, log_prob_flatten: torch.Tensor) -> torch.Tensor:
+    """Flatten loss_mask using TPU binned packing active seqlens.
+
+    Called in `verl/workers/utils/losses.py` during loss calculation when data.pad_mode=no_padding on TPU.
+    """
+    if isinstance(loss_mask, torch.Tensor) and not getattr(loss_mask, "is_nested", False):
+        mbsz = loss_mask.shape[0]
+        cu_seqlens_list = data["tpu_cu_seqlens"]
+        if hasattr(cu_seqlens_list, "data"):
+            cu_seqlens_list = cu_seqlens_list.data
+        if not isinstance(cu_seqlens_list, list | tuple):
+            cu_seqlens_list = [cu_seqlens_list]
+
+        num_seqs_list = data["tpu_num_seqs"]
+        if hasattr(num_seqs_list, "data"):
+            num_seqs_list = num_seqs_list.data
+        if not isinstance(num_seqs_list, list | tuple):
+            num_seqs_list = [num_seqs_list]
+
+        loss_mask_parts = []
+        for row_idx in range(mbsz):
+            cu_seqlens = cu_seqlens_list[row_idx]
+            if isinstance(cu_seqlens, list):
+                cu_seqlens = cu_seqlens[0]
+            if not isinstance(cu_seqlens, torch.Tensor):
+                cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
+
+            num_seqs = num_seqs_list[row_idx]
+            if isinstance(num_seqs, list):
+                num_seqs = num_seqs[0]
+
+            cu_seqlens_active = cu_seqlens[: num_seqs + 1]
+            active_len = int(cu_seqlens_active[-1].item())
+
+            loss_mask_parts.append(loss_mask[row_idx, :active_len])
+
+        return torch.cat(loss_mask_parts, dim=0).to(log_prob_flatten.device)
+    else:
+        return loss_mask.values()
+
+
+def get_packed_sequence_offsets_and_lens_tpu(
+    tensor: torch.Tensor, data: TensorDict, values: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Extract and compute sequence offsets, response lengths, and maximum response length for packed data on TPU."""
+    # Handle SFT fallback when "prompts" or "responses" are not in the TensorDict keys.
+    if "prompts" in data.keys() and "responses" in data.keys():
+        prompt_ids = data["prompts"]
+        response_ids = data["responses"]
+
+        if isinstance(prompt_ids, NonTensorData):
+            prompt_ids = prompt_ids.data
+        if isinstance(response_ids, NonTensorData):
+            response_ids = response_ids.data
+    else:
+        prompt_ids = None
+        response_ids = None
+
+    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
+    if isinstance(max_response_len, list | tuple):
+        max_response_len = max(max_response_len) if len(max_response_len) > 0 else -1
+
+    if getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets"):
+        sequence_offsets = tensor.offsets()[1:].to(device=values.device)
+        sequence_lens = tensor.offsets().diff().to(device=values.device)
+
+        if response_ids is not None and (getattr(response_ids, "is_nested", False) or hasattr(response_ids, "offsets")):
+            response_lens = response_ids.offsets().diff().to(device=values.device)
+        elif response_ids is not None and isinstance(response_ids, list | tuple):
+            response_lens = torch.tensor(
+                [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+                device=values.device,
+                dtype=torch.int64,
+            )
+        elif response_ids is not None and isinstance(response_ids, torch.Tensor) and response_ids.ndim >= 2:
+            if "response_mask" in data.keys():
+                response_lens = data["response_mask"].sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = torch.tensor(
+                    [response_ids.shape[1]] * response_ids.shape[0], device=values.device, dtype=torch.int64
+                )
+        else:
+            # SFT fallback: response_lens is the sum of loss_mask/response_mask within each sequence
+            mask_key = (
+                "response_mask"
+                if "response_mask" in data.keys()
+                else ("loss_mask" if "loss_mask" in data.keys() else None)
+            )
+            if mask_key is not None:
+                mask_val = data[mask_key]
+                if getattr(mask_val, "is_nested", False) or hasattr(mask_val, "offsets"):
+                    response_lens = torch.tensor(
+                        [int(x.sum().item()) for x in mask_val],
+                        device=values.device,
+                        dtype=torch.int64,
+                    )
+                else:
+                    response_lens = mask_val.sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = sequence_lens // 2
+
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+    elif prompt_ids is not None and (getattr(prompt_ids, "is_nested", False) or hasattr(prompt_ids, "offsets")):
+        prompt_lens = prompt_ids.offsets().diff().to(device=values.device)
+        response_lens = response_ids.offsets().diff().to(device=values.device)
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    elif prompt_ids is not None and isinstance(prompt_ids, list | tuple):
+        prompt_lens = torch.tensor(
+            [p.shape[-1] if hasattr(p, "shape") else len(p) for p in prompt_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        response_lens = torch.tensor(
+            [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    else:
+        # SFT Fallback: tensor is not nested, standard 2D tensor or packed 2D tensor
+        mask_key = (
+            "response_mask" if "response_mask" in data.keys() else ("loss_mask" if "loss_mask" in data.keys() else None)
+        )
+        if mask_key is not None:
+            mask_val = data[mask_key]
+            response_lens = mask_val.sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            if "input_ids" in data.keys():
+                input_ids = data["input_ids"]
+                prompt_lens = (
+                    torch.tensor([input_ids.shape[1]] * input_ids.shape[0], device=values.device) - response_lens
+                )
+            else:
+                prompt_lens = response_lens
+            max_response_len = int(response_lens.max().item())
+        else:
+            prompt_lens = torch.tensor([tensor.shape[1] // 2] * tensor.shape[0], device=values.device)
+            response_lens = torch.tensor([tensor.shape[1] // 2] * tensor.shape[0], device=values.device)
+            max_response_len = tensor.shape[1] // 2
+
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+
+    return sequence_offsets, response_lens, max_response_len


### PR DESCRIPTION
### What does this PR do?

This PR adds Supervised Fine-Tuning (SFT) support for Google TPU devices in `verl` using the TorchTitan execution engine and static sequence packing.    

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Validated SFT training on a TPU v6e-4 VM using `examples/tpu/sft/run_qwen3_0_6b_torchtitan.sh`.  

### API and Usage Example

```bash
bash examples/tpu/sft/run_qwen3_0_6b_torchtitan.sh
```

### Design & Code Changes

1. **Platform & Ray Worker Integration**: Added TPU platform plugin (`PlatformTPU`), multi-host Ray workarounds, and inlined local rank (`LOCAL_RANK`) and device setup directly in `Worker`.
2. **SFT Ray Trainer on TPU**: Executed trainer initialization inside remote Ray actors for direct on-worker PJRT setup, and added multi-host metric aggregation.
3. **Static Sequence Packing**: Added `tpu_binned_pack` mode to pad batch sequences to fixed bin lengths (e.g., 512, 1024, 2048), eliminating XLA JIT recompilations from dynamic shapes.
4. **TorchTitan Engine & Loss Adaptation**: Added TPU 2D DeviceMesh (TP + DP) helpers, adapted Qwen transformer modules for TPU SPMD sharding, and updated `sft_loss` with static sequence unpacking.
5. **Example Script & Documentation**: Added `examples/tpu/sft/run_qwen3_0_6b_torchtitan.sh` for Qwen3-0.6B on TPU v6e-4 and updated `docs/hardware/multi_chip_support.rst`.
  

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. 
    - If not feasible, explain why: Requires TPU hardware to execute.  
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
