### PR TITLE
[ckpt] fix: remove loaded local checkpoints

### DIFF
--- a/tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py
+++ b/tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py
@@ -228,6 +228,54 @@ class TestFSDPCheckpointManagerLoraOnly:
 
         assert model_after._fsdp_wrapped_module.base_weight.item() == 42.0
 
+    def test_load_checkpoint_preserves_barrier_when_cleanup_disabled(self, tmp_path, monkeypatch):
+        model = _FakeFSDPModel(has_lora=True)
+        manager = self._make_fsdp_manager(
+            checkpoint_config={"save_contents": ["model"]},
+            model=model,
+        )
+        checkpoint_path = tmp_path / "actor"
+        manager.save_checkpoint(local_path=str(checkpoint_path), global_step=1)
+
+        barriers = []
+        monkeypatch.setattr("torch.distributed.barrier", lambda: barriers.append("barrier"))
+        loading_manager = self._make_fsdp_manager(
+            checkpoint_config={"load_contents": ["model"]},
+            model=_FakeFSDPModel(has_lora=True),
+        )
+        loading_manager.load_checkpoint(local_path=str(checkpoint_path))
+
+        assert barriers == ["barrier"]
+        assert checkpoint_path.exists()
+
+    def test_load_checkpoint_removes_only_role_directory_when_enabled(self, tmp_path):
+        model = _FakeFSDPModel(has_lora=True)
+        manager = self._make_fsdp_manager(
+            checkpoint_config={"save_contents": ["model"]},
+            model=model,
+        )
+        step_path = tmp_path / "global_step_1"
+        checkpoint_path = step_path / "actor"
+        critic_path = step_path / "critic"
+        critic_path.mkdir(parents=True)
+        data_path = step_path / "data.pt"
+        data_path.write_bytes(b"driver state")
+        manager.save_checkpoint(local_path=str(checkpoint_path), global_step=1)
+
+        loaded_model = _FakeFSDPModel(has_lora=True)
+        loading_manager = self._make_fsdp_manager(
+            checkpoint_config={"load_contents": ["model"]},
+            model=loaded_model,
+        )
+        loading_manager.load_checkpoint(
+            local_path=str(checkpoint_path),
+            del_local_after_load=True,
+        )
+
+        assert not checkpoint_path.exists()
+        assert critic_path.exists()
+        assert data_path.exists()
+
 
 class _FakeConfig:
     """Minimal config mock that supports save_pretrained."""

--- a/tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py
+++ b/tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py
@@ -12,11 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocessing
 import os
 import shutil
 import tempfile
 
 import pytest
+
+
+def _distributed_cleanup_worker(rank, world_size, init_method, checkpoint_path, results):
+    import torch.distributed as dist
+
+    from verl.utils.checkpoint.checkpoint_manager import BaseCheckpointManager
+
+    dist.init_process_group("gloo", init_method=init_method, rank=rank, world_size=world_size)
+    try:
+        manager = BaseCheckpointManager.__new__(BaseCheckpointManager)
+        manager.rank = rank
+        manager._cleanup_local_checkpoint_after_load(checkpoint_path, enabled=True)
+        results.put((rank, os.path.exists(checkpoint_path)))
+    finally:
+        dist.destroy_process_group()
 
 
 class TestCheckpointCleanupLogic:
@@ -137,3 +153,76 @@ class TestCheckpointCleanupLogic:
         manager.register_checkpoint(ckpt_300, 1)
         assert not os.path.exists(ckpt_200)
         assert manager.previous_saved_paths == [ckpt_300]
