### PR TITLE
[BREAKING][fsdp, trainer] fix: apply selective weight decay

### DIFF
--- a/tests/models/test_engine.py
+++ b/tests/models/test_engine.py
@@ -49,6 +49,7 @@ from verl.utils.device import get_device_name, get_nccl_backend, get_torch_devic
 from verl.utils.model import compute_position_id_with_mask, create_random_mask
 from verl.utils.torch_functional import logprobs_from_logits_naive
 from verl.workers.config import (
+    WEIGHT_DECAY_SCALE_KEY,
     ActorConfig,
     CriticConfig,
     FSDPEngineConfig,
@@ -88,6 +89,21 @@ def test_tinker_workers_expose_split_training_primitives():
         assert name in TinkerTrainingWorker.__dict__
         assert name not in ActorRolloutRefWorker.__dict__
         assert name in TinkerActorRolloutRefWorker.__dict__
+
+
+def test_tinker_weight_decay_override_preserves_group_policy():
+    parameters = [torch.nn.Parameter(torch.ones(1)) for _ in range(2)]
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": [parameters[0]], WEIGHT_DECAY_SCALE_KEY: 1.0},
+            {"params": [parameters[1]], WEIGHT_DECAY_SCALE_KEY: 0.0},
+        ],
+        weight_decay=0.0,
+    )
+
+    _apply_optim_step_params(optimizer, {"weight_decay": 0.2})
+
+    assert [group["weight_decay"] for group in optimizer.param_groups] == pytest.approx([0.2, 0.0])
 
 
 def create_training_config(model_type, strategy, device_count, model):
