### PR TITLE
[megatron] feat: PP/VPP support for the steady delta export

### DIFF
--- a/tests/special_distributed/test_mcore_probe_differential.py
+++ b/tests/special_distributed/test_mcore_probe_differential.py
@@ -43,6 +43,7 @@ sys.path.insert(0, os.environ.get("VERL_PATH", "/home/changyi/verl_ab_pre"))
 MODEL_KIND = os.environ.get("MODEL_KIND", "qwen2")
 TP = int(os.environ.get("TP_SIZE", "2"))
 PP = int(os.environ.get("PP_SIZE", "1"))
+EP = int(os.environ.get("EP_SIZE", "1"))
 
 
 def _build_tiny_hf_dir(rank: int) -> str:
@@ -182,13 +183,28 @@ def _pp_differential(bridge, model, rank: int, world: int) -> None:
     slot_cache: dict = {}
     index = build_export_index(bridge, model, slot_cache)
 
-    # 1. directory lockstep: every rank must hold the identical name sequence.
+    # 1. directory lockstep: same ROW COUNT everywhere (mcore expert param
+    # NAMES legitimately differ per ep rank -- the row is the unit).
     names = [r.megatron_name for r in index]
     all_names: list = [None] * world
     dist.all_gather_object(all_names, names)
     failures = []
-    if rank == 0 and any(n != names for n in all_names):
-        failures.append("directory diverges across ranks")
+    if rank == 0 and any(len(n) != len(names) for n in all_names):
+        failures.append(f"directory row counts diverge: {[len(n) for n in all_names]}")
+
+    # 1b. per-row slot-table identity: the batched gather merges BY SLOT
+    # POSITION within a row and rank 0 names merged pieces from its own list,
+    # so the row's table must be identical on every rank (the ep_size>1
+    # collision this oracle now guards).
+    row_tables = [r.slots for r in index]
+    all_tables: list = [None] * world
+    dist.all_gather_object(all_tables, row_tables)
+    if rank == 0:
+        for r_i, tbls in enumerate(all_tables):
+            bad = [k for k in range(len(row_tables)) if tbls[k] != row_tables[k]][:3]
+            if bad:
+                failures.append(f"row slot tables diverge on rank {r_i} (rows {bad})")
+                break
 
     # 2. entries: owned params ship a full delta (every local element), rows
     # owned by other stages must come back as zero-count lockstep entries.
@@ -279,7 +295,12 @@ def main():
 
     from megatron.core import parallel_state as mpu
 
-    mpu.initialize_model_parallel(tensor_model_parallel_size=TP, pipeline_model_parallel_size=PP)
+    mpu.initialize_model_parallel(
+        tensor_model_parallel_size=TP,
+        pipeline_model_parallel_size=PP,
+        expert_model_parallel_size=EP,
+        expert_tensor_parallel_size=1 if EP > 1 else None,
+    )
     from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 
     model_parallel_cuda_manual_seed(1234)
@@ -292,6 +313,9 @@ def main():
     provider = bridge.to_megatron_provider(load_weights=False)
     provider.tensor_model_parallel_size = TP
     provider.pipeline_model_parallel_size = PP
+    if EP > 1:
+        provider.expert_model_parallel_size = EP
+        provider.expert_tensor_parallel_size = 1
     provider.bf16 = True
     provider.params_dtype = torch.bfloat16
     provider.finalize()
@@ -302,7 +326,7 @@ def main():
     # differential would flag test artifacts instead of probe bugs.
     bridge.load_hf_weights(model)
 
-    if PP > 1:
+    if PP > 1 or EP > 1 or os.environ.get("ENGINE_DIFF"):
         _pp_differential(bridge, model, rank, world)
         return
 

--- a/tests/special_distributed/test_mcore_probe_differential.py
+++ b/tests/special_distributed/test_mcore_probe_differential.py
@@ -42,13 +42,14 @@ sys.path.insert(0, os.environ.get("VERL_PATH", "/home/changyi/verl_ab_pre"))
 
 MODEL_KIND = os.environ.get("MODEL_KIND", "qwen2")
 TP = int(os.environ.get("TP_SIZE", "2"))
+PP = int(os.environ.get("PP_SIZE", "1"))
 
 
 def _build_tiny_hf_dir(rank: int) -> str:
     from transformers import AutoConfig
 
