### PR TITLE
[training_utils] fix: gate FusedLinearForPPO backward grads on ctx.needs_input_grad

### DIFF
--- a/tests/utils/test_fused_linear_for_ppo_grad_gating.py
+++ b/tests/utils/test_fused_linear_for_ppo_grad_gating.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for FusedLinearForPPO gradient gating.
+
+``autograd.Function.forward`` runs with grad mode disabled, so
+``hidden_states.flatten(0, 1)`` on a NON-contiguous 3-D input returns a *copy*
+whose ``requires_grad`` is False (a contiguous input returns a view and keeps
+the flag). That copy is what gets saved via ``ctx.save_for_backward``.
+
+``backward`` used to gate the allocation of ``dhidden_states`` on the saved
+tensor's ``requires_grad``, so for non-contiguous inputs it silently returned
+``dhidden_states=None``: with the FSDP engine (which feeds exactly such a
+``(1, total_nnz, hidden)`` tensor after remove-padding / SP gathers), every
+parameter upstream of the LM head trained with ZERO gradient while lm_head
+kept updating and all forward-side metrics (loss / entropy / reward) looked
+normal — the only observable symptom was grad_norm dropping ~8x.
+
+The fix gates on ``ctx.needs_input_grad``, which autograd records at
+``apply()`` time and is immune to how the saved tensors were transformed.
+These tests force the pure-PyTorch CE fallback so they run on CPU.
+"""
+
+import pytest
+import torch
+
+import verl.utils.experimental.torch_functional as tf
+from verl.utils.experimental.torch_functional import FusedLinearForPPO
+
+
+@pytest.fixture(autouse=True)
+def _use_torch_fallback(monkeypatch):
+    # flash-attn's triton cross entropy needs CUDA; the bug is independent of
+    # the CE backend, so force the pure-PyTorch path to keep the test on CPU.
+    monkeypatch.setattr(tf, "_FLASH_ATTN_CROSS_ENTROPY_AVAILABLE", False)
+
+
+def _make_hidden(leaf: torch.Tensor, contiguous: bool) -> torch.Tensor:
+    """Non-leaf hidden with the same logical values, contiguous or not."""
+    if contiguous:
+        return leaf * 1.0
+    # Materialize in (T, B, H) order, then view back as (B, T, H): logically
+    # identical values, but is_contiguous() is False — the layout the FSDP
+    # engine actually feeds. flatten(0, 1) on this input copies (and, under
+    # the Function's no-grad forward, drops requires_grad).
+    return (leaf * 1.0).permute(1, 0, 2).contiguous().permute(1, 0, 2)
+
+
+@pytest.mark.parametrize("contiguous", [True, False], ids=["contiguous", "non_contiguous"])
+def test_hidden_grad_flows_regardless_of_contiguity(contiguous):
+    torch.manual_seed(0)
+    B, T, H, V = 2, 24, 16, 48
+
+    hidden_leaf = torch.randn(B, T, H, requires_grad=True)
+    vocab_weights = torch.randn(V, H, requires_grad=True)
+    input_ids = torch.randint(0, V, (B, T))
+
+    hidden = _make_hidden(hidden_leaf, contiguous)
+    assert hidden.is_contiguous() == contiguous
+
+    log_probs, _entropy = FusedLinearForPPO()(hidden_states=hidden, vocab_weights=vocab_weights, input_ids=input_ids)
+    log_probs.sum().backward()
+
+    assert hidden_leaf.grad is not None, "trunk gradient was silently dropped"
+    assert hidden_leaf.grad.abs().sum() > 0
+    assert vocab_weights.grad is not None
+
+    g_hidden_fused = hidden_leaf.grad.detach().clone()
+    g_vocab_fused = vocab_weights.grad.detach().clone()
+    hidden_leaf.grad = None
+    vocab_weights.grad = None
+
+    # Eager log-softmax reference over the identical graph
+    ref_hidden = _make_hidden(hidden_leaf, contiguous)
+    logits = (ref_hidden @ vocab_weights.t()).float()
+    ref_log_probs = logits.log_softmax(dim=-1).gather(-1, input_ids.unsqueeze(-1)).squeeze(-1)
+    ref_log_probs.sum().backward()
+
+    torch.testing.assert_close(g_hidden_fused, hidden_leaf.grad, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(g_vocab_fused, vocab_weights.grad, rtol=1e-4, atol=1e-4)
+
+
+def test_no_grad_inputs_return_none_grads():
+    """needs_input_grad gating must not allocate grads that aren't needed."""
+    torch.manual_seed(0)
+    B, T, H, V = 1, 8, 16, 32
+    hidden = torch.randn(B, T, H)  # requires_grad=False
+    vocab_weights = torch.randn(V, H, requires_grad=True)
+    input_ids = torch.randint(0, V, (B, T))
+
+    log_probs, _ = FusedLinearForPPO()(hidden_states=hidden, vocab_weights=vocab_weights, input_ids=input_ids)
+    log_probs.sum().backward()
+    assert vocab_weights.grad is not None
+    assert hidden.grad is None

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -100,19 +100,23 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
         orig_ndim = hidden_states.ndim
         assert orig_ndim in (2, 3), f"Invalid hidden_states shape, received {hidden_states.shape}"
 
