### PR TITLE
[agent-loop] fix: preserve routed experts across turns

### DIFF
--- a/tests/experimental/agent_loop/test_tool_agent_loop_routed_experts_on_cpu.py
+++ b/tests/experimental/agent_loop/test_tool_agent_loop_routed_experts_on_cpu.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU regression tests for routed-expert alignment across tool-agent turns."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+from verl.experimental.agent_loop.tool_agent_loop import (
+    AgentState,
+    ToolAgentLoop,
+    _merge_routed_experts,
+    _trim_routed_experts_to_prefix,
+)
+from verl.experimental.agent_loop.tool_parser import FunctionCall
+from verl.tools.schemas import ToolResponse
+from verl.utils.tokenizer.continuous_token import MergeResult
+from verl.workers.rollout.replica import TokenOutput
+
+LAYERS, TOPK = 2, 2
+
+
+def _routing(markers: list[int], *, read_only: bool = False) -> np.ndarray:
+    array = np.repeat(np.asarray(markers, dtype=np.int32), LAYERS * TOPK).reshape(-1, LAYERS, TOPK)
+    if read_only:
+        return np.frombuffer(array.tobytes(), dtype=np.int32).reshape(-1, LAYERS, TOPK)
+    return array
+
+
+def _markers(routed_experts: Any) -> list[int]:
+    return [int(value) for value in routed_experts[:, 0, 0]]
+
+
+def test_merge_preserves_previous_turn_and_appends_newly_covered_suffix() -> None:
+    previous = _routing([10, 11, 12, 13], read_only=True)
+    current = _routing([20, 21, 22, 23, 24, 25, 26, 27], read_only=True)
+
+    merged = _merge_routed_experts(previous, current, prompt_length=7)
+
+    assert isinstance(merged, np.ndarray)
+    assert _markers(merged) == [10, 11, 12, 13, 24, 25, 26, 27]
+    assert merged.flags.writeable
+
+
+def test_merge_supports_torch_routing_without_changing_the_output_type() -> None:
+    previous = torch.from_numpy(_routing([10, 11]))
+    current = torch.from_numpy(_routing([20, 21, 22, 23]))
+
+    merged = _merge_routed_experts(previous, current, prompt_length=3)
+
+    assert isinstance(merged, torch.Tensor)
+    assert _markers(merged) == [10, 11, 22, 23]
+
+
+def test_merge_keeps_existing_routes_when_current_turn_has_none() -> None:
+    previous = _routing([10, 11])
+
+    assert _merge_routed_experts(previous, None, prompt_length=3) is previous
+    assert _merge_routed_experts(None, None, prompt_length=3) is None
+
+
+def test_merge_rejects_misaligned_snapshots() -> None:
+    previous = _routing([10, 11, 12, 13])
+
+    with pytest.raises(ValueError, match="exceed the current generation prompt"):
+        _merge_routed_experts(previous, _routing([20, 21, 22, 23]), prompt_length=3)
+
+    with pytest.raises(ValueError, match="shorter than the already captured prefix"):
+        _merge_routed_experts(previous, _routing([20, 21, 22]), prompt_length=4)
+
+    with pytest.raises(ValueError, match="layer/top-k dimensions changed"):
+        _merge_routed_experts(previous, np.zeros((5, LAYERS + 1, TOPK), dtype=np.int32), prompt_length=4)
+
+
+def test_trim_only_drops_routing_rows_that_were_already_covered() -> None:
+    fully_covered = _routing([10, 11, 12, 13, 14])
+    trimmed = _trim_routed_experts_to_prefix(fully_covered, prefix_length=4)
+    assert _markers(trimmed) == [10, 11, 12, 13]
+
+    final_token_not_covered = _routing([10, 11, 12, 13])
+    unchanged = _trim_routed_experts_to_prefix(final_token_not_covered, prefix_length=4)
+    assert unchanged is final_token_not_covered
+
+
+class _SequenceServer:
+    def __init__(self, outputs: list[TokenOutput]):
+        self._outputs = iter(outputs)
+        self.prompts_seen: list[list[int]] = []
+
+    async def generate(self, request_id: str, *, prompt_ids: list[int], **kwargs: Any) -> TokenOutput:
+        del request_id, kwargs
+        self.prompts_seen.append(list(prompt_ids))
+        return next(self._outputs)
+
+
+class _NoToolCallsParser:
+    stop_token_ids: list[int] = []
+
+    async def extract_tool_calls(self, response_ids: list[int], tools: list[Any]) -> tuple[str, list[Any]]:
+        del response_ids, tools
+        return "", []
+
+
+@pytest.mark.asyncio
+async def test_generating_state_preserves_routes_across_tool_turns() -> None:
+    server = _SequenceServer(
+        [
+            TokenOutput(
+                token_ids=[101, 102],
+                routed_experts=_routing([10, 11, 12, 13]),
+                extra_fields={"max_global_steps": 1},
+            ),
+            TokenOutput(
+                token_ids=[103, 104],
+                routed_experts=_routing([20, 21, 22, 23, 24, 25, 26, 27]),
+                extra_fields={"max_global_steps": 2},
+            ),
+        ]
+    )
+    loop = SimpleNamespace(
+        server_manager=server,
+        tool_parser=_NoToolCallsParser(),
+        enable_continuous_token=False,
+        response_length=64,
+        max_assistant_turns=0,
+        max_user_turns=0,
+        tools={},
+    )
+    agent_data = SimpleNamespace(
+        request_id="request-0",
+        prompt_ids=[1, 2, 3],
+        metrics={},
+        image_data=None,
+        video_data=None,
+        audio_data=None,
+        mm_processor_kwargs={},
+        extra_fields={},
+        assistant_turns=0,
+        response_ids=[],
+        response_mask=[],
+        response_logprobs=[],
+        routed_experts=None,
+        user_turns=0,
+        tool_calls=[],
+        messages=[],
+    )
+
+    await ToolAgentLoop._handle_generating_state(loop, agent_data, {}, ignore_termination=True)
+    agent_data.prompt_ids.extend([201, 202])
+    agent_data.response_mask.extend([0, 0])
+    await ToolAgentLoop._handle_generating_state(loop, agent_data, {}, ignore_termination=True)
+
+    assert server.prompts_seen == [[1, 2, 3], [1, 2, 3, 101, 102, 201, 202]]
+    assert _markers(agent_data.routed_experts) == [10, 11, 12, 13, 24, 25, 26, 27]
+
+
+@pytest.mark.asyncio
+async def test_continuous_token_prefix_removal_trims_captured_routes() -> None:
+    async def call_tool(
+        tool_call: FunctionCall, tools_kwargs: dict[str, Any], agent_data: SimpleNamespace
+    ) -> tuple[ToolResponse, None, dict[str, Any]]:
+        del tool_call, tools_kwargs, agent_data
+        return ToolResponse(text="result"), None, {}
+
+    async def merge_non_assistant(
+        previous_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
+        runtime_token_ids: list[int],
+        response_mask: list[int],
+        response_logprobs: None,
+        *,
+        tools: list[Any],
+    ) -> tuple[MergeResult, list[int], None]:
+        del previous_messages, updated_messages, runtime_token_ids, response_mask, response_logprobs, tools
+        return (
+            MergeResult(
+                token_ids=[1, 2, 3, 4, 90, 91],
+                appended_token_count=1,
+                kind="non_assistant",
+                inserted_token_ids=[90],
+                removed_prefix_token_count=1,
+            ),
+            [1, 0, 0],
+            None,
+        )
+
+    loop = SimpleNamespace(
+        max_parallel_calls=1,
+        processor=None,
+        enable_continuous_token=True,
+        response_length=64,
+        tool_parser_name="qwen3_coder",
+        tool_schemas=[],
+        _call_tool=call_tool,
+        ct_merge_non_assistant_msg=merge_non_assistant,
+    )
+    agent_data = SimpleNamespace(
+        messages=[{"role": "user", "content": "question"}, {"role": "assistant", "content": "call"}],
+        tool_calls=[FunctionCall(name="lookup", arguments="{}")],
+        tools_kwargs={},
+        metrics={},
+        tool_rewards=[],
+        prompt_ids=[1, 2, 3, 4, 5],
+        response_mask=[1, 1],
+        response_logprobs=[],
+        image_data=None,
+        user_turns=0,
+        routed_experts=_routing([10, 11, 12, 13, 14]),
+    )
+
+    state = await ToolAgentLoop._handle_processing_tools_state(loop, agent_data)
+
+    assert state == AgentState.GENERATING
+    assert agent_data.prompt_ids == [1, 2, 3, 4, 90, 91]
+    assert _markers(agent_data.routed_experts) == [10, 11, 12, 13]

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -19,6 +19,7 @@ from enum import Enum
 from typing import Any, Optional
 from uuid import uuid4
 