-    cfg_dir = f"/tmp/tiny_{MODEL_KIND}_probe_diff_v2"
-    if MODEL_KIND == "qwen2":
+    cfg_dir = f"/tmp/tiny_{MODEL_KIND}_probe_diff_v4"
+    if MODEL_KIND in ("qwen2", "qwen2_tied"):
         hf_config = AutoConfig.for_model(
             "qwen2",
             hidden_size=64,
@@ -58,7 +59,7 @@ def _build_tiny_hf_dir(rank: int) -> str:
             num_key_value_heads=2,
             vocab_size=512,
             max_position_embeddings=256,
-            tie_word_embeddings=False,
+            tie_word_embeddings=(MODEL_KIND == "qwen2_tied"),
         )
         hf_config.architectures = ["Qwen2ForCausalLM"]
     elif MODEL_KIND == "qwen3_moe":
@@ -152,8 +153,122 @@ def _build_tiny_hf_dir(rank: int) -> str:
         m = AutoModelForCausalLM.from_config(hf_config).to(torch.bfloat16)
         m.save_pretrained(cfg_dir, safe_serialization=True)
         del m
+        if MODEL_KIND in ("nemotron_h", "falcon_h1"):
+            # newer transformers' serialization rename table emits
+            # "backbone.embedding.weight" (singular) while the bridge mappings
+            # (and the RELEASED checkpoints) use "backbone.embeddings.weight".
+            # Normalize the stray key so the tiny checkpoint matches the
+            # released format the bridge expects.
+            from safetensors.torch import load_file, save_file
+
+            f = str(pathlib.Path(cfg_dir, "model.safetensors"))
+            sd = load_file(f)
+            fixed = {k.replace("backbone.embedding.", "backbone.embeddings."): v for k, v in sd.items()}
+            if fixed.keys() != sd.keys():
+                save_file(fixed, f, metadata={"format": "pt"})
     dist.barrier()
     return cfg_dir
+
+
+def _pp_differential(bridge, model, rank: int, world: int) -> None:
+    """PP>1 differential: run the PRODUCTION export path (global directory +
+    slot pre-seed + probe entries, a full-delta sync where every local element
+    is 'changed') and compare the merged wire-view against
+    ``bridge.export_hf_weights`` -- the bridge's own PP-broadcast full export,
+    an independent chain. Bitwise, per HF tensor, with directory-lockstep and
+    placeholder-row checks on the way."""
+    from verl.workers.engine.megatron.delta_export import build_export_index, mcore_hf_delta_entry
+
+    slot_cache: dict = {}
+    index = build_export_index(bridge, model, slot_cache)
+
+    # 1. directory lockstep: every rank must hold the identical name sequence.
+    names = [r.megatron_name for r in index]
+    all_names: list = [None] * world
+    dist.all_gather_object(all_names, names)
+    failures = []
+    if rank == 0 and any(n != names for n in all_names):
+        failures.append("directory diverges across ranks")
+
+    # 2. entries: owned params ship a full delta (every local element), rows
+    # owned by other stages must come back as zero-count lockstep entries.
+    mine: dict = {}  # slot name -> (shape, positions int64 cpu, values bf16 cpu)
+    for rec in index:
+        if rec.param is None:
+            e_idx = torch.empty(0, dtype=torch.int64, device="cuda")
+            e_val = torch.empty(0, dtype=torch.bfloat16, device="cuda")
+            slots, _dt, counts, hf_idx, _hf_val = mcore_hf_delta_entry(rec, 0, e_idx, e_val, slot_cache)
+            if int(counts.sum()) != 0 or hf_idx.numel() != 0:
+                failures.append(f"{rec.megatron_name}: placeholder row shipped a non-empty delta")
+            continue
+        if not rec.param.is_floating_point():
+            continue
+        local = rec.param.data.to(torch.bfloat16).reshape(-1)
+        lidx = torch.arange(local.numel(), dtype=torch.int64, device=local.device)
+        slots, _dt, counts, hf_idx, hf_val = mcore_hf_delta_entry(rec, 0, lidx, local, slot_cache)
+        off = 0
+        for (sname, sshape), c in zip(slots, counts.tolist(), strict=True):
+            if c:
+                pos = hf_idx[off : off + c].to(torch.int64).cpu()
+                val = hf_val[off : off + c].cpu()
+                off += c
+                prev = mine.get(sname)
+                if prev is None:
+                    mine[sname] = (tuple(sshape), pos, val)
+                else:
+                    mine[sname] = (tuple(sshape), torch.cat([prev[1], pos]), torch.cat([prev[2], val]))
+
+    # 3. independent reference: the bridge's own full export (PP broadcasts
+    # inside; full tensors on every rank).
+    exported = bridge.export_hf_weights(model, cpu=True, show_progress=False)
+    ref = {name: t.detach().to(torch.bfloat16).cpu() for name, t in exported}
+
+    all_pieces: list = [None] * world
+    dist.all_gather_object(all_pieces, mine)
+    n_checked = n_pass = 0
+    if rank == 0:
+        slot_names = {k for d in all_pieces for k in d}
+        missing_ref = sorted(set(ref) - slot_names)
+        if missing_ref:
+            more = max(0, len(missing_ref) - 5)
+            failures.append(f"HF tensors never covered by any entry: {missing_ref[:5]} (+{more})")
+        for sname in sorted(slot_names):
+            if sname not in ref:
+                failures.append(f"entry slot {sname} absent from bridge export")
+                continue
+            full = ref[sname]
+            merged = torch.full_like(full, float("nan"))
+            covered = torch.zeros(full.numel(), dtype=torch.int32)
+            mflat = merged.view(-1)
+            for d in all_pieces:
+                got = d.get(sname)
+                if got is None:
+                    continue
+                sshape, pos, val = got
+                if tuple(sshape) != tuple(full.shape):
+                    failures.append(f"{sname}: slot shape {sshape} != export shape {tuple(full.shape)}")
+                    continue
+                both = covered[pos] > 0
+                if both.any() and not torch.equal(mflat[pos[both]].view(torch.int16), val[both].view(torch.int16)):
+                    failures.append(f"{sname}: conflicting rank contributions")
+                mflat[pos] = val
+                covered[pos] += 1
+            n_checked += 1
+            if torch.isnan(mflat).any():
+                failures.append(f"{sname}: uncovered positions remain NaN")
+            elif not torch.equal(mflat.view(torch.int16), full.view(-1).view(torch.int16)):
+                failures.append(f"{sname}: bitwise mismatch")
+            else:
+                n_pass += 1
+        print("=" * 60)
+        for f in failures[:20]:
+            print("FAIL:", f)
+        print(f"PROBE DIFFERENTIAL [{MODEL_KIND} tp={TP} pp={PP}]: {n_pass}/{n_checked} bitwise-equal")
+        print("PROBE DIFFERENTIAL PASSED" if (n_checked > 0 and not failures) else "PROBE DIFFERENTIAL FAILED")
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0 and (failures or n_checked == 0):
+        sys.exit(1)
 
 
 def main():
