### PR TITLE
[algo] fix: micro-batch normalization for distillation loss

### DIFF
--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -286,6 +286,12 @@ def distillation_loss(
         # Directly backpropagate distillation loss as a supervised loss, as in https://arxiv.org/abs/2306.13649.
         if response_mask.is_nested:
             response_mask = response_mask.to_padded_tensor(False)
+
+        # global batch info for loss aggregation
+        config.global_batch_info["dp_size"] = data["dp_size"]
+        config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
+        config.global_batch_info["global_batch_size"] = data["global_batch_size"]
+        config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
         distillation_loss = agg_loss(
             loss_mat=distillation_losses,
             loss_mask=response_mask,

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -292,7 +292,6 @@ def distillation_loss(
         # Directly backpropagate distillation loss as a supervised loss, as in https://arxiv.org/abs/2306.13649.
         if response_mask.is_nested:
             response_mask = response_mask.to_padded_tensor(False)
-
         distillation_loss = agg_loss(
             loss_mat=distillation_losses,
             loss_mask=response_mask,

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -259,6 +259,12 @@ def distillation_loss(
         # clamping min is for k1 loss which can be negative
         distillation_losses = distillation_losses.clamp(min=-loss_config.loss_max_clamp, max=loss_config.loss_max_clamp)
 
+    # global batch info for loss aggregation
+    config.global_batch_info["dp_size"] = data["dp_size"]
+    config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
+    config.global_batch_info["global_batch_size"] = data["global_batch_size"]
+    config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
+
     if loss_config.use_policy_gradient:
         # Use negative distillation loss as reward, as done by https://thinkingmachines.ai/blog/on-policy-distillation/.
         policy_loss_fn = get_policy_loss_fn(loss_config.policy_loss_mode)
@@ -287,11 +293,6 @@ def distillation_loss(
         if response_mask.is_nested:
             response_mask = response_mask.to_padded_tensor(False)
 
-        # global batch info for loss aggregation
-        config.global_batch_info["dp_size"] = data["dp_size"]
-        config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
-        config.global_batch_info["global_batch_size"] = data["global_batch_size"]
-        config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
         distillation_loss = agg_loss(
             loss_mat=distillation_losses,
             loss_mask=response_mask,


### PR DESCRIPTION
### What does this PR do?

Applies fix proposed by @wuxibin89 for issue #7200 found by @yph22



### Test

<img width="454" height="276" alt="image" src="https://github.com/user-attachments/assets/b7954153-39e8-42d7-b7c4-0c11176c46e6" />

- Ran Qwen3-0.6B student w/ Qwen3-1.7B teacher on gsm8k for a fixed batch using `RolloutSkip`
- `fixOff` == prior to this PR, `fixOn` == with this PR
- Total batch size for all 4 is 8, `mb{k}` == mico-batch size of size `k` (`mb1` --> 8 accumulations, `mb8` == 1 accumulations)
- `Off` with mb=1 shows 8x higher loss, after applying fix, loss is correctly normalized and is invariant to the micro-batch size 

#### PG branch

With pg enabled (suggested by @ErenAta16)

<img width="485" height="292" alt="image" src="https://github.com/user-attachments/assets/276c9d58-7688-4222-a062-73043170c504" />

