### PR TITLE
[megatron] feat: support contiguous context-parallel layout for DeepSeek V4

### DIFF
--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -174,8 +174,18 @@ def test_preprocess_thd_engine_contiguous_uses_global_packed_intervals(
     )
 
     assert packed_seq_params.cu_seqlens_q_padded.tolist() == [0, 6, 10]
+    # A zigzag-only factor of two would incorrectly pad these rows to 8 and 4.
+    assert packed_seq_params.cu_seqlens_q_padded.tolist() != [0, 8, 12]
     torch.testing.assert_close(local_ids[0], torch.tensor(expected_ids, dtype=torch.long))
     torch.testing.assert_close(local_positions[0], torch.tensor(expected_positions, dtype=torch.long))
+
+
+def test_preprocess_thd_engine_rejects_unknown_cp_layout(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1, cp_size=2)
+    input_ids = _nested_tensor([torch.tensor([10, 11], dtype=torch.long)])
+
+    with pytest.raises(ValueError, match="Unsupported context parallel layout: interleaved"):
+        mcore_util.preprocess_thd_engine(input_ids, cp_layout="interleaved")
 
 
 def test_preprocess_thd_engine_contiguous_rolls_each_sequence_independently(monkeypatch):
@@ -227,3 +237,17 @@ def test_postprocess_thd_engine_contiguous_inverts_global_intervals(monkeypatch)
 
     torch.testing.assert_close(restored[0], torch.tensor([100, 101, 102, 103, 104], dtype=torch.float32))
     torch.testing.assert_close(restored[1], torch.tensor([106, 107, 108], dtype=torch.float32))
+
+
+def test_postprocess_thd_engine_rejects_unknown_cp_layout(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1, cp_size=2)
+
+    with pytest.raises(ValueError, match="Unsupported context parallel layout: interleaved"):
+        mcore_util.postprocess_thd_engine(
+            torch.empty(1, 1),
+            packed_seq_params=None,
+            input_ids=torch.empty(1),
+            batch_size=1,
+            post_process=False,
+            cp_layout="interleaved",
+        )

--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -24,14 +24,15 @@ import torch
 import verl.utils.device as device_module
 
 
-def _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size: int = 4):
+def _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size: int = 4, cp_size: int = 1, cp_rank: int = 0):
     megatron = types.ModuleType("megatron")
     core = types.ModuleType("megatron.core")
     parallel_state = types.ModuleType("megatron.core.parallel_state")
     packed_seq_params = types.ModuleType("megatron.core.packed_seq_params")
 
-    parallel_state.get_context_parallel_world_size = lambda: 1
-    parallel_state.get_context_parallel_rank = lambda: 0
+    parallel_state.get_context_parallel_world_size = lambda: cp_size
+    parallel_state.get_context_parallel_rank = lambda: cp_rank
+    parallel_state.get_context_parallel_group = lambda: object()
     parallel_state.get_tensor_model_parallel_world_size = lambda: tp_size
 
     class PackedSeqParams:
@@ -147,3 +148,82 @@ def test_preprocess_thd_engine_pads_to_minimum_rows(monkeypatch):
     torch.testing.assert_close(local_ids[0, 100:], torch.zeros(28, dtype=torch.long))
     torch.testing.assert_close(local_positions[0, :100], torch.arange(100, dtype=torch.long))
     torch.testing.assert_close(local_positions[0, 100:], torch.zeros(28, dtype=torch.long))