@@ -164,7 +279,7 @@ def main():
 
     from megatron.core import parallel_state as mpu
 
-    mpu.initialize_model_parallel(tensor_model_parallel_size=TP, pipeline_model_parallel_size=1)
+    mpu.initialize_model_parallel(tensor_model_parallel_size=TP, pipeline_model_parallel_size=PP)
     from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 
     model_parallel_cuda_manual_seed(1234)
@@ -176,7 +291,7 @@ def main():
     bridge = AutoBridge.from_hf_pretrained(cfg_dir, trust_remote_code=True)
     provider = bridge.to_megatron_provider(load_weights=False)
     provider.tensor_model_parallel_size = TP
-    provider.pipeline_model_parallel_size = 1
+    provider.pipeline_model_parallel_size = PP
     provider.bf16 = True
     provider.params_dtype = torch.bfloat16
     provider.finalize()
@@ -186,6 +301,10 @@ def main():
     # (layernorms, routers) must be bit-identical across TP ranks or the
     # differential would flag test artifacts instead of probe bugs.
     bridge.load_hf_weights(model)
+
+    if PP > 1:
+        _pp_differential(bridge, model, rank, world)
+        return
 
     from verl.workers.engine.megatron.delta_export import make_probe
 

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -32,7 +32,11 @@ shard as a NaN buffer with the rank's own delta scattered in yields HF tensors
 whose non-NaN survivors are exactly this rank's contributions in final HF
 coordinates.
 
