### PR TITLE
[misc] fix: pin datasets minimum version for pyarrow compatibility

### DIFF
--- a/requirements-npu.txt
+++ b/requirements-npu.txt
@@ -2,7 +2,8 @@
 accelerate
 bytecode
 codetiming
-datasets
+# <2.18.0 subclasses `pa.PyExtensionType`, removed in pyarrow 23. See verl-project/verl#5073.
+datasets>=2.18.0
 dill
 hydra-core
 numpy<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # requirements.txt records the full set of dependencies for development
 accelerate
 codetiming
-datasets
+# <2.18.0 subclasses `pa.PyExtensionType`, removed in pyarrow 23. See verl-project/verl#5073.
+datasets>=2.18.0
 dill
 hydra-core
 liger-kernel

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ with open(os.path.join(version_folder, "verl/version/version")) as f:
 install_requires = [
     "accelerate",
     "codetiming",
-    "datasets",
+    # <2.18.0 subclasses `pa.PyExtensionType`, removed in pyarrow 23. See verl-project/verl#5073.
+    "datasets>=2.18.0",
     "dill",
     "hydra-core",
     "numpy>=2.0.0",


### PR DESCRIPTION
### What does this PR do?

`datasets` is currently unpinned in `setup.py`, `requirements.txt`, and `requirements-npu.txt`.
That lets pip resolve an old `datasets` alongside a modern `pyarrow`, which produces an
environment that fails as soon as verl touches training data: `verl.utils.dataset.rl_dataset`
imports `datasets`, and old `datasets` versions subclass `pa.PyExtensionType`, which modern
pyarrow no longer provides. Older `datasets` also hits
`NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported` on
local parquet loads.

This adds the missing lower bound, `datasets>=2.18.0`. No other dependency changes.

Fixes #5073.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - [`is:pr is:open 5073 in:body`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+5073+in%3Abody) — 0 results
  - [`is:pr is:open datasets pyarrow PyExtensionType`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+datasets+pyarrow+PyExtensionType) — 0 results
  - [`is:pr is:open datasets in:title`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+datasets+in%3Atitle) — 0 results

  No open PR currently adds a `datasets` version bound.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Environment note: tests were run on Windows with Python 3.11. A local Application Control
policy blocks newly installed native DLLs in fresh venvs, so a fully isolated
`pip install -e .` was not possible; instead `pyarrow` came from an already-present install
and `datasets` (pure Python) was pinned to the version under test. Every repo check below was
also run against an unmodified `main` worktree with the same interpreter, so the comparison
is apples to apples.

**1. Control — old `datasets` with modern `pyarrow` (reproduces the issue):**

```
$ pip install "datasets==2.14.4" "pyarrow==23.0.0" "pandas==2.2.3" "numpy==1.26.4"
$ python -c "import datasets"
  File ".../datasets/features/features.py", line 634, in <module>
    class _ArrayXDExtensionType(pa.PyExtensionType):
AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'. Did you mean: 'ExtensionType'?
```

**2. At the new floor — the import path from the issue now works:**

```
$ python -c "from verl.utils.dataset.rl_dataset import RLHFDataset; ..."
RLHFDataset OK | datasets 2.18.0 | pyarrow 24.0.0
```

**3. Minimal local-parquet load** (`datasets.load_dataset("parquet", data_files=...)["train"]`
on a 2-row file), which also covers the `LocalFileSystem` failure mode in the issue:

| datasets | pyarrow | result |
| --- | --- | --- |
| 2.14.4 | 23.0.0 | FAIL — `AttributeError` above |
| 2.18.0 | 24.0.0 | OK — `rows: 2`, `PARQUET SMOKE OK` |
| 5.0.0  | 24.0.0 | OK — `rows: 2`, `PARQUET SMOKE OK` |

**4. Constraint check** — confirms the broken combination is now excluded and nothing modern is:

```
setup.py install_requires -> ['datasets>=2.18.0', 'pyarrow>=19.0.0']
requirements.txt          -> ['datasets>=2.18.0', 'pyarrow>=19.0.0']
requirements-npu.txt      -> ['datasets>=2.18.0', 'pyarrow>=15.0.0,<=24.0.0']

  datasets==2.14.4    old allowed=True    new allowed=False
  datasets==2.17.1    old allowed=True    new allowed=False
  datasets==2.18.0    old allowed=True    new allowed=True
  datasets==5.0.1     old allowed=True    new allowed=True
```

**5. pre-commit** — this branch vs. unmodified `main`, same interpreter:

```
$ pre-commit run --files setup.py requirements.txt requirements-npu.txt

                                    main      this branch
ruff (legacy alias)                 Passed    Passed
ruff format                         Passed    Passed
mypy                                Failed    Failed    <- local blocked DLL
autogen-trainer-cfg                 Failed    Failed    <- python3 not on local bash PATH
Check docs Last updated info        Passed    Passed
Check doc string coverage           Passed    Passed
Check license                       Passed    Passed
Check device API usage              Passed    Passed
Check DataProto usage               Passed    Passed
Validate test structure             Failed    Failed    <- pre-existing, tests/ untouched here
Check naming conventions            Passed    Passed
Check example script naming         Passed    Passed
Compile all python files            Passed    Passed
```

Identical on both sides — this PR introduces no new pre-commit failures. The three failures
are local environment limitations or pre-existing on `main`.

**6. CPU dataset tests** — this branch vs. unmodified `main`:

```
$ pytest tests/utils/dataset/ -k on_cpu -q
12 failed, 5 passed    (this branch)
12 failed, 5 passed    (unmodified main, identical failure list)
```

All 12 failures are `OSError` from HuggingFace model resolution — the tests expect local
model checkouts (Qwen2.5-0.5B, Qwen3-VL-2B-Instruct, gpt-oss-20b, ...) that are not present
on this machine. None involve `datasets` or `pyarrow`. No regression.

**Not verified locally:** `datasets 2.18.0` with `pyarrow 25.0.0` — that binary could not be
installed here. @Kirrito-k423 validated `2.18.0 + 23.0.0` and `5.0.1 + 25.0.0` in #5073.

### API and Usage Example

No API change. This is dependency metadata only — no CLI arguments, config fields, or
function signatures are affected. Existing environments are unaffected unless they already
carry `datasets < 2.18.0`, which is the broken case this PR prevents.

### Design & Code Changes

Three files, one line each (plus a short comment citing the issue):

- `setup.py` — `install_requires`: `"datasets"` → `"datasets>=2.18.0"`
- `requirements.txt` — `datasets` → `datasets>=2.18.0`
- `requirements-npu.txt` — `datasets` → `datasets>=2.18.0`

`requirements-npu.txt` is included because it has the same defect, not for consistency
cosmetics: it leaves `datasets` unpinned while allowing `pyarrow` up to `24.0.0`, i.e. exactly
the combination that breaks.

**Why no `pyarrow` upper cap.** The issue originally suggested `pyarrow>=19.0.0,<23.0.0`.
That is the wrong lever. Per @Kirrito-k423's recheck on the issue, modern `datasets` works
fine with modern `pyarrow` — the failure only appears when an *old* `datasets` is paired with
a current `pyarrow`. Capping `pyarrow` would block current releases while leaving the actual
cause in place, and it would fight the ecosystem: current `datasets` releases require
`pyarrow>=21.0.0`, so a `<23` cap narrows the resolver for no benefit. The existing
`pyarrow>=19.0.0` is therefore left untouched.

**Why 2.18.0 and not 4.0.0.** 2.18.0 is the lowest version confirmed to clear both failure
modes from the issue, and its own metadata only asks for `pyarrow>=12.0.0`, so it does not
force any change to verl's `pyarrow` line. A `>=4.0.0` floor would additionally drop
environments and pull in 4.x's breaking removals without evidence that it is needed.

### Why this is not a duplicate, and AI disclosure

**Not a duplicate.** The three searches linked above return zero open PRs — none referencing
issue #5073, and none adding a `datasets` bound. This change does not overlap with any open
dependency PR.

**AI assistance.** This change was prepared with AI assistance (Claude). I reviewed every
changed line, ran the tests above myself, and can explain and defend the change end to end.
The commit carries an `Assisted-by:` trailer alongside my `Signed-off-by:`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting) — results above.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs) — N/A. No user-facing doc states a `datasets` version, so there is nothing to keep in sync.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) — N/A, explanation: this is a packaging-metadata constraint, not runtime behaviour. A meaningful test would have to install a deliberately conflicting `datasets`/`pyarrow` pair inside CI and assert the import breaks, which is slow and fragile. It is verified instead by the install/import matrix in the Test section.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel — not yet done.
- [ ] `recipe` submodule — N/A. This PR does not touch `recipe/`, `.gitmodules`, or any submodule SHA.

3. Still TODO before opening

Your committed one-line comment in all three files reads "removed in pyarrow 23" — the body above deliberately softens that to "modern pyarrow no longer provides", per your instruction, so the two are slightly out of step; amend the comment to match if you want them consistent, and post in ci-request after opening to get CI to run.