+
+
+@pytest.mark.parametrize(
+    ("cp_rank", "expected_ids", "expected_positions"),
+    [
+        (0, [10, 11, 12, 13, 14], [0, 1, 2, 3, 4]),
+        (1, [0, 20, 21, 22, 0], [0, 0, 1, 2, 0]),
+    ],
+)
+def test_preprocess_thd_engine_contiguous_uses_global_packed_intervals(
+    monkeypatch, cp_rank, expected_ids, expected_positions
+):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1, cp_size=2, cp_rank=cp_rank)
+    input_ids = _nested_tensor(
+        [
+            torch.tensor([10, 11, 12, 13, 14], dtype=torch.long),
+            torch.tensor([20, 21, 22], dtype=torch.long),
+        ]
+    )
+
+    local_ids, packed_seq_params, local_positions = mcore_util.preprocess_thd_engine(
+        input_ids,
+        cp_layout="contiguous",
+    )
+
+    assert packed_seq_params.cu_seqlens_q_padded.tolist() == [0, 6, 10]
+    torch.testing.assert_close(local_ids[0], torch.tensor(expected_ids, dtype=torch.long))
+    torch.testing.assert_close(local_positions[0], torch.tensor(expected_positions, dtype=torch.long))
+
+
+def test_preprocess_thd_engine_contiguous_rolls_each_sequence_independently(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1, cp_size=2, cp_rank=0)
+    labels = _nested_tensor(
+        [
+            torch.tensor([1, 2, 3, 4], dtype=torch.long),
+            torch.tensor([5, 6, 7, 8], dtype=torch.long),
+        ]
+    )
+
+    local_labels, _, _ = mcore_util.preprocess_thd_engine(
+        labels,
+        need_roll=True,
+        cp_layout="contiguous",
+    )
+
+    torch.testing.assert_close(local_labels[0], torch.tensor([2, 3, 4, 1], dtype=torch.long))
+
+
+def test_postprocess_thd_engine_contiguous_inverts_global_intervals(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1, cp_size=2, cp_rank=0)
+    input_ids = _nested_tensor(
+        [
+            torch.tensor([10, 11, 12, 13, 14], dtype=torch.long),
+            torch.tensor([20, 21, 22], dtype=torch.long),
+        ]
+    )
+    _, packed_seq_params, _ = mcore_util.preprocess_thd_engine(input_ids, cp_layout="contiguous")
+    rank_outputs = [
+        torch.tensor([[100, 101, 102, 103, 104]], dtype=torch.float32),
+        torch.tensor([[105, 106, 107, 108, 109]], dtype=torch.float32),
+    ]
+
+    def fake_all_gather(outputs, local_output, group):
+        del local_output, group
+        for destination, source in zip(outputs, rank_outputs, strict=True):
+            destination.copy_(source)
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+
+    restored = mcore_util.postprocess_thd_engine(
+        rank_outputs[0],
+        packed_seq_params,
+        input_ids,
+        batch_size=2,
+        cp_layout="contiguous",
+    )
+
+    torch.testing.assert_close(restored[0], torch.tensor([100, 101, 102, 103, 104], dtype=torch.float32))
+    torch.testing.assert_close(restored[1], torch.tensor([106, 107, 108], dtype=torch.float32))

--- a/tests/workers/test_megatron_value_head_cp_layout_on_cpu.py
+++ b/tests/workers/test_megatron_value_head_cp_layout_on_cpu.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from tensordict import TensorDict
+
+from verl.workers.engine.megatron.transformer_impl import MegatronEngineWithValueHead
+
+
+def test_dsv4_value_head_forwards_contiguous_cp_layout():
+    engine = object.__new__(MegatronEngineWithValueHead)
+    engine.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(),
+        tokenizer=SimpleNamespace(pad_token_id=0),
+    )
+    engine.engine_config = SimpleNamespace(use_remove_padding=True)
+    engine.prepare_model_inputs = lambda batch: {
+        "input_ids": batch["input_ids"],
+        "multi_modal_inputs": None,
+    }
+
+    batch = TensorDict({"input_ids": torch.tensor([[1, 2, 3]])}, batch_size=[1])
+    model = SimpleNamespace(config=SimpleNamespace(experimental_attention_variant="dsv4_hybrid"))
+    captured = {}
+
+    def forward_fn(*args, **kwargs):
+        captured.update(kwargs)
+        return torch.zeros(1)
+
+    with (
+        patch("verl.workers.engine.megatron.transformer_impl.get_device_id", return_value="cpu"),
+        patch("verl.models.mcore.get_mcore_engine_forward_fn", return_value=forward_fn),
+    ):
+        engine.forward_step(iter([batch]), model, None, lambda: None)
+
+    assert captured["value_model"] is True
+    assert captured["cp_layout"] == "contiguous"

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -274,6 +274,7 @@ def gptmodel_forward_model_engine(
     mtp_enable_train: bool = False,
     local_cp_size: Optional[int] = None,
     forced_max_seqlen: Optional[int] = None,
+    cp_layout: str = "zigzag",
 ):
     """Default forward pass for GPT models with optional sequence packing."""
 
