### PR TITLE
[trainer] refactor: move shared PPO helpers out of RayPPOTrainer

### DIFF
--- a/tests/trainer/ppo/test_spec_decode_metrics_on_cpu.py
+++ b/tests/trainer/ppo/test_spec_decode_metrics_on_cpu.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
 
-pytest.importorskip("ray")
-
-from verl.trainer.ppo.ray_trainer import compute_spec_decode_metrics
+from verl.trainer.ppo.trainer_utils import compute_spec_decode_metrics
 
 
 def test_spec_decode_metrics_detect_drafts_with_zero_acceptance():

--- a/tests/workers/rollout/rollout_vllm/test_mtp_hybrid_sleep_acceptance_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_mtp_hybrid_sleep_acceptance_on_cpu.py
@@ -21,7 +21,7 @@ import pytest
 pytest.importorskip("ray")
 pytest.importorskip("vllm")
 
-from verl.trainer.ppo.ray_trainer import compute_spec_decode_metrics
+from verl.trainer.ppo.trainer_utils import compute_spec_decode_metrics
 from verl.workers.rollout.vllm_rollout import vllm_async_server
 
 

--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -21,7 +21,7 @@ import numpy as np
 import torch
 
 from verl import DataProto
-from verl.trainer.ppo.ray_trainer import compute_response_mask
+from verl.trainer.ppo.trainer_utils import compute_response_mask
 
 
 @dataclass

--- a/verl/experimental/one_step_off_policy/ray_trainer.py
+++ b/verl/experimental/one_step_off_policy/ray_trainer.py
@@ -34,11 +34,9 @@ from verl import DataProto
 from verl.experimental.separation.ray_trainer import SeparateRayPPOTrainer
 from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup
 from verl.trainer.ppo import core_algos
-from verl.trainer.ppo.ray_trainer import (
-    ResourcePoolManager,
-    compute_response_mask,
-)
+from verl.trainer.ppo.ray_trainer import ResourcePoolManager
 from verl.trainer.ppo.reward import extract_reward
+from verl.trainer.ppo.trainer_utils import compute_response_mask
 from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference_policy, need_reward_model
 from verl.utils.debug import marked_timer
 from verl.utils.import_utils import load_class_from_fqn

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -39,8 +39,9 @@ from verl.trainer.ppo.metric_utils import (
     compute_timing_metrics,
     compute_variance_proxy_metrics,
 )
-from verl.trainer.ppo.ray_trainer import RayPPOTrainer, apply_kl_penalty, compute_advantage, compute_response_mask
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer
 from verl.trainer.ppo.reward import extract_reward
+from verl.trainer.ppo.trainer_utils import apply_kl_penalty, compute_advantage, compute_response_mask
 from verl.trainer.ppo.utils import Role, WorkerType
 from verl.utils.checkpoint.checkpoint_manager import should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -37,7 +37,6 @@ from verl import DataProto
 from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
 from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup, ResourcePoolManager
 from verl.single_controller.ray.base import create_colocated_worker_cls
-from verl.trainer.config import AlgoConfig
 from verl.trainer.distillation.losses import is_distillation_enabled
 from verl.trainer.ppo import core_algos
 from verl.trainer.ppo.core_algos import AdvantageEstimator, agg_loss
@@ -49,6 +48,12 @@ from verl.trainer.ppo.metric_utils import (
     process_validation_metrics,
 )
 from verl.trainer.ppo.reward import extract_reward