+
+    def test_cleanup_after_load_removes_role_dir_on_rank_zero(self, manager, monkeypatch):
+        checkpoint_path = self._create_checkpoint_dir(100)
+        events = []
+        remove_path = manager.remove_previous_save_local_path
+
+        def record_remove(path):
+            events.append("remove")
+            remove_path(path)
+
+        monkeypatch.setattr("torch.distributed.barrier", lambda: events.append("barrier"))
+        monkeypatch.setattr(manager, "remove_previous_save_local_path", record_remove)
+
+        manager._cleanup_local_checkpoint_after_load(checkpoint_path, enabled=True)
+
+        assert not os.path.exists(checkpoint_path)
+        assert events == ["barrier", "remove", "barrier"]
+
+    def test_cleanup_after_load_is_rank_zero_only(self, manager, monkeypatch):
+        checkpoint_path = self._create_checkpoint_dir(100)
+        manager.rank = 1
+        events = []
+        monkeypatch.setattr("torch.distributed.barrier", lambda: events.append("barrier"))
+        monkeypatch.setattr(
+            manager,
+            "remove_previous_save_local_path",
+            lambda path: events.append("remove"),
+        )
+
+        manager._cleanup_local_checkpoint_after_load(checkpoint_path, enabled=True)
+
+        assert os.path.exists(checkpoint_path)
+        assert events == ["barrier", "barrier"]
+
+    def test_cleanup_after_load_disabled_preserves_role_dir(self, manager, monkeypatch):
+        checkpoint_path = self._create_checkpoint_dir(100)
+        events = []
+        monkeypatch.setattr("torch.distributed.barrier", lambda: events.append("barrier"))
+
+        manager._cleanup_local_checkpoint_after_load(checkpoint_path, enabled=False)
+
+        assert os.path.exists(checkpoint_path)
+        assert events == []
+
+    def test_cleanup_after_load_with_two_gloo_processes(self):
+        checkpoint_path = self._create_checkpoint_dir(100)
+        init_file = os.path.join(self.test_dir, "gloo-init")
+        init_method = f"file://{init_file}"
+        context = multiprocessing.get_context("spawn")
+        results = context.Queue()
+        processes = [
+            context.Process(
+                target=_distributed_cleanup_worker,
+                args=(rank, 2, init_method, checkpoint_path, results),
+            )
+            for rank in range(2)
+        ]
+
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=15)
+
+        exitcodes = [process.exitcode for process in processes]
+        try:
+            assert exitcodes == [0, 0]
+            assert sorted(results.get(timeout=1) for _ in range(2)) == [(0, False), (1, False)]
+            assert not os.path.exists(checkpoint_path)
+        finally:
+            for process in processes:
+                if process.is_alive():
+                    process.terminate()
+                    process.join(timeout=1)

--- a/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
+++ b/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
@@ -22,7 +22,9 @@ Uses real megatron.core with gloo backend on a single CPU process.
 
 import os
 import shutil
+import sys
 import tempfile
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -109,6 +111,7 @@ def _make_manager(
     bridge="auto",
     peft_cls=None,
     use_distributed_optimizer=False,
+    use_megatron_fsdp=False,
 ):
     if save_contents is None:
         save_contents = ["model", "optimizer", "extra"]
@@ -148,6 +151,7 @@ def _make_manager(
         optimizer_scheduler=lr_scheduler,
         use_distributed_optimizer=use_distributed_optimizer,
         use_dist_checkpointing=use_dist_checkpointing,
+        use_megatron_fsdp=use_megatron_fsdp,
         bridge=bridge,
         peft_cls=peft_cls,
     )