@@ -301,6 +302,7 @@ def gptmodel_forward_model_engine(
             pre_process=pre_process or (post_process and mtp_enable_train),
             use_fp8_padding=use_fp8_padding,
             local_cp_size=local_cp_size,
+            cp_layout=cp_layout,
         )
         input_ids_rmpad = input_ids_rmpad.contiguous()
 
@@ -324,6 +326,7 @@ def gptmodel_forward_model_engine(
                     need_roll=True,
                     use_fp8_padding=use_fp8_padding,
                     local_cp_size=local_cp_size,
+                    cp_layout=cp_layout,
                 )[0]
 
             model_kwargs["labels"] = args["label"].contiguous()
@@ -355,13 +358,20 @@ def gptmodel_forward_model_engine(
                     need_roll=(k == "label"),
                     use_fp8_padding=use_fp8_padding,
                     local_cp_size=local_cp_size,
+                    cp_layout=cp_layout,
                 )[0]
                 for k, v in logits_processor_args.items()
             }
             output_dict = logits_processor(output_orig, **args)
             output = {
                 k: postprocess_thd_engine(
-                    v, packed_seq_params, input_ids, batch_size, post_process=post_process, local_cp_size=local_cp_size
+                    v,
+                    packed_seq_params,
+                    input_ids,
+                    batch_size,
+                    post_process=post_process,
+                    local_cp_size=local_cp_size,
+                    cp_layout=cp_layout,
                 )
                 for k, v in output_dict.items()
             }