+from verl.trainer.ppo.trainer_utils import (
+    apply_kl_penalty,
+    compute_advantage,
+    compute_response_mask,
+    compute_spec_decode_metrics,
+)
 from verl.trainer.ppo.utils import (
     Role,
     WorkerType,
@@ -68,218 +73,10 @@ from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
 from verl.utils.skip.skip_manager import SkipManager
-from verl.utils.torch_functional import masked_mean
 from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.config import DistillationConfig, EngineConfig
 from verl.workers.rollout.llm_server import LLMServerManager
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
-
-
-def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, kl_penalty="kl"):
-    """Apply KL penalty to the token-level rewards.
-
-    This function computes the KL divergence between the reference policy and current policy,
-    then applies a penalty to the token-level rewards based on this divergence.
-
-    Args:
-        data (DataProto): The data containing batched model outputs and inputs.
-        kl_ctrl (core_algos.AdaptiveKLController): Controller for adaptive KL penalty.
-        kl_penalty (str, optional): Type of KL penalty to apply. Defaults to "kl".
-
-    Returns:
-        tuple: A tuple containing:
-            - The updated data with token-level rewards adjusted by KL penalty
-            - A dictionary of metrics related to the KL penalty
-    """
-    response_mask = data.batch["response_mask"]
-    token_level_scores = data.batch["token_level_scores"]
-    batch_size = data.batch.batch_size[0]
-
-    # compute kl between ref_policy and current policy
-    # When apply_kl_penalty, algorithm.use_kl_in_reward=True, so the reference model has been enabled.
-    kld = core_algos.kl_penalty(
-        data.batch["old_log_probs"], data.batch["ref_log_prob"], kl_penalty=kl_penalty
-    )  # (batch_size, response_length)
-    kld = kld * response_mask
-    beta = kl_ctrl.value
-
-    token_level_rewards = token_level_scores - beta * kld
-
-    current_kl = masked_mean(kld, mask=response_mask, axis=-1)  # average over sequence
-    current_kl = torch.mean(current_kl, dim=0).item()
-
-    # according to https://github.com/huggingface/trl/blob/951ca1841f29114b969b57b26c7d3e80a39f75a0/trl/trainer/ppo_trainer.py#L837
-    kl_ctrl.update(current_kl=current_kl, n_steps=batch_size)
-    data.batch["token_level_rewards"] = token_level_rewards
-
-    metrics = {"actor/reward_kl_penalty": current_kl, "actor/reward_kl_penalty_coeff": beta}
-
-    return data, metrics
-
-
-def compute_response_mask(data: DataProto):
-    """Compute the attention mask for the response part of the sequence.
-
-    This function extracts the portion of the attention mask that corresponds to the model's response,
-    which is used for masking computations that should only apply to response tokens.
-
-    Args:
-        data (DataProto): The data containing batched model outputs and inputs.
-
-    Returns:
-        torch.Tensor: The attention mask for the response tokens.
-    """
-    responses = data.batch["responses"]
-    response_length = responses.size(1)
-    attention_mask = data.batch["attention_mask"]
-    return attention_mask[:, -response_length:]
-
-
-def compute_spec_decode_metrics(
-    spec_drafts,
-    spec_accepts,
-    spec_verifies,
-    non_padding_mask=None,
-) -> dict:
-    """Aggregate per-request speculative decoding stats.
-
-    Ratios are computed per request and then averaged, so long and short
-    responses have equal metric weight.
-
-    The three inputs come from the rollout engine (vLLM request spec-decode
-    stats or sglang ``meta_info["spec_*"]`` keys). Either all three are ``None``
-    (caller didn't fetch them, e.g. spec rollout disabled) and the function
-    is a no-op, or all three are populated; mixed state is a programmer error.
-
-    ``non_padding_mask`` is a numpy bool array used by sync PPO to drop padded
-    placeholder samples; pass ``None`` for async PPO.
-    """
-    if spec_drafts is None and spec_accepts is None and spec_verifies is None:
-        return {}
-    assert spec_drafts is not None and spec_accepts is not None and spec_verifies is not None, (
-        "spec_decode metrics require all three of spec_num_draft_tokens / "
-        "spec_num_accepted_tokens / spec_num_verify_steps; got partial inputs"
-    )
-
-    drafts = spec_drafts.tolist() if hasattr(spec_drafts, "tolist") else list(spec_drafts)
-    accepts = spec_accepts.tolist() if hasattr(spec_accepts, "tolist") else list(spec_accepts)
-    verifies = spec_verifies.tolist() if hasattr(spec_verifies, "tolist") else list(spec_verifies)
-
-    if non_padding_mask is not None:
-        drafts = [d for d, keep in zip(drafts, non_padding_mask, strict=True) if keep]
-        accepts = [a for a, keep in zip(accepts, non_padding_mask, strict=True) if keep]
-        verifies = [v for v, keep in zip(verifies, non_padding_mask, strict=True) if keep]
-
-    if len(drafts) == 0:
-        return {}
-
-    # Treat zero-denominator samples as 0.0 and keep them in the mean.
-    per_sample_accept_rate = [(a / d) if d > 0 else 0.0 for a, d in zip(accepts, drafts, strict=True)]
-    per_sample_accept_length = [(1.0 + a / v) if v > 0 else 0.0 for a, v in zip(accepts, verifies, strict=True)]
-
-    n = len(drafts)
-    return {
-        "rollout/spec_accept_rate": float(sum(per_sample_accept_rate) / n),
-        "rollout/spec_accept_length": float(sum(per_sample_accept_length) / n),
-    }
-
-
-def compute_advantage(
-    data: DataProto,
-    adv_estimator: AdvantageEstimator,
-    gamma: float = 1.0,
-    lam: float = 1.0,
-    num_repeat: int = 1,
-    norm_adv_by_std_in_grpo: bool = True,
-    config: Optional[AlgoConfig] = None,
-) -> DataProto:
-    """Compute advantage estimates for policy optimization.
-
-    This function computes advantage estimates using various estimators like GAE, GRPO, REINFORCE++, etc.
-    The advantage estimates are used to guide policy optimization in RL algorithms.
-
-    Args:
-        data (DataProto): The data containing batched model outputs and inputs.
-        adv_estimator (AdvantageEstimator): The advantage estimator to use (e.g., GAE, GRPO, REINFORCE++).
-        gamma (float, optional): Discount factor for future rewards. Defaults to 1.0.
-        lam (float, optional): Lambda parameter for GAE. Defaults to 1.0.
-        num_repeat (int, optional): Number of times to repeat the computation. Defaults to 1.
-        norm_adv_by_std_in_grpo (bool, optional): Whether to normalize advantages by standard deviation in
-            GRPO. Defaults to True.
-        config (dict, optional): Configuration dictionary for algorithm settings. Defaults to None.
-
-    Returns:
-        DataProto: The updated data with computed advantages and returns.
-    """
-    # Back-compatible with trainers that do not compute response mask in fit
-    if "response_mask" not in data.batch.keys():
-        data.batch["response_mask"] = compute_response_mask(data)
-    # prepare response group
-    if adv_estimator == AdvantageEstimator.GAE:
-        # Compute advantages and returns using Generalized Advantage Estimation (GAE)
-        advantages, returns = core_algos.compute_gae_advantage_return(
-            token_level_rewards=data.batch["token_level_rewards"],
-            values=data.batch["values"],
-            response_mask=data.batch["response_mask"],
-            gamma=gamma,
-            lam=lam,
-        )
-        data.batch["advantages"] = advantages
-        data.batch["returns"] = returns
-        if config.get("use_pf_ppo", False):
-            data = core_algos.compute_pf_ppo_reweight_data(
-                data,
-                config.pf_ppo.get("reweight_method"),
-                config.pf_ppo.get("weight_pow"),
-            )
-    elif adv_estimator == AdvantageEstimator.GRPO:
-        # Initialize the mask for GRPO calculation
-        grpo_calculation_mask = data.batch["response_mask"]
-
-        # Call compute_grpo_outcome_advantage with parameters matching its definition
-        advantages, returns = core_algos.compute_grpo_outcome_advantage(
-            token_level_rewards=data.batch["token_level_rewards"],
-            response_mask=grpo_calculation_mask,
-            index=data.non_tensor_batch["uid"],
-            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
-        )
-        data.batch["advantages"] = advantages
-        data.batch["returns"] = returns
-    else:
-        # handle all other adv estimator type other than GAE and GRPO
-        adv_estimator_fn = core_algos.get_adv_estimator_fn(adv_estimator)
-        adv_kwargs = {
-            "token_level_rewards": data.batch["token_level_rewards"],
-            "response_mask": data.batch["response_mask"],
-            "config": config,
-        }
-        if "uid" in data.non_tensor_batch:  # optional
-            adv_kwargs["index"] = data.non_tensor_batch["uid"]
-        if "reward_baselines" in data.batch:  # optional
-            adv_kwargs["reward_baselines"] = data.batch["reward_baselines"]
-        # GDPO: pass raw data for per-dimension reward extraction
-        if adv_estimator in (AdvantageEstimator.GDPO, "gdpo"):
-            adv_kwargs["non_tensor_batch"] = data.non_tensor_batch
-            adv_kwargs["batch"] = data.batch
-        # Add sum_pi_squared for Optimal Token Baseline
-        if adv_estimator in (AdvantageEstimator.OPTIMAL_TOKEN_BASELINE, AdvantageEstimator.TIR_OPTIMAL_TOKEN_BASELINE):
-            # Check if sum_pi_squared is available
-            assert "sum_pi_squared" in data.batch, (
-                "Step-dependent optimal baseline requires sum_pi_squared from actor. "
-                "Please set actor.calculate_sum_pi_squared=True in config."
-            )
-            adv_kwargs["sum_pi_squared"] = data.batch["sum_pi_squared"]
-            # old_log_probs needed for path-variance proxy: w_t = 1 - 2*exp(old_log_probs) + sum_pi_squared
-            adv_kwargs["old_log_probs"] = data.batch["old_log_probs"]
-            # Get pre-computed rollout IS weights if available
-            rollout_is_weights = data.batch.get("rollout_is_weights", None)
-            adv_kwargs["rollout_is_weights"] = rollout_is_weights
-
-        # calculate advantage estimator
-        advantages, returns = adv_estimator_fn(**adv_kwargs)
-        data.batch["advantages"] = advantages
-        data.batch["returns"] = returns
-    return data
 
 
 @deprecated("Legacy trainer is deprecated, and wil be removed in v0.9.0. Please use `trainer.use_v1=True` instead.")

