### PR TITLE
[vllm, rollout] fix: avoid MultiprocExecutor init port races

### DIFF
--- a/tests/workers/rollout/rollout_vllm/test_race_free_multiproc_executor_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_race_free_multiproc_executor_on_cpu.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import pickle
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("vllm")
+
+from vllm.v1.executor import multiproc_executor
+from vllm.v1.executor.multiproc_executor import MultiprocExecutor
+
+from verl.workers.rollout.vllm_rollout import vllm_async_server
+from verl.workers.rollout.vllm_rollout.race_free_multiproc_executor import RaceFreeMultiprocExecutor
+
+
+def test_executor_uses_unique_file_rendezvous_and_restores_vllm(monkeypatch):
+    original_get_distributed_init_method = multiproc_executor.get_distributed_init_method
+    init_methods = []
+
+    def fake_init_executor(self):
+        init_methods.append(multiproc_executor.get_distributed_init_method("127.0.0.1", 12345))
+
+    monkeypatch.setattr(MultiprocExecutor, "_init_executor", fake_init_executor)
+
+    for _ in range(2):
+        executor = object.__new__(RaceFreeMultiprocExecutor)
+        executor._init_executor()
+
+    assert all(init_method.startswith("file://") for init_method in init_methods)
+    assert len(init_methods) == len(set(init_methods))
+    assert multiproc_executor.get_distributed_init_method is original_get_distributed_init_method
+
+
+def test_executor_cleans_up_rendezvous_file(monkeypatch, tmp_path):
+    rendezvous_file = tmp_path / "vllm-rendezvous"
+    rendezvous_file.touch()
+
+    monkeypatch.setattr(MultiprocExecutor, "shutdown", lambda self: None)
+
+    executor = object.__new__(RaceFreeMultiprocExecutor)
+    executor._verl_rendezvous_path = str(rendezvous_file)
+    executor.shutdown()
+
+    assert not rendezvous_file.exists()
+    assert executor._verl_rendezvous_path is None
+
+
+def test_executor_class_is_spawn_serializable():
+    assert pickle.loads(pickle.dumps(RaceFreeMultiprocExecutor)) is RaceFreeMultiprocExecutor
+
+
+def test_single_node_mp_server_selects_race_free_executor(monkeypatch):
+    class StopServerStartup(Exception):
+        pass
+
+    parallel_config = SimpleNamespace(data_parallel_master_port=None, distributed_executor_backend="mp")
+    vllm_config = SimpleNamespace(parallel_config=parallel_config)
+    engine_args = SimpleNamespace(create_engine_config=lambda usage_context: vllm_config)
+
+    monkeypatch.setattr(
+        vllm_async_server.AsyncEngineArgs,
+        "from_cli_args",
+        staticmethod(lambda args: engine_args),
+    )
+
+    def capture_vllm_config(vllm_config, usage_context):
+        assert vllm_config.parallel_config.distributed_executor_backend is RaceFreeMultiprocExecutor
+        raise StopServerStartup
+
+    monkeypatch.setattr(
+        vllm_async_server.AsyncLLM,
+        "from_vllm_config",
+        staticmethod(capture_vllm_config),
+    )
+
+    server = object.__new__(vllm_async_server.vLLMHttpServer)
+    server.nnodes = 1
+    server._dp_master_port = 12345
+
+    with pytest.raises(StopServerStartup):
+        asyncio.run(server.run_server(SimpleNamespace()))