@@ -373,6 +383,7 @@ def gptmodel_forward_model_engine(
                 batch_size,
                 post_process=post_process,
                 local_cp_size=local_cp_size,
+                cp_layout=cp_layout,
             )
     else:
         """

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -146,6 +146,7 @@ def fused_forward_model_engine(vision_model: bool = False):
         temperature: float,
         calculate_entropy: bool,
         pad_token_id: int,
+        cp_layout: str = "zigzag",
     ):
         pre_process = unwrap_model(model).pre_process
         post_process = unwrap_model(model).post_process
@@ -162,6 +163,7 @@ def fused_forward_model_engine(vision_model: bool = False):
             pre_process=pre_process,
             use_fp8_padding=use_fp8_padding,
             min_local_rows=min_local_rows,
+            cp_layout=cp_layout,
         )
         input_ids_rmpad = input_ids_rmpad.contiguous()
 
@@ -190,6 +192,7 @@ def fused_forward_model_engine(vision_model: bool = False):
             need_roll=True,
             use_fp8_padding=use_fp8_padding,
             min_local_rows=min_local_rows,
+            cp_layout=cp_layout,
         )
         labels_rmpad = labels_rmpad.contiguous()
         output_orig: CausalLMOutputForPPO = model(
@@ -209,7 +212,12 @@ def fused_forward_model_engine(vision_model: bool = False):
         if log_probs.dim() == 1:
             log_probs = log_probs.unsqueeze(0)
         log_probs = postprocess_thd_engine(
-            log_probs, packed_seq_params, input_ids, input_ids.shape[0], post_process=post_process
+            log_probs,
+            packed_seq_params,
+            input_ids,
+            input_ids.shape[0],
+            post_process=post_process,
+            cp_layout=cp_layout,
         )
 
         output = {"log_probs": log_probs}
@@ -219,7 +227,12 @@ def fused_forward_model_engine(vision_model: bool = False):
             if entropy.dim() == 1:
                 entropy = entropy.unsqueeze(0)
             entropy = postprocess_thd_engine(
-                entropy, packed_seq_params, input_ids, input_ids.shape[0], post_process=post_process
+                entropy,
+                packed_seq_params,
+                input_ids,
+                input_ids.shape[0],
+                post_process=post_process,
+                cp_layout=cp_layout,
             )
             output["entropy"] = entropy
 

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -16,7 +16,7 @@
 import logging
 import math
 import os
-from typing import Optional
+from typing import Literal, Optional
 
 import torch
 from megatron.core import parallel_state as mpu
@@ -27,6 +27,8 @@ from verl.utils.model import CausalLMOutputForPPO
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+ContextParallelLayout = Literal["zigzag", "contiguous"]
 
 
 def _compute_fp8_thd_align_size(align_size: int) -> tuple[int, int]:
@@ -321,13 +323,19 @@ def preprocess_thd_engine(
     use_fp8_padding: bool = False,
     local_cp_size: Optional[int] = None,
     min_local_rows: Optional[int] = None,
+    cp_layout: ContextParallelLayout = "zigzag",
 ) -> tuple[torch.Tensor, PackedSeqParams, Optional[torch.Tensor]]:
+    """Pack nested THD sequences and shard their rows across CP ranks.
+
+    ``zigzag`` is the default causal-attention layout: each rank receives a
+    chunk from both ends of every sequence. ``contiguous`` assigns each rank
+    one consecutive interval of the *global padded THD buffer*. The latter is
+    required by attention variants whose CP kernels address rows through one
+    rank-local ``global_start``.
     """
-    Preprocess packed sequences
-    CP splits sequence into CP*2 chunks, and each GPU gets 2 chunks (GPU0 gets first and last chunks, GPU1
-    gets second and second last chunks, and so on), this is for load balancing with causal masking.
-    See https://github.com/NVIDIA/TransformerEngine/issues/1368
-    """
+    if cp_layout not in ("zigzag", "contiguous"):
+        raise ValueError(f"Unsupported context parallel layout: {cp_layout}")
+
     batch_size = input_ids.shape[0]
 
     tp_size = mpu.get_tensor_model_parallel_world_size()