--- a/verl/trainer/ppo/trainer_utils.py
+++ b/verl/trainer/ppo/trainer_utils.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from verl.trainer.ppo import core_algos
+from verl.trainer.ppo.core_algos import AdvantageEstimator
+from verl.utils.torch_functional import masked_mean
+
+if TYPE_CHECKING:
+    from verl import DataProto
+    from verl.trainer.config import AlgoConfig
+
+
+def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, kl_penalty="kl"):
+    """Apply KL penalty to the token-level rewards.
+
+    This function computes the KL divergence between the reference policy and current policy,
+    then applies a penalty to the token-level rewards based on this divergence.
+
+    Args:
+        data (DataProto): The data containing batched model outputs and inputs.
+        kl_ctrl (core_algos.AdaptiveKLController): Controller for adaptive KL penalty.
+        kl_penalty (str, optional): Type of KL penalty to apply. Defaults to "kl".
+
+    Returns:
+        tuple: A tuple containing:
+            - The updated data with token-level rewards adjusted by KL penalty
+            - A dictionary of metrics related to the KL penalty
+    """
+    response_mask = data.batch["response_mask"]
+    token_level_scores = data.batch["token_level_scores"]
+    batch_size = data.batch.batch_size[0]
+
+    # compute kl between ref_policy and current policy
+    # When apply_kl_penalty, algorithm.use_kl_in_reward=True, so the reference model has been enabled.
+    kld = core_algos.kl_penalty(
+        data.batch["old_log_probs"], data.batch["ref_log_prob"], kl_penalty=kl_penalty
+    )  # (batch_size, response_length)
+    kld = kld * response_mask
+    beta = kl_ctrl.value
+
+    token_level_rewards = token_level_scores - beta * kld
+
+    current_kl = masked_mean(kld, mask=response_mask, axis=-1)  # average over sequence
+    current_kl = torch.mean(current_kl, dim=0).item()
+
+    # Follow TRL PPOTrainer's convention: update the KL controller from the batch-level mean KL.
+    kl_ctrl.update(current_kl=current_kl, n_steps=batch_size)
+    data.batch["token_level_rewards"] = token_level_rewards
+
+    metrics = {"actor/reward_kl_penalty": current_kl, "actor/reward_kl_penalty_coeff": beta}
+
+    return data, metrics
+
+
+def compute_response_mask(data: DataProto):
+    """Compute the attention mask for the response part of the sequence.
+
+    This function extracts the portion of the attention mask that corresponds to the model's response,
+    which is used for masking computations that should only apply to response tokens.
+
+    Args:
+        data (DataProto): The data containing batched model outputs and inputs.
+
+    Returns:
+        torch.Tensor: The attention mask for the response tokens.
+    """
+    responses = data.batch["responses"]
+    response_length = responses.size(1)
+    attention_mask = data.batch["attention_mask"]
+    return attention_mask[:, -response_length:]
+
+
+def compute_spec_decode_metrics(
+    spec_drafts,
+    spec_accepts,
+    spec_verifies,
+    non_padding_mask=None,
+) -> dict:
+    """Aggregate per-request speculative decoding stats.
+
+    Ratios are computed per request and then averaged, so long and short
+    responses have equal metric weight.
+
+    The three inputs come from the rollout engine (vLLM request spec-decode
+    stats or sglang ``meta_info["spec_*"]`` keys). Either all three are ``None``
+    (caller didn't fetch them, e.g. spec rollout disabled) and the function
+    is a no-op, or all three are populated; mixed state is a programmer error.
+
+    ``non_padding_mask`` is a numpy bool array used by sync PPO to drop padded
+    placeholder samples; pass ``None`` for async PPO.
+    """
+    if spec_drafts is None and spec_accepts is None and spec_verifies is None:
+        return {}
+    assert spec_drafts is not None and spec_accepts is not None and spec_verifies is not None, (
+        "spec_decode metrics require all three of spec_num_draft_tokens / "
+        "spec_num_accepted_tokens / spec_num_verify_steps; got partial inputs"
+    )
+
+    drafts = spec_drafts.tolist() if hasattr(spec_drafts, "tolist") else list(spec_drafts)
+    accepts = spec_accepts.tolist() if hasattr(spec_accepts, "tolist") else list(spec_accepts)
+    verifies = spec_verifies.tolist() if hasattr(spec_verifies, "tolist") else list(spec_verifies)
+
+    if non_padding_mask is not None:
+        drafts = [d for d, keep in zip(drafts, non_padding_mask, strict=True) if keep]
+        accepts = [a for a, keep in zip(accepts, non_padding_mask, strict=True) if keep]
+        verifies = [v for v, keep in zip(verifies, non_padding_mask, strict=True) if keep]
+
+    if len(drafts) == 0:
+        return {}
+
+    # Treat zero-denominator samples as 0.0 and keep them in the mean.
+    per_sample_accept_rate = [(a / d) if d > 0 else 0.0 for a, d in zip(accepts, drafts, strict=True)]
+    per_sample_accept_length = [(1.0 + a / v) if v > 0 else 0.0 for a, v in zip(accepts, verifies, strict=True)]
+
+    n = len(drafts)
+    return {
+        "rollout/spec_accept_rate": float(sum(per_sample_accept_rate) / n),
+        "rollout/spec_accept_length": float(sum(per_sample_accept_length) / n),
+    }
+
+
+def compute_advantage(
+    data: DataProto,
+    adv_estimator: AdvantageEstimator,
+    gamma: float = 1.0,
+    lam: float = 1.0,
+    num_repeat: int = 1,
+    norm_adv_by_std_in_grpo: bool = True,
+    config: Optional[AlgoConfig] = None,
+) -> DataProto:
+    """Compute advantage estimates for policy optimization.
+
+    This function computes advantage estimates using various estimators like GAE, GRPO, REINFORCE++, etc.
+    The advantage estimates are used to guide policy optimization in RL algorithms.
+
+    Args:
+        data (DataProto): The data containing batched model outputs and inputs.
+        adv_estimator (AdvantageEstimator): The advantage estimator to use (e.g., GAE, GRPO, REINFORCE++).
+        gamma (float, optional): Discount factor for future rewards. Defaults to 1.0.
+        lam (float, optional): Lambda parameter for GAE. Defaults to 1.0.
+        num_repeat (int, optional): Number of times to repeat the computation. Defaults to 1.
+        norm_adv_by_std_in_grpo (bool, optional): Whether to normalize advantages by standard deviation in
+            GRPO. Defaults to True.
+        config (dict, optional): Configuration dictionary for algorithm settings. Defaults to None.
+
+    Returns:
+        DataProto: The updated data with computed advantages and returns.
+    """
+    # Back-compatible with trainers that do not compute response mask in fit
+    if "response_mask" not in data.batch.keys():
+        data.batch["response_mask"] = compute_response_mask(data)
+    # prepare response group
+    if adv_estimator == AdvantageEstimator.GAE:
+        # Compute advantages and returns using Generalized Advantage Estimation (GAE)
+        advantages, returns = core_algos.compute_gae_advantage_return(
+            token_level_rewards=data.batch["token_level_rewards"],
+            values=data.batch["values"],
+            response_mask=data.batch["response_mask"],
+            gamma=gamma,
+            lam=lam,
+        )
+        data.batch["advantages"] = advantages
+        data.batch["returns"] = returns
+        if config.get("use_pf_ppo", False):
+            data = core_algos.compute_pf_ppo_reweight_data(
+                data,
+                config.pf_ppo.get("reweight_method"),
+                config.pf_ppo.get("weight_pow"),
+            )
+    elif adv_estimator == AdvantageEstimator.GRPO:
+        # Initialize the mask for GRPO calculation
+        grpo_calculation_mask = data.batch["response_mask"]
+
+        # Call compute_grpo_outcome_advantage with parameters matching its definition
+        advantages, returns = core_algos.compute_grpo_outcome_advantage(
+            token_level_rewards=data.batch["token_level_rewards"],
+            response_mask=grpo_calculation_mask,
+            index=data.non_tensor_batch["uid"],
+            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+        )
+        data.batch["advantages"] = advantages
+        data.batch["returns"] = returns
+    else:
+        # handle all other adv estimator type other than GAE and GRPO
+        adv_estimator_fn = core_algos.get_adv_estimator_fn(adv_estimator)
+        adv_kwargs = {
+            "token_level_rewards": data.batch["token_level_rewards"],
+            "response_mask": data.batch["response_mask"],
+            "config": config,
+        }
+        if "uid" in data.non_tensor_batch:  # optional
+            adv_kwargs["index"] = data.non_tensor_batch["uid"]
+        if "reward_baselines" in data.batch:  # optional
+            adv_kwargs["reward_baselines"] = data.batch["reward_baselines"]
+        # GDPO: pass raw data for per-dimension reward extraction
+        if adv_estimator in (AdvantageEstimator.GDPO, "gdpo"):
+            adv_kwargs["non_tensor_batch"] = data.non_tensor_batch
+            adv_kwargs["batch"] = data.batch
+        # Add sum_pi_squared for Optimal Token Baseline
+        if adv_estimator in (AdvantageEstimator.OPTIMAL_TOKEN_BASELINE, AdvantageEstimator.TIR_OPTIMAL_TOKEN_BASELINE):
+            # Check if sum_pi_squared is available
+            assert "sum_pi_squared" in data.batch, (
+                "Step-dependent optimal baseline requires sum_pi_squared from actor. "
+                "Please set actor.calculate_sum_pi_squared=True in config."
+            )
+            adv_kwargs["sum_pi_squared"] = data.batch["sum_pi_squared"]
+            # old_log_probs needed for path-variance proxy: w_t = 1 - 2*exp(old_log_probs) + sum_pi_squared
+            adv_kwargs["old_log_probs"] = data.batch["old_log_probs"]
+            # Get pre-computed rollout IS weights if available
+            rollout_is_weights = data.batch.get("rollout_is_weights", None)
+            adv_kwargs["rollout_is_weights"] = rollout_is_weights
+
+        # calculate advantage estimator
+        advantages, returns = adv_estimator_fn(**adv_kwargs)
+        data.batch["advantages"] = advantages
+        data.batch["returns"] = returns
+    return data
+
+
+__all__ = [
+    "apply_kl_penalty",
+    "compute_advantage",
+    "compute_response_mask",
+    "compute_spec_decode_metrics",
+]

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -61,8 +61,8 @@ from verl.trainer.ppo.metric_utils import (
     process_validation_metrics,
 )
 from verl.trainer.ppo.padding_utils import upsample_batch_to_divisible_size
