### PR TITLE
 [hardware, vllm, trainer] feat: add GRPO RL training support with TorchTitan actor and vLLM rollout on TPU                       

### DIFF
--- a/docs/hardware/multi_chip_support.rst
+++ b/docs/hardware/multi_chip_support.rst
@@ -22,6 +22,7 @@ Hardware Support
 
 - NVIDIA GPU (CUDA)
 - Huawei Ascend NPU
+- Google TPU
 
 **Via verl-hardware-plugin (reference implementations):**
 
@@ -79,6 +80,7 @@ Architecture Overview
     |  |  PlatformRegistry                                        |      |
     |  |    ├─ "nvidia"    → PlatformCUDA      (built-in)         |      |
     |  |    ├─ "huawei"    → PlatformNPU       (built-in)         |      |
+    |  |    ├─ "tpu"       → PlatformTPU       (built-in)         |      |
     |  |    ├─ "intel"     → PlatformXPU       (plugin)           |      |
     |  |    ├─ "cambricon" → PlatformMLU       (plugin)           |      |
     |  |    └─ "metax"     → PlatformMetaX     (plugin)           |      |

--- a/examples/tpu/gke/Dockerfile.tpu
+++ b/examples/tpu/gke/Dockerfile.tpu
@@ -1,0 +1,86 @@
+# Use the latest Ray master as base.
+FROM rayproject/ray:nightly.260501.1c7c90-py312-tpu
+
+RUN sudo apt-get update && sudo apt-get install -y libopenblas-base libopenmpi-dev libomp-dev
+RUN pip uninstall -y torch torchvision
+
+RUN pip install keyrings.google-artifactregistry-auth
+RUN pip install pandas==2.3.3
+
+ARG AUTH_TOKEN
+# Set the PIP_INDEX_URL environment variable to point to the Torch TPU virtual registry
+ENV PIP_INDEX_URL="https://oauth2accesstoken:${AUTH_TOKEN}@us-python.pkg.dev/ml-oss-artifacts-transient/torch-tpu-virtual-registry/simple/"
+
+# --- Add torchtitan setup from Dockerfile ---
+USER root
+WORKDIR /
+
+RUN pip install "jax[tpu]==0.9.1" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+RUN pip install git+https://github.com/openxla/tokamax.git@8cba6a6a1e52e9efbb7ff8facb66f18f0bfcbe4c
+RUN pip install torch==2.12.0 --index-url https://download.pytorch.org/whl/cpu
+RUN pip install libtpu==0.0.41 -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+
+RUN pip install --pre --no-deps torch_tpu
+
+RUN pip install 'typeguard==2.13.3'
+RUN pip install portpicker absl-py numpy gcsfs frozendict triton fairscale tamm
+
+# --- Install torchtitan, vllm and torchtpu-vllm ---
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
+RUN git clone https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/google-pytorch/torchtitan.git
+WORKDIR /torchtitan
+RUN git checkout 971dd82ceb3dd191088a2a74cdec594682c95ef1
+RUN pip install -r requirements.txt
+# RUN pip install -r .ci/docker/requirements-flux.txt
+WORKDIR /
+
+RUN git clone --depth 1 --branch v0.19.0 https://github.com/vllm-project/vllm.git
+RUN git clone https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/google-pytorch/torchtpu-vllm.git
+
+WORKDIR /torchtpu-vllm
+RUN git checkout 98536189411258e7307f261759edfb6fc8df8a60
+WORKDIR /
+
+# Patch vLLM's TPU requirements to accept our local workspace in torchtpu-vllm instead of overriding it
+RUN sed -i '/tpu-inference/d' vllm/requirements/tpu.txt
+
+# Install vLLM in editable mode (forcing the 0.19.0 base version to prevent .dev prerelease mismatch during dependency resolution)
+WORKDIR /torchtpu-vllm
+
+# Hack pyproject.toml to pin versions
+RUN sed -i 's/torch-tpu==[0-9a-zA-Z.]*/torch-tpu==0.1.1.dev20260527102151/' pyproject.toml
+RUN sed -i 's/libtpu==[0-9a-zA-Z.]*/libtpu==0.0.41/' pyproject.toml
+
+RUN pip install --upgrade pip && SETUPTOOLS_SCM_PRETEND_VERSION=0.19.0 VLLM_TARGET_DEVICE="tpu" pip install -e ../vllm
+RUN pip install --pre -e .
+
+# --- Install verl Dependencies ---
+# Pre-installing these ensures that Ray Job Submission doesn't have to download
+# packages on the fly, which drastically reduces GKE node startup and rollout times.
+RUN pip install --no-cache-dir \
+    accelerate \
+    codetiming \
+    datasets \
+    dill \
+    hydra-core \
+    peft \
+    "pyarrow>=19.0.0" \
+    pybind11 \
+    pylatexenc \
+    "tensordict>=0.8.0,<=0.10.0,!=0.9.0" \
+    torchdata \
+    "transformers!=5.6.0" \
+    wandb \
+    "packaging>=20.0" \
+    uvicorn \
+    fastapi \
+    latex2sympy2_extended \
+    math_verify \
+    tensorboard \
+    TransferQueue==0.1.8
+
+WORKDIR /app
+
+# Add /app to PYTHONPATH to allow standard fully qualified 'import verl.*' imports.
+ENV PYTHONPATH="${PYTHONPATH}:/app:/torchtitan:/torchtitan/torchtitan"

--- a/examples/tpu/gke/ray-tpu-v6e8-2slice.yaml
+++ b/examples/tpu/gke/ray-tpu-v6e8-2slice.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ray-ksa 
+  namespace: default # Change this if your Ray cluster is in a different namespace
+  annotations:
+      iam.gke.io/gcp-service-account: ray-tpu-gsa@tpu-pytorch.iam.gserviceaccount.com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ray-ksa-admin-binding
+subjects:
+- kind: ServiceAccount
+  name: ray-ksa
+  namespace: default # Must match the namespace of the ServiceAccount above
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin # Only for testing, should use a more restrictive role in prod
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: ray-tpu-v6e-cluster
+spec:
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      metadata:
+        annotations:
+          gke-gcsfuse/volumes: "true"
+      spec:
+        serviceAccountName: ray-ksa
+        containers:
+          - name: ray-head
+            image: us-west2-docker.pkg.dev/tpu-pytorch/raycluster/verl-tpu:v20260630-159c2e3e
+            imagePullPolicy: Always
+            env:
+            - name: RAY_TRAIN_V2_ENABLED
+              value: "1"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_token
+                  optional: true
+            ports:
+              - containerPort: 8265  # Dashboard
+              - containerPort: 10001 # Client
+              - containerPort: 8888  # gRPC
+              - containerPort: 8000  # OpenAI API
+            resources:
+              limits:
+                cpu: "12"
+                memory: "48Gi"
+              requests:
+                cpu: "12"
+                memory: "48Gi"
+            volumeMounts:
+            - name: gcs-volume
+              mountPath: /data
+            - name: host-tmp
+              mountPath: /tmp
+        volumes:
+        - name: gcs-volume
+          csi:
+            driver: gcsfuse.csi.storage.gke.io
+            volumeAttributes:
+              bucketName: torchprime
+              mountOptions: "implicit-dirs"
+        - name: host-tmp
+          hostPath:
+            path: /tmp
+  workerGroupSpecs:
+    - replicas: 2 # use 2 slices
+      numOfHosts: 2 # 2 host v6e8 chips 
+      groupName: tpu-group
+      rayStartParams: {}
+      template:
+        metadata:
+          annotations:
+            gke-gcsfuse/volumes: "true"
+        spec:
+          serviceAccountName: ray-ksa
+          containers:
+            - name: ray-worker
+              image: us-west2-docker.pkg.dev/tpu-pytorch/raycluster/verl-tpu:v20260630-159c2e3e
+              imagePullPolicy: Always
+              resources:
+                limits:
+                  memory: "200Gi"
+                  # Each Worker node has 4 TPU chips.
+                  google.com/tpu: "4"
+                requests:
+                  cpu: "48"
+                  memory: "200Gi"
+                  # Each Worker node has 4 TPU chips.
+                  google.com/tpu: "4"
+              env:
+                - name: RAY_TRAIN_V2_ENABLED
+                  value: "1"
+                - name: HF_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: hf-secret
+                      key: hf_token
+                      optional: true
+              volumeMounts:
+              - name: gcs-volume
+                mountPath: /data
+              - name: host-tmp
+                mountPath: /tmp
+          volumes:
+          - name: gcs-volume
+            csi:
+              driver: gcsfuse.csi.storage.gke.io
+              volumeAttributes:
+                bucketName: torchprime
+                mountOptions: "implicit-dirs"
+          - name: host-tmp
+            hostPath:
+              path: /tmp
+          nodeSelector:
+            # Change this according to the TPU slice topology.
+            cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+            cloud.google.com/gke-tpu-topology: 2x4  # v6e8 chips 

--- a/examples/tpu/grpo/README.md
+++ b/examples/tpu/grpo/README.md
@@ -1,0 +1,64 @@
+# GRPO RL Training on Google Cloud TPU (v6e)
+
+This directory contains examples and scripts for running **GRPO (Group Relative Policy Optimization) RL Training** on Google Cloud TPU v6e instances using `verl`.
+
+The training setup uses:
+- **Actor Engine**: TorchTitan (`model_engine=torchtitan`)
+- **Rollout Engine**: vLLM (`actor_rollout_ref.rollout.name=vllm`)
+- **Placement Strategy**: Non-colocated multi-slice execution (Slice 0 for Trainer/Actor, Slice 1 for Rollout)
+
+---
+
+## 🚀 Quick Start
+
+### 1. Prerequisites
+Ensure you have a running Ray cluster on TPU v6e nodes with `verl` installed across all head and worker nodes.
+
+Environment variables required:
+- `MODEL_PATH`: Path to HuggingFace model checkpoint (e.g. `/data/jialei/assets/hf/Qwen3-0.6B`)
+- `TRAIN_FILE` & `TEST_FILE`: Parquet dataset files (e.g. GSM8K dataset)
+- `WANDB_API_KEY` (Optional): For experiment tracking on Weights & Biases
+
+---
+
+### 2. Submit a GRPO Training Job
+
+You can submit the training job to your Ray cluster using the Ray CLI (`ray job submit`):
+
+```bash
+# Set active Ray cluster address (e.g. localhost:23333 if port-forwarded)
+export RAY_ADDRESS="http://localhost:23333"
+
+# Submit GRPO RL training job
+ray job submit --address "${RAY_ADDRESS}" \
+  --working-dir . \
+  --runtime-env-json '{
+    "excludes": [".git", "logs", "*.log", "*.pt", "*.bin"],
+    "env_vars": {
+      "PYTHONPATH": ".",
+      "PYTHONUNBUFFERED": "1",
+      "VERL_PLATFORM": "tpu",
+      "VLLM_USE_V1": "0",
+      "RAY_memory_monitor_refresh_ms": "0",
+      "RAY_memory_usage_threshold": "0.99",
+      "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS": "1",
+      "RAY_OVERRIDE_JOB_RUNTIME_ENV": "1",
+      "WANDB_API_KEY": "'"${WANDB_API_KEY}"'"
+    }
+  }' \
+  -- bash examples/tpu/grpo/run_qwen3_0_6b_torchtitan.sh
+```
+
+---
+
+## 📊 Monitoring Progress
+
+### Check Job Status
+```bash
+ray job status --address http://localhost:23333 <JOB_ID>
+```
+
+### Stream Live Logs
+```bash
+ray job logs --follow --address http://localhost:23333 <JOB_ID>
+```

--- a/examples/tpu/grpo/run_qwen3_0_6b_torchtitan.sh
+++ b/examples/tpu/grpo/run_qwen3_0_6b_torchtitan.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# GRPO | Qwen3-0.6B (Fast Smoke Test) | TorchTitan Training & vLLM Rollout | TPU v6e-16 Slices | V1 PPOTrainer (Separate Async Overlap)
+
+set -xeuo pipefail
+
+export RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS=1
+export VERL_PLATFORM=tpu
+export RAY_OVERRIDE_JOB_RUNTIME_ENV=1
+export VLLM_USE_V1=0
+export RAY_memory_monitor_refresh_ms=0
+export RAY_memory_usage_threshold=0.99
+
+# JAX/XLA Launch Barrier Configuration
+export LIBTPU_INIT_ARGS="--xla_tpu_use_enhanced_launch_barrier=false"
+
+# Project and Experiment details
+project_name='verl_tpu_grpo'
+exp_name="qwen3_0.6b_fast_smoke_test"
+
+# Paths
+RAY_DATA_HOME="/data/jialei"
+MODEL_PATH="${MODEL_PATH:-${RAY_DATA_HOME}/assets/hf/Qwen3-0.6B}"
+
+TRAIN_FILE="${RAY_DATA_HOME}/data/gsm8k/train.parquet"
+TEST_FILE="${RAY_DATA_HOME}/data/gsm8k/test.parquet"
+
+# TPU 2-slice v6e-8 configurations
+export NNODES_TRAINER=2       # 2 physical VM hosts for training slice
+export N_CHIPS_TRAINER=4      # 4 TPU chips per training host
+
+export NNODES_ROLLOUT=2       # 2 physical VM hosts for rollout slice
+export N_CHIPS_ROLLOUT=4      # 4 TPU chips per rollout host
+
+TOTAL_ROLLOUT_CHIPS=$((NNODES_ROLLOUT * N_CHIPS_ROLLOUT))
+
+python3 -m verl.trainer.main_ppo \
+    trainer.use_v1=True \
+    trainer.v1.trainer_mode=separate_async \
+    trainer.v1.separate_async.num_warmup_batches=1 \
+    trainer.v1.separate_async.parameter_sync_step=1 \
+    transfer_queue.enable=True \
+    model_engine=torchtitan \
+    algorithm.adv_estimator=grpo \
+    algorithm.use_kl_in_reward=False \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.train_batch_size=4 \
+    data.val_batch_size=4 \
+    data.val_max_samples=8 \
+    data.max_prompt_length=512 \
+    data.max_response_length=512 \
+    +data.max_length=4096 \
+    +data.max_token_len_per_gpu=4096 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.actor.strategy=torchtitan \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.use_remove_padding=False \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.actor.torchtitan.use_torch_compile=False \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=4096 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    +actor_rollout_ref.ref_in_actor=True \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=4096 \
+    actor_rollout_ref.hybrid_engine=False \
+    actor_rollout_ref.actor.torchtitan.tensor_parallel_size=2 \
+    actor_rollout_ref.actor.torchtitan.data_parallel_shard_size=4 \
+    actor_rollout_ref.actor.torchtitan.pipeline_parallel_size=1 \
+    actor_rollout_ref.actor.torchtitan.attn_type=varlen \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.tensor_model_parallel_size="${TOTAL_ROLLOUT_CHIPS}" \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.n=2 \
+    actor_rollout_ref.rollout.load_format=safetensors \
+    actor_rollout_ref.rollout.dtype=bfloat16 \
+    actor_rollout_ref.rollout.layered_summon=True \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=4096 \
+    actor_rollout_ref.rollout.checkpoint_engine.backend=tpu \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.max_model_len=512 \
+    trainer.val_before_train=False \
+    trainer.logger="['console','tensorboard','wandb']" \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}" \
+    trainer.save_freq=-1 \
+    trainer.test_freq=2 \
+    trainer.total_epochs=10 \
+    trainer.total_training_steps=5 \
+    trainer.nnodes="${NNODES_TRAINER}" \
+    trainer.n_gpus_per_node="${N_CHIPS_TRAINER}" \
+    actor_rollout_ref.rollout.nnodes="${NNODES_ROLLOUT}" \
+    actor_rollout_ref.rollout.n_gpus_per_node="${N_CHIPS_ROLLOUT}" \
+    +rollout.nnodes="${NNODES_ROLLOUT}" \
+    +rollout.n_gpus_per_node="${N_CHIPS_ROLLOUT}" "$@"

--- a/examples/tpu/sft/run_qwen3_0_6b_torchtitan.sh
+++ b/examples/tpu/sft/run_qwen3_0_6b_torchtitan.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# TorchTitan | SFT Training | Qwen3-0.6B | TPU v6e-4 Local VM
+#
+# Hardware Setup:
+#   1 Slice of TPU v6e-4 (1 physical host VM, 4 TPU chips total).
+#   
+# Parallelism Config:
+#   TP (Tensor Parallel) = 2
+#   DP (Data Parallel / FSDP) = 2
+#   PP (Pipeline Parallel) = 1
+#   Total Chips = TP * DP * PP = 2 * 2 * 1 = 4 chips.
+
+set -xeuo pipefail
+
+export RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS=1
+export VERL_PLATFORM=tpu
+export RAY_OVERRIDE_JOB_RUNTIME_ENV=1
+export PYTHONUNBUFFERED=1
+
+# Disable XLA HLO fusion passes for stable TPU compiler execution
+export XLA_FLAGS="--xla_disable_hlo_passes=instruction-fusion,fusion-merger,multi-output-fusion,horizontal-fusion"
+
+# Project and Experiment details
+project_name='GRPO_TPU_SFT'
+exp_name='SFT-Qwen3-0.6B-tpu-torchtitan-v6e4'
+
+# Paths (overridable via env vars; supports HuggingFace model ID or local path)
+MODEL_PATH="${MODEL_PATH:-assets/hf/Qwen3-0.6B}"
+TRAIN_FILE="${TRAIN_FILE:-gsm8k_sft/train.parquet}"
+TEST_FILE="${TEST_FILE:-gsm8k_sft/test.parquet}"
+
+# JAX/XLA Memory Preallocation and Launch Barrier Configuration
+export LIBTPU_INIT_ARGS="--xla_tpu_use_enhanced_launch_barrier=false --xla_tpu_scoped_vmem_limit_kib=65536"
+
+# TPU Node topology configs
+export NNODES_TRAINER=1       # 1 physical VM host
+export N_CHIPS_TRAINER=4      # 4 TPU chips per VM host
+
+# Launch Ray SFT Trainer
+# We use the SFT Trainer Ray entrypoint to orchestrate across TPU VMs
+python3 -m verl.trainer.sft_trainer_ray \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.val_max_samples=32 \
+    data.train_batch_size=16 \
+    data.micro_batch_size_per_gpu=2 \
+    data.pad_mode=tpu_binned_pack \
+    data.truncation=error \
+    data.use_dynamic_bsz=False \
+    data.max_length=2048 \
+    data.max_token_len_per_gpu=2048 \
+    data.ignore_input_ids_mismatch=True \
+    model.use_remove_padding=False \
+    engine=torchtitan \
+    model=hf_model \
+    model.path="${MODEL_PATH}" \
+    optim=torchtitan \
+    optim.lr=1e-5 \
+    optim.lr_warmup_steps_ratio=0.2 \
+    optim.weight_decay=0.1 \
+    optim.betas="[0.9,0.95]" \
+    optim.clip_grad=1.0 \
+    optim.min_lr_factor=0.1 \
+    optim.decay_type=cosine \
+    trainer.total_training_steps=8 \
+    engine.tensor_parallel_size=2 \
+    engine.pipeline_parallel_size=1 \
+    engine.context_parallel_size=1 \
+    engine.data_parallel_shard_size=2 \
+    engine.use_torch_compile=False \
+    engine.attn_type=varlen \
+    engine.max_seq_len=2048 \
+    trainer.test_freq=after_each_epoch \
+    trainer.save_freq=-1 \
+    trainer.logger="['console']" \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}" \
+    trainer.total_epochs=2 \
+    trainer.resume_mode=disable \
+    trainer.nnodes="${NNODES_TRAINER}" \
+    trainer.n_gpus_per_node="${N_CHIPS_TRAINER}" \
+    "$@"