+import numpy as np
 import torch
 from PIL import Image
 
@@ -44,6 +45,79 @@ SPEC_DECODE_EXTRA_KEYS = (
     "spec_num_accepted_tokens",
     "spec_num_verify_steps",
 )
+
+
+def _merge_routed_experts(
+    previous: Optional[Any],
+    current: Optional[Any],
+    *,
+    prompt_length: int,
+) -> Optional[Any]:
+    """Preserve routed experts already captured by earlier agent turns.
+
+    A rollout backend returns a full-sequence routing snapshot for the current
+    prompt and response. In fully async training, an earlier prefix may have
+    been evaluated by older model weights, so only the not-yet-covered suffix
+    from the current snapshot should be appended.
+    """
+    if current is None:
+        return previous
+
+    supported_types = (np.ndarray, torch.Tensor)
+    if not isinstance(current, supported_types):
+        raise TypeError(f"Unsupported type for routed_experts: {type(current)}")
+    if current.ndim != 3:
+        raise ValueError(f"Expected routed_experts with 3 dimensions, got shape {tuple(current.shape)}")
+
+    if previous is None:
+        return current
+    if not isinstance(previous, supported_types):
+        raise TypeError(f"Unsupported type for previous routed_experts: {type(previous)}")
+    if type(previous) is not type(current):
+        raise TypeError(
+            "routed_experts type changed across agent turns: "
+            f"previous={type(previous).__name__}, current={type(current).__name__}"
+        )
+    if previous.ndim != 3:
+        raise ValueError(f"Expected previous routed_experts with 3 dimensions, got shape {tuple(previous.shape)}")
+    if previous.shape[1:] != current.shape[1:]:
+        raise ValueError(
+            "routed_experts layer/top-k dimensions changed across agent turns: "
+            f"previous={tuple(previous.shape)}, current={tuple(current.shape)}"
+        )
+    if previous.dtype != current.dtype:
+        raise ValueError(
+            f"routed_experts dtype changed across agent turns: previous={previous.dtype}, current={current.dtype}"
+        )
+
+    covered_length = previous.shape[0]
+    if covered_length > prompt_length:
+        raise ValueError(
+            "Previously captured routed_experts exceed the current generation prompt: "
+            f"covered_length={covered_length}, prompt_length={prompt_length}"
+        )
+    if covered_length > current.shape[0]:
+        raise ValueError(
+            "Current routed_experts snapshot is shorter than the already captured prefix: "
+            f"covered_length={covered_length}, current_length={current.shape[0]}"
+        )
+    if covered_length == 0:
+        return current
+    if covered_length == current.shape[0]:
+        return previous
+
+    if isinstance(previous, np.ndarray):
+        return np.concatenate([previous, current[covered_length:]], axis=0)
+    return torch.cat([previous, current[covered_length:]], dim=0)
+
+
+def _trim_routed_experts_to_prefix(routed_experts: Optional[Any], prefix_length: int) -> Optional[Any]:
+    """Drop captured routing rows removed from the runtime token prefix."""
+    if prefix_length < 0:
+        raise ValueError(f"prefix_length must be non-negative, got {prefix_length}")
+    if routed_experts is None or routed_experts.shape[0] <= prefix_length:
+        return routed_experts
+    return routed_experts[:prefix_length]
 
 
 class AgentState(Enum):