-from verl.trainer.ppo.ray_trainer import apply_kl_penalty, compute_spec_decode_metrics
 from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
+from verl.trainer.ppo.trainer_utils import apply_kl_penalty, compute_spec_decode_metrics
 from verl.trainer.ppo.utils import (
     Role,
     create_rl_dataset,
@@ -1794,7 +1794,7 @@ class PPOTrainer(ABC):
         )
 
         # 4. per-request speculative-decoding aggregation (same metrics async PPO logs;
-        # see compute_spec_decode_metrics in verl/trainer/ppo/ray_trainer.py).
+        # see compute_spec_decode_metrics in verl/trainer/ppo/trainer_utils.py).
         metrics.update(compute_spec_decode_metrics(spec_drafts, spec_accepts, spec_verifies, non_padding_mask))
 
         # 5. off-policy staleness metrics

--- a/verl/trainer/ppo/v1/utils.py
+++ b/verl/trainer/ppo/v1/utils.py
@@ -19,7 +19,7 @@ import torch
 
 from verl.protocol import DataProto
 from verl.trainer.ppo import core_algos
-from verl.trainer.ppo.ray_trainer import compute_advantage
+from verl.trainer.ppo.trainer_utils import compute_advantage
 from verl.trainer.ppo.v1.replay_buffer import DAPO_FILTERED_REWARD_COUNTS_KEY
 
 