--- a/verl/workers/rollout/vllm_rollout/race_free_multiproc_executor.py
+++ b/verl/workers/rollout/vllm_rollout/race_free_multiproc_executor.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import tempfile
+import uuid
+from contextlib import suppress
+from unittest.mock import patch
+
+from vllm.v1.executor import multiproc_executor
+from vllm.v1.executor.multiproc_executor import MultiprocExecutor
+
+logger = logging.getLogger(__name__)
+
+
+class RaceFreeMultiprocExecutor(MultiprocExecutor):
+    """Use a unique FileStore rendezvous for vLLM's single-node workers.
+
+    vLLM's ``MultiprocExecutor`` normally reserves an unused TCP port, releases
+    it, and lets ``TCPStore`` bind it after the workers have spawned. Concurrent
+    rollout engines can select the same port during that gap, causing one of
+    them to fail with ``EADDRINUSE``.
+
+    Replace only that rendezvous method with a unique file URI. vLLM passes the
+    executor class to its spawned EngineCore process, so the override runs in
+    the process that constructs ``MultiprocExecutor``.
+    """
+
+    _verl_rendezvous_path: str | None = None
+
+    def _init_executor(self) -> None:
+        def get_file_init_method(_ip: str, _port: int) -> str:
+            path = os.path.join(tempfile.gettempdir(), f"verl-vllm-dist-{os.getpid()}-{uuid.uuid4().hex}")
+            self._verl_rendezvous_path = path
+            init_method = f"file://{path}"
+            logger.info("Using race-free vLLM worker rendezvous: %s", init_method)
+            return init_method
+
+        # MultiprocExecutor resolves this name from its defining module. Keep
+        # the override active only while the base initializer creates workers.
+        with patch.object(multiproc_executor, "get_distributed_init_method", get_file_init_method):
+            super()._init_executor()
+
+    def shutdown(self) -> None:
+        try:
+            super().shutdown()
+        finally:
+            if path := self._verl_rendezvous_path:
+                with suppress(OSError):
+                    os.unlink(path)
+                self._verl_rendezvous_path = None

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -53,6 +53,7 @@ from verl.workers.rollout.utils import (
     qwen2_5_vl_dedup_image_tokens,
     run_uvicorn,
 )
+from verl.workers.rollout.vllm_rollout.race_free_multiproc_executor import RaceFreeMultiprocExecutor
 from verl.workers.rollout.vllm_rollout.utils import (
     VLLM_LORA_INT_ID,
     VLLM_LORA_NAME,
@@ -436,6 +437,8 @@ class vLLMHttpServer:
         usage_context = UsageContext.OPENAI_API_SERVER
         vllm_config = engine_args.create_engine_config(usage_context=usage_context)
         vllm_config.parallel_config.data_parallel_master_port = self._dp_master_port
+        if self.nnodes == 1 and vllm_config.parallel_config.distributed_executor_backend == "mp":
+            vllm_config.parallel_config.distributed_executor_backend = RaceFreeMultiprocExecutor
 
         fn_args = set(dict(inspect.signature(AsyncLLM.from_vllm_config).parameters).keys())
         kwargs = {}


### PR DESCRIPTION
### What does this PR do?

Fixes #6677 by removing the TCP port TOCTOU race in vLLM's single-node `MultiprocExecutor` initialization. Concurrent rollout engines can currently probe the same free port, close the probe sockets, and then race when PyTorch's `TCPStore` binds that port; one engine fails with `EADDRINUSE`. This PR uses a unique `file://` rendezvous for that internal worker group, so concurrent engines no longer contend for a TCP port.

This is not a duplicate of an existing verl PR: both required searches returned no open match ([issue-reference query](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6677+in%3Abody), [error-signature query](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+vLLM+MultiprocExecutor+EADDRINUSE+distributed+init+port)). The related [vLLM PR #41983](https://github.com/vllm-project/vllm/pull/41983) remains unmerged, and both vLLM v0.24.0 (verl's stable image) and current vLLM main still use the racy `get_open_port()` path.

AI assistance was used for investigation, implementation, testing, and drafting this description. This PR is intentionally opened as a draft so the human submitter can review every changed line and rerun or confirm the tests before requesting review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [issue-reference query](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6677+in%3Abody)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

- `pytest -q tests/workers/rollout/rollout_vllm/test_race_free_multiproc_executor_on_cpu.py` with vLLM 0.19.1 available on `PYTHONPATH`: 4 passed.
- `pre-commit run --all-files --show-diff-on-failure --color=always`: all hooks passed, including Ruff, Ruff format, mypy, license, test-structure, and compile checks.
- Source compatibility was checked against vLLM v0.24.0 and current vLLM main; both expose the overridden initialization helper and compatible `shutdown()` interface.

### API and Usage Example

No user-facing API, CLI, configuration, or documentation change is required. Existing single-node async vLLM rollouts automatically select the race-free executor; multi-node rollouts and non-`mp` backends are unchanged.

### Design & Code Changes

- Add a `MultiprocExecutor` subclass that temporarily replaces vLLM's module-local distributed-init helper while the base executor creates its workers.
- Generate a UUID-keyed `file://` rendezvous path for each executor and remove the FileStore path during shutdown.
- Select the subclass only when verl is launching the single-node `mp` backend.
- Add CPU unit tests for unique file URIs, restoration of vLLM's original helper, cleanup, spawn serialization, and server-side executor selection.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. The new `*_on_cpu.py` test is discovered by the CPU unit-test workflow.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.