-Scope (asserted in the exporter): TP + EP, PP=1, VPP=1, no LoRA.
+Scope (asserted in the exporter): TP + EP + PP/VPP, no LoRA. Under PP the
+bridge's conversion tasks already enumerate the GLOBAL parameter directory
+(identical order on every rank, tied embeddings deduped, placeholders for
+other stages); non-owner ranks ship zero-count lockstep rows and every
+param merges over the WORLD group, so the wire master needs no relay.
 
 Safety boundary: communication must stay confined to the four stubbed helpers
 (``gather_from_tp_ranks`` / ``gather_from_ep_ranks[_scale]`` / the PP
@@ -49,7 +53,7 @@ from __future__ import annotations
 import copy
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 import torch
 
@@ -133,8 +137,9 @@ def make_probe(mapping, module):
 
     def _stub(c):
         # size-faithful groups, sizes/ranks read from the ORIGINAL (real) groups
-        # BEFORE replacement. PP is asserted =1 in the exporter; a (1, 0) group
-        # keeps the pp broadcast helpers on their identity fast path.
+        # BEFORE replacement. The probe only ever runs on the stage that OWNS
+        # the param, where a pp broadcast is the identity -- a (1, 0) group
+        # keeps the pp helpers on that fast path regardless of the real pp size.
         c.pp_group = _ProbeGroup(1, 0)
         for attr in ("ep_group", "_tp_group", "_etp_group"):
             g = getattr(c, attr, None)
@@ -176,38 +181,45 @@ def make_probe(mapping, module):
 
 @dataclass
 class McoreParamExport:
-    """One mcore parameter's export record: geometry + probe + module handle."""
+    """One mcore parameter's export record: geometry + probe + module handle.
+    ``param is None`` marks a parameter owned by another pipeline stage: the
+    rank ships a zero-count lockstep row for it (probe/module unused)."""
 
     megatron_name: str
-    param: torch.Tensor
+    param: Optional[torch.Tensor]
     spec: ShardSpec
     probe: Any  # comm-stubbed mapping copy (local megatron_to_hf evaluator)
     module: Any  # module handle megatron_to_hf reads config from
 
 
-def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
-    """Enumerate every local mcore parameter through the bridge's conversion
-    tasks and precompute its probe + wire routing.
+def build_export_index(bridge, megatron_model, slot_cache: dict | None = None) -> list[McoreParamExport]:
+    """Enumerate every mcore parameter through the bridge's conversion tasks
+    and precompute its probe + wire routing.
 
     No shard geometry is hand-computed here: the comm-stubbed probe emits final
     HF coordinates straight from the local shard, so the engine only needs to
     know WHICH group's entries to merge per parameter (the spec's
-    ``gather_group``; ``full_shape`` is the nominal local shape) and that
-    replicated params contribute from rank 0 only. The index is built once
-    (parameter sets are static) and reused by both the shard export and the
-    delta entry hook. Order follows the bridge's task enumeration, identical on
-    every rank (lockstep requirement).
+    ``gather_group``; ``full_shape`` is the nominal local shape) and which
+    ranks contribute. The index is built once (parameter sets are static) and
+    reused by both the shard export and the delta entry hook.
+
+    Lockstep: ``get_conversion_tasks`` already enumerates the GLOBAL parameter
+    list in an order identical on every rank (the bridge allgathers and sorts
+    names across pp ranks, dedupes tied embeddings, and leaves
+    ``param_weight=None`` placeholders for parameters owned by other pipeline
+    stages). Under PP>1 those placeholders become zero-count lockstep rows and
+    every param's entries merge over the WORLD group (owner-stage ranks
+    contribute, dp/cp replicas and other stages stay empty); their slot tables
+    are pre-seeded once via :func:`_preseed_slot_tables`. Under PP=1 the
+    routing is unchanged (tp / etp x ep subgroups, replicated rank-0 direct).
     """
     from megatron.core import parallel_state as mpu
 
-    assert mpu.get_pipeline_model_parallel_world_size() == 1, (
-        "megatron delta_sharded supports TP+EP only for now (PP=1); the seed full "
-        "sync supports PP already, the steady relay is roadmapped"
-    )
-
+    pp_world = mpu.get_pipeline_model_parallel_world_size()
     tp_group = mpu.get_tensor_model_parallel_group()
     tp_world = torch.distributed.get_world_size(group=tp_group)
     ep_size = mpu.get_expert_model_parallel_world_size()
+    world = torch.distributed.group.WORLD
 
     tasks = bridge.get_conversion_tasks(megatron_model)
     index: list[McoreParamExport] = []
@@ -216,12 +228,44 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
         param = task.param_weight
         name = task.global_param_name
         if param is None:
-            # parameter not owned by this rank (pp scope guard keeps this rare)
+            if pp_world == 1:
+                # not a pp placeholder (e.g. a skipped mapping); nothing to ship
+                continue
+            # owned by another pipeline stage: zero-count lockstep row -- the
+            # rank walks the same global directory and contributes nothing.
+            index.append(
+                McoreParamExport(
+                    megatron_name=name,
+                    param=None,
+                    spec=ShardSpec(full_shape=(0,), place=0, gather_group=world, contributes=False),
+                    probe=None,
+                    module=None,
+                )
+            )
             continue
         module = task.megatron_module
         local_shape = tuple(int(x) for x in param.shape)
 
-        if mapping.is_expert and (ep_size > 1 or tp_world > 1):
+        is_expert = mapping.is_expert and (ep_size > 1 or tp_world > 1)
+        is_tp_sharded = getattr(param, "tensor_model_parallel", False) and tp_world > 1
+
+        if pp_world > 1:
+            # single WORLD merge group for every param: the wire master (global
+            # rank 0) sits in every gather regardless of which stage owns the
+            # param, so no relay hop is needed. Owner-stage ranks contribute
+            # their shard pieces; dp/cp replicas dedupe via ``contributes``
+            # (identical copies -- exactly one replica set ships).
+            if is_expert:
+                contributes = mpu.get_expert_data_parallel_rank() == 0
+            elif is_tp_sharded:
+                contributes = mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+            else:
+                contributes = (
+                    mpu.get_tensor_model_parallel_rank() == 0
+                    and mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+                )
+            spec = ShardSpec(full_shape=local_shape, place=0, gather_group=world, contributes=contributes)
+        elif is_expert:
             # every rank holding a piece of this expert set contributes; the
             # engine merges their probe entries over the joint etp x ep group.
             spec = ShardSpec(
@@ -229,7 +273,7 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
                 place=0,
                 gather_group=mpu.get_expert_tensor_and_model_parallel_group(),
             )
-        elif getattr(param, "tensor_model_parallel", False) and tp_world > 1:
+        elif is_tp_sharded:
             spec = ShardSpec(full_shape=local_shape, place=0, gather_group=tp_group)
         else:
             # replicated: engine's pg=None path (rank 0 consumes its own entry
@@ -245,7 +289,52 @@ def build_export_index(bridge, megatron_model) -> list[McoreParamExport]:
                 module=module,
             )
         )
+
+    if pp_world > 1:
+        _preseed_slot_tables(index, slot_cache)
+        # a placeholder with no slot table after the exchange has no owner on
+        # ANY stage: the bridge skipped it everywhere (no mapping / missing HF
+        # key), so it is outside the bridge's own export scope -- exactly what
+        # PP=1 does by skipping param_weight=None tasks. Drop it from the
+        # directory (all ranks agree: the exchange result is identical) and
+        # say so, instead of shipping unsized rows.
+        unowned = [rec.megatron_name for rec in index if rec.param is None and rec.megatron_name not in slot_cache]
+        if unowned:
+            logger.warning(
+                "delta export drops %d param(s) the bridge skipped on every pp stage "
+                "(no mapping or missing HF key; out of export scope): %s",
+                len(unowned),
+                unowned[:8],
+            )
+            dropped = set(unowned)
+            index = [rec for rec in index if rec.megatron_name not in dropped]
     return index
+
+
+def _preseed_slot_tables(index: list[McoreParamExport], slot_cache: dict) -> None:
+    """One-time PP slot-table exchange: each rank probes a zero delta through
+    its OWNED params (filling ``slot_cache`` with their ``(hf_name, hf_shape)``
+    tables), then allgathers the tables over the pp group so every rank can
+    emit correctly-sized zero-count entries for stages it does not own. Tables
+    are static metadata; the cost is one probe pass at first export."""
+    from megatron.core import parallel_state as mpu
+
+    assert slot_cache is not None, "PP>1 slot pre-seeding needs the engine's slot cache"
+    owned: dict[str, list] = {}
+    for rec in index:
+        if rec.param is None:
+            continue
+        if rec.megatron_name not in slot_cache:
+            empty_idx = torch.empty(0, dtype=torch.int64, device=rec.param.device)
+            empty_val = torch.empty(0, dtype=torch.bfloat16, device=rec.param.device)
+            mcore_hf_delta_entry(rec, 0, empty_idx, empty_val, slot_cache)
+        owned[rec.megatron_name] = slot_cache[rec.megatron_name]
+
+    pp_group = mpu.get_pipeline_model_parallel_group()
+    gathered: list = [None] * torch.distributed.get_world_size(group=pp_group)
+    torch.distributed.all_gather_object(gathered, owned, group=pp_group)
+    for tables in gathered:
+        slot_cache.update(tables)
 
 
 def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval: torch.Tensor, slot_cache: dict):
@@ -265,6 +354,14 @@ def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval
     )
 
     cached = slot_cache.get(rec.megatron_name)
+    if rec.param is None:
+        # owned by another pipeline stage: pure lockstep row. The slot table
+        # was pre-seeded from the owner stage (fail loud if not -- an
+        # unsized entry would silently misalign the batched gather).
+        assert cached is not None, (
+            f"{rec.megatron_name}: slot table not pre-seeded for a non-owned PP param"
+        )
+        assert lidx.numel() == 0, f"{rec.megatron_name}: delta reported for a param this rank does not own"
     if lidx.numel() == 0 and cached is not None:
         # empty delta: the slot table froze after the first probe, so the
         # zero-count lockstep entry needs no probe run at all -- skip the

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -190,6 +190,9 @@ class McoreParamExport:
     spec: ShardSpec
     probe: Any  # comm-stubbed mapping copy (local megatron_to_hf evaluator)
     module: Any  # module handle megatron_to_hf reads config from
+    # GLOBAL slot table for this directory row (set by the index-build
+    # exchange): identical on every rank of the row's merge group.
+    slots: Optional[list] = None
 
 
 def build_export_index(bridge, megatron_model, slot_cache: dict | None = None) -> list[McoreParamExport]:
@@ -290,51 +293,69 @@ def build_export_index(bridge, megatron_model, slot_cache: dict | None = None) -
             )
         )
 
-    if pp_world > 1:
-        _preseed_slot_tables(index, slot_cache)
-        # a placeholder with no slot table after the exchange has no owner on
-        # ANY stage: the bridge skipped it everywhere (no mapping / missing HF
-        # key), so it is outside the bridge's own export scope -- exactly what
-        # PP=1 does by skipping param_weight=None tasks. Drop it from the
-        # directory (all ranks agree: the exchange result is identical) and
-        # say so, instead of shipping unsized rows.
-        unowned = [rec.megatron_name for rec in index if rec.param is None and rec.megatron_name not in slot_cache]
-        if unowned:
-            logger.warning(
-                "delta export drops %d param(s) the bridge skipped on every pp stage "
-                "(no mapping or missing HF key; out of export scope): %s",
-                len(unowned),
-                unowned[:8],
-            )
-            dropped = set(unowned)
-            index = [rec for rec in index if rec.megatron_name not in dropped]
+    _exchange_slot_tables(index, slot_cache)
+    # a row with an empty union has no owner on ANY rank: the bridge skipped
+    # it everywhere (no mapping / missing HF key), so it is outside the
+    # bridge's own export scope -- exactly what PP=1 does by skipping
+    # param_weight=None tasks. Drop it (all ranks agree: the exchange result
+    # is identical) instead of shipping unsized rows.
+    unowned = [rec.megatron_name for rec in index if rec.slots is None]
+    if unowned:
+        logger.warning(
+            "delta export drops %d row(s) the bridge skipped on every rank "
+            "(no mapping or missing HF key; out of export scope): %s",
+            len(unowned),
+            unowned[:8],
+        )
+        index = [rec for rec in index if rec.slots is not None]
     return index
 
 
-def _preseed_slot_tables(index: list[McoreParamExport], slot_cache: dict) -> None:
-    """One-time PP slot-table exchange: each rank probes a zero delta through
-    its OWNED params (filling ``slot_cache`` with their ``(hf_name, hf_shape)``
-    tables), then allgathers the tables over the pp group so every rank can
-    emit correctly-sized zero-count entries for stages it does not own. Tables
-    are static metadata; the cost is one probe pass at first export."""
-    from megatron.core import parallel_state as mpu
+def _exchange_slot_tables(index: list[McoreParamExport], slot_cache: dict) -> None:
+    """One-time GLOBAL slot-table exchange, run at every world size, keyed by
+    DIRECTORY ROW (not by param name).
 