@@ -537,6 +541,73 @@ class TestLoadCheckpointDispatch:
         assert set(calls) == {"extra"}
         assert "rng_state" in calls["extra"]
         mgr.model[0].sharded_state_dict.assert_not_called()
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_load_checkpoint_removes_role_directory_when_enabled(self, mock_load_dc, _mock_meta):
+        _make_v2_layout(self.ckpt_path, "extra")
+        mock_load_dc.return_value = {"rng_state": [{"random_rng_state": None}]}
+        manager = _make_manager(load_contents=["extra"])
+
+        with patch.object(manager, "load_rng_states"):
+            manager.load_checkpoint(self.ckpt_path, del_local_after_load=True)
+
+        assert not os.path.exists(self.ckpt_path)
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_load_checkpoint_disabled_does_not_add_barrier(self, mock_load_dc, _mock_meta):
+        manager = _make_manager(load_contents=[])
+
+        with patch("torch.distributed.barrier") as mock_barrier:
+            manager.load_checkpoint(self.ckpt_path)
+
+        mock_barrier.assert_not_called()
+        assert os.path.exists(self.ckpt_path)
+
+    def test_megatron_fsdp_load_removes_role_directory_when_enabled(self):
+        model_dist_path = os.path.join(self.ckpt_path, "model", "dist_ckpt")
+        os.makedirs(model_dist_path, exist_ok=True)
+        with open(os.path.join(model_dist_path, ".metadata"), "w") as f:
+            f.write("")
+
+        manager = _make_manager(load_contents=[], use_megatron_fsdp=True)
+        checkpointing = types.ModuleType("megatron.bridge.training.checkpointing")
+        checkpointing.load_fsdp_dtensor_checkpoint = MagicMock(return_value=({}, None, None, None))
+
+        with (
+            patch.dict(sys.modules, {"megatron.bridge.training.checkpointing": checkpointing}),
+            patch.object(manager, "_build_sharded_state_dict_metadata", return_value={}),
+            patch.object(manager, "_build_model_sharded_state_dict", return_value={}),
+            patch.object(manager, "_build_optimizer_state_dict", return_value={}),
+            patch.object(manager, "_build_extra_state_dict", return_value={}),
+        ):
+            manager._load_megatron_fsdp_checkpoint(self.ckpt_path, del_local_after_load=True)
+
+        assert not os.path.exists(self.ckpt_path)
+
+    def test_megatron_fsdp_load_disabled_does_not_add_barrier(self):
+        model_dist_path = os.path.join(self.ckpt_path, "model", "dist_ckpt")
+        os.makedirs(model_dist_path, exist_ok=True)
+        with open(os.path.join(model_dist_path, ".metadata"), "w") as f:
+            f.write("")
+
+        manager = _make_manager(load_contents=[], use_megatron_fsdp=True)
+        checkpointing = types.ModuleType("megatron.bridge.training.checkpointing")
+        checkpointing.load_fsdp_dtensor_checkpoint = MagicMock(return_value=({}, None, None, None))
+
+        with (
+            patch.dict(sys.modules, {"megatron.bridge.training.checkpointing": checkpointing}),
+            patch.object(manager, "_build_sharded_state_dict_metadata", return_value={}),
+            patch.object(manager, "_build_model_sharded_state_dict", return_value={}),
+            patch.object(manager, "_build_optimizer_state_dict", return_value={}),
+            patch.object(manager, "_build_extra_state_dict", return_value={}),
+            patch("torch.distributed.barrier") as mock_barrier,
+        ):
+            manager._load_megatron_fsdp_checkpoint(self.ckpt_path)
+
+        mock_barrier.assert_not_called()
+        assert os.path.exists(self.ckpt_path)
 
     @patch(_PATCH_LOAD_META, return_value=None)
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -163,6 +163,16 @@ class BaseCheckpointManager:
                 continue
             shutil.rmtree(abs_path, ignore_errors=True)
 
+    def _cleanup_local_checkpoint_after_load(self, local_path: str, enabled: bool) -> None:
+        """Synchronize checkpoint loading and optionally remove the shared role directory."""
+        if not enabled:
+            return
+
+        torch.distributed.barrier()
+        if self.rank == 0:
+            self.remove_previous_save_local_path(local_path)
+        torch.distributed.barrier()
+
     def ensure_checkpoint_capacity(self, max_ckpt_to_keep: int):
         """
         Remove old checkpoints to make room for a new one, keeping a safety buffer.

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -29,7 +29,7 @@ from transformers import GenerationConfig, PreTrainedTokenizer, ProcessorMixin
 from transformers.dynamic_module_utils import custom_object_save
 
 from verl.utils.device import is_cuda_available
-from verl.utils.fs import copy_to_local, is_non_local, local_mkdir_safe
+from verl.utils.fs import copy_to_local, local_mkdir_safe
 from verl.utils.fsdp_utils import fsdp_version, get_fsdp_full_state_dict, get_fsdp_state_ctx
 from verl.utils.logger import log_with_rank
 from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq
@@ -219,20 +219,11 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                 self.lr_scheduler.load_state_dict(lr_scheduler_state_dict)
                 log_with_rank(f"Loaded lr_scheduler from {remote_extra_state_path}", rank=self.rank, logger=logger)
 
-        if self.rank == 0 and del_local_after_load:
-            try:
-                os.remove(local_model_path) if is_non_local(local_model_path) else None
-                os.remove(local_optim_path) if is_non_local(local_optim_path) else None
-                os.remove(local_extra_state_path) if is_non_local(local_extra_state_path) else None
-            except Exception as e:
-                log_with_rank(
-                    f"remove local resume ckpt file after loading failed, exception {e} will be ignored",
-                    rank=self.rank,
-                    logger=logger,
-                )
-
-        # wait for everyone to load checkpoints
-        torch.distributed.barrier()
+        if del_local_after_load:
+            self._cleanup_local_checkpoint_after_load(local_path, enabled=True)
+        else:
+            # Preserve the existing end-of-load synchronization when cleanup is disabled.
+            torch.distributed.barrier()
 
     def save_checkpoint(self, local_path: str, hdfs_path: str = None, global_step: int = 0, max_ckpt_to_keep=None):
         """

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -30,7 +30,7 @@ from packaging import version
 from transformers import GenerationConfig
 
 from verl.utils.device import get_device_name, get_torch_device