@@ -231,6 +305,7 @@ class ToolAgentLoop(AgentLoopBase):
             stop_token_ids = list(set((sampling_params.get("stop_token_ids") or []) + self.tool_parser.stop_token_ids))
             sampling_params = {**sampling_params, "stop_token_ids": stop_token_ids}
 
+        generation_prompt_length = len(agent_data.prompt_ids)
         with simple_timer("generate_sequences", agent_data.metrics):
             output: TokenOutput = await self.server_manager.generate(
                 request_id=agent_data.request_id,
@@ -241,6 +316,11 @@ class ToolAgentLoop(AgentLoopBase):
                 audio_data=agent_data.audio_data,
                 mm_processor_kwargs=agent_data.mm_processor_kwargs,
             )
+        agent_data.routed_experts = _merge_routed_experts(
+            agent_data.routed_experts,
+            output.routed_experts,
+            prompt_length=generation_prompt_length,
+        )
         # first time to set num_preempted
         if agent_data.metrics.get("num_preempted") is None:
             agent_data.metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
@@ -278,9 +358,6 @@ class ToolAgentLoop(AgentLoopBase):
             agent_data.response_mask += [1] * len(agent_data.response_ids)
             if output.log_probs:
                 agent_data.response_logprobs += output.log_probs
-
-        if output.routed_experts is not None:
-            agent_data.routed_experts = output.routed_experts
 
         # Check termination conditions
         if not ignore_termination and len(agent_data.response_mask) >= self.response_length:
@@ -386,6 +463,12 @@ class ToolAgentLoop(AgentLoopBase):
             )
             if len(response_mask) >= self.response_length:
                 return AgentState.TERMINATED
+            # Newly inserted boundary/tool tokens have not been evaluated yet. Keep routing only for the
+            # retained old prefix; the next generation snapshot will fill the uncovered suffix.
+            retained_prefix_length = len(agent_data.prompt_ids) - merge_result.removed_prefix_token_count
+            agent_data.routed_experts = _trim_routed_experts_to_prefix(
+                agent_data.routed_experts, retained_prefix_length
+            )
             agent_data.prompt_ids = merge_result.token_ids
             agent_data.response_mask = response_mask
             if agent_data.response_logprobs:


### PR DESCRIPTION
## Summary

- preserve routed-expert rows captured by earlier tool-agent turns
- append only the newly covered suffix from each later full-sequence routing snapshot
- keep routing aligned when Continuous Token removes already-covered prefix tokens
- add focused CPU regression coverage for NumPy, Torch, multi-turn, and Continuous Token paths

Fixes #6054

## Root cause

`FullyAsyncLLMServerClient` already merges routing snapshots for aborted partial resumes within one `generate()` call. Separate tool-calling turns invoke `generate()` again, however, and `ToolAgentLoop` replaced the accumulated snapshot with the latest one. With asynchronous model updates, that loses the routing selected by the model version that originally evaluated earlier tokens.

This change treats `routed_experts` as a contiguous covered prefix of `prompt_ids`: existing rows remain immutable, while later turns append routing only for tokens that were not previously covered.

## Why this is not a duplicate

The required duplicate checks returned no open PR matching either `6054 in:body` or `routed_experts ToolAgentLoop`. Related fixes #6029 and #6046 address partial resumes inside a single generation call; this PR addresses routing preservation across separate tool turns.

## Tests

- `uv run --no-sync python -m pytest -q tests/experimental/agent_loop/test_tool_agent_loop_routed_experts_on_cpu.py tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py tests/workers/rollout/test_llm_server_routed_experts_on_cpu.py tests/utils/test_continuous_token_on_cpu.py` — 90 passed, 1 warning
- `uv run --no-sync pre-commit run ruff --files verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_routed_experts_on_cpu.py` — passed
- `uv run --no-sync pre-commit run ruff-format --files verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_routed_experts_on_cpu.py` — passed
- `uv run --no-sync pre-commit run mypy --files verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_routed_experts_on_cpu.py` — passed
- `uv run --no-sync python -W error -m compileall -q . -x '(^|[\\/])(\.venv|venv|\.git|verl[\\/]experimental[\\/]vla)([\\/]|$)'` — passed

Environment notes:

- A plain `uv run` attempted to re-resolve the current project and stopped before running tests because `sglang==0.5.8` pins `transformers==4.57.1`, while the current project requirements select `transformers>=5.5.3`. The successful commands above reused the existing uv-managed environment with `--no-sync`.
- `pre-commit run validate-structure --all-files` reports pre-existing layout violations in `tests/test_base_config_on_cpu.py`, `tests/test_protocol_on_cpu.py`, and `tests/test_protocol_v2_on_cpu.py`; this PR does not modify them.
- The pre-commit `compileall` wrapper requires `sh`, which is unavailable in this Windows environment, so the equivalent Python command shown above was run directly and passed.

## AI assistance

OpenAI Codex was used for issue analysis, implementation, test development, and PR preparation. This draft must not be marked ready until the human submitter has reviewed every changed line, reproduced the relevant tests, and is prepared to explain and defend the change end-to-end.