### PR DESCRIPTION
### What does this PR do?

Part of #6985.

This PR moves shared PPO trainer helper functions out of the deprecated `RayPPOTrainer` module and into a dedicated `verl.trainer.ppo.trainer_utils` module.

The refactor is intentionally behavior-preserving:

- moves `apply_kl_penalty`, `compute_response_mask`, `compute_spec_decode_metrics`, and `compute_advantage` into `trainer_utils.py`
- keeps `verl.trainer.ppo.ray_trainer` re-exporting the same helper functions for compatibility with existing imports
- updates V1 trainer, fully-async, one-step-off-policy, separation, and related tests to import the shared helpers from `trainer_utils`
- does not change token ids, masks, rewards, advantages, rollout behavior, or public function signatures

This reduces non-legacy trainer code's dependency on the deprecated `RayPPOTrainer` module and makes the later `RayPPOTrainer` removal path narrower.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [open PR search for RayPPOTrainer / compute_advantage / trainer_utils](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+RayPPOTrainer+compute_advantage+trainer_utils)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - Title: `[trainer] refactor: move shared PPO helpers out of RayPPOTrainer`

### Test

Base commit: `8bda42207cc08a947a49587d38315647740b9e14`  
Head commit: `741245d2dbbe76d53f74cfb412f252f2b486c9c3`