-from verl.utils.fs import is_non_local, local_mkdir_safe
+from verl.utils.fs import local_mkdir_safe
 from verl.utils.logger import log_with_rank
 from verl.utils.megatron.dist_checkpointing import load_dist_checkpointing, save_dist_checkpointing
 from verl.utils.megatron_utils import (
@@ -760,15 +760,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             log_with_rank(f"Loaded RNG states from {local_path}", rank=self.rank, logger=logger)
         log_with_rank(f"Loaded Megatron-FSDP checkpoint from {local_path}", rank=self.rank, logger=logger)
 
-        if del_local_after_load:
-            try:
-                os.remove(local_path) if is_non_local(local_path) else None
-            except Exception as e:
-                log_with_rank(
-                    f"remove local resume ckpt file after loading failed, exception {e} will be ignored",
-                    rank=self.rank,
-                    logger=logger,
-                )
+        self._cleanup_local_checkpoint_after_load(local_path, enabled=del_local_after_load)
 
     def _save_megatron_fsdp_checkpoint(self, dist_checkpoint_path: str):
         """Save a Megatron-FSDP (DTensor) checkpoint.
@@ -974,15 +966,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             self.load_rng_states(loaded_extra["rng_state"])
             log_with_rank(f"Loaded RNG states from {extra_dist_path}", rank=self.rank, logger=logger)
 
-        if del_local_after_load:
-            try:
-                os.remove(local_path) if is_non_local(local_path) else None
-            except Exception as e:
-                log_with_rank(
-                    f"remove local resume ckpt file after loading failed, exception {e} will be ignored",
-                    rank=self.rank,
-                    logger=logger,
-                )
+        self._cleanup_local_checkpoint_after_load(local_path, enabled=del_local_after_load)
 
     # -- Save ------------------------------------------------------------------
 


### PR DESCRIPTION
### What does this PR do?

Fixes #7213.

Make `trainer.del_local_ckpt_after_load` remove the loaded actor or critic role directory on the trainer's shared checkpoint filesystem. All ranks finish loading before rank 0 removes the directory, and all ranks wait for deletion to complete before returning.

The containing `global_step_<N>` directory, `data.pt`, sibling role directories, and checkpoint tracker remain unchanged. Cleanup-disabled paths preserve their existing synchronization behavior.

This does not duplicate an open PR. Searches: [configuration flag](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+del_local_ckpt_after_load), [checkpoint role cleanup](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+checkpoint+role+cleanup).

AI assistance: Codex was used to help implement the code.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [configuration flag](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+del_local_ckpt_after_load), [checkpoint role cleanup](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+checkpoint+role+cleanup).
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

```bash
python -m pytest tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py -q
# 27 passed

python -m pytest tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py -q
# 42 passed

uvx --with hydra-core pre-commit run --files verl/utils/checkpoint/checkpoint_manager.py verl/utils/checkpoint/fsdp_checkpoint_manager.py verl/utils/checkpoint/megatron_checkpoint_manager.py tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
# All hooks passed
```

The submitter reviewed the complete diff and ran the focused tests.

### API and Usage Example

No API or configuration schema changes. This restores the documented behavior:

```yaml
trainer:
  del_local_ckpt_after_load: true
```

### Design & Code Changes

- Add a shared cleanup primitive that uses barrier → rank-0 role-directory deletion → barrier when enabled.
- Keep the original FSDP end-of-load barrier and add no cleanup barrier to Megatron paths when cleanup is disabled.
- Use the existing best-effort directory removal helper.
- Cover rank ownership, barrier ordering, two-process Gloo synchronization, FSDP, Megatron, and Megatron-FSDP load paths with CPU tests.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks to all changed files.
- [ ] Add / Update the documentation. Not needed: this fixes the behavior of an existing documented option.
- [x] Add unit tests to existing CPU test suites; no workflow path change is required.
- [ ] Request CI in the community channel after the PR is ready.
- [ ] Update the `recipe` submodule. Not applicable.