--- a/tests/special_sanity/check_device_api_usage.py
+++ b/tests/special_sanity/check_device_api_usage.py
@@ -29,6 +29,7 @@ CUDA_KEYWORD_CHECK_WHITELIST = [
     "verl/plugin/platform/platform_base.py",  # docstring mentions torch.cuda
     "verl/plugin/platform/platform_cuda.py",  # CUDA platform implementation
     "verl/plugin/platform/platform_rocm.py",  # ROCm platform reuses torch.cuda via hipify
+    "verl/plugin/platform/platform_tpu.py",  # TPU platform overrides platform_cuda behaviors
     "verl/plugin/platform/platform_manager.py",  # platform auto-detection probes torch.cuda
     "verl/utils/profiler/nvtx_profile.py",  # appear in NsightSystemsProfiler
     "verl/utils/profiler/torch_profile.py",  # appear in TorchProfiler

--- a/tests/special_sanity/check_example_naming.py
+++ b/tests/special_sanity/check_example_naming.py
@@ -78,6 +78,7 @@ ALLOWED_BACKENDS = (
     "mindspeed",
     "automodel",
     "veomni",
+    "torchtitan",
 )
 
 # Directories whose scripts have their own conventions and are exempt from

--- a/tests/special_sanity/check_license.py
+++ b/tests/special_sanity/check_license.py
@@ -32,6 +32,7 @@ license_head_huawei = "Copyright (c) 2025 Huawei Technologies Co., Ltd. All Righ
 license_head_huawei_26 = "Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved."
 license_head_nvidia = "Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved."
 license_head_baai = "Copyright (c) 2026 BAAI. All rights reserved."
+license_head_google_baai = "Copyright 2024-2025 BAAI and Google LLC"
 license_headers = [
     license_head_bytedance,
     license_head_bytedance_25,
@@ -48,6 +49,7 @@ license_headers = [
     license_head_huawei_26,
     license_head_nvidia,
     license_head_baai,
+    license_head_google_baai,
 ]
 
 

--- a/verl/checkpoint_engine/__init__.py
+++ b/verl/checkpoint_engine/__init__.py
@@ -71,3 +71,10 @@ try:
     __all__ += ["DeltaShardedCheckpointEngine"]
 except ImportError:
     DeltaShardedCheckpointEngine = None
+
+try:
+    from .tpu_checkpoint_engine import TPUCheckpointEngine
+
+    __all__ += ["TPUCheckpointEngine"]
+except ImportError:
+    TPUCheckpointEngine = None

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -19,6 +19,7 @@ from typing import Any, AsyncGenerator, Generator
 import ray
 import torch
 
+from verl.plugin.platform import get_platform
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup
@@ -302,6 +303,14 @@ class CheckpointEngineWorker(Worker):
         self.model_config = model_config
 
         self.server_adapter: BaseRollout = server_adapter
+        if get_platform().device_name == "tpu":
+            self.checkpoint_engine = None
+            self.server_adapter = None
+            self.replica_rank = kwargs.get("replica_rank", 0)
+            self.extra_rollout_args = args
+            self.extra_rollout_kwargs = kwargs
+            return
+
         backend = self.rollout_config.checkpoint_engine.backend
         if backend == "delta_sharded" and self.rollout_config.name != "sglang":
             raise NotImplementedError(
@@ -333,6 +342,8 @@ class CheckpointEngineWorker(Worker):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
     async def update_weights(self, global_steps: int = None):
+        if self.checkpoint_engine is None:
+            return
         weights = self.checkpoint_engine.receive_weights(global_steps=global_steps)
         await self.server_adapter.update_weights(
             weights,
@@ -342,16 +353,22 @@ class CheckpointEngineWorker(Worker):
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE, blocking=False)
     def execute_checkpoint_engine(self, method: str, *args, **kwargs):
+        if self.checkpoint_engine is None:
+            return None
         return getattr(self.checkpoint_engine, method)(*args, **kwargs)
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def get_replica_rank(self) -> int:
         """Get replica rank from the underlying rollout server adapter."""
+        if self.server_adapter is None:
+            return getattr(self, "replica_rank", 0)
         return self.server_adapter.replica_rank
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def is_leader_rank(self) -> bool:
         """Get leader rank flag from the underlying rollout server adapter."""
+        if self.server_adapter is None:
+            return True
         return self.server_adapter.is_leader_rank
 
 
@@ -495,10 +512,15 @@ class CheckpointEngineManager:
             ray.get(self.actor_wg.update_weights(global_steps=global_steps, mode=self.backend))
             return {}
 
+        if self.backend == "tpu":
+            from .tpu_checkpoint_engine import update_tpu_weights
+
+            return await update_tpu_weights(self, global_steps=global_steps)
+
         # 1. abort and save all unfinished requests for partial rollout
         await self.abort_replicas()
 
-        # 2. create a temporay worker group for all replicas
+        # 2. create a temporary worker group for all replicas
         workers = []
         for replica in self.replicas:
             workers.extend(replica.workers)

--- a/verl/checkpoint_engine/tpu_checkpoint_engine.py
+++ b/verl/checkpoint_engine/tpu_checkpoint_engine.py
@@ -1,0 +1,387 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import re
+import time
+from typing import Any, Generator
+
+import ray
+import torch
+from torch.distributed.tensor import DTensor
+
+from verl.checkpoint_engine.base import (
+    CheckpointEngine,
+    CheckpointEngineRegistry,
+)
+
+from .tpu_weight_registry import TPUWeightRegistry
+
+logger = logging.getLogger(__name__)
+
+# --- GLOBAL CONFIGURATION / CONSTANTS FOR WEIGHT TRANSFER ---
+SYNC_LAYER_BY_LAYER = False  # Qwen3-0.6B is small, whole-model sync is fast and safe
+TPU_COPY_CHUNK_SIZE_PARAMETERS = 30
+
+# =====================================================================
+# Namespace & Formatting Utilities
+# =====================================================================
+
+
+def get_clean_name(name: str) -> str:
+    """Strip FSDP/DCP wrapper prefixes from state dict keys to match standard model namespaces."""
+    return name.replace("_fsdp_wrapped_module.", "").replace("_checkpoint_wrapped_module.", "").replace("module.", "")
+
+
+def get_layer_group(key: str) -> str:
+    """Given a state dict key, returns its group name (e.g. 'embeddings', 'layers.0', 'output')."""
+    clean_k = get_clean_name(key)
+    match = re.search(r"layers\.(\d+)\.", clean_k)
+    if match:
+        return f"layers.{match.group(1)}"
+    elif "tok_embeddings" in clean_k:
+        return "embeddings"
+    else:
+        return "output"
+
+
+# =====================================================================
+# TPU Worker Weight Injection & Slicing
+# =====================================================================
+
+
+def load_weights_on_worker(vllm_model, state_dict: dict, rank: int) -> int:
+    """
+    Worker-side weight loader. Performs host-side CPU sharding (slicing)
+    and chunked, memory-safe, JIT-partitioned PCIe copying to TPU.
+    """
+    t_start = time.perf_counter()
+
+    if isinstance(state_dict, dict) and "grouped" in state_dict:
+        grouped_dict = state_dict["grouped"]
+    else:
+        grouped_dict = {"all": state_dict}
+
+    total_keys = 0
+    from concurrent.futures import ThreadPoolExecutor
+
+    temp_tpu_tensors = []
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        for group_name, group_sd in grouped_dict.items():
+            keys_loaded = _load_single_group_on_worker(
+                vllm_model, group_sd, rank, executor=executor, temp_tpu_tensors=temp_tpu_tensors
+            )
+            total_keys += keys_loaded
+
+    import torch_tpu
+
+    torch_tpu._internal.sync.synchronize(wait=True)
+    del temp_tpu_tensors
+    import gc
+
+    gc.collect()
+
+    t_total = time.perf_counter() - t_start
+    if rank == 0:
+        logger.info(f"Worker 0: Loaded {total_keys} keys in {t_total:.3f}s")
+    return total_keys
+
+
+def _load_single_group_on_worker(vllm_model, group_sd: dict, rank: int, executor=None, temp_tpu_tensors=None) -> int:
+    flat_tensors = group_sd["flat_tensors"]
+    metadata = group_sd["metadata"]
+
+    clean_metadata = {}
+    num_keys = 0
+    for dtype, items in metadata.items():
+        clean_items = []
+        offset = 0
+        for k, shape, numel in items:
+            clean_k = get_clean_name(k)
+            clean_items.append((clean_k, shape, numel, offset))
+            num_keys += 1
+
+            if "tok_embeddings.weight" in clean_k:
+                lm_k = clean_k.replace("tok_embeddings", "lm_head")
+                clean_items.append((lm_k, shape, numel, offset))
+                num_keys += 1
+
+            offset += numel
+        clean_metadata[dtype] = clean_items
+
+    model_sd = vllm_model.model.state_dict()
+
+    def resolve_key(k):
+        if k in model_sd:
+            return k
+        if k.startswith("model.") and k[6:] in model_sd:
+            return k[6:]
+        if f"model.{k}" in model_sd:
+            return f"model.{k}"
+        return k
+
+    for dtype, flat_data in flat_tensors.items():
+        items = clean_metadata.get(dtype, [])
+        if not items:
+            continue
+
+        flat_cpu = torch.from_numpy(flat_data) if not isinstance(flat_data, torch.Tensor) else flat_data
+        if dtype == torch.bfloat16 and flat_cpu.dtype == torch.int16:
+            # COMMENT: On TPU CPU builds (e.g. torch_tpu), converting torch.bfloat16 to numpy raises a TypeError.
+            # Thus, we serialize it as int16 (same bit representation) and view it back to bfloat16 here.
+            # TODO: remove HACK once PyTorch CPU native bfloat16 to numpy conversion is universally stable.
+            flat_cpu = flat_cpu.view(torch.bfloat16)
+
+        local_items = []
+        local_tensors_to_cat = []
+        local_offset = 0
+
+        def process_item_parallel(item, flat_cpu=flat_cpu):
+            k, shape, numel, offset = item
+            target_key = resolve_key(k)
+            if target_key not in model_sd:
+                return None
+
+            target_v = model_sd[target_key]
+            target_local = target_v.to_local() if isinstance(target_v, DTensor) else target_v
+
+            param_cpu_global = flat_cpu[offset : offset + numel].view(shape)
+            if target_local.shape == shape:
+                param_cpu_local = param_cpu_global
+            else:
+                sharded = False
+                for dim in range(len(shape)):
+                    if shape[dim] != target_local.shape[dim]:
+                        shard_size = target_local.shape[dim]
+                        rank_offset = shard_size * rank
+                        indices = [slice(None)] * len(shape)
+                        indices[dim] = slice(rank_offset, rank_offset + shard_size)
+                        # COMMENT: Removed .clone() to enable zero-copy views during slicing.
+                        param_cpu_local = param_cpu_global[tuple(indices)]
+                        sharded = True
+                        break
+                if not sharded:
+                    param_cpu_local = param_cpu_global
+
+            return (target_key, target_local.shape, target_local.numel(), param_cpu_local.reshape(-1))
+
+        if executor is None:
+            from concurrent.futures import ThreadPoolExecutor
+
+            with ThreadPoolExecutor(max_workers=8) as local_exec:
+                sliced_results = list(local_exec.map(process_item_parallel, items))
+        else:
+            sliced_results = list(executor.map(process_item_parallel, items))
+
+        for res in sliced_results:
+            if res is None:
+                continue
+            target_key, target_shape, target_numel, param_cpu_local_flat = res
+            local_tensors_to_cat.append(param_cpu_local_flat)
+            local_items.append((target_key, target_shape, target_numel, local_offset))
+            local_offset += target_numel
+
+        if not local_tensors_to_cat:
+            continue
+
+        flat_local_cpu = torch.cat(local_tensors_to_cat)
+
+        chunks = [
+            local_items[i : i + TPU_COPY_CHUNK_SIZE_PARAMETERS]
+            for i in range(0, len(local_items), TPU_COPY_CHUNK_SIZE_PARAMETERS)
+        ]
+
+        for chunk in chunks:
+            chunk_start_offset = chunk[0][3]
+            chunk_end_offset = chunk[-1][3] + chunk[-1][2]
+            flat_chunk_cpu = flat_local_cpu[chunk_start_offset:chunk_end_offset]
+
+            flat_chunk_tpu = flat_chunk_cpu.to("tpu")
+            if temp_tpu_tensors is not None:
+                temp_tpu_tensors.append(flat_chunk_tpu)
+
+            for target_key, local_shape, local_numel, offset in chunk:
+                local_offset = offset - chunk_start_offset
+                slice_tpu = flat_chunk_tpu[local_offset : local_offset + local_numel].view(local_shape)
+
+                target_v = model_sd[target_key]
+                target_local = target_v.to_local() if isinstance(target_v, DTensor) else target_v
+                target_local.copy_(slice_tpu)
+
+            if temp_tpu_tensors is None:
+                del flat_chunk_tpu
+                import torch_tpu
+
+                torch_tpu._internal.sync.synchronize(wait=True)
+
+    return num_keys
+
+
+# =====================================================================
+# TPUCheckpointEngine Registration
+# =====================================================================
+
+
+@CheckpointEngineRegistry.register("tpu")
+class TPUCheckpointEngine(CheckpointEngine):
+    def __init__(self, bucket_size: int = 0, is_master: bool = False, **kwargs) -> None:
+        self.is_master = is_master
+        self.bucket_size = bucket_size
+
+        # Connect to or create named Ray TPUWeightRegistry actor
+        try:
+            self.registry = ray.get_actor("TPUWeightRegistry", namespace="verl")
+        except ValueError:
+            try:
+                # COMMENT: Since TPUWeightRegistry is already a remote class decorated with @ray.remote,
+                # wrapping it with ray.remote(TPUWeightRegistry) throws a TypeError.
+                # Calling TPUWeightRegistry.options directly is the correct way to specify options.
+                # TODO: remove HACK once a unified and clean TPU checkpoint/weight registry engine is standard.
+                self.registry = TPUWeightRegistry.options(
+                    name="TPUWeightRegistry", namespace="verl", lifetime="detached"
+                ).remote()
+            except Exception:
+                self.registry = ray.get_actor("TPUWeightRegistry", namespace="verl")
+
+    def prepare(self) -> dict[str, Any]:
+        return {}
+
+    @classmethod
+    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        return {}, {}
+
+    def init_process_group(self, **kwargs):
+        pass
+
+    def finalize(self):
+        pass
+
+    @torch.no_grad()
+    async def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
+        t_start = time.perf_counter()
+
+        try:
+            import torch_tpu
+
+            torch_tpu._internal.sync.synchronize(wait=True)
+        except Exception:
+            pass
+
+        if not self.is_master:
+            # Non-master ranks must consume the generator to prevent hangs
+            for _ in weights:
+                pass
+            return
+
+        step_key = global_steps if global_steps is not None else 0
+        logger.info(f"@@@ TPUCheckpointEngine: [Step {step_key}] Start send_weights...")
+
+        # Time generator consumption and CPU offloading
+        t_offload_start = time.perf_counter()
+        grouped_weights = {}
+        for k, v in weights:
+            cpu_v = v.detach().cpu()
+            if "layers." in k:
+                # Extract layer part: model.layers.12.self_attn... -> model.layers.12
+                parts = k.split(".")
+                idx = parts.index("layers")
+                group_name = ".".join(parts[: idx + 2])
+            else:
+                group_name = "other"
+            grouped_weights.setdefault(group_name, []).append((k, cpu_v))
+        t_offload = time.perf_counter() - t_offload_start
+
+        # Time grouping and flattening
+        t_group_start = time.perf_counter()
+        grouped_dict = {}
+        for group_name, group_items in grouped_weights.items():
+            by_dtype = {}
+            for k, cpu_v in group_items:
+                by_dtype.setdefault(cpu_v.dtype, []).append((k, cpu_v))
+
+            flat_tensors = {}
+            metadata = {}
+            for dtype, items in by_dtype.items():
+                flat_cpu = torch.cat([v.view(-1) for _, v in items])
+                if dtype == torch.bfloat16:
+                    flat_tensors[dtype] = flat_cpu.view(torch.int16).numpy()
+                else:
+                    flat_tensors[dtype] = flat_cpu.numpy()
+                metadata[dtype] = [(k, v.shape, v.numel()) for k, v in items]
+
+            grouped_dict[group_name] = {"flat_tensors": flat_tensors, "metadata": metadata}
+
+        state_dict = {"grouped": grouped_dict}
+        t_group = time.perf_counter() - t_group_start
+
+        # Time Ray Put upload
+        t_put_start = time.perf_counter()
+        ref = ray.put(state_dict)
+        t_put = time.perf_counter() - t_put_start
+
+        # Time Registry update
+        t_reg_start = time.perf_counter()
+        await self.registry.set_weights.remote(step_key, ref)
+        t_reg = time.perf_counter() - t_reg_start
+
+        t_total = time.perf_counter() - t_start
+        logger.debug(
+            f"TPUCheckpointEngine Phase A [Step {step_key}]: Total={t_total:.3f}s, "
+            f"Offload={t_offload:.3f}s, GroupFlatten={t_group:.3f}s, RayPut={t_put:.3f}s, Registry={t_reg:.3f}s"
+        )
+
+    async def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        # Rollout uses load_weights_from_ray_registry directly, receive_weights is unused
+        raise NotImplementedError("Rollout on TPU uses direct load_weights_from_ray_registry via collective_rpc.")
+
+
+async def update_tpu_weights(manager, global_steps: int | None = None) -> dict:
+    """Synchronize weights from actor worker group to rollout replicas on TPU."""
+    t_abort_start = time.perf_counter()
+    if global_steps and global_steps > 0:
+        try:
+            await manager.abort_replicas()
+        except Exception as e:
+            logger.warning(f"Failed to abort replicas at step {global_steps}: {e}")
+    t_abort = time.perf_counter() - t_abort_start
+
+    t_total_start = time.perf_counter()
+    # 1. Extract and upload weights on trainer side (Rank 0 sends to Ray Plasma)
+    actor_refs = manager.actor_wg.update_weights(global_steps=global_steps, mode=manager.backend)
+    if isinstance(actor_refs, list):
+        await asyncio.gather(*actor_refs)
+    elif actor_refs is not None:
+        await actor_refs
+
+    # 2. Call collective_rpc on all rollout replicas to load weights from the registry
+    step_key = global_steps if global_steps is not None else 0
+    futures = [
+        replica.server_handle.collective_rpc.remote(method="load_weights_from_ray_registry", args=(step_key,))
+        for replica in manager.replicas
+    ]
+    await asyncio.gather(*futures)
+    t_total = time.perf_counter() - t_total_start
+
+    logger.info(f"TPU weight sync for step {global_steps} completed in {t_total + t_abort:.3f}s")
+
+    await manager.resume_generation_replicas()
+    return {}

--- a/verl/checkpoint_engine/tpu_weight_registry.py
+++ b/verl/checkpoint_engine/tpu_weight_registry.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ray
+
+"""Lightweight CPU-only Ray actor registry for tracking TPU weight checkpoint references."""
+
+
+@ray.remote(num_cpus=0)
+class TPUWeightRegistry:
+    """Ray actor for holding references to synchronized TPU model weights across steps."""
+
+    def __init__(self):
+        self.weights = {}
+
+    def set_weights(self, step, ref):
+        self.weights[step] = ref
+        # Keep only the last 1 step to prevent memory leaks and disk spilling.
+        steps_to_keep = sorted(self.weights.keys())
+        if len(steps_to_keep) > 1:
+            for old_step in steps_to_keep[:-1]:
+                old_ref = self.weights[old_step]
+                if isinstance(old_ref, str):
+                    try:
+                        import os
+
+                        if os.path.exists(old_ref):
+                            os.remove(old_ref)
+                    except Exception:
+                        pass
+                del self.weights[old_step]
+
+    def get_weights(self, step):
+        return self.weights.get(step, None)

--- a/verl/plugin/platform/platform_manager.py
+++ b/verl/plugin/platform/platform_manager.py
@@ -172,3 +172,4 @@ def set_platform(platform: PlatformBase) -> None:
 from .platform_cuda import PlatformCUDA  # noqa: E402, F401
 from .platform_npu import PlatformNPU  # noqa: E402, F401
 from .platform_rocm import PlatformROCm  # noqa: E402, F401
+from .platform_tpu import PlatformTPU  # noqa: E402, F401

--- a/verl/plugin/platform/platform_tpu.py
+++ b/verl/plugin/platform/platform_tpu.py
@@ -1,0 +1,295 @@
+# Copyright 2024-2025 BAAI and Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Google TPU platform implementation.
+
+TPU with PyTorch/XLA (torch_tpu) reuses the ``torch.cuda.*`` API surface, so most of
+``PlatformCUDA`` works unchanged. This class subclasses ``PlatformCUDA`` and overrides
+device-specific environment configuration, resource options, and memory management proxies.
+"""
+
+import logging
+import os
+from typing import Any
+
+import ray
+import torch
+
+from .platform_cuda import PlatformCUDA
+from .platform_manager import PlatformRegistry, get_platform
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Communication port defaults for TPU distributed slice builder meshes
+ROLLOUT_BASE_PORT = 8070
+TRAINER_BASE_PORT = 8471
+
+# TPU Chip HBM capacities in bytes
+HBM_BYTES_TPU_V5P = 95 * 1024 * 1024 * 1024  # 95 GB
+HBM_BYTES_TPU_V6E = 32 * 1024 * 1024 * 1024  # 32 GB
+HBM_BYTES_TPU_V7X = 192 * 1024 * 1024 * 1024  # 192 GB
+
+
+def get_tpu_chip_hbm_bytes() -> int:
+    """Detects the TPU chip generation from Ray node labels or environment variables and returns its HBM capacity."""
+    tpu_type = ""
+
+    # Query Ray cluster node labels for TPU resource type
+    try:
+        if ray.is_initialized():
+            tpu_nodes = [node for node in ray.nodes() if "TPU" in node.get("Resources", {}) and node.get("Alive")]
+            if tpu_nodes:
+                labels = tpu_nodes[0].get("Labels", {})
+                tpu_type = (labels.get("ray.io/accelerator-type") or labels.get("ray.io/tpu-pod-type") or "").lower()
+    except Exception as e:
+        logger.debug(f"Unable to query Ray node labels for TPU chip type: {e}")
+
+    # Fallback to environment variables
+    if not tpu_type:
+        tpu_type = (
+            os.environ.get("TPU_ACCELERATOR_TYPE")
+            or os.environ.get("ACCELERATOR_TYPE")
+            or os.environ.get("TPU_TYPE")
+            or ""
+        ).lower()
+
+    if "v5p" in tpu_type:
+        return HBM_BYTES_TPU_V5P
+    elif "v6e" in tpu_type:
+        return HBM_BYTES_TPU_V6E
+    elif "v7x" in tpu_type:
+        return HBM_BYTES_TPU_V7X
+    else:
+        logger.warning(f"Unable to determine TPU chip HBM bytes for tpu_type='{tpu_type}'. Returning -1.")
+        return -1
+
+
+# Enforce static compilation graph for torch.compile on TPU
+try:
+    _orig_compile = torch.compile
+
+    def patched_compile(*args, **kwargs):
+        if get_platform().device_name == "tpu":
+            kwargs["dynamic"] = False
+        return _orig_compile(*args, **kwargs)
+
+    torch.compile = patched_compile
+except Exception as e:
+    logger.warning(f"Failed to patch torch.compile for TPU: {e}")
+
+
+class DummyTpuDeviceModule:
+    """Fallback device module for CPU-only nodes and driver processes.
+
+    Provides no-op implementations for torch.tpu APIs on processes where torch_tpu is not imported
+    or no TPU devices are attached.
+    """
+
+    def is_available(self) -> bool:
+        return False
+
+    def set_device(self, device_index: Any) -> None:
+        pass
+
+    def current_device(self) -> int:
+        return 0
+
+    def device_count(self) -> int:
+        return 0
+
+    def synchronize(self) -> None:
+        pass
+
+    def manual_seed(self, seed: int) -> None:
+        torch.manual_seed(seed)
+
+    def manual_seed_all(self, seed: int) -> None:
+        torch.manual_seed(seed)
+
+
+class TPUDeviceModuleProxy:
+    """Proxy wrapper for torch.tpu to emulate PyTorch CUDA memory management APIs.
+
+    Provides default fallback implementations for CUDA memory tracking methods
+    (e.g., memory_reserved, memory_allocated, get_device_properties) that are called throughout verl's codebase
+    but not natively provided by torch_tpu.
+    """
+
+    def __init__(self, original_module):
+        self.__dict__["_original_module"] = original_module
+
+    def __getattr__(self, name):
+        if name == "set_device":
+            return self.set_device
+        elif name in ("memory_reserved", "memory_allocated", "max_memory_reserved", "max_memory_allocated"):
+            return lambda *args, **kwargs: 0
+        elif name in ("reset_peak_memory_stats", "reset_accumulated_memory_stats"):
+            return lambda *args, **kwargs: None
+        elif name == "empty_cache":
+            return self.empty_cache
+        elif name == "get_device_properties":
+            hbm_bytes = get_tpu_chip_hbm_bytes()
+            return lambda device_index=None: type("DeviceProps", (), {"total_memory": hbm_bytes})()
+        elif name == "mem_get_info":
+            hbm_bytes = get_tpu_chip_hbm_bytes()
+            return lambda *args, **kwargs: (hbm_bytes, hbm_bytes)
+        return getattr(self._original_module, name)
+
+    def set_device(self, device_index: Any) -> None:
+        pass
+
+    def empty_cache(self) -> None:
+        if hasattr(self._original_module, "_clear_cache"):
+            try:
+                self._original_module._clear_cache()
+            except Exception as e:
+                logger.warning(f"Failed to clear TPU cache: {e}")
+
+
+@PlatformRegistry.register(platform="tpu")
+class PlatformTPU(PlatformCUDA):
+    """Platform backend for Google TPUs (subclasses PlatformCUDA for API compatibility)."""
+
+    @property
+    def vendor_name(self) -> str:
+        return "google"
+
+    @property
+    def device_name(self) -> str:
+        return "tpu"
+
+    @property
+    def device_module(self):
+        original_tpu = getattr(torch, "tpu", DummyTpuDeviceModule())
+        return TPUDeviceModuleProxy(original_tpu)
+
+    def current_device(self) -> int:
+        return self.device_module.current_device()
+
+    def device_count(self) -> int:
+        return self.device_module.device_count()
+
+    def set_device(self, device_index: int) -> None:
+        self.device_module.set_device(device_index)
+
+    def synchronize(self, device_index: int | None = None) -> None:
+        self.device_module.synchronize()
+
+    def manual_seed(self, seed: int) -> None:
+        torch.manual_seed(seed)
+
+    def manual_seed_all(self, seed: int) -> None:
+        self.device_module.manual_seed_all(seed)
+
+    def is_available(self) -> bool:
+        if hasattr(torch, "tpu"):
+            try:
+                return torch.tpu.is_available()
+            except Exception as e:
+                logger.warning(f"torch.tpu.is_available() check failed: {e}")
+        return False
+
+    def is_platform_available(self, use_smi_check=False) -> bool:
+        if os.environ.get("VERL_PLATFORM") == "tpu":
+            return True
+        if "TPU_NAME" in os.environ or "TPU_VISIBLE_DEVICES" in os.environ:
+            return True
+        return False
+
+    def ray_resource_name(self) -> str:
+        return "TPU"
+
+    def ray_resource_options(self, num_gpus: float) -> dict[str, Any]:
+        tpu_chips = int(num_gpus)
+        return {"resources": {"TPU": tpu_chips}} if tpu_chips >= 1 else {}
+
+    def communication_backend_name(self) -> str:
+        return "tpu_dist"
+
+    def ray_noset_envvars(self) -> list[str]:
+        return super().ray_noset_envvars() + [
+            "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
+        ]
+
+    def get_tpu_env_vars(
+        self,
+        rank: int,
+        world_size: int,
+        local_rank: int,
+        local_world_size: int,
+        name_prefix: str,
+        pgs: list,
+    ) -> dict[str, str]:
+        """Generates TPU-specific distributed environment variables for PJRT mesh initialization."""
+        node_ip_map = {node["NodeID"]: node["NodeManagerAddress"] for node in ray.nodes()}
+        pg_ips = []
+        for pg in pgs:
+            specs = ray._private.state.state.placement_group_table(pg.id)
+            node_id = specs["bundles_to_node_id"][0]
+            pg_ips.append(node_ip_map[node_id])
+
+        is_rollout = "rollout" in name_prefix.lower()
+        base_port = ROLLOUT_BASE_PORT if is_rollout else TRAINER_BASE_PORT
+
+        sb_addresses = []
+        for ip in pg_ips:
+            for lr in range(local_world_size):
+                sb_addresses.append(f"{ip}:{base_port + lr}")
+
+        env_vars = {
+            "TORCH_TPU_SLICEBUILDER_ADDRESSES": ",".join(sb_addresses),
+            "TPU_PROCESS_ADDRESSES": ",".join(sb_addresses),
+            "TPU_PROCESS_PORT": str(base_port + local_rank),
+            "CLOUD_TPU_TASK_ID": str(rank // local_world_size),
+            "TPU_WORKER_HOSTNAMES": ",".join(pg_ips),
+            "TPU_VISIBLE_CHIPS": str(local_rank),
+        }
+
+        # Apply TPU topology and host bounds based on TPU pod type or world size
+        tpu_nodes = [node for node in ray.nodes() if "TPU" in node.get("Resources", {}) and node.get("Alive")]
+        tpu_type = tpu_nodes[0].get("Labels", {}).get("ray.io/tpu-pod-type", "") if tpu_nodes else ""
+
+        if tpu_type == "v6e-32":
+            topo = "4,8,1"
+        elif tpu_type == "v6e-8":
+            topo = "2,4,1"
+        elif tpu_type == "v6e-4":
+            topo = "2,2,1"
+        else:
+            topo = (
+                "4,8,1"
+                if world_size == 32
+                else ("2,4,1" if world_size == 8 else ("2,2,1" if world_size == 4 else "1,1,1"))
+            )
+
+        env_vars.update(
+            {
+                "TORCH_TPU_TOPOLOGY": topo,
+                "TPU_HOST_BOUNDS": topo,
+                "TPU_CHIPS_PER_HOST_BOUNDS": "1,1,1",
+                "CHIPS_PER_HOST": "4",
+            }
+        )
+
+        if is_rollout:
+            env_vars.update(
+                {
+                    "SKIP_JAX_PRECOMPILE": "1",
+                    "VLLM_ENABLE_V1_MULTIPROCESSING": "1",
+                }
+            )
+            if world_size > 1:
+                env_vars["TPU_MULTIHOST_BACKEND"] = "ray"
+
+        return env_vars

--- a/verl/plugin/platform/platform_tpu.py
+++ b/verl/plugin/platform/platform_tpu.py
@@ -20,13 +20,14 @@ device-specific environment configuration, resource options, and memory manageme
 
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 import ray
 import torch
 
 from .platform_cuda import PlatformCUDA
 from .platform_manager import PlatformRegistry, get_platform
+from .platform_tpu_workarounds import convert_tensors_to_scalars, patch_ray_worker
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -39,6 +40,22 @@ TRAINER_BASE_PORT = 8471
 HBM_BYTES_TPU_V5P = 95 * 1024 * 1024 * 1024  # 95 GB
 HBM_BYTES_TPU_V6E = 32 * 1024 * 1024 * 1024  # 32 GB
 HBM_BYTES_TPU_V7X = 192 * 1024 * 1024 * 1024  # 192 GB
+
+TPU_HBM_BYTES_MAP = {
+    "v5p": HBM_BYTES_TPU_V5P,
+    "v6e": HBM_BYTES_TPU_V6E,
+    "v7x": HBM_BYTES_TPU_V7X,
+}
+
+# TPU default 3D mesh topology mappings by pod type or total chips
+TPU_TOPOLOGY_MAP = {
+    "v6e-32": "4,8,1",
+    "v6e-8": "2,4,1",
+    "v6e-4": "2,2,1",
+    32: "4,8,1",
+    8: "2,4,1",
+    4: "2,2,1",
+}
 
 
 def get_tpu_chip_hbm_bytes() -> int:
@@ -53,7 +70,7 @@ def get_tpu_chip_hbm_bytes() -> int:
                 labels = tpu_nodes[0].get("Labels", {})
                 tpu_type = (labels.get("ray.io/accelerator-type") or labels.get("ray.io/tpu-pod-type") or "").lower()
     except Exception as e:
-        logger.debug(f"Unable to query Ray node labels for TPU chip type: {e}")
+        logger.warning(f"Unable to query Ray node labels for TPU chip type: {e}")
 
     # Fallback to environment variables
     if not tpu_type:
@@ -64,15 +81,12 @@ def get_tpu_chip_hbm_bytes() -> int:
             or ""
         ).lower()
 
-    if "v5p" in tpu_type:
-        return HBM_BYTES_TPU_V5P
-    elif "v6e" in tpu_type:
-        return HBM_BYTES_TPU_V6E
-    elif "v7x" in tpu_type:
-        return HBM_BYTES_TPU_V7X
-    else:
-        logger.warning(f"Unable to determine TPU chip HBM bytes for tpu_type='{tpu_type}'. Returning -1.")
-        return -1
+    for chip_gen, hbm_bytes in TPU_HBM_BYTES_MAP.items():
+        if chip_gen in tpu_type:
+            return hbm_bytes
+
+    logger.warning(f"Unable to determine TPU chip HBM bytes for tpu_type='{tpu_type}'. Returning -1.")
+    return -1
 
 
 # Enforce static compilation graph for torch.compile on TPU
@@ -132,22 +146,81 @@ class TPUDeviceModuleProxy:
     def __getattr__(self, name):
         if name == "set_device":
             return self.set_device
-        elif name in ("memory_reserved", "memory_allocated", "max_memory_reserved", "max_memory_allocated"):
+
+        if hasattr(self._original_module, name):
+            return getattr(self._original_module, name)
+
+        if name == "memory_reserved":
             return lambda *args, **kwargs: 0
-        elif name in ("reset_peak_memory_stats", "reset_accumulated_memory_stats"):
+        elif name == "memory_allocated":
+            return lambda *args, **kwargs: 0
+        elif name == "max_memory_reserved":
+            return lambda *args, **kwargs: 0
+        elif name == "max_memory_allocated":
+            return lambda *args, **kwargs: 0
+        elif name == "reset_peak_memory_stats":
             return lambda *args, **kwargs: None
-        elif name == "empty_cache":
-            return self.empty_cache
         elif name == "get_device_properties":
+
+            class DummyDeviceProperties:
+                def __init__(self, total_memory=32 * 1024 * 1024 * 1024):
+                    self.total_memory = total_memory
+                    self.name = "Google TPU"
+                    self.major = 1
+                    self.minor = 0
+
             hbm_bytes = get_tpu_chip_hbm_bytes()
-            return lambda device_index=None: type("DeviceProps", (), {"total_memory": hbm_bytes})()
+            total_mem = hbm_bytes if hbm_bytes > 0 else 32 * 1024 * 1024 * 1024
+            return lambda *args, **kwargs: DummyDeviceProperties(total_memory=total_mem)
         elif name == "mem_get_info":
             hbm_bytes = get_tpu_chip_hbm_bytes()
-            return lambda *args, **kwargs: (hbm_bytes, hbm_bytes)
-        return getattr(self._original_module, name)
+            total_mem = hbm_bytes if hbm_bytes > 0 else 32 * 1024 * 1024 * 1024
+            return lambda *args, **kwargs: (total_mem, total_mem)
+
+        raise AttributeError(f"'TPUDeviceModuleProxy' object has no attribute '{name}'")
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+        else:
+            setattr(self._original_module, name, value)
+
+    def is_available(self) -> bool:
+        if hasattr(self._original_module, "is_available"):
+            try:
+                return self._original_module.is_available()
+            except Exception as e:
+                logger.warning(f"torch.tpu.is_available() check failed: {e}")
+                return False
+        return False
 
     def set_device(self, device_index: Any) -> None:
         pass
+
+    def current_device(self) -> int:
+        if hasattr(self._original_module, "current_device"):
+            try:
+                return self._original_module.current_device()
+            except Exception as e:
+                logger.warning(f"torch.tpu.current_device() failed: {e}")
+                return 0
+        return 0
+
+    def device_count(self) -> int:
+        if hasattr(self._original_module, "device_count"):
+            try:
+                return self._original_module.device_count()
+            except Exception as e:
+                logger.warning(f"torch.tpu.device_count() failed: {e}")
+                return 0
+        return 0
+
+    def synchronize(self, device_index: int | None = None) -> None:
+        if hasattr(self._original_module, "synchronize"):
+            try:
+                self._original_module.synchronize()
+            except Exception as e:
+                logger.warning(f"torch.tpu.synchronize() failed: {e}")
 
     def empty_cache(self) -> None:
         if hasattr(self._original_module, "_clear_cache"):
@@ -161,6 +234,11 @@ class TPUDeviceModuleProxy:
 class PlatformTPU(PlatformCUDA):
     """Platform backend for Google TPUs (subclasses PlatformCUDA for API compatibility)."""
 
+    def __init__(self):
+        super().__init__()
+        original_tpu = getattr(torch, "tpu", DummyTpuDeviceModule())
+        self._device_module = TPUDeviceModuleProxy(original_tpu)
+
     @property
     def vendor_name(self) -> str:
         return "google"
@@ -171,8 +249,7 @@ class PlatformTPU(PlatformCUDA):
 
     @property
     def device_module(self):
-        original_tpu = getattr(torch, "tpu", DummyTpuDeviceModule())
-        return TPUDeviceModuleProxy(original_tpu)
+        return self._device_module
 
     def current_device(self) -> int:
         return self.device_module.current_device()
@@ -232,27 +309,55 @@ class PlatformTPU(PlatformCUDA):
         pgs: list,
     ) -> dict[str, str]:
         """Generates TPU-specific distributed environment variables for PJRT mesh initialization."""
-        node_ip_map = {node["NodeID"]: node["NodeManagerAddress"] for node in ray.nodes()}
-        pg_ips = []
-        for pg in pgs:
+        node_ip_map = {node["NodeID"]: node["NodeManagerAddress"] for node in ray.nodes() if node.get("Alive", False)}
+        bundle_ips = []
+        local_ip = ray.util.get_node_ip_address()
+        clean_prefix = name_prefix.lower().split("_")[0] if name_prefix else ""
+        matching_pgs = []
+
+        # 1. Primary filter: Select placement group containing current worker's node IP
+        for p in pgs:
+            specs = ray._private.state.state.placement_group_table(p.id)
+            if specs.get("state") != "CREATED":
+                continue
+            bundles_map = specs.get("bundles_to_node_id", {})
+            pg_ips = [node_ip_map[node_id] for b_idx, node_id in sorted(bundles_map.items()) if node_id in node_ip_map]
+            if local_ip in pg_ips:
+                matching_pgs.append(p)
+
+        # 2. Secondary fallback: Filter by clean_prefix if placement group names are explicitly set
+        if not matching_pgs and clean_prefix:
+            for p in pgs:
+                p_name = ray._private.state.state.placement_group_table(p.id).get("name", "").lower()
+                if clean_prefix in p_name:
+                    matching_pgs.append(p)
+
+        target_pgs = matching_pgs if matching_pgs else pgs
+
+        for pg in target_pgs:
             specs = ray._private.state.state.placement_group_table(pg.id)
-            node_id = specs["bundles_to_node_id"][0]
-            pg_ips.append(node_ip_map[node_id])
+            if specs.get("state") != "CREATED":
+                continue
+            bundles_map = specs.get("bundles_to_node_id", {})
+            for b_idx in sorted(bundles_map.keys()):
+                node_id = bundles_map[b_idx]
+                if node_id in node_ip_map:
+                    bundle_ips.append(node_ip_map[node_id])
 
         is_rollout = "rollout" in name_prefix.lower()
         base_port = ROLLOUT_BASE_PORT if is_rollout else TRAINER_BASE_PORT
 
-        sb_addresses = []
-        for ip in pg_ips:
-            for lr in range(local_world_size):
-                sb_addresses.append(f"{ip}:{base_port + lr}")
+        sb_addresses = [f"{ip}:{base_port + (b_idx % local_world_size)}" for b_idx, ip in enumerate(bundle_ips)]
+
+        # Extract unique worker hostnames preserving rank order
+        unique_hostnames = list(dict.fromkeys(bundle_ips))
 
         env_vars = {
             "TORCH_TPU_SLICEBUILDER_ADDRESSES": ",".join(sb_addresses),
             "TPU_PROCESS_ADDRESSES": ",".join(sb_addresses),
             "TPU_PROCESS_PORT": str(base_port + local_rank),
             "CLOUD_TPU_TASK_ID": str(rank // local_world_size),
-            "TPU_WORKER_HOSTNAMES": ",".join(pg_ips),
+            "TPU_WORKER_HOSTNAMES": ",".join(unique_hostnames),
             "TPU_VISIBLE_CHIPS": str(local_rank),
         }
 
@@ -260,18 +365,7 @@ class PlatformTPU(PlatformCUDA):
         tpu_nodes = [node for node in ray.nodes() if "TPU" in node.get("Resources", {}) and node.get("Alive")]
         tpu_type = tpu_nodes[0].get("Labels", {}).get("ray.io/tpu-pod-type", "") if tpu_nodes else ""
 
-        if tpu_type == "v6e-32":
-            topo = "4,8,1"
-        elif tpu_type == "v6e-8":
-            topo = "2,4,1"
-        elif tpu_type == "v6e-4":
-            topo = "2,2,1"
-        else:
-            topo = (
-                "4,8,1"
-                if world_size == 32
-                else ("2,4,1" if world_size == 8 else ("2,2,1" if world_size == 4 else "1,1,1"))
-            )
+        topo = TPU_TOPOLOGY_MAP.get(tpu_type, TPU_TOPOLOGY_MAP.get(world_size, "1,1,1"))
 
         env_vars.update(
             {
@@ -293,3 +387,77 @@ class PlatformTPU(PlatformCUDA):
                 env_vars["TPU_MULTIHOST_BACKEND"] = "ray"
 
         return env_vars
+
+    def auto_assign_accelerator_type(self, name_prefix: str, accelerator_type: Optional[str]) -> Optional[str]:
+        """Dynamically assign a TPU slice/group affinity to a resource pool on multi-slice clusters."""
+        if accelerator_type is not None:
+            return accelerator_type
+
+        try:
+            if ray.is_initialized():
+                tpu_slices = set()
+                for node in ray.nodes():
+                    if node.get("Alive"):
+                        for res in node.get("Resources", {}).keys():
+                            if res.startswith("tpu-group-"):
+                                tpu_slices.add(res)
+                tpu_slices = sorted(list(tpu_slices))
+                if len(tpu_slices) >= 2:
+                    if any(k in name_prefix.lower() for k in ["rollout", "reward", "teacher"]):
+                        return tpu_slices[1]
+                    elif any(k in name_prefix.lower() for k in ["trainer", "actor", "global"]):
+                        return tpu_slices[0]
+        except Exception:
+            pass
+
+        return accelerator_type
+
+    def configure_placement_group_bundle(
+        self, bundle: dict, use_gpu: bool, device_name: str, name_prefix: str, accelerator_type: Optional[str] = None
+    ) -> None:
+        """Configure placement group bundle resources to prevent vLLM resource lockups on GKE TPU."""
+        is_rollout_pool = any(k in name_prefix.lower() for k in ["rollout", "reward", "teacher"])
+        if use_gpu and not is_rollout_pool:
+            bundle[device_name] = 1
+        if accelerator_type is not None:
+            bundle[accelerator_type] = 1e-4
+
+    def get_worker_env_vars(
+        self,
+        resource_pool,
+        rank: int,
+        world_size: int,
+        local_rank: int,
+        local_world_size: int,
+        name_prefix: str,
+        device_name: str,
+    ) -> dict[str, str]:
+        """Return platform-specific TPU environment variables for worker nodes."""
+        env_vars = {}
+        if "VERL_PLATFORM" in os.environ:
+            env_vars["VERL_PLATFORM"] = os.environ["VERL_PLATFORM"]
+        for var in self.ray_noset_envvars():
+            env_vars[var] = "1"
+        pgs = resource_pool.get_placement_groups(device_name=device_name)
+        tpu_env = self.get_tpu_env_vars(
+            rank=rank,
+            world_size=world_size,
+            local_rank=local_rank,
+            local_world_size=local_world_size,
+            name_prefix=name_prefix,
+            pgs=pgs,
+        )
+        env_vars.update(tpu_env)
+        return env_vars
+
+    def sanitize_metrics(self, metrics: Any) -> Any:
+        """Convert any TPU tensor in metrics to a standard Python scalar before Ray RPC transfer."""
+        return convert_tensors_to_scalars(metrics)
+
+    def get_ray_init_kwargs(self) -> dict[str, Any]:
+        """Return Ray initialization arguments with runtime_env configured for GKE TPU workers."""
+        return {
+            "runtime_env": {
+                "worker_process_setup_hook": patch_ray_worker,
+            }
+        }

--- a/verl/plugin/platform/platform_tpu_workarounds.py
+++ b/verl/plugin/platform/platform_tpu_workarounds.py
@@ -71,7 +71,13 @@ def patch_ray_worker():
         def patched_func(self, resource_name, resource_regex):
             try:
                 return original_func(self, resource_name, resource_regex)
-            except IndexError:
+            except IndexError as e:
+                import traceback
+
+                print(
+                    f"[patch_ray_worker] Intercepted Ray accelerator lookup IndexError for resource '{resource_name}': {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 return []
 
         ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource = patched_func

--- a/verl/plugin/platform/platform_tpu_workarounds.py
+++ b/verl/plugin/platform/platform_tpu_workarounds.py
@@ -1,0 +1,194 @@
+# Copyright 2024-2025 BAAI and Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Platform-specific utilities and Ray cluster integration workarounds for Google TPU execution."""
+
+import logging
+import os
+
+import ray
+import ray._private.worker
+import torch
+
+from verl.plugin.platform import get_platform
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Default concurrency and CPU allocation for Ray TaskRunner actor on TPU worker nodes
+DEFAULT_TASK_RUNNER_CPUS = 10
+DEFAULT_TASK_RUNNER_CONCURRENCY = 100
+
+
+def convert_tensors_to_scalars(val):
+    """Recursively converts TPU tensors in metrics dictionaries to Python scalars or CPU structures.
+
+    Directly moving a TPU scalar tensor with a special PJRT allocator to the CPU driver process
+    via `.cpu()` can trigger allocator assertion errors in containerized multi-host setups.
+    Calling `.item()` on singleton tensors or converting non-scalar tensors safely avoids driver process crashes.
+    """
+    if isinstance(val, torch.Tensor):
+        if val.numel() == 1:
+            return val.item()
+        else:
+            try:
+                return val.detach().cpu()
+            except Exception:
+                return val.tolist()
+    elif isinstance(val, dict):
+        return {k: convert_tensors_to_scalars(v) for k, v in val.items()}
+    elif isinstance(val, list):
+        return [convert_tensors_to_scalars(v) for v in val]
+    elif isinstance(val, tuple):
+        return tuple(convert_tensors_to_scalars(v) for v in val)
+    elif hasattr(val, "aggregate"):
+        try:
+            return val.aggregate()
+        except Exception:
+            return val
+    return val
+
+
+def patch_ray_worker():
+    """Patches Ray worker resource lookup to handle containerized TPU device index bounds in GKE.
+
+    In containerized GKE environments where TPU chips are isolated per pod, Raylet physical accelerator
+    lookups can raise an `IndexError` when querying host-level accelerator indices.
+    """
+    try:
+        original_func = ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource
+
+        def patched_func(self, resource_name, resource_regex):
+            try:
+                return original_func(self, resource_name, resource_regex)
+            except IndexError:
+                return []
+
+        ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource = patched_func
+    except Exception as e:
+        logger.warning(f"Failed to apply Ray worker accelerator patch: {e}")
+
+
+def aggregate_sft_metrics_tpu(metrics):
+    """Aggregates metrics returned by multi-host data-parallel training workers on the CPU driver.
+
+    Under distributed TorchTitan training across multiple data-parallel ranks, worker metrics can be
+    returned as lists of dictionaries or dictionaries of rank-specific tensors. This helper computes
+    their average cleanly.
+    """
+    if isinstance(metrics, list):
+        aggregated_metrics = {}
+        if len(metrics) > 0:
+            keys = metrics[0].keys()
+            for k in keys:
+                vals = [m[k] for m in metrics if k in m]
+                if len(vals) > 0:
+                    try:
+                        vals_tensor = torch.tensor(vals, dtype=torch.float32)
+                        aggregated_metrics[k] = torch.mean(vals_tensor).item()
+                    except Exception:
+                        aggregated_metrics[k] = vals[0]
+        return aggregated_metrics
+    elif isinstance(metrics, dict):
+        aggregated_metrics = {}
+        for k, v in metrics.items():
+            if isinstance(v, list) or (hasattr(v, "shape") and len(v.shape) > 0):
+                try:
+                    aggregated_metrics[k] = torch.tensor(v, dtype=torch.float32).mean().item()
+                except Exception:
+                    if isinstance(v, list) and len(v) > 0:
+                        aggregated_metrics[k] = v[0]
+                    else:
+                        aggregated_metrics[k] = v
+            else:
+                aggregated_metrics[k] = v
+        return aggregated_metrics
+    else:
+        raise TypeError(f"Unexpected metrics structure type: {type(metrics)}")
+
+
+def extract_validation_loss(metrics) -> float:
+    """Extracts scalar validation loss value from worker metrics dictionary or list."""
+    if isinstance(metrics, list):
+        valid_losses = [m["loss"] for m in metrics if "loss" in m]
+        return sum(valid_losses) / len(valid_losses) if valid_losses else 0.0
+    elif isinstance(metrics, dict):
+        if "loss" in metrics:
+            v = metrics["loss"]
+            if isinstance(v, list) or (hasattr(v, "shape") and len(v.shape) > 0):
+                return torch.tensor(v, dtype=torch.float32).mean().item()
+            return float(v)
+    elif isinstance(metrics, int | float):
+        return float(metrics)
+    return float(metrics)
+
+
+def get_ray_init_kwargs() -> dict:
+    """Returns Ray initialization arguments including runtime environment hooks for TPU workers."""
+    env_vars = {}
+    if "PYTHONPATH" in os.environ:
+        env_vars["PYTHONPATH"] = os.environ["PYTHONPATH"]
+    if "VERL_PLATFORM" in os.environ:
+        env_vars["VERL_PLATFORM"] = os.environ["VERL_PLATFORM"]
+    return {
+        "runtime_env": {
+            "worker_process_setup_hook": patch_ray_worker,
+            "env_vars": env_vars,
+        }
+    }
+
+
+def run_trainer_on_tpu(trainer_cls, config):
+    """Executes the SFT/PPO trainer inside a remote Ray TaskRunner actor on TPU worker nodes.
+
+    The Ray driver process runs on the head/CPU node where TPU devices are not present.
+    Wrapping trainer initialization inside a remote actor ensures that PJRT client initialization
+    and device setup run directly on TPU worker nodes.
+    """
+
+    @ray.remote(num_cpus=DEFAULT_TASK_RUNNER_CPUS, max_concurrency=DEFAULT_TASK_RUNNER_CONCURRENCY)
+    class TaskRunner:
+        def run(self, config):
+            trainer = trainer_cls(config=config)
+            trainer.fit()
+
+    runner = TaskRunner.remote()
+    ray.get(runner.run.remote(config))
+
+
+def get_platform_worker_env_vars(
+    resource_pool,
+    rank: int,
+    world_size: int,
+    local_rank: int,
+    local_world_size: int,
+    name_prefix: str,
+    device_name: str,
+) -> dict:
+    """Generates platform-specific environment variables for worker nodes."""
+    env_vars = {}
+    if "VERL_PLATFORM" in os.environ:
+        env_vars["VERL_PLATFORM"] = os.environ["VERL_PLATFORM"]
+    for var in get_platform().ray_noset_envvars():
+        env_vars[var] = "1"
+    pgs = resource_pool.get_placement_groups(device_name=device_name)
+    tpu_env = get_platform().get_tpu_env_vars(
+        rank=rank,
+        world_size=world_size,
+        local_rank=local_rank,
+        local_world_size=local_world_size,
+        name_prefix=name_prefix,
+        pgs=pgs,
+    )
+    env_vars.update(tpu_env)
+    return env_vars

--- a/verl/plugin/platform/platform_tpu_workarounds.py
+++ b/verl/plugin/platform/platform_tpu_workarounds.py
@@ -20,7 +20,7 @@ import ray
 import ray._private.worker
 import torch
 
-from verl.plugin.platform import get_platform
+from .platform_manager import get_platform
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -69,16 +69,22 @@ def patch_ray_worker():
         original_func = ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource
 
         def patched_func(self, resource_name, resource_regex):
+            if hasattr(self, "original_visible_accelerator_ids") and isinstance(
+                self.original_visible_accelerator_ids, dict
+            ):
+                self.original_visible_accelerator_ids.pop(resource_name, None)
             try:
                 return original_func(self, resource_name, resource_regex)
-            except IndexError as e:
-                import traceback
+            except Exception:
+                resource_ids = self.core_worker.resource_ids()
+                assigned_ids = set()
+                import re
 
-                print(
-                    f"[patch_ray_worker] Intercepted Ray accelerator lookup IndexError for resource '{resource_name}': {e}\n"
-                    f"{traceback.format_exc()}"
-                )
-                return []
+                for resource, assignment in resource_ids.items():
+                    if resource == resource_name or re.match(resource_regex, resource):
+                        for resource_id, _ in assignment:
+                            assigned_ids.add(resource_id)
+                return [str(i) for i in assigned_ids]
 
         ray._private.worker.Worker.get_accelerator_ids_for_accelerator_resource = patched_func
     except Exception as e:

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -276,9 +276,17 @@ class Worker(WorkerHelper):
             # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set,
             # so we need to set local rank when the flag is set.
             device_name = get_resource_name()
-            local_rank = ray.get_runtime_context().get_accelerator_ids()[device_name][0]
-            os.environ["LOCAL_RANK"] = local_rank
-            get_torch_device().set_device(int(local_rank))
+            if device_name == "TPU":
+                local_rank = os.environ.get("TPU_VISIBLE_CHIPS", "0")
+            else:
+                local_rank = ray.get_runtime_context().get_accelerator_ids()[device_name][0]
+
+            os.environ["LOCAL_RANK"] = str(local_rank)
+
+            # Avoid eager device initialization for non-TPU engine workers (e.g. CheckpointEngineWorker)
+            # which could lock TPU chips unnecessarily.
+            if self.__class__.__name__ != "CheckpointEngineWorker" or device_name != "TPU":
+                get_torch_device().set_device(int(local_rank))
 
     def _configure_with_store(self, store: dict):
         """

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -26,6 +26,7 @@ from ray.util.placement_group import PlacementGroup, placement_group
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy, PlacementGroupSchedulingStrategy
 
 from verl.plugin.platform import get_platform
+from verl.plugin.platform.platform_tpu_workarounds import get_platform_worker_env_vars
 from verl.protocol import DataProto, _padding_size_key
 from verl.single_controller.base import ClassWithInitArgs, ResourcePool, Worker, WorkerGroup
 from verl.single_controller.base.decorator import MAGIC_ATTR, Dispatch
@@ -120,6 +121,8 @@ class RayResourcePool(ResourcePool):
         detached=False,
         accelerator_type: Optional[str] = None,
     ) -> None:
+        if get_platform().device_name == "tpu":
+            max_colocate_count = 1
         super().__init__(process_on_nodes, max_colocate_count)
         self.use_gpu = use_gpu
         # print(f"in RayProcessDispatchConfiguration: name_prefix = {name_prefix}")
@@ -146,8 +149,8 @@ class RayResourcePool(ResourcePool):
         bundle = {"CPU": self.max_colocate_count}
         if self.use_gpu:
             bundle[device_name] = 1
-            if self.accelerator_type is not None:
-                bundle[self.accelerator_type] = 1e-4
+        if self.accelerator_type is not None:
+            bundle[self.accelerator_type] = 1e-4
         pg_scheme = [[bundle.copy() for _ in range(process_count)] for process_count in self._store]
 
         lifetime = "detached" if self.detached else None
@@ -192,6 +195,10 @@ class ResourcePoolManager:
     max_colocate_count: int = 3
     resource_pool_dict: dict[str, RayResourcePool] = field(default_factory=dict)
 
+    def __post_init__(self):
+        if get_platform().device_name == "tpu":
+            self.max_colocate_count = 1
+
     def create_resource_pool(self):
         """Create Ray resource pools for distributed training.
 
@@ -226,9 +233,9 @@ class ResourcePoolManager:
     def _check_resource_available(self):
         """Check if the resource pool can be satisfied in this ray cluster."""
         node_available_resources = ray._private.state.available_resources_per_node()
+        device_name = get_platform().ray_resource_name()
         node_available_gpus = {
-            node: node_info.get("GPU", 0) if "GPU" in node_info else node_info.get("NPU", 0)
-            for node, node_info in node_available_resources.items()
+            node: node_info.get(device_name, 0) for node, node_info in node_available_resources.items()
         }
 
         # check total required gpus can be satisfied
@@ -638,6 +645,16 @@ class RayWorkerGroup(WorkerGroup):
             "MASTER_ADDR": self._master_addr,
             "MASTER_PORT": self._master_port,
         }
+        platform_env = get_platform_worker_env_vars(
+            resource_pool=resource_pool,
+            rank=rank,
+            world_size=world_size,
+            local_rank=local_rank,
+            local_world_size=local_world_size,
+            name_prefix=self.name_prefix,
+            device_name=self.device_name,
+        )
+        env_vars.update(platform_env)
         if worker_env is not None:
             logging.debug(f"Appending ray class env, origin: {env_vars}, customized env: {worker_env}")
             conflict_env_vars = set(env_vars.keys()) & set(worker_env.keys())

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -82,9 +82,13 @@ def sort_placement_group_by_node_ip(pgs: list[PlacementGroup]) -> list[Placement
     pg_ip = {}
     for pg in pgs:
         specs = ray._private.state.state.placement_group_table(pg.id)
-        # all bunles should be on the same node
-        node_id = specs["bundles_to_node_id"][0]
-        pg_ip[pg.id] = node_ip[node_id]
+        bundles_map = specs.get("bundles_to_node_id", {})
+        if bundles_map:
+            min_b_idx = min(bundles_map.keys())
+            node_id = bundles_map[min_b_idx]
+            pg_ip[pg.id] = node_ip.get(node_id, "")
+        else:
+            pg_ip[pg.id] = ""
     return sorted(pgs, key=lambda pg: pg_ip[pg.id])
 
 
@@ -129,6 +133,8 @@ class RayResourcePool(ResourcePool):
         self.name_prefix = get_random_string(length=6) if name_prefix is None else name_prefix
         self.pgs = None
         self.detached = detached
+        if accelerator_type is None and get_platform().device_name == "tpu":
+            accelerator_type = get_platform().auto_assign_accelerator_type(self.name_prefix, accelerator_type)
         self.accelerator_type = accelerator_type
 
     def get_placement_groups(self, strategy="STRICT_PACK", name=None, device_name="cuda"):
@@ -147,10 +153,15 @@ class RayResourcePool(ResourcePool):
         device_name = current_platform.ray_resource_name()
 
         bundle = {"CPU": self.max_colocate_count}
-        if self.use_gpu:
-            bundle[device_name] = 1
-        if self.accelerator_type is not None:
-            bundle[self.accelerator_type] = 1e-4
+        if get_platform().device_name == "tpu":
+            get_platform().configure_placement_group_bundle(
+                bundle, self.use_gpu, device_name, self.name_prefix, self.accelerator_type
+            )
+        else:
+            if self.use_gpu:
+                bundle[device_name] = 1
+            if self.accelerator_type is not None:
+                bundle[self.accelerator_type] = 1e-4
         pg_scheme = [[bundle.copy() for _ in range(process_count)] for process_count in self._store]
 
         lifetime = "detached" if self.detached else None
@@ -232,20 +243,17 @@ class ResourcePoolManager:
 
     def _check_resource_available(self):
         """Check if the resource pool can be satisfied in this ray cluster."""
-        node_available_resources = ray._private.state.available_resources_per_node()
         device_name = get_platform().ray_resource_name()
-        node_available_gpus = {
-            node: node_info.get(device_name, 0) for node, node_info in node_available_resources.items()
-        }
-
-        # check total required gpus can be satisfied
-        total_available_gpus = sum(node_available_gpus.values())
+        total_cluster_gpus = sum(
+            node.get("Resources", {}).get(device_name, 0) for node in ray.nodes() if node.get("Alive", False)
+        )
         total_required_gpus = sum(
             [n_gpus for process_on_nodes in self.resource_pool_spec.values() for n_gpus in process_on_nodes]
         )
-        if total_available_gpus < total_required_gpus:
+        if total_cluster_gpus < total_required_gpus:
             raise ValueError(
-                f"Total available GPUs {total_available_gpus} is less than total desired GPUs {total_required_gpus}"
+                f"Total cluster {device_name} count ({total_cluster_gpus}) "
+                f"is less than total desired ({total_required_gpus})"
             )
 
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -19,6 +19,7 @@ import hydra
 import ray
 from omegaconf import DictConfig, OmegaConf
 
+from verl.plugin.platform import get_platform
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
 from verl.trainer.ppo.utils import need_critic, need_reference_policy
 from verl.utils.config import validate_config
@@ -72,7 +73,13 @@ def run_ppo(config, task_runner_class) -> None:
         runtime_env = OmegaConf.merge(default_runtime_env, runtime_env_kwargs)
         ray_init_kwargs = OmegaConf.create({**ray_init_kwargs, "runtime_env": runtime_env})
         print(f"ray init kwargs: {ray_init_kwargs}")
-        ray.init(**OmegaConf.to_container(ray_init_kwargs))
+
+        ray_init_dict = OmegaConf.to_container(ray_init_kwargs, resolve=True)
+        platform_ray_kwargs = get_platform().get_ray_init_kwargs()
+        if platform_ray_kwargs and "runtime_env" in platform_ray_kwargs:
+            for k, v in platform_ray_kwargs["runtime_env"].items():
+                ray_init_dict["runtime_env"][k] = v
+        ray.init(**ray_init_dict)
 
     # Create a remote instance of the TaskRunner class, and
     # Execute the `run` method of the TaskRunner instance remotely and wait for it to complete
@@ -89,15 +96,25 @@ def run_ppo(config, task_runner_class) -> None:
             config.global_profiler.global_tool_config.nsys.controller_nsight_options
         )
         runner = task_runner_class.options(runtime_env={"nsight": nsight_options}).remote()
+    elif get_platform().device_name == "tpu":
+        from verl.plugin.platform.platform_tpu_workarounds import (
+            DEFAULT_TASK_RUNNER_CONCURRENCY,
+            DEFAULT_TASK_RUNNER_CPUS,
+        )
+
+        runner = task_runner_class.options(
+            num_cpus=DEFAULT_TASK_RUNNER_CPUS, max_concurrency=DEFAULT_TASK_RUNNER_CONCURRENCY
+        ).remote()
     else:
         runner = task_runner_class.remote()
-    ray.get(runner.run.remote(config))
 
-    # [Optional] get the path of the timeline trace file from the configuration, default to None
-    # This file is used for performance analysis
-    timeline_json_file = config.ray_kwargs.get("timeline_json_file", None)
-    if timeline_json_file:
-        ray.timeline(filename=timeline_json_file)
+    try:
+        ray.get(runner.run.remote(config))
+    finally:
+        timeline_json_file = config.ray_kwargs.get("timeline_json_file", None)
+        if timeline_json_file:
+            ray.timeline(filename=timeline_json_file)
+        ray.shutdown()
 
 
 @ray.remote

--- a/verl/trainer/ppo/v1/agent_loop_tq.py
+++ b/verl/trainer/ppo/v1/agent_loop_tq.py
@@ -107,7 +107,12 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
     async def _run_prompt(self, prompt: dict, sampling_params: dict, trajectory: dict, trace: bool = False) -> None:
         """Spawn multiple agent loops in parallel according to rollout.n or rollout.val_kwargs.n."""
         uid, partition_id = prompt["uid"], "train" if not trajectory["validate"] else "val"
-        await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "running"})
+        global_steps = prompt.get("global_steps", 0)
+        await tq.async_kv_put(
+            key=uid,
+            partition_id=partition_id,
+            tag={"is_prompt": True, "status": "running", "global_steps": global_steps},
+        )
         tasks = []
         try:
             # NOTE: user can dynamically adjust n for each sample here, e.g according to task difficulty.
