### PR TITLE
[rollout, sglang] fix: keep SGLang LoRA-free when model.lora.merge=True

### DIFF
--- a/tests/workers/rollout/rollout_sglang/test_lora_merge_mode_on_cpu.py
+++ b/tests/workers/rollout/rollout_sglang/test_lora_merge_mode_on_cpu.py
@@ -1,0 +1,80 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for LoRA merge-vs-adapter detection in the SGLang rollout.
+
+``lora_served_as_adapter`` drives every LoRA branch of ``SGLangHttpServer``:
+``enable_lora`` in ``launch_server``, ``lora_path`` on each ``generate`` request, and the
+release tags in ``sleep``. With ``model.lora.merge=True`` the trainer merges the adapter
+into the base weights and pushes a full weight update (``peft_config=None``), so SGLang
+must stay LoRA-free -- otherwise requests reference an adapter that is never loaded.
+
+Note the two config blocks of ``HFModelConfig``, which are never synced: megatron runs set
+``model.lora.rank``, fsdp runs set the flat ``model.lora_rank``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from verl.workers.rollout.sglang_rollout.utils import lora_served_as_adapter
+
+
+@dataclass
+class _StubModelConfig:
+    """Minimal stand-in exposing the HFModelConfig fields the helper reads."""
+
+    lora_rank: int = 0
+    lora: dict[str, Any] = field(default_factory=dict)
+
+
+class TestLoraServedAsAdapter:
+    def test_no_lora(self):
+        assert lora_served_as_adapter(_StubModelConfig()) is False
+
+    def test_megatron_merge(self):
+        """megatron + merge: keep SGLang LoRA-free even though lora.rank > 0."""
+        assert lora_served_as_adapter(_StubModelConfig(lora={"rank": 16, "merge": True})) is False
+
+    def test_megatron_adapter(self):
+        assert lora_served_as_adapter(_StubModelConfig(lora={"rank": 16})) is True
+
+    def test_fsdp_merge(self):
+        assert lora_served_as_adapter(_StubModelConfig(lora_rank=8, lora={"merge": True})) is False
+
+    def test_fsdp_adapter(self):
+        assert lora_served_as_adapter(_StubModelConfig(lora_rank=8)) is True
+
+    def test_merge_absent_defaults_to_adapter(self):
+        assert lora_served_as_adapter(_StubModelConfig(lora_rank=8, lora={})) is True
+
+    def test_merge_without_lora(self):
+        """merge=True on a run without LoRA is still 'no adapter'."""
+        assert lora_served_as_adapter(_StubModelConfig(lora={"rank": 0, "merge": True})) is False
+
+
+class TestSleepTags:
+    """``SGLangHttpServer.sleep`` releases the weights only when they are not the base of
+    an adapter that gets hot-swapped in place."""
+
+    @staticmethod
+    def _sleep_tags(model_config) -> list[str]:
+        return ["kv_cache"] if lora_served_as_adapter(model_config) else ["kv_cache", "weights"]
+
+    def test_merge_mode_releases_weights(self):
+        assert self._sleep_tags(_StubModelConfig(lora={"rank": 16, "merge": True})) == ["kv_cache", "weights"]
+
+    def test_adapter_mode_keeps_weights(self):
+        assert self._sleep_tags(_StubModelConfig(lora={"rank": 16})) == ["kv_cache"]

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -51,7 +51,7 @@ from verl.utils.tracking import RLInsightLogger
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.sglang_rollout.sglang_rollout import _set_envs_and_config
-from verl.workers.rollout.sglang_rollout.utils import SGLANG_LORA_NAME
+from verl.workers.rollout.sglang_rollout.utils import SGLANG_LORA_NAME, lora_served_as_adapter
 from verl.workers.rollout.utils import get_max_position_embeddings, run_uvicorn
 
 logger = logging.getLogger(__file__)
@@ -322,7 +322,7 @@ class SGLangHttpServer:
         }
 
         # update lora-related args