Local checks:

```bash
git diff --check
python -m compileall -q \
  verl/trainer/ppo/trainer_utils.py \
  verl/trainer/ppo/ray_trainer.py \
  verl/trainer/ppo/v1/utils.py \
  verl/trainer/ppo/v1/trainer_base.py \
  verl/experimental/separation/ray_trainer.py \
  verl/experimental/fully_async_policy/detach_utils.py \
  verl/experimental/one_step_off_policy/ray_trainer.py \
  tests/trainer/ppo/test_spec_decode_metrics_on_cpu.py \
  tests/workers/rollout/rollout_vllm/test_mtp_hybrid_sleep_acceptance_on_cpu.py
```

Result: passed.

CUDA validation environment:

- GPU: 8 x NVIDIA GeForce RTX 3090, 24 GiB each
- Driver: 580.173.02
- Python 3.11.15
- torch 2.11.0+cu130
- CUDA 13.0
- Ray 2.56.1
- vLLM 0.24.0

From the repository root:

```bash
python -m pytest -q \
  tests/trainer/ppo/test_spec_decode_metrics_on_cpu.py \
  tests/workers/rollout/rollout_vllm/test_mtp_hybrid_sleep_acceptance_on_cpu.py
```

Result: `4 passed, 15 warnings in 9.01s`.