-    assert slot_cache is not None, "PP>1 slot pre-seeding needs the engine's slot cache"
-    owned: dict[str, list] = {}
+    The engine's batched gather merges entries BY SLOT POSITION within each
+    directory row and rank 0 names the merged pieces from ITS OWN list, so
+    the per-row list must be identical on every rank of the row's merge
+    group. Name-keyed merging is not enough on mcore: expert param NAMES
+    embed the expert ids (``...experts.linear_fc1.weight0`` on ep rank 0 vs
+    ``weight1`` on ep rank 1), so the same row carries different names per
+    rank while still gathering together. Each rank therefore probes a zero
+    delta through its OWNED rows to reveal its local ``(hf_name, hf_shape)``
+    list, one ``all_gather_object`` over WORLD exchanges the ordered row
+    lists, and every row's table becomes the rank-order first-seen union --
+    identical everywhere by construction. Dense/TP rows (same list on every
+    rank) dedup to themselves; expert rows concatenate the per-ep-rank
+    lists; PP placeholder rows inherit the owners' union."""
+    local_rows: list = []
     for rec in index:
         if rec.param is None:
+            local_rows.append(None)
             continue
         if rec.megatron_name not in slot_cache:
             empty_idx = torch.empty(0, dtype=torch.int64, device=rec.param.device)
             empty_val = torch.empty(0, dtype=torch.bfloat16, device=rec.param.device)
             mcore_hf_delta_entry(rec, 0, empty_idx, empty_val, slot_cache)