@@ -693,11 +709,15 @@ def _split_training_primitives_fsdp_worker(
         grad_norm = engine.optimizer_step()
 
     assert grad_norm > 0
+    weight_decay_scales = set()
     for param_group in engine.optimizer.param_groups:
         assert param_group["lr"] == pytest.approx(optim_step_params["lr"])
         assert param_group["betas"] == pytest.approx(optim_step_params["betas"])
         assert param_group["eps"] == pytest.approx(optim_step_params["eps"])
-        assert param_group["weight_decay"] == pytest.approx(optim_step_params["weight_decay"])
+        weight_decay_scale = param_group.get(WEIGHT_DECAY_SCALE_KEY, 1.0)
+        weight_decay_scales.add(weight_decay_scale)
+        assert param_group["weight_decay"] == pytest.approx(optim_step_params["weight_decay"] * weight_decay_scale)
+    assert weight_decay_scales == {0.0, 1.0}
     assert _param_delta_norm(engine.module, before).item() > 0
     assert not _has_any_grad(engine.module)
 

--- a/tests/workers/config/test_engine_config_on_cpu.py
+++ b/tests/workers/config/test_engine_config_on_cpu.py
@@ -51,6 +51,7 @@ class TestFSDPEngineConfigCPU:
         assert config.param_offload is False
         assert config.optimizer_offload is False
         assert config.fsdp_size == -1
+        assert config.use_orig_params is True
 
     @pytest.mark.parametrize(
         "offload_params",

--- a/tests/workers/config/test_fsdp_optimizer_on_cpu.py
+++ b/tests/workers/config/test_fsdp_optimizer_on_cpu.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from torch import nn
+
+from verl.workers.config.optimizer import (
+    WEIGHT_DECAY_SCALE_KEY,
+    FSDPOptimizerConfig,
+    build_optimizer,
+)
+
+
+class _CustomRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+
+
+class _ToyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = nn.Embedding(8, 4)
+        self.linear = nn.Linear(4, 4)
+        self.layer_norm = nn.LayerNorm(4)
+        self.rms = _CustomRMSNorm(4)
+        self.bn = nn.BatchNorm1d(4)
+        self.frozen = nn.Parameter(torch.ones(4), requires_grad=False)
+
+
+def _parameter_names_by_weight_decay_scale(model, optimizer):
+    name_by_parameter_id = {id(parameter): name for name, parameter in model.named_parameters()}
+    return {
+        group.get(WEIGHT_DECAY_SCALE_KEY, 1.0): {name_by_parameter_id[id(parameter)] for parameter in group["params"]}
+        for group in optimizer.param_groups
+    }
+
+
+def test_standard_weight_decay_policy_groups_parameters():
+    model = _ToyModel()
+    optimizer = build_optimizer(
+        model,
+        FSDPOptimizerConfig(lr=0.1, weight_decay=0.2),
+    )
+
+    names_by_scale = _parameter_names_by_weight_decay_scale(model, optimizer)
+    assert names_by_scale[1.0] == {"embedding.weight", "linear.weight"}
+    assert names_by_scale[0.0] == {
+        "linear.bias",
+        "layer_norm.weight",
+        "layer_norm.bias",
+        "rms.weight",
+        "bn.weight",
+        "bn.bias",
+    }
+    assert "frozen" not in names_by_scale[1.0] | names_by_scale[0.0]
+    assert optimizer.param_groups[0]["weight_decay"] == pytest.approx(0.2)
+    assert optimizer.param_groups[1]["weight_decay"] == pytest.approx(0.0)
+
+
+def test_standard_policy_applies_weight_decay_only_to_decay_group():
+    model = _ToyModel()
+    optimizer = build_optimizer(
+        model,
+        FSDPOptimizerConfig(lr=0.1, weight_decay=0.2),
+    )
+    before = {name: parameter.detach().clone() for name, parameter in model.named_parameters()}
+
+    for group in optimizer.param_groups:
+        for parameter in group["params"]:
+            parameter.grad = torch.zeros_like(parameter)
+    optimizer.step()
+
+    names_by_scale = _parameter_names_by_weight_decay_scale(model, optimizer)
+    for name, parameter in model.named_parameters():
+        if name in names_by_scale[1.0]:
+            assert not torch.equal(parameter, before[name])
+        else:
+            assert torch.equal(parameter, before[name])
+
+
+def test_optimizer_override_sets_effective_decay_group_value():
+    model = _ToyModel()
+    optimizer = build_optimizer(
+        model,
+        FSDPOptimizerConfig(
+            lr=0.1,
+            weight_decay=0.2,
+            override_optimizer_config={"weight_decay": 0.3},
+        ),
+    )
+
+    weight_decay_by_scale = {group[WEIGHT_DECAY_SCALE_KEY]: group["weight_decay"] for group in optimizer.param_groups}
+    assert weight_decay_by_scale == {1.0: pytest.approx(0.3), 0.0: pytest.approx(0.0)}
+
+
+def test_standard_optimizer_state_dict_round_trip():
+    model = _ToyModel()
+    config = FSDPOptimizerConfig(lr=0.1, weight_decay=0.2)
+    optimizer = build_optimizer(model, config)
+    for group in optimizer.param_groups:
+        for parameter in group["params"]:
+            parameter.grad = torch.zeros_like(parameter)
+    optimizer.step()
+
+    restored_model = _ToyModel()
+    restored_optimizer = build_optimizer(restored_model, config)
+    restored_optimizer.load_state_dict(optimizer.state_dict())
+
+    assert [group[WEIGHT_DECAY_SCALE_KEY] for group in restored_optimizer.param_groups] == [1.0, 0.0]
+    assert [group["weight_decay"] for group in restored_optimizer.param_groups] == pytest.approx([0.2, 0.0])
+
+
+def test_legacy_all_policy_preserves_single_parameter_group():
+    model = _ToyModel()
+    optimizer = build_optimizer(
+        model.parameters(),
+        FSDPOptimizerConfig(lr=0.1, weight_decay=0.2, weight_decay_policy="all"),
+    )
+
+    assert len(optimizer.param_groups) == 1
+    assert optimizer.param_groups[0]["weight_decay"] == pytest.approx(0.2)
+    assert WEIGHT_DECAY_SCALE_KEY not in optimizer.param_groups[0]
+    assert set(optimizer.param_groups[0]["params"]) == set(model.parameters())
+
+
+def test_standard_policy_requires_model_for_parameter_classification():
+    model = _ToyModel()
+
+    with pytest.raises(ValueError, match="requires the model itself"):
+        build_optimizer(model.parameters(), FSDPOptimizerConfig(lr=0.1))

--- a/tests/workers/config/test_optim_config_on_cpu.py
+++ b/tests/workers/config/test_optim_config_on_cpu.py
@@ -23,6 +23,7 @@ class TestFSDPOptimizerConfigCPU:
         assert config.min_lr_ratio is None
         assert config.lr_scheduler_type == "constant"
         assert config.num_cycles == 0.5
+        assert config.weight_decay_policy == "standard"
 
     @pytest.mark.parametrize("lr_scheduler_type", ["constant", "cosine"])
     def test_valid_lr_scheduler_types(self, lr_scheduler_type):
@@ -41,6 +42,10 @@ class TestFSDPOptimizerConfigCPU:
     def test_invalid_warmup_style_type(self):
         with pytest.raises((ValueError, AssertionError)):
             FSDPOptimizerConfig(warmup_style="invalid_style", lr=0.1)
+
+    def test_invalid_weight_decay_policy(self):
+        with pytest.raises((ValueError, AssertionError)):
+            FSDPOptimizerConfig(weight_decay_policy="invalid", lr=0.1)
 
     @pytest.mark.parametrize("num_cycles", [0.1, 1.0, 2.5])
     def test_num_cycles_configuration(self, num_cycles):

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -13,6 +13,7 @@ actor_rollout_ref:
       lr_warmup_steps_ratio: 0.0
       total_training_steps: -1
       weight_decay: 0.01
+      weight_decay_policy: standard
       lr_warmup_steps: -1
       betas:
       - 0.9
@@ -35,7 +36,7 @@ actor_rollout_ref:
       fsdp_size: -1
       forward_prefetch: false
       model_dtype: fp32
-      use_orig_params: false
+      use_orig_params: true
       seed: 42
       full_determinism: false
       ulysses_sequence_parallel_size: 1
@@ -224,7 +225,7 @@ actor_rollout_ref:
       fsdp_size: -1
       forward_prefetch: false
       model_dtype: fp32
-      use_orig_params: false
+      use_orig_params: true
       seed: 42
       full_determinism: false
       ulysses_sequence_parallel_size: 1
@@ -501,6 +502,7 @@ critic:
     lr_warmup_steps_ratio: 0.0
     total_training_steps: -1
     weight_decay: 0.01
+    weight_decay_policy: standard
     lr_warmup_steps: -1
     betas:
     - 0.9
@@ -523,7 +525,7 @@ critic:
     fsdp_size: -1
     forward_prefetch: false
     model_dtype: fp32
-    use_orig_params: false
+    use_orig_params: true
     seed: 42
     full_determinism: false
     ulysses_sequence_parallel_size: 1

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -32,8 +32,8 @@ forward_prefetch: False
 # model dtype of fsdp
 model_dtype: fp32
 
-# Whether to use original parameters in fsdp. Only avaiable in fsdp1
-use_orig_params: false
+# Whether to use original parameters in fsdp. Required for selective weight decay in fsdp1
+use_orig_params: true
 
 # Random seed for reproducibility.
 seed: 42

--- a/verl/trainer/config/optim/fsdp.yaml
+++ b/verl/trainer/config/optim/fsdp.yaml
@@ -20,6 +20,9 @@ total_training_steps: -1
 # Weight decay
 weight_decay: 0.01
 
+# Weight decay policy. "standard" excludes bias and normalization parameters; "all" preserves legacy behavior
+weight_decay_policy: standard
+
 # LR warmup steps
 lr_warmup_steps: -1
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -242,7 +242,7 @@ class FSDPEngineConfig(EngineConfig):
         fsdp_size (int): FSDP group size. -1 means use all available GPUs.
         forward_prefetch (bool): Whether to prefetch parameters for next forward pass, default False
         model_dtype (str): Model data type used to initialize the transformers model. default "fp32"
-        use_orig_params (bool): Whether to use original parameters when initialize FSDP1, default False
+        use_orig_params (bool): Whether to use original parameters when initialize FSDP1, default True
         seed (int): Random seed for reproducibility.
         full_determinism (bool): If true, enable_full_determinism is called to ensure reproducible results
             in distributed training. Important: this will negatively impact performance, so only use it for
@@ -262,7 +262,7 @@ class FSDPEngineConfig(EngineConfig):
     fsdp_size: int = -1
     forward_prefetch: bool = False
     model_dtype: str = "fp32"
-    use_orig_params: bool = False
+    use_orig_params: bool = True
     mixed_precision: Optional[dict[str, Any]] = None
     ulysses_sequence_parallel_size: int = 1
     entropy_from_logits_with_chunking: bool = False

--- a/verl/workers/config/optimizer.py
+++ b/verl/workers/config/optimizer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import warnings
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 from omegaconf import MISSING
 
@@ -23,11 +23,14 @@ __all__ = [
     "OptimizerConfig",
     "FSDPOptimizerConfig",
     "McoreOptimizerConfig",
+    "WEIGHT_DECAY_SCALE_KEY",
     "build_optimizer",
     "VeOmniOptimizerConfig",
     "TorchtitanOptimizerConfig",
     "AutomodelOptimizerConfig",
 ]
+
+WEIGHT_DECAY_SCALE_KEY = "_verl_weight_decay_scale"
 
 
 @dataclass
@@ -98,6 +101,9 @@ class FSDPOptimizerConfig(OptimizerConfig):
         num_cycles (float): Number of cosine cycles in LR schedule.
         zero_indexed_step (bool): Whether the LR schedule uses 0-indexed steps. If True (default),
             step counting starts at 0. If False, step counting starts at 1.
+        weight_decay_policy (str): Parameter selection policy for weight decay. ``"standard"`` excludes
+            biases and normalization parameters, while ``"all"`` preserves the legacy behavior of applying
+            weight decay to every parameter.
     """
 
     _mutable_fields = OptimizerConfig._mutable_fields.copy()
@@ -112,6 +118,7 @@ class FSDPOptimizerConfig(OptimizerConfig):
     num_cycles: float = 0.5
     override_optimizer_config: Optional[dict] = None
     zero_indexed_step: bool = True
+    weight_decay_policy: Literal["standard", "all"] = "standard"
 
     def __post_init__(self):
         if self.warmup_style is not None:
@@ -121,6 +128,7 @@ class FSDPOptimizerConfig(OptimizerConfig):
             )
             self.lr_scheduler_type = self.warmup_style
         assert self.lr_scheduler_type in ["constant", "cosine"]
+        assert self.weight_decay_policy in ["standard", "all"]
         return super().__post_init__()
 
 
@@ -295,13 +303,84 @@ class AutomodelOptimizerConfig(OptimizerConfig):
         return super().__post_init__()
 
 
-def build_optimizer(parameters, config: FSDPOptimizerConfig):
+def _get_weight_decay_parameter_groups(model, weight_decay: float):
+    """Split trainable model parameters into decay and no-decay groups."""
+    from torch import nn
+    from transformers.trainer_pt_utils import get_parameter_names
+
+    normalization_layer_types = [
+        nn.LayerNorm,
+        nn.GroupNorm,
+        nn.BatchNorm1d,
+        nn.BatchNorm2d,
+        nn.BatchNorm3d,
+        nn.SyncBatchNorm,
+        nn.InstanceNorm1d,
+        nn.InstanceNorm2d,
+        nn.InstanceNorm3d,
+    ]
+    if hasattr(nn, "RMSNorm"):
+        normalization_layer_types.append(nn.RMSNorm)
+
+    # Keep this aligned with Hugging Face Trainer's default policy. The explicit
+    # layer types cover standard torch normalization modules, while the patterns
+    # catch model-specific implementations such as LlamaRMSNorm and QwenRMSNorm.
+    forbidden_name_patterns = [
+        r"bias",
+        r"layernorm",
+        r"rmsnorm",
+        r"(?:^|\.)norm(?:$|\.)",
+        r"_norm(?:$|\.)",
+    ]
+    decay_parameter_names = set(get_parameter_names(model, normalization_layer_types, forbidden_name_patterns))
+    custom_normalization_parameter_ids = {
+        id(parameter)
+        for module in model.modules()
+        if module.__class__.__name__.lower().endswith("norm")
+        for parameter in module.parameters(recurse=False)
+    }
+
+    decay_parameters = []
+    no_decay_parameters = []
+    for name, parameter in model.named_parameters():
+        if not parameter.requires_grad:
+            continue
+        if name in decay_parameter_names and id(parameter) not in custom_normalization_parameter_ids:
+            decay_parameters.append(parameter)
+        else:
+            no_decay_parameters.append(parameter)
+
+    parameter_groups = []
+    if decay_parameters:
+        parameter_groups.append(
+            {
+                "params": decay_parameters,
+                "weight_decay": weight_decay,
+                WEIGHT_DECAY_SCALE_KEY: 1.0,
+            }
+        )
+    if no_decay_parameters:
+        parameter_groups.append(
+            {
+                "params": no_decay_parameters,
+                "weight_decay": 0.0,
+                WEIGHT_DECAY_SCALE_KEY: 0.0,
+            }
+        )
+    if not parameter_groups:
+        raise ValueError("Cannot build an optimizer because the model has no trainable parameters.")
+
+    return parameter_groups
+
+
+def build_optimizer(model_or_parameters, config: FSDPOptimizerConfig):
     """Build an optimizer based on the configuration.
 
     Dynamically imports and instantiates an optimizer class from the specified module.
 
     Args:
-        parameters: Model parameters to optimize
+        model_or_parameters: Model to optimize. An iterable of parameters is accepted only when
+            ``weight_decay_policy="all"``.
         config: FSDPOptimizerConfig with optimizer settings
 
     Returns:
@@ -334,6 +413,24 @@ def build_optimizer(parameters, config: FSDPOptimizerConfig):
 
     if config.override_optimizer_config is not None:
         optimizer_args.update(config.override_optimizer_config)
+
+    effective_weight_decay = float(optimizer_args["weight_decay"])
+    optimizer_args["weight_decay"] = effective_weight_decay
+
+    from torch import nn
+
+    if isinstance(model_or_parameters, nn.Module):
+        if config.weight_decay_policy == "standard":
+            parameters = _get_weight_decay_parameter_groups(model_or_parameters, effective_weight_decay)
+        else:
+            parameters = model_or_parameters.parameters()
+    else:
+        if config.weight_decay_policy != "all":
+            raise ValueError(
+                "weight_decay_policy='standard' requires the model itself so parameters can be classified. "
+                "Pass an nn.Module to build_optimizer, or use weight_decay_policy='all' for legacy behavior."
+            )
+        parameters = model_or_parameters
 
     try:
         module = importlib.import_module(config.optimizer_impl)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -473,7 +473,18 @@ class FSDPEngine(BaseEngine):
     def _build_optimizer(self, module):
         from verl.workers.config.optimizer import build_optimizer
 
-        optimizer = build_optimizer(module.parameters(), self.optimizer_config)
+        if (
+            self.engine_config.strategy == "fsdp"
+            and self.optimizer_config.weight_decay_policy == "standard"
+            and not self.engine_config.use_orig_params
+        ):
+            raise ValueError(
+                "FSDP1 requires use_orig_params=True for weight_decay_policy='standard' because flattened "
+                "parameters cannot use per-original-parameter weight decay. Set use_orig_params=True, or use "
+                "weight_decay_policy='all' to preserve the legacy behavior."
+            )
+
+        optimizer = build_optimizer(module, self.optimizer_config)
 
         return optimizer
 

--- a/verl/workers/engine_workers_tinker.py
+++ b/verl/workers/engine_workers_tinker.py
@@ -20,6 +20,7 @@ from verl.single_controller.base.decorator import Dispatch, make_nd_compute_data
 from verl.utils import tensordict_utils as tu
 from verl.utils.profiler import DistProfiler
 from verl.utils.tensordict_utils import maybe_fix_3d_position_ids
+from verl.workers.config.optimizer import WEIGHT_DECAY_SCALE_KEY
 from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker
 
 
@@ -32,10 +33,11 @@ class OptimStepParams(TypedDict, total=False):
     that own scheduling should pass the resulting optimizer values here.
 
     The current implementation applies each provided key to all optimizer param
-    groups before one explicit optimizer step. For VeOmni MultiOptimizer, the
-    Tinker worker flattens the wrapped optimizers' param groups and applies the
-    same global override. Optimizer-specific or group-specific overrides require a
-    different payload shape.
+    groups before one explicit optimizer step. Weight decay respects the group's
+    ``_verl_weight_decay_scale`` marker so no-decay groups remain exempt. For
+    VeOmni MultiOptimizer, the Tinker worker flattens the wrapped optimizers'
+    param groups and applies the same global override. Optimizer-specific or
+    group-specific overrides require a different payload shape.
     """
 
     lr: float
@@ -104,7 +106,10 @@ def _apply_optim_step_params(optimizer, optim_step_params: OptimStepParams | Non
                 raise TypeError(f"{type(optimizer).__name__} has inconsistent param_group type for {key!r}")
 
     for param_group in param_groups:
-        param_group.update(normalized_params)
+        for key, value in normalized_params.items():
+            if key == "weight_decay":
+                value *= param_group.get(WEIGHT_DECAY_SCALE_KEY, 1.0)
+            param_group[key] = value
 
 
 class TinkerTrainingWorker(TrainingWorker):


### PR DESCRIPTION
### What does this PR do?

Fixes #5070 by applying weight decay selectively in the FSDP optimizer path instead of applying one global value to every trainable parameter.

- Add a default `standard` policy that excludes bias and normalization parameters while continuing to decay embeddings, matching the Hugging Face Trainer policy.
- Keep `weight_decay_policy=all` as a legacy compatibility option.
- Change FSDP1's default to `use_orig_params=true`, because flattened parameters cannot be split correctly into decay/no-decay groups.
- Preserve per-group decay exemptions when Tinker overrides optimizer-step parameters.
- Add CPU unit coverage and update the generated PPO reference config.

Root cause: the FSDP engine passed `module.parameters()` as a single collection to the optimizer, so AdamW applied the configured `weight_decay` to all parameters. With FSDP1 and `use_orig_params=false`, a `FlatParameter` can also mix regular weights, biases, and normalization parameters, preventing correct post-wrap classification.

User impact: the default FSDP path now avoids decaying biases and normalization parameters. Existing one-group optimizer checkpoints may need the legacy settings shown below, which is why this PR is marked as breaking.

### Checklist Before Starting

- [x] Searched for similar open PRs: [issue reference search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+5070+in%3Abody), [selective weight decay search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22selective+weight+decay%22). No open PR was found that addresses the same fix.
- [x] PR title follows `[{modules}] {type}: {description}` and includes `[BREAKING]` for the default/config and optimizer-state compatibility change.

### Test

- [x] `python -m pytest tests/workers/config/test_fsdp_optimizer_on_cpu.py tests/workers/config/test_optim_config_on_cpu.py tests/workers/config/test_engine_config_on_cpu.py tests/models/test_engine.py::test_tinker_weight_decay_override_preserves_group_policy` -- **32 passed**.
- [x] `python -m compileall -q` on all changed Python files -- passed.
- [x] `CUDA_VISIBLE_DEVICES=0,1 python -m pytest tests/models/test_engine.py::test_fsdp_engine_split_forward_backward_and_optimizer_step -q -s` -- **2 passed in 32.58s** (FSDP1 and FSDP2) on 2 x NVIDIA GeForce RTX 3090 24 GB, PyTorch 2.9.1+cu128, CUDA 12.8, and NCCL 2.27.5.
- [x] Two-rank NCCL `all_reduce` smoke test -- passed on both ranks (`sum=3.0`).
- [x] **CI readiness:** CPU and dual-GPU validation are complete; this PR is ready for maintainer-triggered CI.
- [x] Linux full pre-commit: `pre-commit run --all-files` -- **13/13 hooks passed** in a no-GPU Linux environment (ruff, ruff-format, mypy, generated configs, docs metadata, docstrings, license, device API, DataProto, test structure, naming conventions, example script naming, and Python compilation).

### API and Usage Example

The new default behavior is:

```yaml
actor_rollout_ref:
  actor:
    optim:
      weight_decay_policy: standard
    fsdp_config:
      use_orig_params: true
```

To preserve the legacy single-group FSDP1 behavior for an old optimizer checkpoint:

```yaml
actor_rollout_ref:
  actor:
    optim:
      weight_decay_policy: all
    fsdp_config:
      use_orig_params: false
```

### Design & Code Changes

The optimizer builder now accepts the wrapped module, classifies trainable parameters into decay/no-decay groups, and tags each group with an internal decay scale. Standard torch normalization layers, model-specific `*Norm` modules, and bias names are excluded. FSDP1 rejects `standard` policy with `use_orig_params=false` and reports the supported migration choices explicitly.

### AI Assistance and Accountability

AI assistance (OpenAI Codex) was used to implement, test, and prepare this draft PR. The human submitter has reviewed every changed line, completed end-to-end validation, understands the change, and can defend it.

### Checklist Before Submitting

- [ ] Read and re-confirm the Contribute Guide before requesting review.
- [x] Complete the full Linux pre-commit run.
- [ ] Add/update documentation if maintainers request user-facing migration notes.
- [x] Added unit tests covering grouping, optimizer behavior, overrides, state round-trip, legacy behavior, and config validation.
- [ ] Post in `ci-request` once the PR is ready for CI.
- [x] Recipe submodule update is not applicable.