+        # Capture requires_grad BEFORE any reshaping: forward() runs with grad mode
+        # disabled, so flatten() of a NON-contiguous input returns a *copy* whose
+        # requires_grad is False (a contiguous input returns a view and keeps the
+        # flag). The saved tensor's flag is therefore unreliable; backward() gates
+        # on ctx.needs_input_grad instead of re-stamping the flag here.
+        output_requires_grad = hidden_states.requires_grad or vocab_weights.requires_grad
+
         orig_batch_size = -1
         if orig_ndim == 3:
             assert input_ids.ndim == 2, f"input_ids shape doesn't match, {hidden_states.shape} {input_ids.shape}"
             orig_batch_size = hidden_states.shape[0]
-            hidden_states_requires_grad = hidden_states.requires_grad
             hidden_states = hidden_states.flatten(0, 1)
-            hidden_states.requires_grad_(hidden_states_requires_grad)
             input_ids = input_ids.flatten(0, 1)
 
         T = hidden_states.shape[0]
 
         # Allocate memory for outputs
-        output_requires_grad = hidden_states.requires_grad or vocab_weights.requires_grad
         # Logits are upcasted to fp32 before computing log_probs, which are also fp32
         log_probs = torch.zeros(T, device=hidden_states.device, dtype=torch.float32, requires_grad=output_requires_grad)
         entropy = hidden_states.new_zeros(T, requires_grad=output_requires_grad)
@@ -162,12 +166,21 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
 
         T = hidden_states.shape[0]
 
-        # Allocate memory for outputs
+        # Allocate memory for outputs.
+        # Gate on ctx.needs_input_grad, NOT on the saved tensors' requires_grad:
+        # the tensor saved in forward() is the post-flatten one, and flatten of a
+        # NON-contiguous input (with grad mode off) returns a requires_grad=False
+        # copy. Gating on that flag silently returned dhidden_states=None, so the
+        # entire trunk upstream of the LM head trained with zero gradient while
+        # lm_head still updated and every forward-side metric looked normal (the
+        # only symptom was grad_norm dropping ~8x). needs_input_grad is recorded
+        # by autograd at apply() time and is immune to how saved tensors were
+        # transformed.
         dhidden_states = None
-        if hidden_states.requires_grad:
+        if ctx.needs_input_grad[0]:
             dhidden_states = torch.zeros_like(hidden_states)
         dvocab_weights = None
-        if vocab_weights.requires_grad:
+        if ctx.needs_input_grad[1]:
             dvocab_weights = torch.zeros_like(vocab_weights)
 
         # Perform backward one chunk at a time
@@ -189,13 +202,13 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
                 temperature=temperature,
             )
 
-            if hidden_states.requires_grad:
+            if dhidden_states is not None:
                 dhidden_states[chunk_start:chunk_end] += h
-            if vocab_weights.requires_grad:
+            if dvocab_weights is not None:
                 dvocab_weights += v
 
         # Cast the output back to the original input dimension
-        if orig_ndim == 3 and hidden_states.requires_grad:
+        if orig_ndim == 3 and dhidden_states is not None:
             hidden_size = hidden_states.shape[-1]
             dhidden_states = dhidden_states.view(orig_batch_size, -1, hidden_size)
 


### PR DESCRIPTION
### What does this PR do?