-        owned[rec.megatron_name] = slot_cache[rec.megatron_name]
+        local_rows.append(slot_cache[rec.megatron_name])
 
-    pp_group = mpu.get_pipeline_model_parallel_group()
-    gathered: list = [None] * torch.distributed.get_world_size(group=pp_group)
-    torch.distributed.all_gather_object(gathered, owned, group=pp_group)
-    for tables in gathered:
-        slot_cache.update(tables)
+    world = torch.distributed.get_world_size()
+    gathered: list = [None] * world
+    torch.distributed.all_gather_object(gathered, local_rows)
+    n_rows = len(local_rows)
+    assert all(len(rows) == n_rows for rows in gathered), (
+        f"directory row counts diverge across ranks: {[len(r) for r in gathered]} -- "
+        "the bridge's global enumeration is expected to be structurally parallel"
+    )
+    for k, rec in enumerate(index):
+        union: dict = {}
+        for rows in gathered:  # rank order -> identical result on every rank
+            row = rows[k]
+            if row is None:
+                continue
+            for slot in row:
+                union[(slot[0], tuple(slot[1]))] = None  # ordered-set semantics
+        rec.slots = [(n, tuple(shape)) for (n, shape) in union.keys()] if union else None
 
 
 def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval: torch.Tensor, slot_cache: dict):