```bash
python -m pytest -q \
  tests/trainer/test_multi_trajectories_advantage_on_cpu.py
```

Result: `2 passed, 2 warnings in 11.96s`.

With `Qwen/Qwen2.5-1.5B-Instruct` available at the test's default `~/models` location:

```bash
RAY_ADDRESS=local CUDA_VISIBLE_DEVICES=0,1 \
ROLLOUT_NAME=vllm VLLM_USE_V1=1 \
python -m pytest tests/workers/rollout/rollout_vllm/test_vllm_abort.py -v -s
```

Result: `1 passed, 15 warnings in 105.81s`.

Targeted pre-commit on the changed files was also run on a Linux validation checkout:

```bash
pre-commit run --files \
  verl/trainer/ppo/trainer_utils.py \
  verl/trainer/ppo/ray_trainer.py \
  verl/trainer/ppo/v1/utils.py \
  verl/trainer/ppo/v1/trainer_base.py \
  verl/experimental/separation/ray_trainer.py \
  verl/experimental/fully_async_policy/detach_utils.py \
  verl/experimental/one_step_off_policy/ray_trainer.py \
  tests/trainer/ppo/test_spec_decode_metrics_on_cpu.py \
  tests/workers/rollout/rollout_vllm/test_mtp_hybrid_sleep_acceptance_on_cpu.py
```