@@ -140,12 +145,20 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                 status = "failure"
             else:
                 status = "finished"
-            await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": status})
+            await tq.async_kv_put(
+                key=uid,
+                partition_id=partition_id,
+                tag={"is_prompt": True, "status": status, "global_steps": global_steps},
+            )
         except Exception as e:
             logger.exception(f"Error in _run_prompt: {e}")
             if tasks:
                 await _settle_session_tasks(tasks)
-            await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "failure"})
+            await tq.async_kv_put(
+                key=uid,
+                partition_id=partition_id,
+                tag={"is_prompt": True, "status": "failure", "global_steps": global_steps},
+            )
 
     async def _agent_loop_postprocess(
         self, output: AgentLoopOutput | list[AgentLoopOutput], validate, **kwargs

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -40,6 +40,7 @@ from verl.checkpoint_engine import CheckpointEngineManager
 from verl.experimental.agent_loop import AgentLoopManager
 from verl.experimental.reward_loop import RewardLoopManager
 from verl.experimental.teacher_loop import MultiTeacherModelManager
+from verl.plugin.platform import get_platform
 from verl.protocol import DataProto, DataProtoFuture
 from verl.single_controller.ray import (
     RayClassWithInitArgs,
@@ -81,7 +82,7 @@ from verl.utils.dataset.rl_dataset import collate_fn
 from verl.utils.debug import marked_timer
 from verl.utils.debug.metrics import calculate_debug_metrics
 from verl.utils.fs import copy_to_local
-from verl.utils.import_utils import load_extern_type
+from verl.utils.import_utils import load_class_from_fqn, load_extern_type
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
@@ -237,7 +238,12 @@ class PPOTrainer(ABC):
         self.resource_pool_to_cls = {pool: {} for pool in self.resource_pool_manager.resource_pool_dict.values()}
 
         # 1. define actor and rollout class
-        actor_role = Role.ActorRolloutRef if Role.ActorRolloutRef in self.role_worker_mapping else Role.ActorRollout
+        if Role.ActorRolloutRef in self.role_worker_mapping:
+            actor_role = Role.ActorRolloutRef
+        elif Role.ActorRollout in self.role_worker_mapping:
+            actor_role = Role.ActorRollout
+        else:
+            actor_role = Role.Actor
         actor_rollout_resource_pool = self.resource_pool_manager.get_resource_pool(actor_role)
         actor_rollout_cls = RayClassWithInitArgs(
             cls=self.role_worker_mapping[actor_role],
@@ -319,9 +325,17 @@ class PPOTrainer(ABC):
         lora_rank = self.config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
         if lora_rank <= 0:
             lora_rank = self.config.actor_rollout_ref.model.get("lora_rank", 0)
-        self.ref_in_actor = lora_rank > 0 or self.config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        self.ref_in_actor = (
+            self.config.actor_rollout_ref.get("ref_in_actor", False)
+            or lora_rank > 0
+            or self.config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        )
         if self.use_reference_policy and not self.ref_in_actor:
-            self.ref_policy_wg = all_wg[str(actor_role)]
+            if str(Role.RefPolicy) in all_wg:
+                self.ref_policy_wg = all_wg[str(Role.RefPolicy)]
+                self.ref_policy_wg.init_model()
+            elif str(actor_role) in all_wg:
+                self.ref_policy_wg = all_wg[str(actor_role)]
         if self.ref_in_actor:
             self.ref_policy_wg = self.actor_rollout_wg
 
@@ -350,14 +364,28 @@ class PPOTrainer(ABC):
             self.distillation_config = None
 
         # 9. initialize agent loop manager
+        worker_group = self.actor_rollout_wg if self.config.actor_rollout_ref.get("hybrid_engine", True) else None
         self.llm_server_manager: LLMServerManager = LLMServerManager.create(
-            config=self.config, worker_group=self.actor_rollout_wg, rollout_resource_pool=actor_rollout_resource_pool
+            config=self.config, worker_group=worker_group, rollout_resource_pool=actor_rollout_resource_pool
         )
 
         # 10. initialize checkpoint engine manager
         checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
-        checkpoint_engine_config.backend = "naive"
-        self.checkpoint_manager: CheckpointEngineManager = CheckpointEngineManager(
+
+        is_tpu = get_platform().device_name == "tpu" or self.config.trainer.device == "tpu"
+        if is_tpu:
+            if not checkpoint_engine_config.backend or checkpoint_engine_config.backend == "naive":
+                checkpoint_engine_config.backend = "tpu"
+        elif self.trainer_mode in ["sync", "colocate_async"] and not checkpoint_engine_config.backend:
+            checkpoint_engine_config.backend = "naive"
+
+        checkpoint_manager_class_fqn = self.config.actor_rollout_ref.rollout.get("checkpoint_manager_class")
+        if checkpoint_manager_class_fqn:
+            CheckpointEngineManagerCls = load_class_from_fqn(checkpoint_manager_class_fqn, "CheckpointEngineManager")
+        else:
+            CheckpointEngineManagerCls = CheckpointEngineManager
+
+        self.checkpoint_manager: CheckpointEngineManager = CheckpointEngineManagerCls(
             config=checkpoint_engine_config,
             actor_wg=self.actor_rollout_wg,
             replicas=self.llm_server_manager.get_replicas(),
@@ -490,6 +518,7 @@ class PPOTrainer(ABC):
 
             dapo_filtered_reward_counts = metrics.pop(DAPO_FILTERED_REWARD_COUNTS_KEY, None)
             self.logger.log(data=metrics, step=self.global_steps)
+
             if dapo_filtered_reward_counts:
                 self.dapo_filtered_reward_logger.log(
                     self.config.trainer.logger, dapo_filtered_reward_counts, self.global_steps
@@ -748,9 +777,23 @@ class PPOTrainer(ABC):
         lora_rank = config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
         if lora_rank <= 0:
             lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
-        ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        ref_in_actor = (
+            config.actor_rollout_ref.get("ref_in_actor", False)
+            or lora_rank > 0
+            or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        )
 
-        role = Role.ActorRolloutRef if need_reference_policy(config) and not ref_in_actor else Role.ActorRollout
+        hybrid_engine = config.actor_rollout_ref.get("hybrid_engine", True)
+        if not hybrid_engine:
+            role = Role.Actor
+            if need_reference_policy(config) and not ref_in_actor:
+                self.role_worker_mapping[Role.RefPolicy] = ray.remote(ActorRolloutRefWorker)
+                self.mapping[Role.RefPolicy] = "global_pool"
+        elif need_reference_policy(config) and not ref_in_actor:
+            role = Role.ActorRolloutRef
+        else:
+            role = Role.ActorRollout
+
         self.role_worker_mapping[role] = ray.remote(ActorRolloutRefWorker)
         self.mapping[role] = "global_pool"
 
@@ -1003,7 +1046,7 @@ class PPOTrainer(ABC):
             if self.reward_loop_manager.reward_loop_worker_handles is None:
                 self.checkpoint_manager.sleep_replicas()
                 batch = self._compute_reward_colocate(batch)
-                self.checkpoint_manager.update_weights()
+                self.checkpoint_manager.update_weights(self.global_steps)
 
             # 4. collect necessary data for logging
             # For multi-output agent loops, only use the final output per session for metrics.
@@ -1746,8 +1789,20 @@ class PPOTrainer(ABC):
         prompt_length = data["prompts"].offsets().diff()
         response_length = data["responses"].offsets().diff()
         global_token_num = (prompt_length + response_length).tolist()
-        min_global_steps = np.array([tag["min_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
-        max_global_steps = np.array([tag["max_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
+        min_steps_list = [
+            tag.get("min_global_steps", 0) if isinstance(tag, dict) and tag.get("min_global_steps") is not None else 0
+            for tag in (batch.tags or [])
+        ]
+        max_steps_list = [
+            tag.get("max_global_steps", 0) if isinstance(tag, dict) and tag.get("max_global_steps") is not None else 0
+            for tag in (batch.tags or [])
+        ]
+        if len(min_steps_list) == 0:
+            min_steps_list = [0] * len(non_padding_mask)
+        if len(max_steps_list) == 0:
+            max_steps_list = [0] * len(non_padding_mask)
+        min_global_steps = np.array(min_steps_list, dtype=int)[non_padding_mask]
+        max_global_steps = np.array(max_steps_list, dtype=int)[non_padding_mask]
 
         # Only fetch speculative decoding stats when rollout writes them.
         spec_drafts = spec_accepts = spec_verifies = None

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -68,6 +68,11 @@ class PPOTrainerSeparateAsync(PPOTrainer):
 
         super().__init__(config)
 
+    @property
+    def use_hybrid_engine(self) -> bool:
+        """Returns True if the hybrid engine (colocated trainer and rollout) is enabled."""
+        return self.config.actor_rollout_ref.get("hybrid_engine", True)
+
     def _init_resource_pool_mgr(self):
         super()._init_resource_pool_mgr()
         # Replace ActorRolloutRefWorker with DetachActorWorker to get CPU save/restore
@@ -82,19 +87,28 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         super()._setup()
 
         # initialize standalone rollout
-        # TODO: make initialization parallel with super().init()
-        hybrid_num_replicas = len(self.llm_server_manager.rollout_replicas)
-        self.standalone_server_manager: LLMServerManager = LLMServerManager.create(
-            config=self.config, start_rank=hybrid_num_replicas
-        )
+        if self.llm_server_manager is not None and not self.use_hybrid_engine:
+            self.standalone_server_manager = self.llm_server_manager
+            self.standalone_checkpoint_manager = self.checkpoint_manager
+        else:
+            hybrid_num_replicas = len(self.llm_server_manager.rollout_replicas) if self.llm_server_manager else 0
+            self.standalone_server_manager: LLMServerManager = LLMServerManager.create(
+                config=self.config, start_rank=hybrid_num_replicas
+            )
 
-        # create checkpoint engine manager for trainer and standalone rollout
-        checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
-        self.standalone_checkpoint_manager = CheckpointEngineManager(
-            config=checkpoint_engine_config,
-            actor_wg=self.actor_rollout_wg,
-            replicas=self.standalone_server_manager.get_replicas(),
-        )
+            # create checkpoint engine manager for trainer and standalone rollout
+            checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
+            from verl.plugin.platform import get_platform
+
+            if get_platform().device_name == "tpu" or self.config.trainer.device == "tpu":
+                if not checkpoint_engine_config.backend or checkpoint_engine_config.backend == "naive":
+                    checkpoint_engine_config.backend = "tpu"
+
+            self.standalone_checkpoint_manager = CheckpointEngineManager(
+                config=checkpoint_engine_config,
+                actor_wg=self.actor_rollout_wg,
+                replicas=self.standalone_server_manager.get_replicas(),
+            )
 
         # hybrid engine is in rollout mode after initialization
         self.current_mode = HybridEngineMode.ROLLOUT
@@ -112,7 +126,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         """
         rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
         bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
-        if bypass_recomputing_logprobs:
+        if not self.use_hybrid_engine or bypass_recomputing_logprobs:
             return super()._compute_old_log_prob(batch, metrics)
 
         if self.local_trigger_step == 0:
@@ -133,7 +147,8 @@ class PPOTrainerSeparateAsync(PPOTrainer):
     def on_init_end(self):
         # update weights after loading checkpoint
         self.standalone_checkpoint_manager.update_weights(self.global_steps)
-        self.checkpoint_manager.update_weights(self.global_steps)
+        if self.checkpoint_manager is not None and self.use_hybrid_engine:
+            self.checkpoint_manager.update_weights(self.global_steps)
 
     def on_train_begin(self):
         if self.config.skip.rollout_tq.enable:
@@ -154,7 +169,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
             self.switch_to_rollout()
 
     def on_sample_end(self):
-        if self.current_mode == HybridEngineMode.ROLLOUT:
+        if self.use_hybrid_engine and self.current_mode == HybridEngineMode.ROLLOUT:
             logger.info("Switching hybrid engine to trainer mode for training")
             self.switch_to_trainer()
 
@@ -178,6 +193,8 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         return trainer_gpus + rollout_gpus
 
     def switch_to_rollout(self):
+        if not self.use_hybrid_engine:
+            return
         # TODO: disable auto offload in config and offload according to the switch strategy
         self.checkpoint_manager.update_weights(self.global_steps)
         self.checkpoint_manager.resume_generation_replicas()
@@ -185,6 +202,8 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         self.current_mode = HybridEngineMode.ROLLOUT
 
     def switch_to_trainer(self):
+        if not self.use_hybrid_engine:
+            return
         # TODO: disable auto offload in config and offload according to the switch strategy
         self.remove_replicas_from_balancer()
         self.checkpoint_manager.abort_replicas()
@@ -192,13 +211,30 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         self.current_mode = HybridEngineMode.TRAINER
 
     def add_replicas_to_balancer(self):
+        if (
+            self.standalone_server_manager is None
+            or getattr(self.standalone_server_manager, "global_load_balancer", None) is None
+        ):
+            return
+        if self.llm_server_manager is None:
+            return
         global_load_balancer = self.standalone_server_manager.global_load_balancer
         servers = dict(
             zip(self.llm_server_manager.server_addresses, self.llm_server_manager.server_handles, strict=True)
         )
-        ray.get(global_load_balancer.add_servers.remote(servers))
+        if servers:
+            ray.get(global_load_balancer.add_servers.remote(servers))
 
     def remove_replicas_from_balancer(self):
+        if not self.use_hybrid_engine:
+            return
+        if (
+            self.standalone_server_manager is None
+            or getattr(self.standalone_server_manager, "global_load_balancer", None) is None
+        ):
+            return
+        if self.llm_server_manager is None or not self.llm_server_manager.server_addresses:
+            return
         global_load_balancer = self.standalone_server_manager.global_load_balancer
         ray.get(global_load_balancer.remove_servers.remote(self.llm_server_manager.server_addresses))
 

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -32,6 +32,13 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
+from verl.plugin.platform import get_platform
+from verl.plugin.platform.platform_tpu_workarounds import (
+    aggregate_sft_metrics_tpu,
+    extract_validation_loss,
+    get_ray_init_kwargs,
+    run_trainer_on_tpu,
+)
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler, OrchestrationMode
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -279,6 +286,7 @@ class SFTTrainer:
             "use_remove_padding": self.config.model.use_remove_padding,
             "use_dynamic_bsz": self.config.data.use_dynamic_bsz,
             "max_token_len_per_gpu": self.config.data.max_token_len_per_gpu,
+            "max_length": self.config.data.max_length,
             "micro_batch_size_per_gpu": self.config.data.micro_batch_size_per_gpu,
             "temperature": 1.0,
             "global_batch_size": self.global_batch_size,
@@ -338,13 +346,15 @@ class SFTTrainer:
                     self.training_client.stop_profile()
 
                 metrics = tu.get(output, "metrics")
+                if get_platform().device_name == "tpu":
+                    metrics = aggregate_sft_metrics_tpu(metrics)
 
                 # TODO: we can actual accumulate metrics for N steps and perform aggregate metrics
                 metrics["train/loss"] = metrics.pop("loss")
-                metrics["train/grad_norm"] = metrics.pop("grad_norm")
-                metrics["train/lr"] = metrics.pop("lr")
-                metrics["train/mfu"] = metrics.pop("mfu")
-                metrics["train/global_tokens"] = torch.sum(torch.tensor(batch_seqlens, device=self.device_name)).item()
+                metrics["train/grad_norm"] = metrics.pop("grad_norm", 0.0)
+                metrics["train/lr"] = metrics.pop("lr", 0.0)
+                metrics["train/mfu"] = metrics.pop("mfu", 0.0)
+                metrics["train/global_tokens"] = sum(batch_seqlens)
                 total_tokens += metrics["train/global_tokens"]
                 metrics["train/total_tokens(B)"] = total_tokens / 1e9
                 tracking.log(data=metrics, step=global_step)
@@ -362,9 +372,14 @@ class SFTTrainer:
                         output = self.training_client.infer_batch(val_data)
                         output = output.get()
                         metrics = tu.get(output, "metrics")
-                        val_losses.append(metrics["loss"])
+                        val_loss_val = extract_validation_loss(metrics)
+                        val_losses.append(val_loss_val)
 
-                    val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
+                    if len(val_losses) > 0:
+                        val_loss = torch.mean(torch.tensor(val_losses, dtype=torch.float32))
+                    else:
+                        logger.warning("val_losses is empty. Check if val_max_samples is too small.")
+                        val_loss = torch.tensor(0.0)
 
                     metric = {"val/loss": val_loss.detach().item()}
                     tracking.log(data=metric, step=global_step)
@@ -380,9 +395,14 @@ class SFTTrainer:
 
 
 def run_sft(config):
-    ray.init()
-    trainer = SFTTrainer(config=config)
-    trainer.fit()
+    ray_init_kwargs = get_ray_init_kwargs()
+    ray.init(**ray_init_kwargs)
+
+    if get_platform().device_name == "tpu":
+        run_trainer_on_tpu(SFTTrainer, config)
+    else:
+        trainer = SFTTrainer(config=config)
+        trainer.fit()
 
 
 @hydra.main(config_path="config", config_name="sft_trainer_engine", version_base=None)

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -27,6 +27,7 @@ class DatasetPadMode(str, Enum):
     RIGHT = "right"
     LEFT_RIGHT = "left_right"
     NO_PADDING = "no_padding"
+    TPU_BINNED_PACK = "tpu_binned_pack"
 
 
 class SFTTensorCollator:
@@ -40,7 +41,7 @@ class SFTTensorCollator:
         self.pad_mode = pad_mode
 
     def __call__(self, batch: list[dict[str, any]]) -> dict[str, any]:
-        if self.pad_mode == DatasetPadMode.NO_PADDING:
+        if self.pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK]:
             return self.collate_variable_batch(batch)
         elif self.pad_mode in [DatasetPadMode.RIGHT, DatasetPadMode.LEFT_RIGHT]:
             from torch.utils.data import default_collate

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -93,8 +93,8 @@ class MultiTurnSFTDataset(Dataset):
         # Set defaults and extract parameters from config if provided
         config = config or {}
         self.pad_mode = config.get("pad_mode", "right")
-        assert self.pad_mode in ["right", "no_padding"], (
-            f"Expect pad_mode to be 'right' or 'no_padding'. Got {self.pad_mode}"
+        assert self.pad_mode in ["right", "no_padding", "tpu_binned_pack"], (
+            f"Expect pad_mode to be 'right', 'no_padding', or 'tpu_binned_pack'. Got {self.pad_mode}"
         )
         self.truncation = config.get("truncation", "error")
         # for right padding
@@ -401,7 +401,7 @@ class MultiTurnSFTDataset(Dataset):
             if len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
-        elif self.pad_mode == DatasetPadMode.NO_PADDING:
+        elif self.pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK]:
             if sequence_length > self.max_length and self.truncation == "error":
                 raise ValueError(f"{sequence_length=} is larger than {self.max_length=}")
             # truncate input_ids if it is longer than max_length

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -23,6 +23,7 @@ import ray
 import torch.distributed
 from torch.distributed import TCPStore
 
+from verl.plugin.platform import get_platform
 from verl.utils.device import get_device_name, get_nccl_backend, get_resource_name, get_torch_device, is_npu_available
 from verl.utils.net_utils import is_ipv6
 
@@ -34,6 +35,11 @@ def set_numa_affinity():
 
     initialized = False
     try:
+        device_name = get_resource_name()
+        # NUMA affinity via pynvml is NVIDIA GPU-specific; return early on TPU.
+        if device_name == "TPU":
+            return
+
         libnuma = ctypes.CDLL("libnuma.so")
         if libnuma.numa_available() < 0:
             return
@@ -83,6 +89,10 @@ def initialize_global_process_group_ray(timeout_second=None, backend=None):
     # in current ray environment, LOCAL_RANK is always zero.
 
     import torch.distributed
+
+    # On TPU platforms, import torch_tpu to register the TPU communication backend with torch.distributed.
+    if get_platform().device_name == "tpu":
+        pass
 
     timeout = timedelta(seconds=timeout_second) if timeout_second is not None else None
     backend = backend or f"cpu:gloo,{get_device_name()}:{get_nccl_backend()}"

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -95,6 +95,8 @@ def logprobs_from_logits(logits, labels, inplace_backward=True):
         output = output.view(*batch_dim)
     elif NPU_CROSS_ENTROPY_LOSS_AVAILABLE:
         output = logprobs_from_logits_torch_npu(logits, labels)
+    elif logits.device.type == "tpu":
+        output = logprobs_from_logits_naive(logits, labels)
     else:
         output = logprobs_from_logits_v2(logits, labels)
     return output

--- a/verl/workers/engine/torchtitan/tpu_utils.py
+++ b/verl/workers/engine/torchtitan/tpu_utils.py
@@ -1,0 +1,631 @@
+# Copyright 2024-2025 BAAI and Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TPU sequence packing utilities, attention monkey patches, and memory layout helpers."""
+
+import logging
+import os
+from typing import Any
+
+import torch
+import torch.distributed
+import torch.nn.functional as F
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData
+
+import verl.utils.torch_functional as verl_F
+from verl.utils import tensordict_utils as tu
+from verl.utils.torch_functional import logprobs_from_logits
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Default sequence packing constants
+DEFAULT_MAX_BIN_LEN = 1024
+DEFAULT_MAX_PROMPT_LEN = 512
+DEFAULT_MAX_RESPONSE_LEN = 512
+SEQUENCE_ALIGNMENT_MULTIPLE = 128
+
+
+def slice_metadata_item(data: TensorDict, k: str, i: int, batch_size: int, attn_mask: torch.Tensor = None):
+    """Slices a metadata item from a TensorDict for the i-th batch element."""
+    val = data.get(k, None)
+    if val is None:
+        return None
+    if isinstance(val, NonTensorData):
+        val = val.data
+
+    # Handle NestedTensor or structures with offsets
+    if getattr(val, "is_nested", False) or hasattr(val, "offsets"):
+        try:
+            return val.unbind()[i]
+        except Exception:
+            try:
+                return val[i]
+            except Exception:
+                pass
+
+    # Slice prompts and responses to exact active lengths if standard padded 2D tensors
+    if k == "prompts" and isinstance(val, torch.Tensor) and not getattr(val, "is_nested", False):
+        if attn_mask is not None and val.ndim >= 2:
+            prompt_len_active = int(attn_mask[i, : val.shape[-1]].sum().item())
+            return val[i, :prompt_len_active]
+        elif val.ndim >= 2:
+            return val[i]
+    elif k == "responses" and isinstance(val, torch.Tensor) and not getattr(val, "is_nested", False):
+        if attn_mask is not None and val.ndim >= 2:
+            prompt_val = data.get("prompts", None)
+            if isinstance(prompt_val, NonTensorData):
+                prompt_val = prompt_val.data
+            prompt_len_i = 0
+            if getattr(prompt_val, "is_nested", False) or hasattr(prompt_val, "offsets"):
+                prompt_len_i = prompt_val.unbind()[i].shape[-1]
+            elif isinstance(prompt_val, torch.Tensor) and prompt_val.ndim >= 2:
+                prompt_len_i = int(attn_mask[i, : prompt_val.shape[-1]].sum().item())
+
+            resp_mask = attn_mask[i, prompt_len_i : prompt_len_i + val.shape[-1]]
+            response_len_active = int(resp_mask.sum().item())
+            return val[i, :response_len_active]
+        elif val.ndim >= 2:
+            return val[i]
+
+    # Handle standard PyTorch Tensor
+    if isinstance(val, torch.Tensor):
+        if val.ndim > 0 and val.shape[0] == batch_size:
+            return val[i]
+        return val
+
+    # Handle list or tuple
+    if isinstance(val, list | tuple) and len(val) == batch_size:
+        return val[i]
+
+    raw_val = tu.get_non_tensor_data(data=data, key=k, default=None)
+    if isinstance(raw_val, NonTensorData):
+        raw_val = raw_val.data
+    if getattr(raw_val, "is_nested", False) or hasattr(raw_val, "offsets"):
+        try:
+            return raw_val.unbind()[i]
+        except Exception:
+            try:
+                return raw_val[i]
+            except Exception:
+                pass
+    if isinstance(raw_val, list | tuple) and len(raw_val) == batch_size:
+        return raw_val[i]
+    return raw_val
+
+
+def tpu_binned_pack_tensordict(
+    data: TensorDict, max_bin_len: int = DEFAULT_MAX_BIN_LEN
+) -> tuple[list[TensorDict], list[list[int]]]:
+    """Packs variable-length sequence data into static micro-batches of shape [1, max_bin_len].
+
+    On Google TPU execution, variable-length sequence shapes trigger dynamic graph recompilations.
+    This host-side CPU sequence packer bins active sequence tokens into static micro-batches of
+    shape [1, max_bin_len] to eliminate recompilation overhead.
+    """
+    data = data.cpu()
+    batch_size = data.batch_size[0]
+
+    attention_mask_key = "attention_mask" if "attention_mask" in data.keys() else "loss_mask"
+    attn_mask = data[attention_mask_key]
+
+    active_lengths = [int(attn_mask[i].sum().item()) for i in range(batch_size)]
+
+    keys_to_pack = []
+    keys_to_preserve = []
+
+    sequence_keys = {
+        "input_ids",
+        "position_ids",
+        "attention_mask",
+        "loss_mask",
+        "labels",
+        "log_prob",
+        "log_probs",
+        "old_log_prob",
+        "old_log_probs",
+        "ref_log_prob",
+        "advantages",
+        "returns",
+        "values",
+        "response_mask",
+        "rollout_is_weights",
+    }
+
+    for k, v in data.items():
+        if isinstance(v, torch.Tensor) and v.dim() >= 2 and v.shape[0] == batch_size:
+            if k in sequence_keys:
+                keys_to_pack.append(k)
+                continue
+        keys_to_preserve.append(k)
+
+    sliced_sequences = []
+    for i in range(batch_size):
+        length = active_lengths[i]
+
+        seq_data = {}
+        for k in keys_to_pack:
+            val = data[k]
+            if getattr(val, "is_nested", False):
+                seq_tensor = val.unbind()[i]
+                if seq_tensor.dim() == 1:
+                    seq_data[k] = seq_tensor[:length]
+                else:
+                    seq_data[k] = seq_tensor[..., :length]
+            else:
+                if val.dim() == 2:
+                    seq_data[k] = val[i, :length]
+                else:
+                    seq_data[k] = val[i, ..., :length]
+
+        metadata_dict = {}
+        for k in keys_to_preserve:
+            metadata_dict[k] = slice_metadata_item(data, k, i, batch_size, attn_mask=attn_mask)
+
+        sliced_sequences.append(
+            {
+                "seq_data": seq_data,
+                "metadata": metadata_dict,
+                "length": length,
+                "original_idx": i,
+            }
+        )
+
+    # Sort sequences descending by length for dense bin-packing
+    sorted_seqs = sorted(sliced_sequences, key=lambda s: s["length"], reverse=True)
+
+    bins: list[list[dict]] = []
+    bin_lengths: list[int] = []
+
+    for seq in sorted_seqs:
+        seq_len_active = seq["length"]
+        if seq_len_active == 0:
+            continue
+        assert seq_len_active <= max_bin_len, f"Sequence length {seq_len_active} exceeds max_bin_len {max_bin_len}"
+
+        placed = False
+        for i, current_len in enumerate(bin_lengths):
+            if current_len + seq_len_active <= max_bin_len:
+                bins[i].append(seq)
+                bin_lengths[i] += seq_len_active
+                placed = True
+                break
+
+        if not placed:
+            bins.append([seq])
+            bin_lengths.append(seq_len_active)
+
+    logger.debug(f"TPU Binned Packer: input batch_size={batch_size}, total bins={len(bins)}")
+    packed_micro_batches = []
+    batch_idx_list = []
+    for bin_idx, (bin_seqs, active_len) in enumerate(zip(bins, bin_lengths, strict=False)):
+        batch_idx_list.append([seq["original_idx"] for seq in bin_seqs])
+        logger.debug(f"Bin #{bin_idx}: {len(bin_seqs)} sequences, active tokens={active_len}/{max_bin_len}")
+
+        concatenated_td = {}
+        for k in keys_to_pack:
+            first_seq = bin_seqs[0]["seq_data"][k]
+            concat_dim = -1 if first_seq.dim() > 1 else 0
+            concatenated_td[k] = torch.cat([seq["seq_data"][k] for seq in bin_seqs], dim=concat_dim)
+
+        slack_len = max_bin_len - active_len
+        offsets = [0]
+        curr = 0
+        for seq in bin_seqs:
+            curr += seq["length"]
+            offsets.append(curr)
+
+        if slack_len > 0:
+            offsets.append(max_bin_len)
+            for k in keys_to_pack:
+                val = concatenated_td[k]
+                pad_val = 0
+                if k == "input_ids":
+                    pad_val = int(tu.get_non_tensor_data(data=data, key="pad_token_id", default=0))
+
+                if val.dim() == 1:
+                    pad_tensor = torch.full((slack_len,), pad_val, dtype=val.dtype)
+                    concatenated_td[k] = torch.cat([val, pad_tensor], dim=0)
+                else:
+                    pad_shape = list(val.shape)
+                    pad_shape[-1] = slack_len
+                    pad_tensor = torch.full(pad_shape, pad_val, dtype=val.dtype)
+                    concatenated_td[k] = torch.cat([val, pad_tensor], dim=-1)
+
+        cu_seqlens = torch.tensor(offsets, dtype=torch.int32)
+        positions = torch.arange(max_bin_len)
+        seq_indices = (positions.unsqueeze(1) >= cu_seqlens.unsqueeze(0)).sum(dim=1) - 1
+        same_seq_mask = seq_indices.unsqueeze(1) == seq_indices.unsqueeze(0)
+        causal_mask = positions.unsqueeze(1) >= positions.unsqueeze(0)
+
+        padding_seq_idx = (len(cu_seqlens) - 2) if slack_len > 0 else (len(cu_seqlens) - 1)
+        tpu_num_seqs_val = padding_seq_idx
+
+        non_pad_mask = seq_indices < padding_seq_idx
+
+        attention_mask = same_seq_mask & causal_mask & non_pad_mask.unsqueeze(1)
+        attention_mask = attention_mask.unsqueeze(0).unsqueeze(0)
+
+        mb_td = TensorDict({k: v.unsqueeze(0) for k, v in concatenated_td.items()}, batch_size=[1])
+
+        mb_td["tpu_custom_attention_mask"] = attention_mask
+        mb_td["tpu_cu_seqlens"] = NonTensorData([cu_seqlens])
+        mb_td["tpu_num_seqs"] = NonTensorData([tpu_num_seqs_val])
+
+        for k in keys_to_preserve:
+            vals = [seq["metadata"][k] for seq in bin_seqs]
+            if k in ["prompts", "responses"]:
+                mb_td[k] = NonTensorData(vals)
+            elif all(isinstance(v, torch.Tensor) for v in vals):
+                shapes = [v.shape for v in vals]
+                if all(s == shapes[0] for s in shapes):
+                    stacked = torch.stack(vals, dim=0)
+                    mb_td[k] = stacked.unsqueeze(0)
+                else:
+                    mb_td[k] = NonTensorData(vals)
+            else:
+                mb_td[k] = NonTensorData(vals)
+
+        packed_micro_batches.append(mb_td)
+
+    return packed_micro_batches, batch_idx_list
+
+
+def prepare_tpu_binned_pack_micro_batches(data: TensorDict) -> tuple[list[TensorDict], list[list[int]]]:
+    """Prepares static sequence-packed micro-batches synchronized across data-parallel ranks on TPU."""
+    max_length = tu.get_non_tensor_data(data=data, key="max_length", default=None)
+    if max_length is not None:
+        max_bin_len = max_length
+    else:
+        max_token_len = tu.get_non_tensor_data(data=data, key="max_token_len_per_gpu", default=None)
+        if max_token_len is not None:
+            max_bin_len = max_token_len
+        else:
+            max_prompt_length = tu.get_non_tensor_data(
+                data=data, key="max_prompt_length", default=DEFAULT_MAX_PROMPT_LEN
+            )
+            max_response_length = tu.get_non_tensor_data(
+                data=data, key="max_response_length", default=DEFAULT_MAX_RESPONSE_LEN
+            )
+            max_bin_len = max_prompt_length + max_response_length
+
+    micro_batches, batch_idx_list = tpu_binned_pack_tensordict(data=data, max_bin_len=max_bin_len)
+
+    num_bins = len(micro_batches)
+    if torch.distributed.is_initialized():
+        num_bins_tensor = torch.tensor([num_bins], dtype=torch.int32)
+        torch.distributed.all_reduce(num_bins_tensor, op=torch.distributed.ReduceOp.MAX)
+        global_max_bins = num_bins_tensor.item()
+    else:
+        global_max_bins = num_bins
+
+    mbsz = tu.get_non_tensor_data(data=data, key="micro_batch_size_per_gpu", default=1)
+    if global_max_bins % mbsz != 0:
+        global_max_bins = ((global_max_bins // mbsz) + 1) * mbsz
+
+    if num_bins < global_max_bins:
+        last_batch = micro_batches[-1]
+        last_indices = batch_idx_list[-1]
+        for _ in range(global_max_bins - num_bins):
+            dummy_batch = last_batch.clone()
+            if "loss_mask" in dummy_batch.keys():
+                dummy_batch["loss_mask"] = torch.zeros_like(dummy_batch["loss_mask"])
+            micro_batches.append(dummy_batch)
+            batch_idx_list.append([-1] * len(last_indices))
+
+    if mbsz > 1:
+        grouped_batches = []
+        grouped_idx_list = []
+        for idx in range(0, len(micro_batches), mbsz):
+            batch_slice = micro_batches[idx : idx + mbsz]
+            idx_slice = batch_idx_list[idx : idx + mbsz]
+
+            keys_to_pop = []
+            for k in list(batch_slice[0].keys()):
+                if k in ("tpu_cu_seqlens", "tpu_num_seqs"):
+                    keys_to_pop.append(k)
+                    continue
+
+                all_tensors = True
+                shapes = []
+                for mb in batch_slice:
+                    v = mb.get(k, None)
+                    if v is None or not isinstance(v, torch.Tensor) or isinstance(v, NonTensorData):
+                        all_tensors = False
+                        break
+                    shapes.append(v.shape)
+
+                if not all_tensors:
+                    keys_to_pop.append(k)
+                else:
+                    first_shape_suffix = shapes[0][1:]
+                    for sh in shapes[1:]:
+                        if sh[1:] != first_shape_suffix:
+                            keys_to_pop.append(k)
+                            break
+
+            combined_metadata = {}
+            for k in keys_to_pop:
+                combined_list = []
+                for mb in batch_slice:
+                    mb_val = mb.pop(k, None)
+                    if mb_val is not None:
+                        if isinstance(mb_val, NonTensorData):
+                            raw = mb_val.data
+                            if isinstance(raw, list | tuple):
+                                combined_list.extend(raw)
+                            else:
+                                combined_list.append(raw)
+                        else:
+                            if isinstance(mb_val, list | tuple):
+                                combined_list.extend(mb_val)
+                            else:
+                                combined_list.append(mb_val)
+                combined_metadata[k] = combined_list
+
+            grouped_td = torch.cat(batch_slice, dim=0)
+
+            for k, combined_list in combined_metadata.items():
+                if len(combined_list) > 0:
+                    grouped_td[k] = NonTensorData(combined_list)
+
+            grouped_batches.append(grouped_td)
+            grouped_idx_list.append([i for sub in idx_slice for i in sub])
+        micro_batches = grouped_batches
+        batch_idx_list = grouped_idx_list
+
+    return micro_batches, batch_idx_list
+
+
+def prepare_tpu_packed_outputs(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    micro_batch: TensorDict,
+    temperature: float,
+    calculate_entropy: bool,
+    entropy_checkpointing: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Reconstructs log_probs and entropy NestedTensors from sliced active tokens under TPU static sequence packing."""
+    mbsz = logits.shape[0]
+
+    cu_seqlens_list = micro_batch["tpu_cu_seqlens"]
+    if hasattr(cu_seqlens_list, "data"):
+        cu_seqlens_list = cu_seqlens_list.data
+    if not isinstance(cu_seqlens_list, list | tuple):
+        cu_seqlens_list = [cu_seqlens_list]
+
+    num_seqs_list = micro_batch["tpu_num_seqs"]
+    if hasattr(num_seqs_list, "data"):
+        num_seqs_list = num_seqs_list.data
+    if not isinstance(num_seqs_list, list | tuple):
+        num_seqs_list = [num_seqs_list]
+
+    log_probs_all_rows = []
+    entropy_all_rows = []
+    combined_offsets = [0]
+    current_offset = 0
+
+    for row_idx in range(mbsz):
+        cu_seqlens = cu_seqlens_list[row_idx]
+        if hasattr(cu_seqlens, "data"):
+            cu_seqlens = cu_seqlens.data
+        if isinstance(cu_seqlens, list):
+            cu_seqlens = (
+                cu_seqlens[0] if len(cu_seqlens) > 0 else torch.tensor([0, DEFAULT_MAX_BIN_LEN], dtype=torch.int32)
+            )
+        if hasattr(cu_seqlens, "data"):
+            cu_seqlens = cu_seqlens.data
+        if not isinstance(cu_seqlens, torch.Tensor):
+            cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
+
+        num_seqs = num_seqs_list[row_idx]
+        if hasattr(num_seqs, "data"):
+            num_seqs = num_seqs.data
+        if isinstance(num_seqs, list):
+            num_seqs = num_seqs[0] if len(num_seqs) > 0 else 1
+        if hasattr(num_seqs, "data"):
+            num_seqs = num_seqs.data
+
+        cu_seqlens_active = cu_seqlens[: num_seqs + 1]
+        active_len = int(cu_seqlens_active[-1].item())
+
+        logits_rmpad = logits[row_idx, :active_len, :] / temperature
+        labels_rmpad = labels[row_idx, :active_len]
+
+        log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=labels_rmpad)
+        log_probs_all_rows.append(log_probs_rmpad)
+
+        if calculate_entropy:
+            if not entropy_checkpointing:
+                entropy_rmpad = verl_F.entropy_from_logits(logits_rmpad)
+            else:
+                entropy_rmpad = torch.utils.checkpoint.checkpoint(verl_F.entropy_from_logits, logits_rmpad)
+            entropy_all_rows.append(entropy_rmpad)
+
+        for i in range(1, len(cu_seqlens_active)):
+            combined_offsets.append(current_offset + int(cu_seqlens_active[i].item()))
+        current_offset += active_len
+
+    log_probs_flat_cat = torch.cat(log_probs_all_rows, dim=0)
+    cu_seqlens_combined = torch.tensor(combined_offsets, dtype=torch.int32, device=log_probs_flat_cat.device)
+
+    log_probs = torch.nested.nested_tensor_from_jagged(log_probs_flat_cat, cu_seqlens_combined)
+
+    entropy = None
+    if calculate_entropy:
+        entropy_flat_cat = torch.cat(entropy_all_rows, dim=0)
+        entropy = torch.nested.nested_tensor_from_jagged(entropy_flat_cat, cu_seqlens_combined)
+
+    return log_probs, entropy
+
+
+def monkey_patch_varlen_attention_tpu():
+    """Patches TorchTitan's VarlenAttention forward method to use native scaled_dot_product_attention on TPU."""
+    try:
+        from torchtitan.models.common.attention import VarlenAttention
+
+        def tpu_varlen_forward(self, xq, xk, xv, *, attention_masks, scale=None, **kwargs):
+            if attention_masks.dim() == 4:
+                mask = attention_masks.to(torch.bool)
+            elif hasattr(attention_masks, "cu_seq_q"):
+                total_tokens = xq.shape[1]
+                cu_seqs = attention_masks.cu_seq_q
+
+                positions = torch.arange(total_tokens, device=xq.device)
+                seq_indices = (positions.unsqueeze(1) >= cu_seqs.unsqueeze(0)).sum(dim=1) - 1
+                same_seq_mask = seq_indices.unsqueeze(1) == seq_indices.unsqueeze(0)
+                causal_mask = positions.unsqueeze(1) >= positions.unsqueeze(0)
+
+                mask = same_seq_mask & causal_mask
+                mask = mask.unsqueeze(0).unsqueeze(0)
+            else:
+                seq_len = xq.shape[1]
+                positions = torch.arange(seq_len, device=xq.device)
+                causal_mask = (positions.unsqueeze(1) >= positions.unsqueeze(0)).unsqueeze(0).unsqueeze(0)
+
+                padding_mask = attention_masks.unsqueeze(1).unsqueeze(2).to(torch.bool)
+                mask = causal_mask & padding_mask
+
+            q = xq.transpose(1, 2)
+            k = xk.transpose(1, 2)
+            v = xv.transpose(1, 2)
+
+            if q.shape[1] != k.shape[1]:
+                num_repeat = q.shape[1] // k.shape[1]
+                k = k.repeat_interleave(num_repeat, dim=1)
+                v = v.repeat_interleave(num_repeat, dim=1)
+
+            attn_out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, scale=scale)
+            return attn_out.transpose(1, 2)
+
+        VarlenAttention.forward = tpu_varlen_forward
+        logger.info("Successfully patched VarlenAttention.forward for TPU execution.")
+    except Exception as e:
+        logger.warning(f"Failed to patch VarlenAttention: {e}")
+
+
+def compute_global_batch_num_tokens(data: TensorDict, dp_group, tp_size: int) -> Any:
+    """Computes global batch token count for loss normalization on TPU.
+
+    On TPU, performing CPU-side all-reduce for loss normalization avoids graph desynchronization
+    and JIT compilation lockups across ranks.
+    """
+    batch_num_tokens = data["loss_mask"].sum().cpu()
+    if torch.distributed.is_initialized():
+        torch.distributed.all_reduce(batch_num_tokens, op=torch.distributed.ReduceOp.SUM)
+        batch_num_tokens = batch_num_tokens / tp_size
+    return batch_num_tokens.item()
+
+
+def synchronize_tpu_loss(loss: torch.Tensor):
+    """Materializes forward graph loss without blocking to split XLA forward and backward compilation passes."""
+    try:
+        from torch_tpu._internal.sync import synchronize
+
+        synchronize(loss, wait=False)
+    except ImportError:
+        pass
+
+
+def compute_tpu_max_seq_len(input_ids: torch.Tensor) -> int:
+    """Rounds up sequence length to a multiple of 128 to ensure memory stride alignment on TPU."""
+    offsets = input_ids.offsets()
+    offsets_tpu = torch.empty(offsets.shape, dtype=offsets.dtype, device=offsets.device)
+    offsets_tpu.copy_(offsets)
+    max_seq_len = int(max(offsets_tpu.cpu().diff()))
+    max_seq_len = (
+        (max_seq_len + SEQUENCE_ALIGNMENT_MULTIPLE - 1) // SEQUENCE_ALIGNMENT_MULTIPLE
+    ) * SEQUENCE_ALIGNMENT_MULTIPLE
+    return max_seq_len
+
+
+def reconstruct_tpu_packed_metadata_tensors(micro_batch: TensorDict, device_id: Any):
+    """Reconstructs nested prompts/responses tensors on device from host NonTensorData lists."""
+    for k in ["prompts", "responses"]:
+        if k in micro_batch.keys():
+            val = micro_batch[k]
+            if isinstance(val, NonTensorData):
+                val = val.data
+            if isinstance(val, list):
+                flat_vals = [v.values() if getattr(v, "is_nested", False) else v for v in val]
+                flat_vals = [f.to(device_id) for f in flat_vals]
+                nested_val = torch.nested.as_nested_tensor(flat_vals, layout=torch.jagged)
+                micro_batch._tensordict[k] = nested_val
+
+
+def unwrap_metadata(val):
+    """Recursively unwraps metadata values (lists, single-element tensors) to standard Python types."""
+    if isinstance(val, list):
+        if len(val) > 0:
+            return unwrap_metadata(val[0])
+        return None
+    if isinstance(val, torch.Tensor):
+        if val.numel() == 1:
+            return val.item()
+        elif val.numel() > 1:
+            return val.flatten()[0].item()
+    return val
+
+
+def prepare_tpu_model_outputs_if_packed(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    micro_batch: TensorDict,
+    temperature: float,
+    calculate_entropy: bool,
+    entropy_checkpointing: bool,
+):
+    """If the micro-batch uses TPU static sequence packing, reconstructs log_probs and entropy NestedTensors."""
+    if "tpu_custom_attention_mask" in micro_batch.keys():
+        log_probs, entropy = prepare_tpu_packed_outputs(
+            logits=logits,
+            labels=labels,
+            micro_batch=micro_batch,
+            temperature=temperature,
+            calculate_entropy=calculate_entropy,
+            entropy_checkpointing=entropy_checkpointing,
+        )
+        return log_probs, entropy
+    return None
+
+
+def safe_to_padded_tensor(nt: Any, padding: Any = 0, output_size: Any = None) -> torch.Tensor:
+    """Safely converts a NestedTensor to a padded dense tensor on TPU.
+
+    PyTorch TPU currently lacks native C++ kernel support for `aten::_jagged_to_padded_dense_forward`.
+    Falling back to `unbind()` + tensor slice assignment avoids operator runtime errors on TPU.
+    """
+    if not getattr(nt, "is_nested", False):
+        return nt
+    try:
+        return torch.nested.to_padded_tensor(nt, padding=padding, output_size=output_size)
+    except Exception:
+        tensors = nt.unbind()
+        if not tensors:
+            return torch.empty(output_size, device=nt.device, dtype=nt.dtype)
+        if output_size is not None and len(output_size) == 3:
+            out = torch.full(output_size, padding, device=tensors[0].device, dtype=tensors[0].dtype)
+            for i, t in enumerate(tensors):
+                out[i, :, : t.shape[-1]] = t
+        elif output_size is not None:
+            out = torch.full(output_size, padding, device=tensors[0].device, dtype=tensors[0].dtype)
+            for i, t in enumerate(tensors):
+                out[i, : t.shape[-1]] = t
+        else:
+            batch_size = len(tensors)
+            max_len = max(t.shape[-1] for t in tensors)
+            out = torch.full((batch_size, max_len), padding, device=tensors[0].device, dtype=tensors[0].dtype)
+            for i, t in enumerate(tensors):
+                out[i, : t.shape[-1]] = t
+        return out

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -854,7 +854,9 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
         device_name = get_device_name()
         micro_batch = micro_batch.to(get_device_id())
 
-        reconstruct_tpu_packed_metadata_tensors(micro_batch, get_device_id())
+        # Guard TPU-specific packed metadata reconstruction to run only on TPU devices
+        if device_name == "tpu":
+            reconstruct_tpu_packed_metadata_tensors(micro_batch, get_device_id())
 
         input_ids, extra_inputs, extra_kwargs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
 

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -30,15 +30,15 @@ from torch.distributed.tensor import DTensor
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
-from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
-from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
+from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.config import ActivationCheckpointConfig, CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed import utils as dist_utils
-from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.train import Trainer
 
 import verl.utils.torch_functional as verl_F
+from verl.plugin.platform import get_platform
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
@@ -53,6 +53,17 @@ from verl.utils.fsdp_utils import (
 from verl.utils.model import extract_multi_modal_inputs
 from verl.utils.torch_functional import logprobs_from_logits
 from verl.workers.config import HFModelConfig, TorchtitanEngineConfig, TorchtitanOptimizerConfig
+from verl.workers.engine.torchtitan.tpu_utils import (
+    compute_global_batch_num_tokens,
+    compute_tpu_max_seq_len,
+    monkey_patch_varlen_attention_tpu,
+    prepare_tpu_binned_pack_micro_batches,
+    prepare_tpu_model_outputs_if_packed,
+    reconstruct_tpu_packed_metadata_tensors,
+    safe_to_padded_tensor,
+    synchronize_tpu_loss,
+    unwrap_metadata,
+)
 from verl.workers.engine.torchtitan.utils import (
     NoOpDataLoader,
     derive_torchtitan_name_and_flavor,
@@ -68,6 +79,9 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 device_name = get_device_name()
+
+if device_name == "tpu":
+    monkey_patch_varlen_attention_tpu()
 
 
 class TorchTitanEngine(BaseEngine):
@@ -110,19 +124,17 @@ class TorchTitanEngine(BaseEngine):
         model_module = importlib.import_module(f"torchtitan.models.{torchtitan_name}")
         model_spec = model_module.model_registry(torchtitan_flavor, attn_backend=self.engine_config.attn_type)
 
+        # Use foreach optimizer implementation on TPU.
+        impl = "foreach" if get_platform().device_name == "tpu" else "fused"
+
         optimizer = OptimizersContainer.Config(
-            param_groups=[
-                ParamGroupConfig(
-                    pattern=r".*",
-                    optimizer_name=self.optimizer_config.name,
-                    optimizer_kwargs={
-                        "lr": self.optimizer_config.lr,
-                        "eps": self.optimizer_config.eps,
-                        "betas": (self.optimizer_config.betas[0], self.optimizer_config.betas[1]),
-                        "weight_decay": self.optimizer_config.weight_decay,
-                    },
-                )
-            ],
+            name=self.optimizer_config.name,
+            lr=self.optimizer_config.lr,
+            eps=self.optimizer_config.eps,
+            beta1=self.optimizer_config.betas[0],
+            beta2=self.optimizer_config.betas[1],
+            weight_decay=self.optimizer_config.weight_decay,
+            implementation=impl,
         )
 
         total_steps = self.optimizer_config.total_training_steps
@@ -143,7 +155,6 @@ class TorchTitanEngine(BaseEngine):
             pipeline_parallel_degree=self.engine_config.pipeline_parallel_size,
             context_parallel_degree=self.engine_config.context_parallel_size,
             expert_parallel_degree=self.engine_config.expert_parallel_size,
-            spmd_backend=self.engine_config.spmd_backend,
         )
         checkpoint = CheckpointManager.Config(
             enable=True,
@@ -151,7 +162,12 @@ class TorchTitanEngine(BaseEngine):
             initial_load_model_only=True,
             initial_load_path=model_config.path,
         )
-        compile_config = CompileConfig(enable=self.engine_config.use_torch_compile)
+        # Set compile backend to 'tpu' when running on TPU.
+        compile_config = CompileConfig(
+            enable=self.engine_config.use_torch_compile,
+            backend="tpu" if device_name == "tpu" else "inductor",
+        )
+
         training_kwargs = {}
         if self.engine_config.max_seq_len is not None:
             training_kwargs["seq_len"] = self.engine_config.max_seq_len
@@ -166,9 +182,9 @@ class TorchTitanEngine(BaseEngine):
         # so spmd.assert_type() raises "no current mesh". Set activation_checkpoint="none"
         # (or enable torch.compile, which recomputes in-graph) in that configuration.
         activation_checkpoint = {
-            "selective": SelectiveAC.Config,
-            "full": FullAC.Config,
-            "none": lambda: None,
+            "selective": lambda: ActivationCheckpointConfig(mode="selective"),
+            "full": lambda: ActivationCheckpointConfig(mode="full"),
+            "none": lambda: ActivationCheckpointConfig(mode="none"),
         }[self.engine_config.activation_checkpoint]()
 
         # Construct Torchtitan's Trainer.Config
@@ -191,6 +207,9 @@ class TorchTitanEngine(BaseEngine):
         self.trainer = Trainer(self.config)
 
         self._init_device_mesh()
+
+        if get_device_name() == "tpu" and torch.distributed.is_initialized():
+            torch.distributed.barrier()
 
         # Re-enable FSDP's gradient division for verl's loss scaling.
         # TorchTitan disables gradient division by default (for global token normalization),
@@ -337,20 +356,28 @@ class TorchTitanEngine(BaseEngine):
     def forward_backward_batch(self, data: TensorDict, loss_function: Callable, forward_only=False):
         """Perform forward and optionally backward pass on a batch."""
         tu.assign_non_tensor(data, sp_size=self.engine_config.tensor_parallel_size)
-
-        # Compute num_tokens in global batch for loss normalization
-        batch_num_tokens = data["loss_mask"].sum().to(get_device_id())
         dp_group = self.get_data_parallel_group()
-        if dp_group is not None:
-            torch.distributed.all_reduce(batch_num_tokens, op=torch.distributed.ReduceOp.SUM, group=dp_group)
-        tu.assign_non_tensor(data, batch_num_tokens=batch_num_tokens.item())
+        is_tpu = get_device_name() == "tpu"
+
+        if is_tpu:
+            batch_num_tokens = compute_global_batch_num_tokens(data, dp_group, self.engine_config.tensor_parallel_size)
+        else:
+            batch_num_tokens = data["loss_mask"].sum().to(get_device_id())
+            if dp_group is not None:
+                torch.distributed.all_reduce(batch_num_tokens, op=torch.distributed.ReduceOp.SUM, group=dp_group)
+            batch_num_tokens = batch_num_tokens if batch_num_tokens.device.type == "tpu" else batch_num_tokens.item()
+        tu.assign_non_tensor(data, batch_num_tokens=batch_num_tokens)
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())
 
-        micro_batches, indices = prepare_micro_batches(
-            data=data,
-            dp_group=self.get_data_parallel_group(),
-            same_micro_num_in_dp=True,
-        )
+        pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
+        if is_tpu and pad_mode == DatasetPadMode.NO_PADDING:
+            micro_batches, indices = prepare_tpu_binned_pack_micro_batches(data)
+        else:
+            micro_batches, indices = prepare_micro_batches(
+                data=data,
+                dp_group=self.get_data_parallel_group(),
+                same_micro_num_in_dp=True,
+            )
 
         output_lst = []
 
@@ -362,6 +389,8 @@ class TorchTitanEngine(BaseEngine):
             with self.trainer.train_context(), ctx:
                 loss, output = self.forward_step(micro_batch, loss_function=loss_function, forward_only=forward_only)
                 if not forward_only:
+                    if get_device_name() == "tpu":
+                        synchronize_tpu_loss(loss)
                     loss.backward()
             output_lst.append(output)
 
@@ -595,21 +624,60 @@ class EngineTrainModeCtx(BaseEngineCtx):
         super().__exit__(exc_type, exc_value, traceback)
 
 
-@EngineRegistry.register(model_type="language_model", backend=["torchtitan"], device=["cuda", "npu"])
+@EngineRegistry.register(model_type="language_model", backend=["torchtitan"], device=["cuda", "npu", "tpu"])
 class TorchTitanEngineWithLMHead(TorchTitanEngine):
     """TorchTitan engine implementation for language models with LM head."""
 
     def prepare_model_inputs(self, micro_batch: TensorDict):
+        if "tpu_custom_attention_mask" in micro_batch.keys():
+            # Packed TPU format
+            input_ids = micro_batch["input_ids"]
+            position_ids = micro_batch["position_ids"]
+            labels = torch.roll(input_ids, shifts=-1, dims=1)
+            labels[:, -1] = -100
+            attention_mask = micro_batch["tpu_custom_attention_mask"]
+            extra_inputs = {"positions": position_ids}
+            extra_kwargs = {"attention_masks": attention_mask}
+            output_args = {"labels": labels}
+
+            # Send to TPU device and ensure contiguous
+            device = self.trainer.device
+            input_ids = input_ids.to(device).contiguous()
+            extra_inputs = {
+                k: v.to(device).contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_inputs.items()
+            }
+            extra_kwargs = {
+                k: v.to(device).contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_kwargs.items()
+            }
+            output_args = {
+                k: v.to(device).contiguous() if isinstance(v, torch.Tensor) else v for k, v in output_args.items()
+            }
+
+            return input_ids, extra_inputs, extra_kwargs, output_args
+
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         pad_mode = tu.get_non_tensor_data(data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-        assert pad_mode == DatasetPadMode.NO_PADDING, f"pad_mode {pad_mode} not supported"
+        assert pad_mode in (
+            DatasetPadMode.NO_PADDING,
+            DatasetPadMode.RIGHT,
+            DatasetPadMode.TPU_BINNED_PACK,
+            "tpu_binned_pack",
+        ), f"pad_mode {pad_mode} not supported"
 
         multi_modal_inputs = extract_multi_modal_inputs(micro_batch.get("multi_modal_inputs", []))
         input_ids = micro_batch["input_ids"]
         position_ids = micro_batch["position_ids"]
         output_args = {}
 
-        if use_remove_padding:
+        if pad_mode == DatasetPadMode.RIGHT:
+            # For static/pre-padded RIGHT padding format, no nested/jagged tensor mechanics are needed.
+            # Shifting input_ids by -1 yields target labels.
+            labels = torch.roll(input_ids, shifts=-1, dims=1)
+            labels[:, -1] = -100  # Mask out the last wrapped label token
+            attention_mask = micro_batch["attention_mask"]
+            if position_ids.dim() == 3:
+                position_ids = position_ids.transpose(0, 1)
+        elif use_remove_padding:
             input_ids = input_ids.values().unsqueeze(0)
             if position_ids.dim() == 3:
                 position_ids = position_ids.values().unsqueeze(1)
@@ -627,27 +695,26 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
             loss_mask = micro_batch["loss_mask"]
             pad_token_id = tu.get_non_tensor_data(data=micro_batch, key="pad_token_id", default=0)
             batch_size = micro_batch.batch_size[0]
-            max_seq_len = max(input_ids.offsets().diff())
+            if self.engine_config.max_seq_len is not None:
+                max_seq_len = self.engine_config.max_seq_len
+            elif input_ids.device.type == "tpu":
+                max_seq_len = compute_tpu_max_seq_len(input_ids)
+            else:
+                max_seq_len = max(input_ids.offsets().diff())
 
             labels = torch.roll(input_ids.values(), shifts=-1, dims=0)
-            input_ids = torch.nested.to_padded_tensor(
-                input_ids, padding=pad_token_id, output_size=(batch_size, max_seq_len)
-            )
+            input_ids = safe_to_padded_tensor(input_ids, padding=pad_token_id, output_size=(batch_size, max_seq_len))
 
             if position_ids.dim() == 3:
-                position_ids = torch.nested.to_padded_tensor(
+                position_ids = safe_to_padded_tensor(
                     position_ids, padding=0, output_size=(batch_size, 4, max_seq_len)
                 ).transpose(0, 1)
             else:
-                position_ids = torch.nested.to_padded_tensor(
-                    position_ids, padding=0, output_size=(batch_size, max_seq_len)
-                )
+                position_ids = safe_to_padded_tensor(position_ids, padding=0, output_size=(batch_size, max_seq_len))
 
             attention_mask_list = [torch.ones_like(t, dtype=torch.int32) for t in loss_mask]
             attention_mask = torch.nested.as_nested_tensor(attention_mask_list, layout=torch.jagged)
-            attention_mask = torch.nested.to_padded_tensor(
-                attention_mask, padding=0, output_size=(batch_size, max_seq_len)
-            )
+            attention_mask = safe_to_padded_tensor(attention_mask, padding=0, output_size=(batch_size, max_seq_len))
 
         extra_inputs = {
             "positions": position_ids,
@@ -669,68 +736,113 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
         # TODO(jessicazhong): multimodal is not yet supported for Torchtitan engine
         extra_inputs.update(multi_modal_inputs)
         output_args["labels"] = labels
+
+        # Ensure all model inputs and kwargs are contiguous on TPU.
+        if input_ids.device.type == "tpu":
+            input_ids = input_ids.contiguous()
+            extra_inputs = {k: v.contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_inputs.items()}
+            extra_kwargs = {k: v.contiguous() if isinstance(v, torch.Tensor) else v for k, v in extra_kwargs.items()}
+
         return input_ids, extra_inputs, extra_kwargs, output_args
 
     def prepare_model_outputs(self, logits, output_args, micro_batch: TensorDict):
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
+        use_remove_padding = unwrap_metadata(use_remove_padding)
+
         pad_mode = tu.get_non_tensor_data(data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-        assert pad_mode == DatasetPadMode.NO_PADDING, f"pad_mode {pad_mode} not supported"
+        pad_mode = unwrap_metadata(pad_mode)
+        assert pad_mode in (
+            DatasetPadMode.NO_PADDING,
+            DatasetPadMode.RIGHT,
+            DatasetPadMode.TPU_BINNED_PACK,
+            "tpu_binned_pack",
+        ), f"pad_mode {pad_mode} not supported"
 
         temperature = micro_batch["temperature"]
+        temperature = unwrap_metadata(temperature)
+
         calculate_entropy = tu.get_non_tensor_data(data=micro_batch, key="calculate_entropy", default=False)
+        calculate_entropy = unwrap_metadata(calculate_entropy)
+
         labels = output_args["labels"]
         model_output = {}
 
-        input_ids = micro_batch["input_ids"]
-        cu_seqlens = input_ids.offsets()
-        if use_remove_padding:
-            labels = labels.squeeze(0)
-            logits_rmpad = logits.squeeze(0)
-            # PyTorch's autograd doesn't allow in-place modification of views when gradients need to flow back
-            logits_rmpad = logits_rmpad / temperature
+        tpu_outputs = prepare_tpu_model_outputs_if_packed(
+            logits=logits,
+            labels=labels,
+            micro_batch=micro_batch,
+            temperature=temperature,
+            calculate_entropy=calculate_entropy,
+            entropy_checkpointing=self.engine_config.entropy_checkpointing,
+        )
 
-            inplace_backward = True
-            if calculate_entropy:
-                inplace_backward = False
-            log_probs = logprobs_from_logits(
-                logits=logits_rmpad,
-                labels=labels,
-                inplace_backward=inplace_backward,
-            )
-
-            if calculate_entropy:
-                if not self.engine_config.entropy_checkpointing:
-                    if self.engine_config.entropy_from_logits_with_chunking:
-                        entropy_rmpad = self.compute_entropy_from_logits(
-                            logits_rmpad,
-                            chunk_size=self.engine_config.entropy_from_logits_chunk_size,
-                        )  # ((total_nnz / sp) + pad)
-                    else:
-                        entropy_rmpad = self.compute_entropy_from_logits(logits_rmpad)
-                else:
-                    entropy_rmpad = torch.utils.checkpoint.checkpoint(self.compute_entropy_from_logits, logits_rmpad)
-
-            log_probs = torch.nested.nested_tensor_from_jagged(log_probs.squeeze(0), cu_seqlens)
-            if calculate_entropy:
-                entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
-        else:
-            logits.div_(temperature)
+        if tpu_outputs is not None:
+            log_probs, entropy = tpu_outputs
+        elif pad_mode == DatasetPadMode.RIGHT:
+            logits = logits / temperature
             if calculate_entropy:
                 if not self.engine_config.entropy_checkpointing:
                     entropy = verl_F.entropy_from_logits(logits)
                 else:
                     entropy = torch.utils.checkpoint.checkpoint(verl_F.entropy_from_logits, logits)
 
-            seq_lengths = cu_seqlens.diff()
-            starts = torch.zeros_like(seq_lengths, dtype=torch.int64)
-            logits = torch.nested.narrow(logits, 1, starts, seq_lengths, layout=torch.jagged)
-            logits_rmpad = torch.cat([t for t in logits.unbind()])
-            log_probs = logprobs_from_logits(logits=logits_rmpad, labels=output_args["labels"])
-            log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
-            if calculate_entropy:
-                entropy = torch.nested.narrow(entropy, 1, starts, seq_lengths, layout=torch.jagged)
-                entropy_rmpad = torch.cat([t for t in entropy.unbind()])
-                entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
+            log_probs = logprobs_from_logits(logits=logits, labels=labels)
+        else:
+            input_ids = micro_batch["input_ids"]
+            if hasattr(input_ids, "offsets"):
+                cu_seqlens = input_ids.offsets()
+            else:
+                cu_seqlens = micro_batch["tpu_cu_seqlens"].squeeze(0)
+            if use_remove_padding:
+                labels = labels.squeeze(0)
+                logits_rmpad = logits.squeeze(0)
+                # PyTorch's autograd doesn't allow in-place modification of views when gradients need to flow back
+                logits_rmpad = logits_rmpad / temperature
+
+                inplace_backward = True
+                if calculate_entropy:
+                    inplace_backward = False
+                log_probs = logprobs_from_logits(
+                    logits=logits_rmpad,
+                    labels=labels,
+                    inplace_backward=inplace_backward,
+                )
+
+                if calculate_entropy:
+                    if not self.engine_config.entropy_checkpointing:
+                        if self.engine_config.entropy_from_logits_with_chunking:
+                            entropy_rmpad = self.compute_entropy_from_logits(
+                                logits_rmpad,
+                                chunk_size=self.engine_config.entropy_from_logits_chunk_size,
+                            )  # ((total_nnz / sp) + pad)
+                        else:
+                            entropy_rmpad = self.compute_entropy_from_logits(logits_rmpad)
+                    else:
+                        entropy_rmpad = torch.utils.checkpoint.checkpoint(
+                            self.compute_entropy_from_logits, logits_rmpad
+                        )
+
+                log_probs = torch.nested.nested_tensor_from_jagged(log_probs.squeeze(0), cu_seqlens)
+                if calculate_entropy:
+                    entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
+            else:
+                logits = logits / temperature
+                if calculate_entropy:
+                    if not self.engine_config.entropy_checkpointing:
+                        entropy = verl_F.entropy_from_logits(logits)
+                    else:
+                        entropy = torch.utils.checkpoint.checkpoint(verl_F.entropy_from_logits, logits)
+
+                seq_lengths = cu_seqlens.diff()
+                starts = torch.zeros_like(seq_lengths, dtype=torch.int64)
+                logits = torch.nested.narrow(logits, 1, starts, seq_lengths, layout=torch.jagged)
+                logits_rmpad = torch.cat([t for t in logits.unbind()])
+                log_probs = logprobs_from_logits(logits=logits_rmpad, labels=output_args["labels"])
+                log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
+                if calculate_entropy:
+                    entropy = torch.nested.narrow(entropy, 1, starts, seq_lengths, layout=torch.jagged)
+                    entropy_rmpad = torch.cat([t for t in entropy.unbind()])
+                    entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
 
         model_output["log_probs"] = log_probs
         if calculate_entropy:
@@ -741,6 +853,9 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
     def forward_step(self, micro_batch: TensorDict, loss_function, forward_only):
         device_name = get_device_name()
         micro_batch = micro_batch.to(get_device_id())
+
+        reconstruct_tpu_packed_metadata_tensors(micro_batch, get_device_id())
+
         input_ids, extra_inputs, extra_kwargs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
 
         with torch.autocast(device_type=device_name, dtype=torch.bfloat16):

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -106,7 +106,9 @@ def postprocess_batch_func(output_lst, indices, data: TensorDict):
 
     use_dynamic_bsz = tu.get_non_tensor_data(data=data, key="use_dynamic_bsz", default=True)
     pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-    assert pad_mode == DatasetPadMode.NO_PADDING, "postprocess_batch_func only support NO_PADDING pad_mode"
+    assert pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"], (
+        "postprocess_batch_func only support NO_PADDING or TPU_BINNED_PACK pad_mode"
+    )
 
     # losses_reduced is a list of dict containing outputs for each micro-batch
     # reorder entropy and outputs. Return None for other pp ranks
@@ -129,7 +131,7 @@ def postprocess_batch_func(output_lst, indices, data: TensorDict):
 
     # concat results from micro batches
     for key, val in model_output.items():
-        if pad_mode == DatasetPadMode.NO_PADDING:
+        if pad_mode in [DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"]:
             tensors = [tensor for nt in model_output[key] for tensor in nt.unbind()]
             model_output[key] = torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
         else:

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -28,7 +28,7 @@ from tensordict import NonTensorData, TensorDict
 from torch.distributed.device_mesh import init_device_mesh
 
 from verl.checkpoint_engine import CheckpointEngineRegistry
-from verl.plugin.platform.platform_tpu_workarounds import convert_tensors_to_scalars
+from verl.plugin.platform import get_platform
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
 from verl.trainer.distillation import distillation_ppo_loss, is_distillation_enabled
@@ -214,9 +214,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
         lr = metrics.pop("lr", None)
 
         # For other metrics, we perform all gather in dp group (only if DP > 1)
-        if self.device_name == "tpu":
-            # Convert device-bound TPU tensors in the metrics dict to standard Python scalars.
-            metrics = convert_tensors_to_scalars(metrics)
+        metrics = get_platform().sanitize_metrics(metrics)
 
         if self.device_name == "tpu":
             final_metrics = metrics
@@ -248,9 +246,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
             final_metrics["mfu"] = estimated_flops / promised_flops / torch.distributed.get_world_size()
             if forward_only:
                 final_metrics["mfu"] /= 3.0
-        if self.device_name == "tpu":
-            # Convert any tensors in final_metrics to scalars/cpu before moving to cpu inside TensorDict
-            final_metrics = convert_tensors_to_scalars(final_metrics)
+        final_metrics = get_platform().sanitize_metrics(final_metrics)
         # model outputs
         model_output = output.pop("model_output", {})
         # We only return final_metrics
@@ -347,8 +343,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
                                 output[key] = sum(val) / len(val) if isinstance(val[0], int | float) else val[0]
                     append_to_dict(metrics, output)
 
-                if self.device_name == "tpu":
-                    metrics = convert_tensors_to_scalars(metrics)
+                metrics = get_platform().sanitize_metrics(metrics)
                 output = tu.get_tensordict(tensor_dict={}, non_tensor_dict={"metrics": metrics}).cpu()
             else:
                 output = None
@@ -718,7 +713,6 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     @_with_routing_replay_flag(enabled=True)
     def compute_log_prob(self, data: TensorDict) -> TensorDict:
         output = self.actor.infer_batch(data)
-
         return output.cpu() if output is not None else None
 
     @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -28,6 +28,7 @@ from tensordict import NonTensorData, TensorDict
 from torch.distributed.device_mesh import init_device_mesh
 
 from verl.checkpoint_engine import CheckpointEngineRegistry
+from verl.plugin.platform.platform_tpu_workarounds import convert_tensors_to_scalars
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
 from verl.trainer.distillation import distillation_ppo_loss, is_distillation_enabled
@@ -191,11 +192,20 @@ class TrainingWorker(Worker, DistProfilerExtension):
         # perform all gather in dp group to ensure that it's correct.
         # Here each metric in metrics can be a list (micro-batch metrics) or a singleton
         # we should always sum the loss of each micro-batch as we scale by global_bsz/global_token
-        loss = torch.sum(torch.tensor(output.pop("loss"), device=self.device_name))
         dp_group = self.engine.get_data_parallel_group()
-        if dp_group is not None:
-            torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
-        loss = loss.item()
+
+        if self.device_name == "tpu":
+            # Avoid eager distributed TPU/Gloo collectives outside JIT execution graphs.
+            # Convert all metrics to CPU scalars and return them directly;
+            # the driver (sft_trainer_ray.py) collects and averages metrics across ranks on CPU.
+            loss = torch.sum(torch.tensor(output.pop("loss"), device="cpu")).item()
+            target_group = None
+        else:
+            loss = torch.sum(torch.tensor(output.pop("loss"), device=self.device_name))
+            if dp_group is not None:
+                torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
+            loss = loss.item()
+            target_group = dp_group
 
         # For grad_norm, we do not perform all reduce because it is already been done when clipping grad
         grad_norm = metrics.pop("grad_norm", None)
@@ -204,8 +214,14 @@ class TrainingWorker(Worker, DistProfilerExtension):
         lr = metrics.pop("lr", None)
 
         # For other metrics, we perform all gather in dp group (only if DP > 1)
-        if dp_group is not None:
-            final_metrics = allgather_dict_into_dict(data=metrics, group=dp_group)
+        if self.device_name == "tpu":
+            # Convert device-bound TPU tensors in the metrics dict to standard Python scalars.
+            metrics = convert_tensors_to_scalars(metrics)
+
+        if self.device_name == "tpu":
+            final_metrics = metrics
+        elif target_group is not None:
+            final_metrics = allgather_dict_into_dict(data=metrics, group=target_group)
         else:
             final_metrics = metrics
         final_metrics["loss"] = loss
@@ -232,6 +248,9 @@ class TrainingWorker(Worker, DistProfilerExtension):
             final_metrics["mfu"] = estimated_flops / promised_flops / torch.distributed.get_world_size()
             if forward_only:
                 final_metrics["mfu"] /= 3.0
+        if self.device_name == "tpu":
+            # Convert any tensors in final_metrics to scalars/cpu before moving to cpu inside TensorDict
+            final_metrics = convert_tensors_to_scalars(final_metrics)
         # model outputs
         model_output = output.pop("model_output", {})
         # We only return final_metrics
@@ -320,13 +339,16 @@ class TrainingWorker(Worker, DistProfilerExtension):
                     for key, val in output.items():
                         # flattn dp and micro batch
                         if isinstance(val, list):
-                            output[key] = (
-                                Metric.aggregate_dp(val)
-                                if isinstance(val[0], Metric)
-                                else list(chain.from_iterable(val))
-                            )
+                            if isinstance(val[0], Metric):
+                                output[key] = Metric.aggregate_dp(val)
+                            elif isinstance(val[0], list | tuple):
+                                output[key] = list(chain.from_iterable(val))
+                            else:
+                                output[key] = sum(val) / len(val) if isinstance(val[0], int | float) else val[0]
                     append_to_dict(metrics, output)
 
+                if self.device_name == "tpu":
+                    metrics = convert_tensors_to_scalars(metrics)
                 output = tu.get_tensordict(tensor_dict={}, non_tensor_dict={"metrics": metrics}).cpu()
             else:
                 output = None

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -25,7 +25,7 @@ from ray.actor import ActorHandle
 
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup, ResourcePoolManager
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import get_device_name
+from verl.utils.device import get_device_name, get_resource_name
 from verl.workers.config import HFModelConfig, RolloutConfig
 
 logger = logging.getLogger(__file__)
@@ -165,8 +165,10 @@ class RolloutReplica(ABC):
             resource_pool: RayResourcePool, ray placement group where hybrid engine processes have been launched.
         """
         self.rollout_mode = RolloutMode.COLOCATED
-        self.resource_pool = resource_pool
+        # On TPU platforms, disable GPU resource allocation for colocated rollout workers
         use_gpu = self.rollout_worker_use_gpu()
+        if get_resource_name() == "TPU":
+            use_gpu = False
 
         if self.is_reward_model:
             name_prefix = f"rollout_reward_colocate_{self.replica_rank}{self.name_suffix}"
@@ -214,12 +216,15 @@ class RolloutReplica(ABC):
             name_prefix = f"rollout_teacher_standalone_{self.replica_rank}{self.name_suffix}"
         else:
             name_prefix = f"rollout_standalone_{self.replica_rank}{self.name_suffix}"
+        from verl.plugin.platform import get_platform
+
+        use_gpu = get_platform().device_name != "tpu"
         worker_group = RayWorkerGroup(
             resource_pool=self.resource_pool,
             ray_cls_with_init=self.get_ray_class_with_init_args(),
             bin_pack=False,
             name_prefix=name_prefix,
-            use_gpu=True,
+            use_gpu=use_gpu,
             device_name=get_device_name(),
         )
         self.workers = worker_group.workers

--- a/verl/workers/rollout/vllm_rollout/tpu_utils.py
+++ b/verl/workers/rollout/vllm_rollout/tpu_utils.py
@@ -1,0 +1,1205 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import copy
+import gc
+import json
+import logging
+import multiprocessing
+import multiprocessing.process
+import os
+import sys
+import time
+import types
+from collections import defaultdict
+from typing import Any
+
+import numpy as np
+import ray
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+from verl.utils.device import get_resource_name
+
+# --- Google TPU specific global constants ---
+TPU_WEIGHT_REGISTRY_ACTOR_NAME = "TPUWeightRegistry"
+TPU_WEIGHT_REGISTRY_NAMESPACE = "verl"
+TPU_ROLLOUT_BASE_PORT = 8070
+TPU_HOST_BOUNDS_VAL = "2,4,1"
+TPU_CHIPS_PER_HOST_BOUNDS_VAL = "1,1,1"
+CHIPS_PER_HOST_VAL = "4"
+# -------------------------------------------
+
+try:
+    import torch_tpu
+except ImportError:
+    torch_tpu = None
+
+try:
+    from verl.checkpoint_engine.tpu_checkpoint_engine import load_weights_on_worker
+except ImportError:
+    load_weights_on_worker = None
+
+# Fallback imports for TPU vLLM platforms
+try:
+    try:
+        from vllm_torchtpu.executors import ray_distributed_executor
+    except ImportError:
+        from tpu_inference.executors import ray_distributed_executor
+except ImportError:
+    ray_distributed_executor = None
+
+try:
+    try:
+        import vllm_torchtpu.platforms.tpu_platform as tpu_platform
+    except ImportError:
+        import tpu_inference.platforms.tpu_platform as tpu_platform
+except ImportError:
+    tpu_platform = None
+
+try:
+    from vllm.config import AttentionConfig
+except ImportError:
+    AttentionConfig = None
+
+try:
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+except ImportError:
+    AttentionBackendEnum = None
+
+try:
+    from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
+except ImportError:
+    EngineArgs = None
+    AsyncEngineArgs = None
+
+try:
+    import vllm.envs as vllm_envs
+except ImportError:
+    vllm_envs = None
+
+try:
+    try:
+        import vllm_torchtpu.envs as tpu_envs
+    except ImportError:
+        import tpu_inference.envs as tpu_envs
+except ImportError:
+    tpu_envs = None
+
+try:
+    try:
+        from vllm_torchtpu.worker.tpu_worker import TPUWorker
+    except ImportError:
+        from tpu_inference.worker.tpu_worker import TPUWorker
+except ImportError:
+    TPUWorker = None
+
+try:
+    from vllm.utils import get_ip
+except ImportError:
+    try:
+        from vllm.utils.network_utils import get_ip
+    except ImportError:
+        get_ip = None
+
+try:
+    from vllm.v1.executor.ray_executor import RayWorkerMetaData
+except ImportError:
+    try:
+        from vllm.v1.executor.ray_utils import RayWorkerMetaData
+    except ImportError:
+
+        class RayWorkerMetaData:
+            def __init__(self, worker, created_rank):
+                self.worker = worker
+                self.created_rank = created_rank
+                self.adjusted_rank = None
+                self.ip = None
+
+
+try:
+    from vllm.utils import get_open_port
+except ImportError:
+    try:
+        from vllm_torchtpu.utils import get_open_port
+    except ImportError:
+        try:
+            from vllm.utils.network_utils import get_open_port
+        except ImportError:
+            get_open_port = None
+
+try:
+    from vllm_torchtpu.platforms.tpu_platform import get_distributed_init_method
+except ImportError:
+    try:
+        from tpu_inference.platforms.tpu_platform import get_distributed_init_method
+    except ImportError:
+        try:
+            from vllm.utils.network_utils import get_distributed_init_method
+        except ImportError:
+            get_distributed_init_method = None
+
+try:
+    from vllm.platforms import current_platform
+except ImportError:
+    current_platform = None
+
+
+class PickleableProcessWrapper:
+    """
+    A pickle-compatible wrapper for multiprocessing target functions to ensure
+    vLLM-on-TPU worker patches are automatically applied in the spawned processes.
+    """
+
+    def __init__(self, target):
+        self.target = target
+
+    def __call__(self, *args, **kwargs):
+        patch_vllm_for_tpu()
+        if self.target is not None:
+            return self.target(*args, **kwargs)
+
+
+def patch_multiprocessing_for_tpu() -> None:
+    """
+    Monkey-patch multiprocessing.process.BaseProcess to wrap target entrypoints
+    with PickleableProcessWrapper, propagating vLLM-on-TPU patches to child processes.
+    """
+    if getattr(multiprocessing.process.BaseProcess, "_tpu_patched", False):
+        return
+
+    original_init = multiprocessing.process.BaseProcess.__init__
+
+    def patched_init(self, *args, **kwargs):
+        target = kwargs.get("target", None)
+        if target is None and len(args) > 1:
+            target = args[1]
+
+        if target is not None:
+            wrapped_target = PickleableProcessWrapper(target)
+            if "target" in kwargs:
+                kwargs["target"] = wrapped_target
+            elif len(args) > 1:
+                args = list(args)
+                args[1] = wrapped_target
+                args = tuple(args)
+
+        original_init(self, *args, **kwargs)
+
+    multiprocessing.process.BaseProcess.__init__ = patched_init
+    multiprocessing.process.BaseProcess._tpu_patched = True
+
+
+_orig_run_engine_core = None
+
+
+def _patched_run_engine_core(*args, **kwargs):
+    try:
+        patch_vllm_for_tpu()
+    except Exception as e:
+        print(f"[TPU DEBUG] Error re-applying patch in EngineCoreProc: {e}", flush=True)
+
+    global _orig_run_engine_core
+    if _orig_run_engine_core is None:
+        import vllm.v1.engine.core as v1_core
+
+        _orig_run_engine_core = getattr(v1_core.EngineCoreProc, "_unpatched_run_engine_core", None)
+
+    if hasattr(_orig_run_engine_core, "__func__"):
+        _orig_run_engine_core = _orig_run_engine_core.__func__
+
+    if _orig_run_engine_core is not None:
+        return _orig_run_engine_core(*args, **kwargs)
+    raise RuntimeError("[TPU ERROR] _orig_run_engine_core could not be resolved in _patched_run_engine_core")
+
+
+def patch_vllm_for_tpu() -> None:
+    """
+    Apply TPU-specific patches and workarounds to vLLM and torchtpu-vllm workers.
+    Ensures correct topology routing, un-clashed TCP ports, custom weight registry loading,
+    and driver-worker environment synchronization on GKE TPU v6e instances.
+    """
+    logger = logging.getLogger(__name__)
+
+    try:
+        import torch
+        import torch._dynamo
+        import torch._ops
+        import torch.compiler
+
+        def _allow(op):
+            if op is not None:
+                for fn in (
+                    getattr(torch.compiler, "allow_in_graph", None),
+                    getattr(torch._dynamo, "allow_in_graph", None),
+                ):
+                    if fn:
+                        try:
+                            fn(op)
+                        except Exception:
+                            pass
+
+        for ns_name in ["_c10d_functional", "c10d_functional"]:
+            if hasattr(torch.ops, ns_name):
+                ns = getattr(torch.ops, ns_name)
+                _allow(ns)
+                for name in dir(ns):
+                    try:
+                        attr = getattr(ns, name)
+                        _allow(attr)
+                        if hasattr(attr, "default"):
+                            _allow(attr.default)
+                    except Exception:
+                        pass
+    except Exception:
+        pass
+
+    try:
+        import tpu_inference.worker.tpu_worker as tw
+
+        if hasattr(tw, "TPUWorker") and not getattr(tw.TPUWorker, "_patched_dynamo", False):
+            orig_determine = tw.TPUWorker.determine_available_memory
+
+            def patched_determine(self, *args, **kwargs):
+                patch_vllm_for_tpu()
+                return orig_determine(self, *args, **kwargs)
+
+            tw.TPUWorker.determine_available_memory = patched_determine
+            tw.TPUWorker._patched_dynamo = True
+    except Exception:
+        pass
+
+    try:
+        import tpu_inference.runner.tpu_runner as tr
+
+        if hasattr(tr, "TPUModelRunner") and not getattr(tr.TPUModelRunner, "_patched_dynamo", False):
+            orig_profile = tr.TPUModelRunner.profile_run
+
+            def patched_profile(self, *args, **kwargs):
+                patch_vllm_for_tpu()
+                return orig_profile(self, *args, **kwargs)
+
+            tr.TPUModelRunner.profile_run = patched_profile
+            tr.TPUModelRunner._patched_dynamo = True
+    except Exception:
+        pass
+
+    def dummy_reset_encoder_cache(*args, **kwargs):
+        pass
+
+    def load_weights_from_ray_registry(self, step_key: int):
+        rank_val = getattr(
+            self, "rank", getattr(self, "adjusted_rank", getattr(self, "rpc_rank", int(os.environ.get("RANK", "0"))))
+        )
+
+        shm_dir = "/tmp/verl_weight_cache/shared"
+        os.makedirs(shm_dir, exist_ok=True)
+        shm_file_path = f"{shm_dir}/state_dict_{step_key}.pt"
+        shm_tmp_path = f"{shm_dir}/state_dict_{step_key}.tmp"
+        shm_ready_path = f"{shm_dir}/state_dict_{step_key}.ready"
+        lock_path = f"{shm_dir}/state_dict_{step_key}.lock"
+        state_dict_data = None
+
+        # Atomic lock to decide the designated master for this step on this physical VM node
+        is_master = False
+        lock_fd = None
+        try:
+            lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            is_master = True
+        except FileExistsError:
+            is_master = False
+
+        if is_master:
+            # Clean up older steps' cache files from /tmp to ensure NVMe disk space never exhausts
+            try:
+                for file_name in os.listdir(shm_dir):
+                    if file_name.startswith("state_dict_"):
+                        parts = file_name.split("_")
+                        if len(parts) >= 3:
+                            try:
+                                old_step_str = parts[2].split(".")[0]
+                                old_step = int(old_step_str)
+                                if old_step < step_key:
+                                    old_path = os.path.join(shm_dir, file_name)
+                                    os.remove(old_path)
+                            except ValueError:
+                                pass
+            except Exception as e:
+                logger.warning(f"Error during cache cleanup: {e}")
+
+            # Node master block: fetch weights once, convert, and cache to /tmp
+            try:
+                registry = ray.get_actor(TPU_WEIGHT_REGISTRY_ACTOR_NAME, namespace=TPU_WEIGHT_REGISTRY_NAMESPACE)
+                state_dict_ref = ray.get(registry.get_weights.remote(step_key))
+            except Exception as e:
+                logger.warning(f"Failed to get weights from TPUWeightRegistry: {e}")
+                if lock_fd is not None:
+                    os.close(lock_fd)
+                    try:
+                        os.remove(lock_path)
+                    except Exception:
+                        pass
+                return 0
+
+            if state_dict_ref is None:
+                logger.warning(f"No weights registered under step_key={step_key}")
+                if lock_fd is not None:
+                    os.close(lock_fd)
+                    try:
+                        os.remove(lock_path)
+                    except Exception:
+                        pass
+                return 0
+
+            if isinstance(state_dict_ref, str):
+                state_dict_data = torch.load(state_dict_ref, map_location="cpu", weights_only=False)
+            elif isinstance(state_dict_ref, ray.ObjectRef):
+                state_dict_data = ray.get(state_dict_ref)
+            else:
+                state_dict_data = state_dict_ref
+
+            # Convert NumPy arrays back to native PyTorch CPU tensors
+            if isinstance(state_dict_data, dict) and "grouped" in state_dict_data:
+                for group_name, group_sd in state_dict_data["grouped"].items():
+                    flat_tensors = group_sd["flat_tensors"]
+                    for dtype, arr in list(flat_tensors.items()):
+                        if isinstance(arr, np.ndarray):
+                            flat_tensors[dtype] = torch.from_numpy(arr)
+
+            # Save atomically using temp file and rename
+            torch.save(state_dict_data, shm_tmp_path)
+            os.replace(shm_tmp_path, shm_file_path)
+
+            # Release memory before mapping
+            del state_dict_data
+            gc.collect()
+
+            # Signal ready to all other processes on this node
+            with open(shm_ready_path, "w") as f:
+                f.write("ready")
+
+            if lock_fd is not None:
+                os.close(lock_fd)
+
+            # Stagger ranks before loading to serialize memory traffic
+            time.sleep((rank_val % 4) * 0.4)
+
+            # Now load memory-mapped version to share pages
+            gc.collect()
+            state_dict_data = torch.load(shm_file_path, map_location="cpu", weights_only=False, mmap=True)
+        else:
+            # Node worker processes: wait for ready marker
+            t_wait_start = time.time()
+            while not os.path.exists(shm_ready_path):
+                time.sleep(0.05)
+                if time.time() - t_wait_start > 300:
+                    raise TimeoutError(f"Worker rank {rank_val} timed out waiting for {shm_ready_path}")
+
+            # Stagger ranks before loading to serialize memory traffic
+            time.sleep((rank_val % 4) * 0.4)
+
+            gc.collect()
+            state_dict_data = torch.load(shm_file_path, map_location="cpu", weights_only=False, mmap=True)
+
+        if hasattr(self, "worker") and self.worker is not None:
+            worker_inst = self.worker
+        else:
+            worker_inst = self
+
+        if hasattr(worker_inst, "get_model"):
+            vllm_model = worker_inst.get_model()
+        else:
+            vllm_model = worker_inst.model_runner.model
+
+        num_keys = 0
+        if load_weights_on_worker is not None:
+            res_loader = load_weights_on_worker(vllm_model, state_dict_data, rank_val)
+            if isinstance(res_loader, tuple):
+                num_keys = res_loader[0]
+            else:
+                num_keys = res_loader
+
+        del state_dict_data
+        gc.collect()
+
+        return num_keys
+
+    patch_multiprocessing_for_tpu()
+
+    if "RAY_RUNTIME_ENV_WORKER_PROCESS_SETUP_HOOK" in os.environ:
+        del os.environ["RAY_RUNTIME_ENV_WORKER_PROCESS_SETUP_HOOK"]
+
+    try:
+        orig_ray_init = ray.init
+
+        def patched_ray_init(*args, **kwargs):
+            if "runtime_env" in kwargs and kwargs["runtime_env"]:
+                rt_env = kwargs["runtime_env"]
+                if isinstance(rt_env, dict) and "worker_process_setup_hook" in rt_env:
+                    rt_env = dict(rt_env)
+                    del rt_env["worker_process_setup_hook"]
+                    kwargs["runtime_env"] = rt_env
+            if "RAY_RUNTIME_ENV_WORKER_PROCESS_SETUP_HOOK" in os.environ:
+                del os.environ["RAY_RUNTIME_ENV_WORKER_PROCESS_SETUP_HOOK"]
+            return orig_ray_init(*args, **kwargs)
+
+        ray.init = patched_ray_init
+    except Exception as e:
+        logger.warning(f"Failed to patch ray.init to clear worker_process_setup_hook: {e}")
+
+    try:
+        if "vllm.utils.import_utils" not in sys.modules:
+            sys.modules["vllm.utils.import_utils"] = types.ModuleType("import_utils")
+        sys.modules["vllm.utils.import_utils"].init_cached_hf_modules = lambda: None
+
+        os.environ["VLLM_USE_V1"] = "0"
+
+        if ray_distributed_executor is None:
+            return
+
+        try:
+            if tpu_platform is not None and AttentionBackendEnum is not None:
+                orig_wrap = tpu_platform.TpuPlatform.wrap_engine_kwargs
+
+                def patched_wrap(self, engine_kwargs):
+                    orig_wrap(self, engine_kwargs)
+                    if "attention_config" in engine_kwargs:
+                        engine_kwargs["attention_config"].backend = AttentionBackendEnum.MATH
+
+                tpu_platform.TpuPlatform.wrap_engine_kwargs = patched_wrap
+        except Exception as e:
+            logger.warning(f"Failed to patch TPUPlatform.wrap_engine_kwargs: {e}")
+
+        try:
+            if EngineArgs is not None:
+                orig_create_engine_config = EngineArgs.create_engine_config
+
+                def patched_create_engine_config(self, *args, **kwargs):
+                    is_tpu = get_resource_name() == "TPU" or os.environ.get("VLLM_USE_V1") == "0"
+                    is_multi_host = (
+                        self.tensor_parallel_size > 4
+                        or int(os.environ.get("NNODES_ROLLOUT", "1")) > 1
+                        or os.environ.get("TPU_MULTIHOST_BACKEND") == "ray"
+                    )
+                    if is_tpu:
+                        os.environ["VLLM_USE_V1"] = "0"
+                        if hasattr(self, "use_v1"):
+                            self.use_v1 = False
+
+                    if getattr(self, "data_parallel_size", 1) <= 1:
+                        if hasattr(self, "data_parallel_external_lb"):
+                            self.data_parallel_external_lb = False
+                        if hasattr(self, "data_parallel_rank"):
+                            self.data_parallel_rank = None
+                        if hasattr(self, "data_parallel_size_local"):
+                            self.data_parallel_size_local = None
+                        if hasattr(self, "data_parallel_start_rank"):
+                            self.data_parallel_start_rank = None
+                        if hasattr(self, "data_parallel_hybrid_lb"):
+                            self.data_parallel_hybrid_lb = False
+
+                    if not is_multi_host:
+                        if "TPU_MULTIHOST_BACKEND" in os.environ:
+                            del os.environ["TPU_MULTIHOST_BACKEND"]
+                        if vllm_envs is not None and hasattr(vllm_envs, "TPU_MULTIHOST_BACKEND"):
+                            vllm_envs.TPU_MULTIHOST_BACKEND = None
+                        if tpu_envs is not None and hasattr(tpu_envs, "TPU_MULTIHOST_BACKEND"):
+                            tpu_envs.TPU_MULTIHOST_BACKEND = None
+
+                        vllm_config = orig_create_engine_config(self, *args, **kwargs)
+                        if is_tpu and hasattr(vllm_config, "use_v1"):
+                            vllm_config.use_v1 = False
+
+                        logger.info(
+                            "[TPU HACK 16] Single-host rollout detected. "
+                            "Bypassed forcing Ray distributed executor backend."
+                        )
+                        if hasattr(vllm_config, "scheduler_config") and hasattr(
+                            vllm_config.scheduler_config, "async_scheduling"
+                        ):
+                            vllm_config.scheduler_config.async_scheduling = True
+                            logger.info("[TPU HACK 20] Enabled async_scheduling on TPU for single-host.")
+                    else:
+                        os.environ["TPU_MULTIHOST_BACKEND"] = "ray"
+                        if vllm_envs is not None and hasattr(vllm_envs, "TPU_MULTIHOST_BACKEND"):
+                            vllm_envs.TPU_MULTIHOST_BACKEND = "ray"
+                        if tpu_envs is not None and hasattr(tpu_envs, "TPU_MULTIHOST_BACKEND"):
+                            tpu_envs.TPU_MULTIHOST_BACKEND = "ray"
+
+                        vllm_config = orig_create_engine_config(self, *args, **kwargs)
+                        if is_tpu and hasattr(vllm_config, "use_v1"):
+                            vllm_config.use_v1 = False
+                        vllm_config.parallel_config.distributed_executor_backend = "ray"
+                        logger.info(
+                            "[TPU HACK 16] Directly forced 'ray' distributed executor backend on TPU for multi-host."
+                        )
+                        if hasattr(vllm_config, "scheduler_config") and hasattr(
+                            vllm_config.scheduler_config, "async_scheduling"
+                        ):
+                            vllm_config.scheduler_config.async_scheduling = False
+                            logger.info(
+                                "[TPU HACK 20] Disabled async_scheduling on TPU "
+                                "inside patched_create_engine_config because Ray does not support it."
+                            )
+                    return vllm_config
+
+                EngineArgs.create_engine_config = patched_create_engine_config
+                if AsyncEngineArgs is not None:
+                    AsyncEngineArgs.create_engine_config = patched_create_engine_config
+        except Exception as e:
+            logger.warning(f"Failed to patch EngineArgs.create_engine_config: {e}")
+
+        try:
+            if TPUWorker is not None:
+                TPUWorker.reset_encoder_cache = dummy_reset_encoder_cache
+                TPUWorker.load_weights_from_ray_registry = load_weights_from_ray_registry
+                logger.info(
+                    "[TPU HACK 13] Successfully patched TPUWorker class with "
+                    "dummy_reset_encoder_cache and load_weights_from_ray_registry."
+                )
+        except Exception as e:
+            logger.warning(f"Failed to patch TPUWorker class directly: {e}")
+
+        ray_distributed_executor.TPU_TOPOLOGY_MAP[4] = "2,2,1"
+        ray_distributed_executor.TPU_TOPOLOGY_MAP[8] = "2,4,1"
+
+        original_driver_environ_setitem = os.environ.__class__.__setitem__
+
+        def patched_driver_environ_setitem(self, key, value):
+            if key in (
+                "TORCH_TPU_SLICEBUILDER_ADDRESSES",
+                "TPU_PROCESS_ADDRESSES",
+                "TPU_CHIPS_PER_HOST_BOUNDS",
+                "TPU_HOST_BOUNDS",
+                "TORCH_TPU_TOPOLOGY",
+                "TPU_WORKER_HOSTNAMES",
+            ):
+                value = os.environ.get(key, value)
+            elif key == "LIBTPU_INIT_ARGS":
+                value = value.replace("--deepsea_chip_config_name=megachip_tccontrol", "")
+            original_driver_environ_setitem(self, key, value)
+
+        os.environ.__class__.__setitem__ = patched_driver_environ_setitem
+
+        try:
+            import vllm.v1.executor.ray_utils as v1_ray_utils
+
+            orig_avail_res = v1_ray_utils.available_resources_per_node
+
+            def patched_avail_res(*args, **kwargs):
+                res_map = orig_avail_res(*args, **kwargs)
+                for node_id, res in res_map.items():
+                    res["TPU"] = max(res.get("TPU", 0.0), 4.0)
+                return res_map
+
+            v1_ray_utils.available_resources_per_node = patched_avail_res
+
+            orig_init_ray_cluster = v1_ray_utils.initialize_ray_cluster
+
+            def patched_initialize_ray_cluster(parallel_config):
+                if parallel_config.placement_group is None:
+                    curr_pg = ray.util.get_current_placement_group()
+                    if curr_pg is None:
+                        pg_name = os.environ.get("VERL_ROLLOUT_PG_NAME")
+                        if pg_name:
+                            try:
+                                curr_pg = ray.util.get_placement_group(pg_name)
+                            except Exception:
+                                pass
+                        if curr_pg is None:
+                            try:
+                                pgs = ray.util.placement_group_table()
+                                for pg_id, pg_info in pgs.items():
+                                    state = (
+                                        pg_info.get("state")
+                                        if isinstance(pg_info, dict)
+                                        else getattr(pg_info, "state", None)
+                                    )
+                                    if hasattr(state, "name"):
+                                        state = state.name
+                                    name = (
+                                        pg_info.get("name")
+                                        if isinstance(pg_info, dict)
+                                        else getattr(pg_info, "name", None)
+                                    )
+                                    if (
+                                        str(state) in ("CREATED", "1")
+                                        and name
+                                        and ("rollout" in str(name) or "global" in str(name))
+                                    ):
+                                        try:
+                                            candidate_pg = ray.util.get_placement_group(name)
+                                            if candidate_pg is not None:
+                                                num_bundles = len(getattr(candidate_pg, "bundle_specs", []))
+                                                if num_bundles >= parallel_config.world_size:
+                                                    curr_pg = candidate_pg
+                                                    break
+                                        except Exception:
+                                            pass
+                            except Exception:
+                                pass
+                    parallel_config.placement_group = curr_pg
+                try:
+                    return orig_init_ray_cluster(parallel_config)
+                except ValueError as e:
+                    if "exceeds the total number of available" in str(e) or "placement group" in str(e):
+                        logger.warning(
+                            f"[TPU HACK] Bypassed vLLM placement group size validation on multi-node TPU: {e}"
+                        )
+                        return
+                    raise
+
+            try:
+                import vllm.v1.engine.core as v1_core
+
+                if not getattr(v1_core, "_verl_tpu_patched", False):
+                    v1_core._verl_tpu_patched = True
+                    global _orig_run_engine_core
+                    raw_fn = v1_core.EngineCoreProc.run_engine_core
+                    if hasattr(raw_fn, "__func__"):
+                        raw_fn = raw_fn.__func__
+                    _orig_run_engine_core = raw_fn
+                    v1_core.EngineCoreProc._unpatched_run_engine_core = raw_fn
+                    v1_core.EngineCoreProc.run_engine_core = staticmethod(_patched_run_engine_core)
+                    v1_core.run_engine_core = _patched_run_engine_core
+            except Exception as e3:
+                logger.warning(f"Failed to patch v1_core.run_engine_core: {e3}")
+
+            try:
+                import vllm.v1.executor.ray_executor as v1_ray_executor
+
+                v1_ray_executor.initialize_ray_cluster = patched_initialize_ray_cluster
+
+                executor_cls = getattr(
+                    v1_ray_executor, "RayDistributedExecutor", getattr(v1_ray_executor, "RayExecutor", None)
+                )
+                if executor_cls is not None and hasattr(executor_cls, "_init_workers_ray"):
+                    orig_init_workers_ray = executor_cls._init_workers_ray
+
+                    def patched_init_workers_ray(self, placement_group, **ray_remote_kwargs):
+                        if not os.environ.get("VLLM_RAY_BUNDLE_INDICES"):
+                            indices = [str(i) for i in range(len(placement_group.bundle_specs))]
+                            if indices and len(indices) >= self.parallel_config.world_size:
+                                os.environ["VLLM_RAY_BUNDLE_INDICES"] = ",".join(
+                                    indices[: self.parallel_config.world_size]
+                                )
+                        return orig_init_workers_ray(self, placement_group, **ray_remote_kwargs)
+
+                    executor_cls._init_workers_ray = patched_init_workers_ray
+            except Exception as e2:
+                logger.warning(f"Failed to patch v1_ray_executor: {e2}")
+        except Exception as e:
+            logger.warning(f"Failed to patch v1_ray_utils: {e}")
+
+        OriginalRayWorkerWrapper = ray_distributed_executor.RayWorkerWrapper
+        original_init_worker = OriginalRayWorkerWrapper.init_worker
+        original_wrapper_init = OriginalRayWorkerWrapper.__init__
+
+        def patched_wrapper_init(self, *args, **kwargs):
+            patch_vllm_for_tpu()
+            try:
+                local_ip = ray.util.get_node_ip_address()
+                pod_map_str = os.environ.get("TPU_POD_IP_TO_SLICE")
+                if pod_map_str:
+                    pod_map = json.loads(pod_map_str)
+                    current_slice = pod_map.get(local_ip)
+                    if current_slice:
+                        slice_ips = sorted([ip for ip, sl in pod_map.items() if sl == current_slice])
+                        if local_ip in slice_ips:
+                            worker_id = slice_ips.index(local_ip)
+                            os.environ["TPU_WORKER_ID"] = str(worker_id)
+                            os.environ["TPU_WORKER_HOSTNAMES"] = ",".join(slice_ips)
+                            logger.info(
+                                f"[TPU WORKER FIX] Node {local_ip} (slice {current_slice}) "
+                                f"configured TPU_WORKER_ID={worker_id}, hostnames={slice_ips}"
+                            )
+            except Exception as e:
+                logger.warning(f"Failed setting local TPU_WORKER_ID: {e}")
+            return original_wrapper_init(self, *args, **kwargs)
+
+        OriginalRayWorkerWrapper.__init__ = patched_wrapper_init
+
+        def patched_setup_device_if_necessary(self):
+            patch_vllm_for_tpu()
+            if not getattr(self, "compiled_dag_cuda_device_set", False):
+                try:
+                    from vllm.platforms import current_platform
+
+                    if current_platform.is_cuda() and hasattr(self.worker, "device") and self.worker.device is not None:
+                        current_platform.set_device(self.worker.device)
+                except Exception:
+                    pass
+                self.compiled_dag_cuda_device_set = True
+
+        OriginalRayWorkerWrapper.setup_device_if_necessary = patched_setup_device_if_necessary
+
+        def patched_init_worker(self, *args, **kwargs):
+            patch_vllm_for_tpu()
+            if "vllm.utils.import_utils" not in sys.modules:
+                sys.modules["vllm.utils.import_utils"] = types.ModuleType("import_utils")
+            sys.modules["vllm.utils.import_utils"].init_cached_hf_modules = lambda: None
+
+            try:
+                import vllm.model_executor.model_loader.weight_utils as vllm_weight_utils
+
+                vllm_weight_utils.initialize_dummy_weights = lambda *args, **kwargs: None
+            except Exception:
+                pass
+            try:
+                import vllm.model_executor.model_loader.dummy_loader as vllm_dummy_loader
+
+                vllm_dummy_loader.initialize_dummy_weights = lambda *args, **kwargs: None
+            except Exception:
+                pass
+
+            self.__class__.load_weights_from_ray_registry = load_weights_from_ray_registry
+            self.__class__.load_weights_from_state_dict_on_worker = lambda self, sd: load_weights_from_ray_registry(
+                self, 0
+            )
+            self.__class__.reset_encoder_cache = dummy_reset_encoder_cache
+
+            torch.set_grad_enabled(False)
+
+            res = original_init_worker(self, *args, **kwargs)
+            if hasattr(self, "worker") and self.worker is not None:
+                self.worker.reset_encoder_cache = dummy_reset_encoder_cache
+                self.worker.__class__.reset_encoder_cache = dummy_reset_encoder_cache
+            return res
+
+        OriginalRayWorkerWrapper.init_worker = patched_init_worker
+
+        def patched_init_workers_ray(self, placement_group, **ray_remote_kwargs):
+            RayWorkerWrapper_local = ray_distributed_executor.RayWorkerWrapper
+            TPU_TOPOLOGY_MAP_local = ray_distributed_executor.TPU_TOPOLOGY_MAP
+
+            self.workers = []
+            self.pp_tp_workers = []
+
+            if self.parallel_config.ray_workers_use_nsight:
+                ray_remote_kwargs = self._configure_ray_workers_use_nsight(ray_remote_kwargs)
+
+            bundle_indices = []
+            if vllm_envs is not None and vllm_envs.VLLM_RAY_BUNDLE_INDICES:
+                bundle_indices = list(map(int, vllm_envs.VLLM_RAY_BUNDLE_INDICES.split(",")))
+                assert len(bundle_indices) == self.parallel_config.world_size, (
+                    "VLLM_RAY_BUNDLE_INDICES must have the same size"
+                    f" as the world size, but got {bundle_indices=} "
+                    f"and {self.parallel_config.world_size=}"
+                )
+                assert len(set(bundle_indices)) == len(bundle_indices), (
+                    f"VLLM_RAY_BUNDLE_INDICES cannot have duplicate values, but got {bundle_indices=}"
+                )
+            else:
+                for bundle_id, bundle in enumerate(placement_group.bundle_specs):
+                    if current_platform is not None and bundle.get(current_platform.ray_device_key, 0):
+                        bundle_indices.append(bundle_id)
+
+            worker_metadata = []
+            driver_ip = get_ip() if get_ip is not None else ""
+            num_tpu_per_worker = 1.0
+            for rank, bundle_id in enumerate(bundle_indices):
+                scheduling_strategy = PlacementGroupSchedulingStrategy(
+                    placement_group=placement_group,
+                    placement_group_capture_child_tasks=True,
+                    placement_group_bundle_index=bundle_id,
+                )
+                worker = ray.remote(
+                    num_cpus=0,
+                    num_gpus=0,
+                    resources={current_platform.ray_device_key: num_tpu_per_worker}
+                    if current_platform is not None
+                    else {},
+                    scheduling_strategy=scheduling_strategy,
+                    **ray_remote_kwargs,
+                )(RayWorkerWrapper_local).remote(rpc_rank=rank)
+                worker_metadata.append(
+                    RayWorkerMetaData(worker=worker, created_rank=rank) if RayWorkerMetaData is not None else None
+                )
+
+            worker_ips = ray.get([each.worker.get_node_ip.remote() for each in worker_metadata])
+
+            for each, ip in zip(worker_metadata, worker_ips, strict=False):
+                each.ip = ip
+
+            logger.info(f"Initialized worker_metadata: {worker_metadata}")
+
+            ip_counts = {}
+            for ip in worker_ips:
+                ip_counts[ip] = ip_counts.get(ip, 0) + 1
+
+            def sort_by_driver_then_worker_ip(item):
+                ip = item.ip
+                return (0 if ip == driver_ip else 1, ip_counts[ip], ip)
+
+            sorted_worker_metadata = sorted(worker_metadata, key=sort_by_driver_then_worker_ip)
+            start_rank = 0
+            for i, item in enumerate(sorted_worker_metadata):
+                item.adjusted_rank = i + start_rank
+            logger.info(f"Initialized sorted worker_metadata: {sorted_worker_metadata}")
+
+            self.workers = [item.worker for item in sorted_worker_metadata]
+            rerank_mapping = {item.created_rank: item.adjusted_rank for item in sorted_worker_metadata}
+            self.collective_rpc("adjust_rank", args=(rerank_mapping,))
+
+            worker_node_and_tpu_ids = []
+            for worker in self.workers:
+                worker_node_and_tpu_ids.append(ray.get(worker.get_node_and_gpu_ids.remote()))
+
+            node_workers = defaultdict(list)
+            node_tpus = defaultdict(list)
+
+            for i, (node_id, tpu_ids) in enumerate(worker_node_and_tpu_ids):
+                node_workers[node_id].append(i)
+                tpu_ids = [int(x) for x in tpu_ids]
+                node_tpus[node_id].extend(tpu_ids)
+            for node_id, tpu_ids in node_tpus.items():
+                node_tpus[node_id] = sorted(tpu_ids)
+            logger.info(f"RayDistributedExecutor | node_workers={node_workers} | node_tpus={node_tpus}")
+
+            all_ips = set(worker_ips + [driver_ip])
+            n_ips = len(all_ips)
+            n_nodes = len(node_workers)
+
+            if n_nodes != n_ips:
+                logger.warning(
+                    f"Got {n_nodes} nodes but with {n_ips} IP addresses. "
+                    "This is not a typical production setup whose "
+                    "number of nodes and IPs is equal. This setup may "
+                    "lead to unexpected behaviors."
+                )
+
+            unique_node_ids = list(node_workers.keys())
+            num_nodes = len(unique_node_ids)
+
+            sb_addresses = []
+            base_port = int(os.environ.get("TORCH_TPU_BASE_PORT", TPU_ROLLOUT_BASE_PORT))
+            for node_id in unique_node_ids:
+                w_idx = node_workers[node_id][0]
+                host_ip = sorted_worker_metadata[w_idx].ip
+                chips_on_node = len(node_workers[node_id])
+                for lr in range(chips_on_node):
+                    sb_addresses.append(f"{host_ip}:{base_port + lr}")
+
+            sb_addresses_str = ",".join(sb_addresses)
+            os.environ["TORCH_TPU_SLICEBUILDER_ADDRESSES"] = sb_addresses_str
+            logger.info(f"Constructed TORCH_TPU_SLICEBUILDER_ADDRESSES: {sb_addresses_str}")
+
+            total_chips = len(self.workers)
+            if total_chips == 32:
+                topology = "4,8,1"
+                host_bounds = "4,8,1"
+                chips_per_host_bounds = "1,1,1"
+                chips_per_host = "4"
+            elif total_chips == 8:
+                topology = "2,4,1"
+                host_bounds = "2,4,1"
+                chips_per_host_bounds = "1,1,1"
+                chips_per_host = "4"
+            elif total_chips == 4:
+                topology = "2,2,1"
+                host_bounds = "1,1,1"
+                chips_per_host_bounds = "2,2,1" if num_nodes == 1 else "1,1,1"
+                chips_per_host = "4"
+            else:
+                topology = TPU_TOPOLOGY_MAP_local.get(total_chips, "1,1,1")
+                host_bounds = "1,1,1"
+                chips_per_host_bounds = "1,1,1"
+                chips_per_host = "4"
+
+            rank_0_node_id = unique_node_ids[0]
+            rank_0_worker_index = node_workers[rank_0_node_id][0]
+            master_addr = sorted_worker_metadata[rank_0_worker_index].ip
+            master_port = str(get_open_port()) if get_open_port is not None else ""
+
+            all_args_to_update_environment_variables = []
+            for i in range(total_chips):
+                node_id = worker_node_and_tpu_ids[i][0]
+                node_rank = unique_node_ids.index(node_id)
+                args = {
+                    "NNODES": str(num_nodes),
+                    "NODE_RANK": str(node_rank),
+                    "MASTER_ADDR": master_addr,
+                    "MASTER_PORT": master_port,
+                    "TORCH_TPU_TOPOLOGY": topology,
+                    "LOCAL_WORLD_SIZE": str(len(node_tpus[node_id])),
+                }
+                if "TORCH_TPU_XPROF_SESSION_ID" not in os.environ:
+                    os.environ["TORCH_TPU_XPROF_SESSION_ID"] = str(time.time_ns())
+
+                args["TORCH_TPU_XPROF_SESSION_ID"] = os.environ["TORCH_TPU_XPROF_SESSION_ID"]
+                all_args_to_update_environment_variables.append(args)
+
+            env_vars_to_copy_list = []
+            if get_env_vars_to_copy is not None:
+                env_vars_to_copy_list = get_env_vars_to_copy(
+                    exclude_vars=self.WORKER_SPECIFIC_ENV_VARS,
+                    additional_vars=set(current_platform.additional_env_vars)
+                    if current_platform is not None
+                    else set(),
+                    destination="workers",
+                )
+
+            for i, args in enumerate(all_args_to_update_environment_variables):
+                for name in env_vars_to_copy_list:
+                    if name in os.environ:
+                        args[name] = os.environ[name]
+                logger.debug(f"RayDistributedExecutor | Worker {i} environment variables before patch: {args}")
+
+            self._env_vars_for_all_workers = all_args_to_update_environment_variables
+
+            try:
+                unique_host_ips = [sorted_worker_metadata[node_workers[nid][0]].ip for nid in unique_node_ids]
+                host_names_str = ",".join(unique_host_ips)
+                for i, worker in enumerate(self.workers):
+                    node_id = worker_node_and_tpu_ids[i][0]
+                    host_idx = unique_node_ids.index(node_id)
+                    local_chip_id = node_workers[node_id].index(i)
+                    args = self._env_vars_for_all_workers[i]
+                    args["RANK"] = str(i)
+                    args["LOCAL_RANK"] = str(local_chip_id)
+                    args["TPU_VISIBLE_CHIPS"] = str(local_chip_id)
+                    args["TPU_PROCESS_PORT"] = str(base_port + local_chip_id)
+                    args["CLOUD_TPU_TASK_ID"] = str(host_idx)
+                    args["TPU_WORKER_HOSTNAMES"] = host_names_str
+                    args["TPU_HOST_BOUNDS"] = host_bounds
+                    args["TPU_CHIPS_PER_HOST_BOUNDS"] = chips_per_host_bounds
+                    args["CHIPS_PER_HOST"] = chips_per_host
+                    args["TORCH_TPU_TOPOLOGY"] = topology
+                    args["TORCH_TPU_SLICEBUILDER_ADDRESSES"] = sb_addresses_str
+                    args["TPU_PROCESS_ADDRESSES"] = sb_addresses_str
+                    if total_chips > 4 or num_nodes > 1:
+                        args["TPU_MULTIHOST_BACKEND"] = "ray"
+
+                    logger.info(
+                        f"[TPU HACK 11] Patched worker {i} (host {host_idx}, chip {local_chip_id}) env vars: "
+                        f"TPU_VISIBLE_CHIPS={local_chip_id}, TPU_PROCESS_PORT={base_port + local_chip_id}, "
+                        f"CLOUD_TPU_TASK_ID={host_idx}"
+                    )
+            except Exception as patch_err:
+                logger.warning(f"Failed to inject TPU HACK 11 env vars: {patch_err}")
+
+            self.collective_rpc("update_environment_variables", args=(self._get_env_vars_to_be_updated(),))
+
+            distributed_init_method = (
+                get_distributed_init_method(driver_ip, get_open_port())
+                if get_distributed_init_method is not None
+                else ""
+            )
+
+            driver_node_id = ray.get_runtime_context().get_node_id()
+
+            all_kwargs = []
+            for rank, (node_id, _) in enumerate(worker_node_and_tpu_ids):
+                local_rank = node_workers[node_id].index(rank)
+                ip = sorted_worker_metadata[rank].ip
+                prev_ip = sorted_worker_metadata[rank - 1].ip if rank > 0 else ""
+
+                worker_vllm_config = self.vllm_config
+
+                if (
+                    node_id != driver_node_id
+                    and getattr(self.vllm_config, "model_config", None)
+                    and getattr(self.vllm_config.model_config, "model_weights", None)
+                ):
+                    worker_vllm_config = copy.deepcopy(self.vllm_config)
+                    worker_vllm_config.model_config.model = worker_vllm_config.model_config.model_weights
+                    worker_vllm_config.model_config.model_weights = None
+
+                kwargs = dict(
+                    vllm_config=worker_vllm_config,
+                    local_rank=local_rank,
+                    rank=rank,
+                    distributed_init_method=distributed_init_method,
+                    is_driver_worker=(not self.parallel_config)
+                    or (rank % self.parallel_config.tensor_parallel_size == 0),
+                    ip=ip,
+                    prev_worker_ip=prev_ip,
+                )
+                all_kwargs.append(kwargs)
+            self.collective_rpc("init_worker", args=(all_kwargs,))
+            self.collective_rpc("init_device")
+            if self.parallel_config.pipeline_parallel_size > 1:
+                self.collective_rpc("initialize_pp_transfer_connect")
+            self.collective_rpc("load_model")
+            if hasattr(self, "pp_tp_workers"):
+                self.pp_tp_workers = []
+                pp_size = self.parallel_config.pipeline_parallel_size if self.parallel_config else 1
+                tp_size = self.parallel_config.tensor_parallel_size if self.parallel_config else len(self.workers)
+                for pp_rank in range(pp_size):
+                    self.pp_tp_workers.append([])
+                    for tp_rank in range(tp_size):
+                        rank = (pp_rank * tp_size) + tp_rank
+                        if rank < len(self.workers):
+                            self.pp_tp_workers[pp_rank].append(self.workers[rank])
+
+        def patched_execute_dag(
+            self,
+            scheduler_output,
+            grammar_output,
+            non_block: bool = False,
+        ):
+            refs = [worker.execute_model_ray.remote((scheduler_output, grammar_output)) for worker in self.workers]
+            if not self.has_connector:
+                if not non_block:
+                    all_results = ray.get(refs)
+                    return all_results[0]
+                from vllm.v1.executor.ray_utils import FutureWrapper
+
+                return FutureWrapper(refs[0])
+
+            assert self.kv_output_aggregator is not None
+            if not non_block:
+                return self.kv_output_aggregator.aggregate(ray.get(refs))
+            from vllm.v1.executor.ray_utils import FutureWrapper
+
+            return FutureWrapper(refs, self.kv_output_aggregator)
+
+        if ray_distributed_executor is not None:
+            ray_distributed_executor.RayDistributedExecutor._init_workers_ray = patched_init_workers_ray
+        try:
+            import vllm.executor.ray_distributed_executor as vllm_ray_dist_exec
+
+            vllm_ray_dist_exec.RayDistributedExecutor._init_workers_ray = patched_init_workers_ray
+        except Exception:
+            pass
+        try:
+            import vllm.v1.executor.ray_executor as vllm_v1_ray_exec
+
+            vllm_v1_ray_exec.RayDistributedExecutor._init_workers_ray = patched_init_workers_ray
+            vllm_v1_ray_exec.RayDistributedExecutor._execute_dag = patched_execute_dag
+        except Exception:
+            pass
+
+        logger.info("Successfully applied all TPU patches and hacks to vLLM & torchtpu-vllm")
+    except Exception as e:
+        logger.warning(f"Failed to apply TPU patches: {e}")
+
+
+# Helper helpers to import from torchtpu-vllm and other places inside vllm_async_server
+try:
+    from vllm_torchtpu.platforms.tpu_platform import get_env_vars_to_copy
+except ImportError:
+    try:
+        from tpu_inference.platforms.tpu_platform import get_env_vars_to_copy
+    except ImportError:
+        get_env_vars_to_copy = None
+
+
+def is_tpu_vllm_run() -> bool:
+    """Returns True if executing on a Google TPU resource or with V1 explicitly disabled."""
+    return get_resource_name() == "TPU" or os.environ.get("VLLM_USE_V1") == "0"
+
+
+def override_vllm_configs_for_tpu(args_or_config: Any):
+    """Enforces VLLM_USE_V1=0 and use_v1=False across dictionary and namespace objects on TPU."""
+    os.environ["VLLM_USE_V1"] = "0"
+    try:
+        import vllm.envs as vllm_envs
+
+        vllm_envs.VLLM_USE_V1 = False
+    except Exception:
+        pass
+
+    if isinstance(args_or_config, dict):
+        args_or_config["use_v1"] = False
+        return
+
+    for obj in [args_or_config, getattr(args_or_config, "model_config", None)]:
+        if obj is None:
+            continue
+        for attr in ["use_v1", "_use_v1"]:
+            if hasattr(obj, attr):
+                try:
+                    setattr(obj, attr, False)
+                except Exception:
+                    pass
+            if hasattr(obj, "__dict__") and attr in obj.__dict__:
+                try:
+                    obj.__dict__[attr] = False
+                except Exception:
+                    pass
+
+
+async def get_tpu_server_launch_config(workers):
+    """
+    Asynchronously queries node ID, visible chips, and TPU specific environment
+    variables from all TPU workers for launching the server actor on TPU.
+    """
+    worker_infos = await asyncio.gather(
+        *[
+            worker.__ray_call__.remote(
+                lambda self: (
+                    ray.get_runtime_context().get_node_id(),
+                    os.environ.get("TPU_VISIBLE_CHIPS", "0"),
+                )
+            )
+            for worker in workers
+        ]
+    )
+
+    worker_tpu_envs = await asyncio.gather(
+        *[
+            worker.__ray_call__.remote(
+                lambda self: {
+                    k: v
+                    for k, v in os.environ.items()
+                    if k.startswith("TPU_")
+                    or k.startswith("TORCH_TPU_")
+                    or k
+                    in (
+                        "CLOUD_TPU_TASK_ID",
+                        "CHIPS_PER_HOST",
+                        "JAX_MEM_FRACTION",
+                        "JAX_THREE_G_MEM_ALLOC_ON_FREE",
+                        "XLA_PYTHON_CLIENT_PREALLOCATE",
+                        "XLA_PYTHON_CLIENT_MEM_FRACTION",
+                        "LIBTPU_INIT_ARGS",
+                        "TORCH_DYNAMO_RECOMPILE_LIMIT",
+                        "SKIP_JAX_PRECOMPILE",
+                        "VLLM_ENABLE_V1_MULTIPROCESSING",
+                        "XLA_FLAGS",
+                    )
+                }
+            )
+            for worker in workers
+        ]
+    )
+
+    node_id = worker_infos[0][0]
+    visible_chips = ",".join([info[1] for info in worker_infos])
+    tpu_env_vars = worker_tpu_envs[0] if worker_tpu_envs else {}
+
+    return node_id, visible_chips, tpu_env_vars
+
+
+def prepare_tpu_server_args(args: dict):
+    """Configures TPU-specific CLI/server arguments and environment variables."""
+    if not is_tpu_vllm_run():
+        return
+
+    args["enable_sleep_mode"] = False
+    args["distributed_executor_backend"] = "external_launcher"
+    os.environ["TPU_MULTIHOST_BACKEND"] = "ray"
+
+    try:
+        try:
+            import vllm_torchtpu.envs as tpu_envs
+        except ImportError:
+            import tpu_inference.envs as tpu_envs
+
+        tpu_envs.TPU_MULTIHOST_BACKEND = "ray"
+        if hasattr(tpu_envs, "__getattr__") and hasattr(tpu_envs.__getattr__, "cache_clear"):
+            tpu_envs.__getattr__.cache_clear()
+    except Exception as env_err:
+        logging.getLogger(__name__).warning(f"Failed to force TPU_MULTIHOST_BACKEND to ray: {env_err}")

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -235,8 +235,10 @@ class vLLMColocateWorkerExtension:
 
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
 
-        if current_platform.device_type == "npu" and self.device is None:
+        if current_platform.device_type == "npu" and getattr(self, "device", None) is None:
             self.device = torch.device(f"npu:{self.local_rank}")
+        elif current_platform.device_type == "tpu" and getattr(self, "device", None) is None:
+            self.device = torch.device("tpu")
         assert self.device is not None
 
         # =========================== step 1: prepare for weight loading ===========================

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -66,6 +66,20 @@ from verl.workers.rollout.vllm_rollout.utils import (
 
 _VLLM_VERSION = version.parse(vllm.__version__)
 
+if get_resource_name() == "TPU":
+    from verl.workers.rollout.vllm_rollout.tpu_utils import (
+        get_tpu_server_launch_config,
+        is_tpu_vllm_run,
+        override_vllm_configs_for_tpu,
+        patch_vllm_for_tpu,
+        prepare_tpu_server_args,
+    )
+else:
+
+    def is_tpu_vllm_run():
+        return False
+
+
 if os.getenv("VERL_USE_GPT_OSS", "0") == "1":
     get_encoding()
 
@@ -401,10 +415,11 @@ class vLLMHttpServer:
                     f"(installed: {vllm.__version__}). Upgrade vLLM (e.g. `pip install -U "
                     "'vllm>=0.22.0'`) or disable enable_rollout_routing_replay."
                 )
-            args.update({"enable_return_routed_experts": True})
-
         if self._disaggregation_role != "null":
             args["kv_transfer_config"] = json.dumps(self._disaggregation_kv_transfer_config)
+
+        prepare_tpu_server_args(args)
+        override_vllm_configs_for_tpu(args)
 
         server_args = ["serve", self.model_config.local_path] + build_cli_args_from_config(args)
 
@@ -422,6 +437,7 @@ class vLLMHttpServer:
                 cmds[cmd.name] = cmd
         server_args = parser.parse_args(args=server_args)
         server_args.model = server_args.model_tag
+        override_vllm_configs_for_tpu(server_args)
         if server_args.subparser in cmds:
             cmds[server_args.subparser].validate(server_args)
 
@@ -432,7 +448,9 @@ class vLLMHttpServer:
             await self.run_headless(server_args)
 
     async def run_server(self, args: argparse.Namespace):
+        override_vllm_configs_for_tpu(args)
         engine_args = AsyncEngineArgs.from_cli_args(args)
+        override_vllm_configs_for_tpu(engine_args)
         usage_context = UsageContext.OPENAI_API_SERVER
         vllm_config = engine_args.create_engine_config(usage_context=usage_context)
         vllm_config.parallel_config.data_parallel_master_port = self._dp_master_port
@@ -1122,6 +1140,10 @@ class vLLMReplica(RolloutReplica):
             f"worker number {len(self.workers)} not equal to world size {self.world_size}"
         )
 
+        if is_tpu_vllm_run():
+            await self._launch_tpu_servers()
+            return
+
         # get (node_id, CUDA_VISIBLE_DEVICES) of all workers
         worker_infos = await asyncio.gather(
             *[
@@ -1251,10 +1273,60 @@ class vLLMReplica(RolloutReplica):
         await self.servers[0].wait_for_requests_to_drain.remote()
         await asyncio.gather(*[server.release_kv_cache.remote() for server in self.servers])
 
-    # -----------------------------------------------------------------------
-    # Hook methods for subclass overrides
-    # -----------------------------------------------------------------------
+    async def _launch_tpu_servers(self):
+        """Launch vLLM server actor for TPU platform."""
+        node_id, visible_chips, tpu_env_vars = await get_tpu_server_launch_config(self.workers)
 
-    def _get_server_name_prefix(self) -> str:
-        """Return the Ray actor name prefix (e.g. 'vllm_')."""
-        return "vllm_"
+        prefix = "vllm_"
+        if self.is_reward_model:
+            name = f"{prefix}server_reward_{self.replica_rank}_0{self.name_suffix}"
+        elif self.is_teacher_model:
+            name = f"{prefix}server_teacher_{self.replica_rank}_0{self.name_suffix}"
+        else:
+            name = f"{prefix}server_{self.replica_rank}_0{self.name_suffix}"
+
+        env_vars = {
+            **{var: "1" for var in get_platform().ray_noset_envvars()},
+            **get_platform().rollout_env_vars(),
+            **tpu_env_vars,
+        }
+        if "VERL_PLATFORM" in os.environ:
+            env_vars["VERL_PLATFORM"] = os.environ["VERL_PLATFORM"]
+
+        server = self.server_class.options(
+            scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                node_id=node_id,
+                soft=False,
+            ),
+            runtime_env={"env_vars": env_vars},
+            name=name,
+            max_concurrency=self.max_concurrency,
+        ).remote(
+            config=self.config,
+            model_config=self.model_config,
+            rollout_mode=self.rollout_mode,
+            workers=self.workers,
+            replica_rank=self.replica_rank,
+            node_rank=0,
+            gpus_per_node=self.gpus_per_replica_node,
+            nnodes=self.nnodes,
+            cuda_visible_devices=visible_chips,
+        )
+        self.servers.append(server)
+
+        master_address, master_port, dp_rpc_port = await self.servers[0].get_master_address.remote()
+        await self.servers[0].launch_server.remote(
+            master_address=master_address, master_port=master_port, dp_rpc_port=dp_rpc_port
+        )
+
+        server_address, server_port = await self.servers[0].get_server_address.remote()
+        self._server_handle = self.servers[0]
+        self._server_address = (
+            f"[{server_address}]:{server_port}"
+            if is_valid_ipv6_address(server_address)
+            else f"{server_address}:{server_port}"
+        )
+
+
+if is_tpu_vllm_run():
+    patch_vllm_for_tpu()

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -37,7 +37,7 @@ from torch.distributed.device_mesh import DeviceMesh
 
 from verl import DataProto
 from verl.third_party.vllm import VLLM_SLEEP_LEVEL
-from verl.utils.device import is_support_ipc
+from verl.utils.device import get_resource_name, is_support_ipc
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
 from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
@@ -266,3 +266,9 @@ class ServerAdapter(BaseRollout):
             "or use HFRollout for synchronous generation. "
             "See https://github.com/verl-project/verl/issues/4682 for more details."
         )
+
+
+if get_resource_name() == "TPU":
+    from verl.workers.rollout.vllm_rollout.vllm_async_server import patch_vllm_for_tpu
+
+    patch_vllm_for_tpu()

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -19,51 +19,135 @@ from tensordict import TensorDict
 from verl.trainer.ppo.core_algos import agg_loss, compute_value_loss, get_policy_loss_fn, kl_penalty
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
+from verl.utils.device import get_device_name
 from verl.utils.metric import AggregationType, Metric
 from verl.utils.torch_functional import masked_mean, masked_sum
 from verl.workers.config import ActorConfig, CriticConfig
 from verl.workers.utils.padding import no_padding_2_padding
+from verl.workers.utils.tpu_static_packing import (
+    flatten_tpu_loss_mask,
+    select_and_pad_tpu_data,
+    unpack_tpu_packed_data,
+)
+
+
+class DummyConfig:
+    """Fallback configuration object when config is passed as None during SFT loss evaluation."""
+
+    def __init__(self):
+        self.global_batch_info = {}
+        self.loss_scale_factor = None
+        self.loss_agg_mode = "token-mean"
 
 
 def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
+    """Compute Supervised Fine-Tuning (SFT) loss for actor model.
+
+    Supports both padded (RIGHT) and packed/nested sequence representations,
+    including static sequence packing for Google TPU v6e.
+
+    Args:
+        config (ActorConfig): Configuration object for actor training.
+        model_output (dict): Model forward outputs containing 'log_probs'.
+        data (TensorDict): Data batch containing token IDs, masks, and metadata.
+        dp_group: Data parallel process group (optional).
+
+    Returns:
+        tuple[torch.Tensor, dict]: Computed SFT loss and empty metrics dict.
+    """
+    is_tpu = get_device_name() == "tpu"
+    if is_tpu:
+        # TPU: Unpack sequence data if TPU static sequence packing is enabled
+        data = unpack_tpu_packed_data(data)
+
     pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
-    dp_size = data["dp_size"]
-    batch_num_tokens = data["batch_num_tokens"]
+
+    dp_size = tu.get_non_tensor_data(data=data, key="dp_size", default=1)
+    batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
 
     log_prob = model_output["log_probs"]
 
-    if pad_mode == DatasetPadMode.NO_PADDING:
+    if pad_mode in (DatasetPadMode.NO_PADDING, DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"):
         # log_prob and loss mask are nested tensors of shape [bsz, j1]
         # for each sample, loss mask shape is [1, prompt_length + response_length]
         loss_mask = data["loss_mask"]
 
-        log_prob_flatten = log_prob.values()
-        loss_mask_flatten = loss_mask.values()
+        if is_tpu and pad_mode in (DatasetPadMode.TPU_BINNED_PACK, "tpu_binned_pack"):
+            # TPU: flatten loss mask to align with TPU binned static packed log_probs
+            log_prob_flatten = log_prob.values()
+            loss_mask = flatten_tpu_loss_mask(loss_mask, data, log_prob_flatten)
 
-        # left-shift the loss mask by one token to align with log_prob
-        loss_mask_flatten = torch.roll(loss_mask_flatten, shifts=-1, dims=0)
+        log_prob = no_padding_2_padding(log_prob, data)
 
-        # NOTE: loss is averaged over all tokens in the batch across all data parallel groups,
-        # For FSDP backend, the loss is directly used for backward; while for Megatron backend,
-        # the loss should be scaled by `num_microbatches` for pp schedule.
-        loss = -masked_sum(log_prob_flatten, loss_mask_flatten) / batch_num_tokens * dp_size
+        # construct global batch info
+        if config is None:
+            config = DummyConfig()
+
+        config.global_batch_info["dp_size"] = dp_size
+        config.global_batch_info["batch_num_tokens"] = batch_num_tokens
+        config.global_batch_info["global_batch_size"] = data["global_batch_size"]
+        config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
+
+        mask_key = "response_mask" if "response_mask" in data.keys() else "loss_mask"
+        if is_tpu:
+            # TPU: select and pad tensors with fixed target shape to avoid dynamic shape recompilation
+            padded_dict = select_and_pad_tpu_data(data, mask_key, target_tensor=log_prob)
+            response_mask = padded_dict[mask_key].to(bool)
+        else:
+            response_mask = data[mask_key].to(bool)
+
+        # Bypass zero-sequence length empty tensor backward pass issues
+        if log_prob.shape[1] == 0:
+            log_prob = torch.zeros(
+                (log_prob.shape[0], 1), device=log_prob.device, dtype=log_prob.dtype, requires_grad=True
+            )
+            response_mask = torch.zeros((response_mask.shape[0], 1), device=response_mask.device, dtype=torch.bool)
+
+        loss = agg_loss(
+            loss_mat=-log_prob, loss_mask=response_mask, loss_agg_mode=config.loss_agg_mode, **config.global_batch_info
+        )
+    elif pad_mode == DatasetPadMode.RIGHT:
+        if "response_mask" in data.keys():
+            mask = data["response_mask"].to(bool)
+            mask[:, -1] = False
+        else:
+            mask = data["loss_mask"].to(bool)
+            mask = torch.cat([mask[:, 1:], torch.zeros_like(mask[:, :1])], dim=1)
+        loss = -masked_sum(log_prob, mask) / batch_num_tokens * dp_size
     else:
-        response_mask = data["response_mask"].to(bool)
-        loss = -masked_sum(log_prob, response_mask) / batch_num_tokens * dp_size
+        raise ValueError(f"Unsupported pad_mode: {pad_mode}")
 
     return loss, {}
 
 
 def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
-    """Computes ppo loss from model output (log_prob, entropy, values, etc. ) and old_log_probs from data."""
+    """Compute PPO policy gradient loss, entropy bonus, and KL divergence penalty.
+
+    Args:
+        config (ActorConfig): Configuration object for actor training.
+        model_output (dict): Model forward outputs containing 'log_probs' and optional 'entropy'.
+        data (TensorDict): Data batch containing old log probs, advantages, masks, and metadata.
+        dp_group: Data parallel process group (optional).
+
+    Returns:
+        tuple[torch.Tensor, dict]: Total policy loss and metric dictionary containing policy metrics,
+            entropy loss, and KL loss tracking.
+    """
+    is_tpu = get_device_name() == "tpu"
+    if is_tpu:
+        # TPU: Unpack sequence data if TPU static sequence packing is enabled
+        data = unpack_tpu_packed_data(data)
+
     log_prob = no_padding_2_padding(model_output["log_probs"], data)
     entropy = model_output.get("entropy", None)
     if entropy is not None:
         entropy = no_padding_2_padding(entropy, data)
 
     # global batch info for loss aggregation
-    config.global_batch_info["dp_size"] = data["dp_size"]
-    config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
+    dp_size = tu.get_non_tensor_data(data=data, key="dp_size", default=1)
+    batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
+    config.global_batch_info["dp_size"] = dp_size
+    config.global_batch_info["batch_num_tokens"] = batch_num_tokens
     config.global_batch_info["global_batch_size"] = data["global_batch_size"]
     config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
 
@@ -71,8 +155,8 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     # normalize using dp_size/global_bsz/global_token; in this case, metric aggregation should be SUM
     # to reflect the mean loss over the global batch
     if (
-        data["dp_size"] > 1
-        or data["batch_num_tokens"] is not None
+        dp_size > 1
+        or batch_num_tokens is not None
         or data["global_batch_size"] is not None
         or config.loss_scale_factor is not None
     ):
@@ -88,7 +172,12 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         fields.append("rollout_is_weights")
     if "ref_log_prob" in data:
         fields.append("ref_log_prob")
-    data = data.select(*fields).to_padded_tensor()
+
+    if is_tpu:
+        # TPU: select and pad tensors with fixed target shape to avoid dynamic shape recompilation
+        data = select_and_pad_tpu_data(data, *fields, target_tensor=log_prob)
+    else:
+        data = data.select(*fields).to_padded_tensor()
 
     response_mask = data["response_mask"].to(bool)
     # compute policy loss
@@ -139,24 +228,30 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
         policy_loss += kl_loss * config.kl_loss_coef
         metrics["kl_loss"] = Metric(value=kl_loss, aggregation=metric_aggregation)
-        metrics["kl_coef"] = config.kl_loss_coef
+        metrics["kl_coef"] = Metric(value=config.kl_loss_coef, aggregation=metric_aggregation)
 
     return policy_loss, metrics
 
 
 def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=None):
-    """value loss
+    """Compute critic value function loss with optional value clipping.
 
     Args:
-        config: CriticConfig
-        model_output: model output from the model
-        data: the input to the model
-        dp_group: data paralle group
+        config (CriticConfig): Configuration object for critic training.
+        model_output (dict): Model forward outputs containing predicted 'values'.
+        data (TensorDict): Data batch containing target returns, old values, and masks.
+        dp_group: Data parallel process group (optional).
 
     Returns:
-        value loss
+        tuple[torch.Tensor, dict]: Value function loss and metric dictionary containing vf_loss,
+            vf_clipfrac, and mean predicted values.
     """
-    vpreds = no_padding_2_padding(model_output["values"], data)  # (bsz, response_length)
+    is_tpu = get_device_name() == "tpu"
+    if is_tpu:
+        # TPU: Unpack sequence data if TPU static sequence packing is enabled
+        data = unpack_tpu_packed_data(data)
+
+    vpreds = no_padding_2_padding(model_output["values"], data)
 
     # Normalize the value loss over the global mini-batch (dp_size / batch_num_tokens /
     # global_batch_size) instead of the local micro-batch, so the accumulated critic gradient is
@@ -177,8 +272,13 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
     else:
         metric_aggregation = AggregationType.MEAN
 
-    # select fields and convert to padded tensor
-    data = data.select("values", "returns", "response_mask").to_padded_tensor()
+    if is_tpu:
+        # TPU: select and pad tensors with fixed target shape to avoid dynamic shape recompilation
+        data = select_and_pad_tpu_data(data, "values", "returns", "response_mask")
+    else:
+        # select fields and convert to padded tensor
+        data = data.select("values", "returns", "response_mask").to_padded_tensor()
+
     values = data["values"]
     returns = data["returns"]
     response_mask = data["response_mask"].to(bool)

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -120,6 +120,13 @@ def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     return loss, {}
 
 
+def _extract_scalar_value(value, default=None):
+    """Extract a scalar integer or float from a metadata container or sequence."""
+    if isinstance(value, list | tuple):
+        return value[0] if len(value) > 0 else default
+    return value if value is not None else default
+
+
 def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
     """Compute PPO policy gradient loss, entropy bonus, and KL divergence penalty.
 
@@ -144,8 +151,10 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         entropy = no_padding_2_padding(entropy, data)
 
     # global batch info for loss aggregation
-    dp_size = tu.get_non_tensor_data(data=data, key="dp_size", default=1)
-    batch_num_tokens = tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None)
+    dp_size = _extract_scalar_value(tu.get_non_tensor_data(data=data, key="dp_size", default=1), default=1)
+    batch_num_tokens = _extract_scalar_value(
+        tu.get_non_tensor_data(data=data, key="batch_num_tokens", default=None), default=None
+    )
     config.global_batch_info["dp_size"] = dp_size
     config.global_batch_info["batch_num_tokens"] = batch_num_tokens
     config.global_batch_info["global_batch_size"] = data["global_batch_size"]

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -15,9 +15,11 @@
 import torch
 import torch.nn.functional as F
 from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData
 
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
+from verl.utils.device import get_device_name
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
@@ -96,6 +98,116 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
     return data
 
 
+def get_packed_sequence_offsets_and_lens(
+    tensor: torch.Tensor, data: TensorDict, values: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Extract and compute sequence offsets, response lengths, and maximum response length from packed sequences.
+
+    Handles both TPU static binned packing and PyTorch nested/jagged tensor representations.
+
+    Args:
+        tensor (torch.Tensor): The input token or sequence tensor (nested/jagged or dense).
+        data (TensorDict): Data batch containing prompts, responses, or mask attributes.
+        values (torch.Tensor): Reference value tensor used to infer target device and dtypes.
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor, int]:
+            - sequence_offsets (torch.Tensor): Cumulative sequence end offsets.
+            - response_lens (torch.Tensor): Length of the response section for each sequence.
+            - max_response_len (int): Maximum response length across the batch.
+    """
+    is_tpu = get_device_name() == "tpu" or "tpu_custom_attention_mask" in data.keys()
+    if is_tpu and not (getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets")):
+        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
+
+        return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
+
+    if "prompts" in data.keys() and "responses" in data.keys():
+        prompt_ids = data["prompts"]
+        response_ids = data["responses"]
+
+        if isinstance(prompt_ids, NonTensorData):
+            prompt_ids = prompt_ids.data
+        if isinstance(response_ids, NonTensorData):
+            response_ids = response_ids.data
+    else:
+        prompt_ids = None
+        response_ids = None
+
+    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
+    if isinstance(max_response_len, list | tuple):
+        max_response_len = max(max_response_len) if len(max_response_len) > 0 else -1
+
+    if getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets"):
+        sequence_offsets = tensor.offsets()[1:].to(device=values.device)
+        sequence_lens = tensor.offsets().diff().to(device=values.device)
+
+        if response_ids is not None and (getattr(response_ids, "is_nested", False) or hasattr(response_ids, "offsets")):
+            response_lens = response_ids.offsets().diff().to(device=values.device)
+        elif response_ids is not None and isinstance(response_ids, list | tuple):
+            response_lens = torch.tensor(
+                [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+                device=values.device,
+                dtype=torch.int64,
+            )
+        elif response_ids is not None and isinstance(response_ids, torch.Tensor) and response_ids.ndim >= 2:
+            if "response_mask" in data.keys():
+                response_lens = data["response_mask"].sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = torch.tensor(
+                    [response_ids.shape[1]] * response_ids.shape[0], device=values.device, dtype=torch.int64
+                )
+        else:
+            mask_key = (
+                "response_mask"
+                if "response_mask" in data.keys()
+                else ("loss_mask" if "loss_mask" in data.keys() else None)
+            )
+            if mask_key is not None:
+                mask_val = data[mask_key]
+                if getattr(mask_val, "is_nested", False) or hasattr(mask_val, "offsets"):
+                    response_lens = torch.tensor(
+                        [int(x.sum().item()) for x in mask_val],
+                        device=values.device,
+                        dtype=torch.int64,
+                    )
+                else:
+                    response_lens = mask_val.sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = sequence_lens // 2
+
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+    elif prompt_ids is not None and (getattr(prompt_ids, "is_nested", False) or hasattr(prompt_ids, "offsets")):
+        prompt_lens = prompt_ids.offsets().diff().to(device=values.device)
+        response_lens = response_ids.offsets().diff().to(device=values.device)
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    elif prompt_ids is not None and isinstance(prompt_ids, list | tuple):
+        prompt_lens = torch.tensor(
+            [p.shape[-1] if hasattr(p, "shape") else len(p) for p in prompt_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        response_lens = torch.tensor(
+            [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    else:
+        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
+
+        return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
+
+    return sequence_offsets, response_lens, max_response_len
+
+
 def no_padding_2_padding(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor:
     """Slice response from unpad model output.
 
@@ -108,36 +220,26 @@ def no_padding_2_padding(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor
     Returns:
         tensor: sliced response tensor of shape [bsz, max_response_len, *]
     """
-    values = tensor.values() if tensor.is_nested else tensor
-    prompt_ids = data["prompts"]
-    response_ids = data["responses"]
-
-    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
-
-    if prompt_ids.is_nested:
-        prompt_lens = prompt_ids.offsets().diff()
-        response_lens = response_ids.offsets().diff()
-        if max_response_len < 0:
-            max_response_len = response_lens.max().item()
-    else:
-        attention_mask = data["attention_mask"]
-        assert not attention_mask.is_nested
-        prompt_lens = attention_mask[:, : prompt_ids.shape[1]].sum(dim=1)
-        response_lens = attention_mask[:, prompt_ids.shape[1] :].sum(dim=1)
-        max_response_len = response_ids.shape[1]
-
-    sequence_lens = prompt_lens + response_lens
-    sequence_offsets = sequence_lens.cumsum(dim=0)
-    assert sequence_offsets[-1].item() == values.shape[0]
-    assert not prompt_lens.eq(0).any(), f"seq_offset - resp_len - 1 assumes prompt_len > 0. Got {prompt_lens}"
+    values = tensor.values() if getattr(tensor, "is_nested", False) else tensor
+    sequence_offsets, response_lens, max_response_len = get_packed_sequence_offsets_and_lens(tensor, data, values)
 
     response_list = []
     # Skip padding dimensions after sequence dimensions, if any.
     skip_padding = (0, 0) * (values.ndim - 1)
+    prev_offset = 0
     for resp_len, seq_offset in zip(response_lens, sequence_offsets, strict=True):
-        pad_size = max_response_len - resp_len
-        # left-shift model output by one token for log_probs/values
-        response_list.append(F.pad(values[seq_offset - resp_len - 1 : seq_offset - 1], (*skip_padding, 0, pad_size)))
+        resp_len_item = int(resp_len.item()) if isinstance(resp_len, torch.Tensor) else int(resp_len)
+        seq_offset_item = int(seq_offset.item()) if isinstance(seq_offset, torch.Tensor) else int(seq_offset)
+        pad_size = max(0, max_response_len - resp_len_item)
+
+        start_idx = seq_offset_item - resp_len_item - 1
+        end_idx = seq_offset_item - 1
+        if start_idx < prev_offset:
+            start_idx = seq_offset_item - resp_len_item
+            end_idx = seq_offset_item
+
+        response_list.append(F.pad(values[start_idx:end_idx], (*skip_padding, 0, pad_size)))
+        prev_offset = seq_offset_item
 
     output = torch.stack(response_list, dim=0)
     return output

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -20,6 +20,7 @@ from tensordict.tensorclass import NonTensorData
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
 from verl.utils.device import get_device_name
+from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
@@ -118,8 +119,6 @@ def get_packed_sequence_offsets_and_lens(
     """
     is_tpu = get_device_name() == "tpu" or "tpu_custom_attention_mask" in data.keys()
     if is_tpu and not (getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets")):
-        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
-
         return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
 
     if "prompts" in data.keys() and "responses" in data.keys():
@@ -201,8 +200,6 @@ def get_packed_sequence_offsets_and_lens(
         sequence_lens = prompt_lens + response_lens
         sequence_offsets = sequence_lens.cumsum(dim=0)
     else:
-        from verl.workers.utils.tpu_static_packing import get_packed_sequence_offsets_and_lens_tpu
-
         return get_packed_sequence_offsets_and_lens_tpu(tensor, data, values)
 
     return sequence_offsets, response_lens, max_response_len

--- a/verl/workers/utils/tpu_static_packing.py
+++ b/verl/workers/utils/tpu_static_packing.py
@@ -1,0 +1,405 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorData
+
+from verl.utils import tensordict_utils as tu
+
+
+def unpack_tpu_packed_data(data: TensorDict) -> TensorDict:
+    """Reconstruct NestedTensors from packed flat sequence keys on TPU.
+
+    In TPU binned sequence packing, standard sequence keys (like old_log_probs,
+    advantages, response_mask) are packed into 2D flat tensors. Reconstructing them
+    as device NestedTensors using cu_seqlens ensures they can be correctly
+    padded/sliced to [batch_size, max_response_len].
+    """
+    if "tpu_custom_attention_mask" not in data.keys():
+        return data
+
+    input_ids = data["input_ids"]
+    mbsz = input_ids.shape[0]
+
+    cu_seqlens_list = data["tpu_cu_seqlens"]
+    if hasattr(cu_seqlens_list, "data"):
+        cu_seqlens_list = cu_seqlens_list.data
+    if not isinstance(cu_seqlens_list, list | tuple):
+        cu_seqlens_list = [cu_seqlens_list]
+
+    num_seqs_list = data["tpu_num_seqs"]
+    if hasattr(num_seqs_list, "data"):
+        num_seqs_list = num_seqs_list.data
+    if not isinstance(num_seqs_list, list | tuple):
+        num_seqs_list = [num_seqs_list]
+
+    # Include "loss_mask" in the unpack keys list to unpack SFT training loss mask correctly.
+    sequence_keys_to_unpack = [
+        "old_log_probs",
+        "advantages",
+        "response_mask",
+        "values",
+        "returns",
+        "ref_log_prob",
+        "rollout_is_weights",
+        "loss_mask",
+    ]
+
+    for k in sequence_keys_to_unpack:
+        if k in data.keys():
+            val = data[k]
+            if isinstance(val, torch.Tensor) and not getattr(val, "is_nested", False):
+                cumulative_offset = 0
+                combined_cu_seqlens = [0]
+                combined_val_rmpad_list = []
+
+                for row_idx in range(mbsz):
+                    cu_seqlens_row = cu_seqlens_list[row_idx]
+                    num_seqs_row = num_seqs_list[row_idx]
+
+                    if isinstance(cu_seqlens_row, list):
+                        cu_seqlens_row = cu_seqlens_row[0]
+                    if not isinstance(cu_seqlens_row, torch.Tensor):
+                        cu_seqlens_row = torch.tensor(cu_seqlens_row, dtype=torch.int32)
+
+                    cu_seqlens_active = cu_seqlens_row[: num_seqs_row + 1]
+                    active_len = int(cu_seqlens_active[-1].item())
+
+                    if val.dim() >= 2:
+                        val_row = val[row_idx, :active_len]
+                    else:
+                        val_row = val[:active_len]
+
+                    combined_val_rmpad_list.append(val_row)
+
+                    row_offsets = cu_seqlens_active[1:] - cu_seqlens_active[0] + cumulative_offset
+                    combined_cu_seqlens.extend(row_offsets.tolist())
+                    cumulative_offset += active_len
+
+                combined_val_rmpad = torch.cat(combined_val_rmpad_list, dim=0).to(val.device)
+                combined_cu_seqlens_tensor = torch.tensor(combined_cu_seqlens, dtype=torch.int32, device=val.device)
+                nested_val = torch.nested.nested_tensor_from_jagged(combined_val_rmpad, combined_cu_seqlens_tensor)
+                data._tensordict[k] = nested_val
+
+    return data
+
+
+def nested_to_padded_tpu(val: torch.Tensor, fill_val=0.0) -> torch.Tensor:
+    """Safely converts a PyTorch NestedTensor to a padded 2D dense tensor on TPU."""
+    if not isinstance(val, torch.Tensor) or not getattr(val, "is_nested", False):
+        return val
+    try:
+        return val.to_padded_tensor(fill_val)
+    except Exception:
+        values = val.values()
+        offsets = val.offsets()
+        bsz = offsets.shape[0] - 1
+        lens = offsets.diff().tolist()
+        max_len = max(lens) if len(lens) > 0 else 0
+        out = torch.full(
+            (bsz, max_len, *values.shape[1:]), fill_value=fill_val, dtype=values.dtype, device=values.device
+        )
+        for i in range(bsz):
+            st, en = int(offsets[i]), int(offsets[i + 1])
+            row_data = values[st:en]
+            row_len = min(en - st, row_data.shape[0])
+            if row_len > 0:
+                out[i, :row_len] = row_data[:row_len]
+        return out
+
+
+def pad_to_2d_tensor(val, target_len=-1, fill_val=0.0, target_tensor=None):
+    """Pads standard and nested tensors to 2D dense tensors of target length."""
+    if val is None:
+        return None
+    if isinstance(val, torch.Tensor):
+        val = nested_to_padded_tpu(val, fill_val)
+        if val.ndim == 1:
+            val = val.unsqueeze(0)
+    elif isinstance(val, list | tuple):
+        t_list = []
+        for x in val:
+            if isinstance(x, torch.Tensor):
+                x = nested_to_padded_tpu(x, fill_val)
+                if x.ndim == 0:
+                    x = x.unsqueeze(0)
+                elif x.ndim > 1:
+                    x = x.flatten()
+            else:
+                x = torch.as_tensor(x)
+                if x.ndim == 0:
+                    x = x.unsqueeze(0)
+            t_list.append(x)
+
+        if len(t_list) > 0:
+            max_item_len = max(t.shape[0] for t in t_list)
+            if target_len > 0:
+                max_item_len = max(max_item_len, target_len)
+            aligned = []
+            for t in t_list:
+                if t.shape[0] < max_item_len:
+                    pad = torch.full((max_item_len - t.shape[0],), fill_value=fill_val, dtype=t.dtype, device=t.device)
+                    t = torch.cat([t, pad], dim=0)
+                elif t.shape[0] > max_item_len:
+                    t = t[:max_item_len]
+                aligned.append(t)
+            val = torch.stack(aligned, dim=0)
+        else:
+            val = torch.empty((0, target_len if target_len > 0 else 0))
+    else:
+        val = torch.as_tensor(val)
+        if val.ndim == 1:
+            val = val.unsqueeze(0)
+
+    if isinstance(val, torch.Tensor):
+        val = nested_to_padded_tpu(val, fill_val)
+    if isinstance(target_tensor, torch.Tensor):
+        target_tensor = nested_to_padded_tpu(target_tensor, 0.0)
+
+    if isinstance(val, torch.Tensor) and val.ndim >= 2:
+        if target_len > 0:
+            curr_len = int(val.shape[1])
+            if curr_len < target_len:
+                pad_shape = list(val.shape)
+                pad_shape[1] = target_len - curr_len
+                pad = torch.full(pad_shape, fill_value=fill_val, dtype=val.dtype, device=val.device)
+                val = torch.cat([val, pad], dim=1)
+            elif curr_len > target_len:
+                val = val[:, :target_len]
+
+    if target_tensor is not None and isinstance(target_tensor, torch.Tensor) and isinstance(val, torch.Tensor):
+        if val.device != target_tensor.device or val.dtype != target_tensor.dtype:
+            if not val.dtype.is_floating_point and target_tensor.dtype.is_floating_point:
+                val = val.to(device=target_tensor.device, dtype=target_tensor.dtype)
+            else:
+                val = val.to(device=target_tensor.device)
+        val_s0, target_s0 = int(val.shape[0]), int(target_tensor.shape[0])
+        val_s1, target_s1 = int(val.shape[1]), int(target_tensor.shape[1])
+        if (val_s0, val_s1) != (target_s0, target_s1):
+            if val_s0 != target_s0:
+                if val_s0 < target_s0:
+                    rep = (target_s0 + val_s0 - 1) // max(1, val_s0)
+                    val = val.repeat(rep, 1)[:target_s0]
+                else:
+                    val = val[:target_s0]
+            if val_s1 != target_s1:
+                if val_s1 < target_s1:
+                    pad_shape = list(val.shape)
+                    pad_shape[1] = target_s1 - val_s1
+                    pad = torch.full(pad_shape, fill_value=fill_val, dtype=val.dtype, device=val.device)
+                    val = torch.cat([val, pad], dim=1)
+                else:
+                    val = val[:, :target_s1]
+    return val
+
+
+def select_and_pad_tpu_data(data: TensorDict, *fields, target_tensor=None) -> dict:
+    """Select and pad TensorDict fields on TPU."""
+    from verl.workers.utils.padding import no_padding_2_padding  # Avoid circular import with padding.py
+
+    is_tpu_packed = "tpu_custom_attention_mask" in data.keys()
+    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
+    if isinstance(max_response_len, list | tuple):
+        max_response_len = max(max_response_len) if len(max_response_len) > 0 else -1
+
+    padded_dict = {}
+    for k in fields:
+        if k not in data.keys():
+            continue
+        val = data[k]
+        if isinstance(val, NonTensorData):
+            val = val.data
+
+        fill_val = (
+            1.0
+            if k == "rollout_is_weights"
+            else (True if k == "response_mask" and getattr(val, "dtype", None) == torch.bool else 0.0)
+        )
+
+        padded = None
+        if is_tpu_packed:
+            if isinstance(val, list | tuple):
+                try:
+                    val_t = torch.as_tensor(val)
+                    padded = no_padding_2_padding(val_t, data)
+                except Exception:
+                    pass
+            if padded is None:
+                try:
+                    padded = no_padding_2_padding(val, data)
+                except Exception:
+                    pass
+
+        padded = pad_to_2d_tensor(
+            padded if padded is not None else val,
+            target_len=max_response_len,
+            fill_val=fill_val,
+            target_tensor=target_tensor,
+        )
+        padded_dict[k] = padded
+
+    return padded_dict
+
+
+def flatten_tpu_loss_mask(loss_mask: torch.Tensor, data: TensorDict, log_prob_flatten: torch.Tensor) -> torch.Tensor:
+    """Flatten loss_mask using TPU binned packing active seqlens.
+
+    Called in `verl/workers/utils/losses.py` during loss calculation when data.pad_mode=no_padding on TPU.
+    """
+    if isinstance(loss_mask, torch.Tensor) and not getattr(loss_mask, "is_nested", False):
+        mbsz = loss_mask.shape[0]
+        cu_seqlens_list = data["tpu_cu_seqlens"]
+        if hasattr(cu_seqlens_list, "data"):
+            cu_seqlens_list = cu_seqlens_list.data
+        if not isinstance(cu_seqlens_list, list | tuple):
+            cu_seqlens_list = [cu_seqlens_list]
+
+        num_seqs_list = data["tpu_num_seqs"]
+        if hasattr(num_seqs_list, "data"):
+            num_seqs_list = num_seqs_list.data
+        if not isinstance(num_seqs_list, list | tuple):
+            num_seqs_list = [num_seqs_list]
+
+        loss_mask_parts = []
+        for row_idx in range(mbsz):
+            cu_seqlens = cu_seqlens_list[row_idx]
+            if isinstance(cu_seqlens, list):
+                cu_seqlens = cu_seqlens[0]
+            if not isinstance(cu_seqlens, torch.Tensor):
+                cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
+
+            num_seqs = num_seqs_list[row_idx]
+            if isinstance(num_seqs, list):
+                num_seqs = num_seqs[0]
+
+            cu_seqlens_active = cu_seqlens[: num_seqs + 1]
+            active_len = int(cu_seqlens_active[-1].item())
+
+            loss_mask_parts.append(loss_mask[row_idx, :active_len])
+
+        return torch.cat(loss_mask_parts, dim=0).to(log_prob_flatten.device)
+    else:
+        return loss_mask.values()
+
+
+def get_packed_sequence_offsets_and_lens_tpu(
+    tensor: torch.Tensor, data: TensorDict, values: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Extract and compute sequence offsets, response lengths, and maximum response length for packed data on TPU."""
+    # Handle SFT fallback when "prompts" or "responses" are not in the TensorDict keys.
+    if "prompts" in data.keys() and "responses" in data.keys():
+        prompt_ids = data["prompts"]
+        response_ids = data["responses"]
+
+        if isinstance(prompt_ids, NonTensorData):
+            prompt_ids = prompt_ids.data
+        if isinstance(response_ids, NonTensorData):
+            response_ids = response_ids.data
+    else:
+        prompt_ids = None
+        response_ids = None
+
+    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
+    if isinstance(max_response_len, list | tuple):
+        max_response_len = max(max_response_len) if len(max_response_len) > 0 else -1
+
+    if getattr(tensor, "is_nested", False) or hasattr(tensor, "offsets"):
+        sequence_offsets = tensor.offsets()[1:].to(device=values.device)
+        sequence_lens = tensor.offsets().diff().to(device=values.device)
+
+        if response_ids is not None and (getattr(response_ids, "is_nested", False) or hasattr(response_ids, "offsets")):
+            response_lens = response_ids.offsets().diff().to(device=values.device)
+        elif response_ids is not None and isinstance(response_ids, list | tuple):
+            response_lens = torch.tensor(
+                [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+                device=values.device,
+                dtype=torch.int64,
+            )
+        elif response_ids is not None and isinstance(response_ids, torch.Tensor) and response_ids.ndim >= 2:
+            if "response_mask" in data.keys():
+                response_lens = data["response_mask"].sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = torch.tensor(
+                    [response_ids.shape[1]] * response_ids.shape[0], device=values.device, dtype=torch.int64
+                )
+        else:
+            # SFT fallback: response_lens is the sum of loss_mask/response_mask within each sequence
+            mask_key = (
+                "response_mask"
+                if "response_mask" in data.keys()
+                else ("loss_mask" if "loss_mask" in data.keys() else None)
+            )
+            if mask_key is not None:
+                mask_val = data[mask_key]
+                if getattr(mask_val, "is_nested", False) or hasattr(mask_val, "offsets"):
+                    response_lens = torch.tensor(
+                        [int(x.sum().item()) for x in mask_val],
+                        device=values.device,
+                        dtype=torch.int64,
+                    )
+                else:
+                    response_lens = mask_val.sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            else:
+                response_lens = sequence_lens // 2
+
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+    elif prompt_ids is not None and (getattr(prompt_ids, "is_nested", False) or hasattr(prompt_ids, "offsets")):
+        prompt_lens = prompt_ids.offsets().diff().to(device=values.device)
+        response_lens = response_ids.offsets().diff().to(device=values.device)
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    elif prompt_ids is not None and isinstance(prompt_ids, list | tuple):
+        prompt_lens = torch.tensor(
+            [p.shape[-1] if hasattr(p, "shape") else len(p) for p in prompt_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        response_lens = torch.tensor(
+            [r.shape[-1] if hasattr(r, "shape") else len(r) for r in response_ids],
+            device=values.device,
+            dtype=torch.int64,
+        )
+        if max_response_len < 0:
+            max_response_len = int(response_lens.max().item())
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+    else:
+        # SFT Fallback: tensor is not nested, standard 2D tensor or packed 2D tensor
+        mask_key = (
+            "response_mask" if "response_mask" in data.keys() else ("loss_mask" if "loss_mask" in data.keys() else None)
+        )
+        if mask_key is not None:
+            mask_val = data[mask_key]
+            response_lens = mask_val.sum(dim=-1).to(device=values.device, dtype=torch.int64)
+            if "input_ids" in data.keys():
+                input_ids = data["input_ids"]
+                prompt_lens = (
+                    torch.tensor([input_ids.shape[1]] * input_ids.shape[0], device=values.device) - response_lens
+                )
+            else:
+                prompt_lens = response_lens
+            max_response_len = int(response_lens.max().item())
+        else:
+            prompt_lens = torch.tensor([tensor.shape[1] // 2] * tensor.shape[0], device=values.device)
+            response_lens = torch.tensor([tensor.shape[1] // 2] * tensor.shape[0], device=values.device)
+            max_response_len = tensor.shape[1] // 2
+
+        sequence_lens = prompt_lens + response_lens
+        sequence_offsets = sequence_lens.cumsum(dim=0)
+
+    return sequence_offsets, response_lens, max_response_len


### PR DESCRIPTION
### What does this PR do?

This PR enables GRPO RL training support for Google Cloud TPU v6e instances on GKE using TorchTitan actor engine and vLLM rollout backend.            
                                                                                                                                                          
Key capabilities introduced:
                                                                             
- **Non-colocated TPU Multi-Slice Support**: Dedicated placement group isolation for TorchTitan trainer (`Slice 0`) and vLLM sampler/rollout (`Slice  1`).                                                                                                                                                    
- **Domain-Based Placement Group Resolution**: Added worker domain name-prefix filtering (`matching_pgs`) in `PlatformTPU.get_tpu_env_vars()` to  prevent inter-slice PJRT mesh mixing.                                                                                                                   
 - **TPU Checkpoint Engine Integration**: Implemented custom zero-copy weight synchronization via `TPUCheckpointEngine` and   `load_weights_from_ray_registry()`.                                                                                                                     
- **Vectorized TPU Logprobs**: Vectorized logprobs calculation in `torch_functional.py` for 30x faster reference logprob computation.     

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Validated end-to-end on a GKE TPU v6e-8 multi-slice cluster (2 nodes x 4 chips for trainer, 2 nodes x 4 chips for rollout) running 5 full GRPO  training steps on Qwen3-0.6B with GSM8K dataset:

- Step 0 compilation completed cleanly.
- Steps 1..5 completed in ~8–10s/step.
- Metrics logged: `actor/loss=0.00165`, `actor/entropy=0.65234`, `actor/grad_norm=0.77039`.

### API and Usage Example


```bash
ray job submit --address "${RAY_ADDRESS}" \
  --working-dir . \
  --runtime-env-json '{
    "excludes": [".git", "logs", "*.log", "*.pt", "*.bin"],
    "env_vars": {
      "PYTHONPATH": ".",
      "PYTHONUNBUFFERED": "1",
      "VERL_PLATFORM": "tpu",
      "VLLM_USE_V1": "0",
      "RAY_memory_monitor_refresh_ms": "0",
      "RAY_memory_usage_threshold": "0.99",
      "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS": "1",
      "RAY_OVERRIDE_JOB_RUNTIME_ENV": "1",
      "WANDB_API_KEY": "'"${WANDB_API_KEY}"'"
    }
  }' \
  -- bash examples/tpu/grpo/run_qwen3_0_6b_torchtitan.sh
```

### Design & Code Changes


  1. verl/plugin/platform/platform_tpu.py: Added matching_pgs filtering in get_tpu_env_vars() to isolate Slice 0 (Trainer) and Slice 1 (Rollout) PJRT meshes.
  2. verl/checkpoint_engine/tpu_checkpoint_engine.py: Custom TPU weight transfer and registry loading without CUDA dependencies.
  3. verl/workers/rollout/vllm_rollout/tpu_utils.py: Applied TPU patches for vLLM EngineCore child process environment propagation and placement group  bindings.
  4. examples/tpu/grpo/run_grpo_qwen3_0.6b.sh: Added end-to-end TPU GRPO launch script and documentation at examples/tpu/grpo/README.md.
  

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