@@ -353,7 +374,7 @@ def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval
         f"{rec.megatron_name}: NaN sentinels require a floating-point param, got {lval.dtype}"
     )
 
-    cached = slot_cache.get(rec.megatron_name)
+    cached = rec.slots if rec.slots is not None else slot_cache.get(rec.megatron_name)
     if rec.param is None:
         # owned by another pipeline stage: pure lockstep row. The slot table
         # was pre-seeded from the owner stage (fail loud if not -- an
@@ -381,15 +402,26 @@ def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval
     outs = rec.probe.megatron_to_hf(buf, rec.module)
 
     key = rec.megatron_name
-    slots = slot_cache.get(key)
+    slots = rec.slots if rec.slots is not None else slot_cache.get(key)
     if slots is None:
+        # only reachable from the index-build exchange itself, which probes a
+        # zero delta to reveal this rank's local list before the row unions
+        # are installed on the recs; steady entries always find rec.slots.
         slots = [(n, tuple(int(x) for x in t.shape)) for n, t in outs.items()]
         slot_cache[key] = slots
+    unknown = set(outs) - {n for n, _ in slots}
+    assert not unknown, (
+        f"{key}: probe emitted slots missing from the global table {sorted(unknown)[:4]} -- "
+        "non-deterministic converter naming would misalign the batched gather"
+    )
     counts = torch.zeros(len(slots), dtype=torch.int64)
     idx_pieces: list[torch.Tensor] = []
     val_pieces: list[torch.Tensor] = []
     for s_i, (sname, _sshape) in enumerate(slots):
-        fl = outs[sname].reshape(-1)
+        out = outs.get(sname)
+        if out is None:
+            continue  # another rank's slot (e.g. its ep-local experts): zero count here
+        fl = out.reshape(-1)
         p_ = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
         if p_.numel():
             counts[s_i] = p_.numel()

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -867,22 +867,27 @@ class MegatronEngine(BaseEngine):
                 "the deprecated vanilla mbridge flavor is not supported"
             )
             assert self.peft_cls is None, "megatron delta_sharded does not support LoRA"
-            index = build_export_index(self.bridge, self.module)
+            self._delta_slot_cache: dict = {}
+            index = build_export_index(self.bridge, self.module, self._delta_slot_cache)
             self._delta_export_index = index
             self._delta_export_by_name = {rec.megatron_name: rec for rec in index}