Fixes a silent gradient-dropping bug in `FusedLinearForPPOFunction.backward` (`use_fused_kernels=True`): the allocation of `dhidden_states` / `dvocab_weights` was gated on the **saved tensors'** `requires_grad`, which is not reliable. `autograd.Function.forward` runs with grad mode disabled, so `hidden_states.flatten(0, 1)` on a **non-contiguous** 3-D input returns a *copy* with `requires_grad=False`, and that copy is what `ctx.save_for_backward` stores. Backward then silently returns `dhidden_states=None`.

Impact when it triggers (observed on verl 0.8.0, FSDP engine, Qwen3.5 VLM, `use_remove_padding=True`, SP=2 — the engine feeds exactly such a non-contiguous `(1, total_nnz, hidden)` tensor): **every parameter upstream of the LM head trains with zero gradient while `lm_head` keeps updating.** Loss / entropy / reward metrics all look normal; the only observable symptom is `grad_norm` dropping ~8x (we measured 0.11 vs 0.91 with the eager path; a per-FSDP-unit probe showed 0–1 of 60 flat-params receiving any gradient vs 60/60 eager).

Minimal repro (CPU, pure PyTorch CE fallback), fails before this fix with `leaf.grad is None`:

```python
import torch
import verl.utils.experimental.torch_functional as tf
from verl.utils.experimental.torch_functional import FusedLinearForPPO
tf._FLASH_ATTN_CROSS_ENTROPY_AVAILABLE = False

B, T, H, V = 2, 24, 16, 48
leaf = torch.randn(B, T, H, requires_grad=True)
w = torch.randn(V, H, requires_grad=True)
ids = torch.randint(0, V, (B, T))
hidden = (leaf * 1.0).permute(1, 0, 2).contiguous().permute(1, 0, 2)  # non-contiguous
lp, ent = FusedLinearForPPO()(hidden_states=hidden, vocab_weights=w, input_ids=ids)
lp.sum().backward()
assert leaf.grad is not None   # BEFORE #6556's re-stamp: fails — trunk got no gradient
```

Current `main` masks the engine-visible case through the `requires_grad_()` re-stamp introduced in passing by #6556, but the backward gating itself remains contract-fragile: any saved-tensor transformation that does not preserve the flag re-introduces the silent freeze. `ctx.needs_input_grad` is the canonical gate — autograd records it at `apply()` time from the graph, so it is immune to how saved tensors were transformed.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+needs_input_grad (none); the flag re-stamp from #6556 is the closest related change.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- New CPU regression test `tests/utils/test_fused_linear_for_ppo_grad_gating.py`:
  - `test_hidden_grad_flows_regardless_of_contiguity[contiguous|non_contiguous]` — asserts trunk gradients exist **and match an eager log-softmax reference** (`rtol=1e-4`). The non-contiguous case reproduces `hidden.grad is None` on the pre-#6556 code and passes with this fix.
  - `test_no_grad_inputs_return_none_grads` — `needs_input_grad` gating must not allocate grads that are not needed.
- End-to-end (verl 0.8.0 + this fix backported, 8xH100, FSDP + SP=2 + remove-padding, Qwen3.5-9B-VLM GRPO): per-FSDP-unit gradient probe went from 0–1/60 nonzero flat-param grads per rank to 60/60, `grad_norm` recovered from ~0.11 to ~1.36 (eager baseline 0.91–3.0), entropy/reward unchanged.

### API and Usage Example

No API change.

### Design & Code Changes

- `verl/utils/experimental/torch_functional.py`
  - `backward`: gate `dhidden_states` / `dvocab_weights` allocation on `ctx.needs_input_grad[0]` / `[1]` instead of the saved tensors' `requires_grad`; downstream accumulation guards follow the allocation.
  - `forward`: capture `output_requires_grad` **before** the flatten and drop the `requires_grad_()` re-stamp (no longer needed once backward stops reading the saved tensor's flag; mutating flags on maybe-views inside a no-grad forward was the fragile part).
- `tests/utils/test_fused_linear_for_ppo_grad_gating.py`: new regression tests (CPU-only, forces the PyTorch CE fallback).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `ruff check` / `ruff format` clean on both files.
- [ ] Add / Update the documentation — N/A (internal fix, behavior documented in code comments).
- [x] Add unit test(s): `tests/utils/test_fused_linear_for_ppo_grad_gating.py` (CPU, no new CI workflow needed — picked up by the existing utils test job).
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
