### PR TITLE
[trainer] fix: build RL tokenizer/processor from HFModelConfig

### DIFF
--- a/verl/trainer/main_ppo_v0.py
+++ b/verl/trainer/main_ppo_v0.py
@@ -161,8 +161,6 @@ class TaskRunner(BaseTaskRunner):
         # Print the initial configuration. `resolve=True` will evaluate symbolic values.
         from pprint import pprint
 
-        from verl.utils.fs import copy_to_local
-
         print(f"TaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
         pprint(OmegaConf.to_container(config, resolve=True))
         OmegaConf.resolve(config)
@@ -184,19 +182,14 @@ class TaskRunner(BaseTaskRunner):
             use_critic=need_critic(config),
         )
 
-        # Download the checkpoint from HDFS to the local machine.
-        # `use_shm` determines whether to use shared memory, which could lead to faster model loading if turned on
-        local_path = copy_to_local(
-            config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False)
-        )
+        # Instantiate the tokenizer and processor from the model config.
+        from verl.utils.config import omega_conf_to_dataclass
+        from verl.workers.config import HFModelConfig
 
-        # Instantiate the tokenizer and processor.
-        from verl.utils import hf_processor, hf_tokenizer
-
-        trust_remote_code = config.data.get("trust_remote_code", False)
-        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        model_config: HFModelConfig = omega_conf_to_dataclass(config.actor_rollout_ref.model)
+        tokenizer = model_config.tokenizer
         # Used for multimodal LLM, could be None
-        processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
+        processor = model_config.processor
 
         resource_pool_manager = self.init_resource_pool_mgr(config)
 

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -73,21 +73,19 @@ from verl.trainer.ppo.utils import (
 )
 from verl.trainer.ppo.v1.replay_buffer import DAPO_FILTERED_REWARD_COUNTS_KEY, ReplayBuffer, ReplayBufferAsync
 from verl.trainer.ppo.v1.utils import MetricsAggregator, compute_advantage_for_multi_trajectories
-from verl.utils import hf_processor, hf_tokenizer
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import collate_fn
 from verl.utils.debug import marked_timer
 from verl.utils.debug.metrics import calculate_debug_metrics
-from verl.utils.fs import copy_to_local
 from verl.utils.import_utils import load_extern_type
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
 from verl.utils.skip import SkipManager
 from verl.utils.tracking import DapoFilteredRewardTableLogger, Tracking, ValidationGenerationsLogger
-from verl.workers.config import CriticConfig, DistillationConfig
+from verl.workers.config import CriticConfig, DistillationConfig, HFModelConfig
 from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker, TrainingWorkerConfig
 from verl.workers.rollout.llm_server import LLMServerClient, LLMServerManager
 from verl.workers.utils.losses import value_loss
@@ -646,16 +644,11 @@ class PPOTrainer(ABC):
         return self.resource_pool_manager.get_n_gpus()
 
     def _init_tokenizer(self):
-        """Initialize tokenizer."""
-        # Download the checkpoint from HDFS to the local machine.
-        # `use_shm` determines whether to use shared memory, which could lead to faster model loading if turned on
-        local_path = copy_to_local(
-            self.config.actor_rollout_ref.model.path, use_shm=self.config.actor_rollout_ref.model.get("use_shm", False)
-        )
-        trust_remote_code = self.config.data.get("trust_remote_code", False)
-        self.tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        """Initialize tokenizer and processor from the model config."""
+        model_config: HFModelConfig = omega_conf_to_dataclass(self.config.actor_rollout_ref.model)
+        self.tokenizer = model_config.tokenizer
         # Used for multimodal LLM, could be None
-        self.processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
+        self.processor = model_config.processor
 
     def _init_dataloader(self):
         """Initialize train and validate dataloader."""


### PR DESCRIPTION
### What does this PR do?

Make the PPO entrypoints build the dataset's tokenizer/processor from `HFModelConfig`, the same way the SFT trainer ([`sft_trainer.py:141`](https://github.com/verl-project/verl/blob/76324f1de4aabad06441a01fc17b605d9b3e564a/verl/trainer/sft_trainer.py#L141)) and the engine workers ([`engine_workers.py:534`](https://github.com/verl-project/verl/blob/76324f1de4aabad06441a01fc17b605d9b3e564a/verl/workers/engine_workers.py#L534)) already do. Both PPO entrypoints (`verl/trainer/main_ppo_v0.py` and the v1 `verl/trainer/ppo/v1/trainer_base.py`) currently hand-roll `copy_to_local` + `hf_tokenizer` + `hf_processor`, duplicating what `HFModelConfig.__post_init__` already encapsulates. This aligns the RL entrypoints with SFT (and the workers) and removes the duplicated construction.

A side benefit: because `HFModelConfig` is built through `omega_conf_to_dataclass` (which honors `model._target_`), a custom model-config subclass can now influence the tokenizer/processor the RL dataset receives — consistent with how SFT already behaves. This may help multimodal models whose processor class is not in the `hf_processor()` allow-list. (Background on that custom-processor use case: discussion #7084.)

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+hf_processor+HFModelConfig
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

No behavior change for standard runs: the tokenizer/processor are still built by the same `hf_tokenizer()` / `hf_processor()` calls, now reached through `HFModelConfig` (the same path SFT and the workers use). The v1 `main_ppo` → `_init_tokenizer` path is exercised by the existing `e2e_ppo_trainer*` CI jobs (default `trainer.use_v1=true`).

### API and Usage Example

No new or changed config keys; standard usage is unaffected. As a side benefit, a custom model config can now be selected on the RL path via `model._target_`, exactly as the SFT path already allows:

```bash
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.model._target_=your_pkg.YourHFModelConfig \
    actor_rollout_ref.model.path=/path/to/model \
    ...
```

### Design & Code Changes

Behavior differences from the previous inline construction:
- **`use_shm`** — preserved (`HFModelConfig.__post_init__` passes it into `copy_to_local`).
- **`use_fast`** — the processor's `use_fast` now follows the library default rather than being forced to `True`, matching SFT. Fast tokenizers are still auto-selected when available.
- **`trust_remote_code`** — for the tokenizer/processor this now comes from the model config (`actor_rollout_ref.model.trust_remote_code`) rather than `data.trust_remote_code`. Both default to `False`, so default runs are unaffected; this matches how the workers build the model.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