@@ -342,7 +350,8 @@ def preprocess_thd_engine(
     else:
         cp_size = mpu.get_context_parallel_world_size()
         cp_rank = mpu.get_context_parallel_rank()
-    align_size = tp_size * cp_size * 2 if cp_size > 1 else tp_size
+    cp_layout_factor = 2 if cp_layout == "zigzag" and cp_size > 1 else 1
+    align_size = tp_size * cp_size * cp_layout_factor
     seqlens_in_batch = input_ids.offsets().diff()
 
     if use_fp8_padding:
@@ -391,8 +400,35 @@ def preprocess_thd_engine(
         if need_roll:
             saved_roll_dict = {}
             saved_position_roll_dict = {}
+        local_global_start = shape[0] * cp_rank
+        local_global_end = local_global_start + shape[0]
         for i in range(batch_size):
             # Use Python int, so no GPU→CPU sync in the loop
+            if cp_layout == "contiguous":
+                seq_global_start = cu_seqlens_padded_cpu[i]
+                seq_valid_end = seq_global_start + seqlens_in_batch_cpu[i]
+                copy_global_start = max(local_global_start, seq_global_start)
+                copy_global_end = min(local_global_end, seq_valid_end)
+                if copy_global_start >= copy_global_end:
+                    continue
+
+                source_start = copy_global_start - seq_global_start
+                source_end = copy_global_end - seq_global_start
+                destination_start = copy_global_start - local_global_start
+                destination_end = copy_global_end - local_global_start
+                d = input_ids[i]
+                if need_roll:
+                    source_indices = torch.arange(source_start, source_end, device=d.device)
+                    source_indices = (source_indices + 1) % seqlens_in_batch_cpu[i]
+                    input_ids_rmpad[destination_start:destination_end] = torch.index_select(d, 0, source_indices)
+                    position_ids_rmpad[destination_start:destination_end] = source_indices
+                else:
+                    input_ids_rmpad[destination_start:destination_end] = d[source_start:source_end]
+                    position_ids_rmpad[destination_start:destination_end] = torch.arange(
+                        source_start, source_end, dtype=torch.long, device=input_ids.device
+                    )
+                continue
+
             if cp_size <= 1:
                 seqlen = seqlens_in_batch_cpu[i]
                 start_idx = cu_seqlens_padded_cpu[i]
@@ -463,7 +499,7 @@ def preprocess_thd_engine(
                             start_idx + half_seqlen + remain_len - 1
                         ]
 
-        if need_roll:
+        if need_roll and cp_layout == "zigzag":
             input_ids_rmpad = torch.roll(input_ids_rmpad, shifts=-1, dims=0)
             position_ids_rmpad = torch.roll(position_ids_rmpad, shifts=-1, dims=0)
             if len(saved_roll_dict) > 0:
@@ -495,10 +531,13 @@ def postprocess_thd_engine(
     batch_size: int,
     post_process: bool = True,
     local_cp_size: Optional[int] = None,
+    cp_layout: ContextParallelLayout = "zigzag",
 ) -> torch.Tensor:
     """
     Postprocess packed sequences
     """
+    if cp_layout not in ("zigzag", "contiguous"):
+        raise ValueError(f"Unsupported context parallel layout: {cp_layout}")
     if not post_process:
         return output
 
@@ -531,6 +570,13 @@ def postprocess_thd_engine(
         output_list[cp_rank] = output
     else:
         output_list = [output]
+
+    if cp_layout == "contiguous":
+        packed_output = torch.cat([rank_output[0] for rank_output in output_list], dim=0)
+        for i in range(batch_size):
+            sequence_start = cu_padded_cpu[i]
+            output_new.append(packed_output[sequence_start : sequence_start + seq_lens_cpu[i]])
+        return torch.nested.as_nested_tensor(output_new, layout=torch.jagged)
 
     for i in range(batch_size):
         if cp_size <= 1:

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -1065,6 +1065,11 @@ class MegatronEngineWithLMHead(MegatronEngine):
         loss_mask = model_inputs["loss_mask"]
 
         unwrapped_model = unwrap_model(model)
+        cp_layout = (
+            "contiguous"
+            if getattr(unwrapped_model.config, "experimental_attention_variant", None) == "dsv4_hybrid"
+            else "zigzag"
+        )
         if hasattr(unwrapped_model, "vp_stage"):
             vp_rank = unwrapped_model.vp_stage
         else:
@@ -1122,6 +1127,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 temperature=temperature_value,
                 calculate_entropy=calculate_entropy,
                 pad_token_id=self.model_config.tokenizer.pad_token_id,
+                cp_layout=cp_layout,
             )
         else:
             if not isinstance(temperature, torch.Tensor):
@@ -1168,6 +1174,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 mtp_enable_train=self.model_config.mtp.enable and self.model_config.mtp.enable_train,
                 local_cp_size=local_cp_size,
                 forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
+                cp_layout=cp_layout,
             )
 
         # Router replay: record routing decisions for R2 mode

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -83,6 +83,12 @@ class MegatronEngine(BaseEngine):
     # default here.
     delta_pin_snapshots = False
 
+    @staticmethod
+    def _get_context_parallel_layout(unwrapped_model) -> str:
+        if getattr(unwrapped_model.config, "experimental_attention_variant", None) == "dsv4_hybrid":
+            return "contiguous"
+        return "zigzag"
+
     def __init__(
         self,
         model_config: HFModelConfig,
@@ -1065,11 +1071,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
         loss_mask = model_inputs["loss_mask"]
 
         unwrapped_model = unwrap_model(model)
-        cp_layout = (
-            "contiguous"
-            if getattr(unwrapped_model.config, "experimental_attention_variant", None) == "dsv4_hybrid"
-            else "zigzag"
-        )
+        cp_layout = self._get_context_parallel_layout(unwrapped_model)
         if hasattr(unwrapped_model, "vp_stage"):
             vp_rank = unwrapped_model.vp_stage
         else:
@@ -1287,6 +1289,7 @@ class MegatronEngineWithValueHead(MegatronEngineWithLMHead):
         model_inputs = self.prepare_model_inputs(batch)
         input_ids = model_inputs["input_ids"]
         multi_modal_inputs = model_inputs["multi_modal_inputs"]
+        cp_layout = self._get_context_parallel_layout(unwrap_model(model))
 
         from verl.models.mcore import get_mcore_engine_forward_fn
 
@@ -1301,6 +1304,7 @@ class MegatronEngineWithValueHead(MegatronEngineWithLMHead):
             pad_token_id=self.model_config.tokenizer.pad_token_id,
             data_format="thd" if self.engine_config.use_remove_padding else "bshd",
             forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
+            cp_layout=cp_layout,
         )
 
         return output, partial(postprocess_micro_batch_func, data=batch)


### PR DESCRIPTION
### What does this PR do?

Adds a `contiguous` context-parallel (CP) sequence layout to the Megatron backend, alongside the existing `zigzag` layout, and wires it up for DeepSeek V4 (`experimental_attention_variant == "dsv4_hybrid"`).

DeepSeek V4's attention expects each CP rank to own **one consecutive interval** of the global padded THD buffer, whereas the existing `zigzag` layout gives each rank chunks taken from both ends of the sequence. Running DS4 under the `zigzag` layout silently produces wrong attention results.

### Design

`preprocess_thd_engine` / `postprocess_thd_engine` take a new `cp_layout: Literal["zigzag", "contiguous"]` argument, defaulting to `"zigzag"`:

- `align_size = tp_size * cp_size * cp_layout_factor`, where `cp_layout_factor` is `2` only for `zigzag` with `cp_size > 1` (zigzag needs the doubled alignment; contiguous does not).
- Contiguous slicing takes `[shape[0] * cp_rank, shape[0] * (cp_rank + 1))` of the global padded buffer, clamped per sequence, skipping sequences that do not intersect the local interval.
- The global `torch.roll` used to realign positions stays restricted to `zigzag`; contiguous rolls each sequence independently.
- `postprocess_thd_engine` inverts the split by concatenating the per-rank outputs in rank order.
- Both entry points reject an unknown `cp_layout` with a `ValueError` rather than silently falling back.

`MegatronEngine` gains `_get_context_parallel_layout()`, used by both `MegatronEngineWithLMHead` and `MegatronEngineWithValueHead`, so the policy and value paths cannot drift apart.

### Backward compatibility

The default remains `zigzag`, and `cp_size == 1` is unchanged, so existing models see no behavioural difference.

### Test

New CPU tests (`tests/utils/test_megatron_bshd_preprocess.py`, `tests/workers/test_megatron_value_head_cp_layout_on_cpu.py`):

- contiguous preprocessing selects the correct global packed intervals, including sequences that straddle the CP cut point;
- contiguous rolls each sequence independently;
- `postprocess_thd_engine` inverts the contiguous split;
- both preprocess and postprocess reject an unknown layout;
- the value head forwards `cp_layout="contiguous"` for `dsv4_hybrid` (this test fails without the `_get_context_parallel_layout` change).

Two-GPU validation against a single-GPU (CP1) reference, same weights, packed THD input with sequence lengths chosen so that a sequence straddles the CP cut point:

- forward/backward on the compressed-sparse-attention module: max absolute output difference `0.000000e+00` and max absolute gradient difference `0.000000e+00` versus the CP1 reference (the CP1 run is executed twice to measure its own determinism floor, and a deliberately mismatched control reports `1.0`);
- one supervised training step end to end: loss difference `4.77e-07`, gradient max absolute difference `2.31e-06`, per-token log-probabilities compared elementwise.

CP sizes 1 and 2 are covered; larger CP sizes have not been exercised.

### Additional Info

- The end-to-end SFT path that goes through a DeepSeek V4 model provider is **not** covered here: `verl` main has no `deepseek_v4` provider that does not depend on Megatron-Bridge, so the validation above uses the native mcore modules directly.