-            self._delta_slot_cache: dict = {}
         return index
 
     def get_per_tensor_param_shard(self, **kwargs):
         """Yield each rank's *local* mcore shard ``(name, local_flat_bf16,
         ShardSpec)`` -- the spec carries only the wire merge group (the
         comm-stubbed probe owns all shard geometry). Pure export, no side
-        effects. TP+EP only (PP=1 asserted in the index builder)."""
+        effects. Params owned by another pipeline stage yield an empty shard
+        (zero-count lockstep rows; see the index builder)."""
         load_megatron_model_to_gpu(self.module, load_grad=False)
         index = self._mcore_export_index()
 
         def _gen():
+            empty = torch.empty(0, dtype=torch.bfloat16, device=get_device_id())
             for rec in index:
+                if rec.param is None:
+                    yield rec.megatron_name, empty, rec.spec
+                    continue
                 local = rec.param.data
                 if local.is_floating_point() and local.dtype != torch.bfloat16:
                     local = local.to(torch.bfloat16)


### PR DESCRIPTION
Adds pipeline-parallel (PP/VPP) support to the Megatron steady delta export of the `delta_sharded` checkpoint engine (follow-up to #7060; PP support was previously guarded by a PP=1 assert).

## Design

The bridge's `build_conversion_tasks` already maintains a **global parameter directory**: it allgathers names across pp ranks, sorts deterministically, dedupes tied embeddings, and leaves `param_weight=None` placeholders for parameters owned by other stages. The steady export rides that directory instead of asserting PP=1:

- **Placeholder rows → zero-count lockstep entries** (empty shard, empty snapshot, cached slot table) — the same mechanism HSDP replicas already use.
- **PP>1 merges every param over the WORLD group**: the wire master (global rank 0) sits in every gather regardless of the owning stage, so no relay hop; owner-stage ranks contribute, dp/cp replicas dedupe via `ShardSpec.contributes`.
- **Slot tables pre-seeded once** at index build: owners probe a zero delta, one `allgather_object` over the pp group; non-owner ranks emit correctly-sized zero-count entries from the first sync.
- **Row-keyed union slot tables** fix an ep_size>1 expert misattribution: per-rank ep-local slot lists violated the position-merge contract; tables are now unioned across the merge group in rank order.
- **Probe unchanged**: it only runs on the owning stage, where a pp broadcast is the identity — the `(1, 0)` pp stand-in stays on its fast path. PP=1 routing is byte-for-byte the old behavior.
- **Graceful degradation**: a directory row the bridge skipped on *every* stage (no mapping / missing HF key) is outside the bridge's own export scope — dropped with a warning, same semantics as PP=1.
- Uneven PP splits (`num_layers_in_first/last_pipeline_stage`) need nothing special: the directory reflects each stage's actual parameters.

Seed and verify-sweep re-export ride `bridge.export_hf_weights` (already PP-capable) — an independent chain from the steady directory, so the idempotence sweep detects even directory-level omissions.

## Validation

| check | result |
|---|---|
| **Differential oracle, PP mode** (production path: directory + pre-seed + full-delta entries vs `bridge.export_hf_weights`, bitwise; + directory-lockstep and placeholder-emptiness checks) | qwen2 TP2×PP2 **27/27**, qwen2_tied (tied-embedding dedup) **26/26**, qwen3_moe **45/45**, nemotron_h (Mamba) **29/29**, qwen2 TP1×PP2 **27/27** |
| **7B TP1×PP2 e2e** (verify_every=2) | v=2/4/6 idempotence sweeps zero-mismatch; steady uw 8.3–8.6s |
| **7B TP2×PP2 e2e** | v=2/4/6 zero-mismatch; steady uw 5.9–6.4s |
| CPU suites | 32 passed |
| **235B TP4×PP8×EP4** (official shape, uneven 11/12×6/11 split) | seed 144.5s/437.9GB; **v=2 sweep zero-mismatch**; steady uw 97.5–111.1s (payload ~20–22GB) vs same-shape NCCL **220.5–236.8s → 2.1–2.4×** |
| **EP oracle matrix** (row-keyed slot tables) | qwen3_moe EP2 × (PP1 / PP2 / PP2+expert-dp2): 45/45 bitwise + per-row table identity; EP1 regressions green |

Perf note: PP shapes add ~1.5–4s steady uw at 7B vs the TP2×PP1 baseline (directory has 2× rows + per-param WORLD gather); expected to amortize at scale, and an owner-subgroup+rank0 hybrid gather group is the follow-up if 235B says otherwise.

Test-infra fix riding along: transformers 5.6.0 serializes tiny NemotronH checkpoints with `backbone.embedding.weight` (singular) while the bridge mappings and released checkpoints use `backbone.embeddings.weight`; the tiny builder normalizes the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