-        if self.model_config.lora_rank > 0:
+        if self.lora_as_adapter:
             args.update(
                 {
                     "enable_lora": True,
@@ -478,9 +478,8 @@ class SGLangHttpServer:
 
     @property
     def lora_as_adapter(self) -> bool:
-        return (
-            self.model_config.lora_rank > 0 or self.model_config.lora.get("rank", 0) > 0
-        ) and not self.model_config.lora.get("merge", False)
+        """See :func:`verl.workers.rollout.sglang_rollout.utils.lora_served_as_adapter`."""
+        return lora_served_as_adapter(self.model_config)
 
     async def sleep(self):
         if self.node_rank != 0 or not self.config.free_cache_engine:
@@ -629,7 +628,7 @@ class SGLangHttpServer:
         generate_request = GenerateReqInput(**request)
 
         # Add lora request
-        if self.model_config.lora_rank > 0:
+        if self.lora_as_adapter:
             generate_request.lora_path = SGLANG_LORA_NAME
 
         with RLInsightLogger.trace_state("sglang_generate", state_lane_id=f"replica_{self.replica_rank}"):

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -26,6 +26,22 @@ from verl.workers.rollout.utils import ensure_async_iterator
 SGLANG_LORA_NAME = "verl_actor_lora_name"
 
 
+def lora_served_as_adapter(model_config) -> bool:
+    """Whether SGLang should serve LoRA as a hot-swappable adapter.
+
+    ``HFModelConfig`` carries two LoRA config blocks that are never synced: megatron
+    runs set ``model.lora.rank`` (dict) while fsdp runs set the flat ``model.lora_rank``,
+    so both must be checked to detect that LoRA is enabled at all.
+
+    With ``model.lora.merge=True`` the trainer merges the adapter into the base weights
+    and pushes a full HF-keyed weight update (``peft_config=None``), so no adapter is ever
+    loaded into SGLang: the engine must not be launched with ``enable_lora`` and requests
+    must not carry a ``lora_path``.
+    """
+    lora_enabled = model_config.lora_rank > 0 or model_config.lora.get("rank", 0) > 0
+    return lora_enabled and not model_config.lora.get("merge", False)
+
+
 def broadcast_pyobj(
     data: list[Any],
     rank: int,


### PR DESCRIPTION
### What does this PR do?

Fixes LoRA `merge` mode (`model.lora.merge=True`) on the SGLang rollout, where the server was configured as if it had to serve a hot-swappable adapter.

In merge mode the training engine merges the LoRA weights into the base weights and exports full HF-keyed parameters with `peft_config=None` (`verl/workers/engine/megatron/transformer_impl.py:832-861`), so `engine_workers.update_weights` takes the plain weight-sync path and never registers an adapter in SGLang (`verl/workers/engine_workers.py:774`). `SGLangHttpServer` nevertheless gated its two LoRA branches on `model_config.lora_rank > 0`:
- `launch_server` passed `enable_lora=True` / `max_lora_rank` / `lora_target_modules` to
  `ServerArgs`;
- `generate` attached `lora_path=SGLANG_LORA_NAME` to every request.

A merge-mode run therefore asks SGLang to generate against an adapter that is never loaded. This PR gates both branches on the already-existing `lora_as_adapter` predicate, which is what the vLLM server has done all along
(`vllm_async_server.py:377-378`: `if model.lora.merge: lora_rank = 0`), so the two backends no longer disagree on what `model.lora.merge` means.

The predicate is moved into `verl/workers/rollout/sglang_rollout/utils.py` as `lora_served_as_adapter` so it can be unit tested without importing `sglang`. It reads both LoRA config blocks of `HFModelConfig`, which are never synced: megatron runs set `model.lora.rank` (dict, `verl/workers/config/model.py:132`) while FSDP runs set the flat `model.lora_rank` (`:124`).

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+sglang+lora+merge
  - Not a duplicate of [fsdp, model] feat: support full-rank VLM modules with LoRA #7187, which adds PEFT `modules_to_save` semantics on the FSDP path.
  - Not a duplicate of [algo] feat: Add SVD-LoRA GRPO #3637, which adds a new algorithm.
- [x] Format the PR title as required by CI:
  `[rollout, sglang] fix: keep SGLang LoRA-free when model.lora.merge=True`

### Test

Executed from a clean checkout at 9ea98748 (base e3573545):
```
pytest -q tests/workers/rollout/rollout_sglang/test_lora_merge_mode_on_cpu.py
9 passed in 13.48s
```
### API and Usage Example

No API, CLI or config change. The fix makes the existing merge-mode config behave as
documented:

```yaml
actor_rollout_ref:
  model:
    lora:
      rank: 32
      alpha: 32
      target_modules: ['linear_qkv', 'linear_proj', 'linear_fc1', 'linear_fc2']
      merge: True          # adapter merged into base weights before rollout sync
  rollout:
    name: sglang
```

### Design & Code Changes
The whole LoRA decision on the rollout side collapses to one question: "does the engine have to hold an adapter?" That is true only when LoRA is enabled and the trainer does not merge it. Encoding it once removes the third-place drift where `model_config.lora_rank` > 0 was used as a proxy for adapter mode.

- `verl/workers/rollout/sglang_rollout/utils.py`\: new `lora_served_as_adapter(model_config)` — checks `model.lora_rank` and `model.lora.rank`, then excludes `model.lora.merge`.
- `verl/workers/rollout/sglang_rollout/async_sglang_server.py`: `launch_server` and `generate` now gate on `self.lora_as_adapter`; the property delegates to the helper.
- `tests/workers/rollout/rollout_sglang/test_lora_merge_mode_on_cpu.py`: CPU regression tests for merge/adapter detection across both config blocks, plus the sleep-tag mapping.

Total diff is 101 additions and 6 deletions across 3 files; 80 of the additions are the new test file, so the runtime change is 21 additions (12 of which are the helper's docstring) and 6 deletions.

### Checklist Before Submitting
 - [x] Read the Contribute Guide.
 - [x] Apply pre-commit checks.
 - [x] Documentation: no user-facing behaviour or config is added, so no doc update.
 - [x] Add unit test(s) to the CI workflow: the new *_on_cpu.py file is picked up by cpu_unit_tests.yml. The launch/generate wiring itself needs a live SGLang server and is left to the existing e2e LoRA jobs.
 - [ ] Request project CI in the ci-request channel after review.
 - [x] Recipe submodule update is not applicable.