Result: all targeted hooks passed (`ruff`, `ruff format`, `mypy`, generated trainer config check, docs/license/device/dataproto/test-structure/naming checks, and compileall).

Limitations:

- I did not run Ascend/NPU CI locally because this change is a device-independent import/refactor and my available validation hardware is CUDA-only.
- I did not run full training e2e; the PR is scoped to helper relocation and import migration.

### API and Usage Example

No API or config change is intended. Existing legacy imports remain compatible through re-exports from `ray_trainer.py`:

```python
from verl.trainer.ppo.trainer_utils import compute_advantage
from verl.trainer.ppo.ray_trainer import compute_advantage as legacy_compute_advantage

assert legacy_compute_advantage is compute_advantage
```

New non-legacy code should import shared PPO helpers from `verl.trainer.ppo.trainer_utils`.

### Design & Code Changes

- Added `verl/trainer/ppo/trainer_utils.py` as the home for PPO trainer helper functions that are shared across trainer implementations.
- Left compatibility re-exports in `verl/trainer/ppo/ray_trainer.py` so downstream users importing these helpers from the legacy module are not broken.
- Updated V1 PPO utilities and trainer base imports to depend on `trainer_utils` instead of `ray_trainer`.
- Updated experimental fully-async, one-step-off-policy, and separation trainers to import shared helpers from `trainer_utils`.
- Updated tests that exercise spec decode metrics and vLLM MTP acceptance helpers to import from the new module.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting) on the changed files, as listed above.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed for this internal refactor; no user-facing API/config behavior changes.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Existing CPU and vLLM tests cover the moved helpers/import paths; no new workflow file is needed.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] Not related to the `recipe` submodule.