### PR TITLE
[trainer] feat: add unbiased pass@k validation metric

### DIFF
--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -27,6 +27,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_data_metrics,
     compute_throughout_metrics,
     compute_timing_metrics,
+    pass_at_k,
     process_validation_metrics,
 )
 from verl.utils.metric import (
@@ -492,6 +493,58 @@ class TestBootstrapMetric(unittest.TestCase):
             bootstrap_metric([], subset_size=1, reduce_fns=[np.mean])
 
 
+class TestPassAtK(unittest.TestCase):
+    """Tests for the pass_at_k unbiased estimator (Codex/HumanEval)."""
+
+    def test_humaneval_reference_values(self):
+        """Match the closed-form reference values from the HumanEval paper."""
+        # n=5, c=2: pass@1 = c/n = 0.4
+        self.assertAlmostEqual(pass_at_k(5, 2, 1), 0.4)
+        # n=5, c=2: pass@2 = 1 - C(3,2)/C(5,2) = 1 - 3/10 = 0.7
+        self.assertAlmostEqual(pass_at_k(5, 2, 2), 0.7)
+        # n=10, c=1: pass@1 = 0.1
+        self.assertAlmostEqual(pass_at_k(10, 1, 1), 0.1)
+
+    def test_reduces_to_any_correct_when_k_equals_n(self):
+        """pass@n is the exact 'any correct' indicator (this is true pass@N)."""
+        self.assertEqual(pass_at_k(4, 0, 4), 0.0)
+        self.assertEqual(pass_at_k(4, 1, 4), 1.0)
+        self.assertEqual(pass_at_k(4, 2, 4), 1.0)
+        self.assertEqual(pass_at_k(4, 4, 4), 1.0)
+
+    def test_partial_pass_intermediate_k(self):
+        """A prompt with 1 correct of 4: pass@1=0.25, pass@2=0.5, pass@4=1.0."""
+        self.assertAlmostEqual(pass_at_k(4, 1, 1), 0.25)
+        self.assertAlmostEqual(pass_at_k(4, 1, 2), 0.5)  # 1 - C(3,2)/C(4,2) = 1 - 3/6
+        self.assertAlmostEqual(pass_at_k(4, 1, 4), 1.0)
+
+    def test_all_correct_and_none_correct(self):
+        """Degenerate counts return 1.0 / 0.0 for every k."""
+        for k in (1, 2, 4):
+            self.assertEqual(pass_at_k(4, 4, k), 1.0)
+            self.assertEqual(pass_at_k(4, 0, k), 0.0)
+
+    def test_monotonic_non_decreasing_in_k(self):
+        """pass@k never decreases as k grows for fixed (n, c)."""
+        vals = [pass_at_k(8, 3, k) for k in range(1, 9)]
+        for lo, hi in zip(vals, vals[1:], strict=False):
+            self.assertLessEqual(lo, hi + 1e-12)
+
+    def test_k_greater_than_n_raises(self):
+        """k must not exceed n."""
+        with self.assertRaises(ValueError):
+            pass_at_k(4, 2, 5)
+
+    def test_bounded_unit_interval(self):
+        """Estimate always lies in [0, 1]."""
+        for n in range(1, 9):
+            for c in range(0, n + 1):
+                for k in range(1, n + 1):
+                    v = pass_at_k(n, c, k)
+                    self.assertGreaterEqual(v, 0.0)
+                    self.assertLessEqual(v, 1.0)
+
+
 class TestCalcMajVal(unittest.TestCase):
     """Tests for the calc_maj_val function."""
 
@@ -550,6 +603,41 @@ class TestProcessValidationMetrics(unittest.TestCase):
 
         # Check the value of mean@2 for source1/score
         self.assertAlmostEqual(result["source1"]["score"]["mean@2"], 0.85)
+
+        # pass@N is emitted alongside mean/std; both scores > 0 so pass@2 == 1.0
+        self.assertIn("pass@2", result["source1"]["score"])
+        self.assertAlmostEqual(result["source1"]["score"]["pass@2"], 1.0)
+
+    def test_process_validation_metrics_pass_at_k_values(self):
+        """pass@N reflects the exact fraction of prompts with >=1 correct sample.
+
+        One prompt with 1 correct of 4, contrasted against the biased bootstrap best@4:
+        pass@4 == 1.0 (the prompt did pass), pass@2 == 0.5, while mean@4 == 0.25.
+        """
+        data_sources = ["src"] * 4
+        sample_uids = ["p1"] * 4
+        infos_dict = {"score": [1.0, 0.0, 0.0, 0.0]}
+
+        result = process_validation_metrics(data_sources, sample_uids, infos_dict, seed=42)
+        score = result["src"]["score"]
+
+        self.assertAlmostEqual(score["mean@4"], 0.25)
+        self.assertAlmostEqual(score["pass@2"], 0.5)
+        self.assertAlmostEqual(score["pass@4"], 1.0)  # exact "any correct", unlike best@4
+        # sanity: the biased bootstrap under-reports the passing prompt
+        self.assertLess(score["best@4/mean"], 1.0)
+
+    def test_process_validation_metrics_pass_at_k_aggregates_across_prompts(self):
+        """pass@N averages per-prompt values: one all-correct + one all-wrong -> 0.5."""
+        data_sources = ["src"] * 8
+        sample_uids = ["good"] * 4 + ["bad"] * 4
+        infos_dict = {"score": [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]}
+
+        result = process_validation_metrics(data_sources, sample_uids, infos_dict, seed=42)
+        score = result["src"]["score"]
+
+        self.assertAlmostEqual(score["pass@4"], 0.5)
+        self.assertAlmostEqual(score["pass@2"], 0.5)
 
     def test_process_validation_metrics_with_pred(self):
         """Test process_validation_metrics with prediction data."""

--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -27,6 +27,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_data_metrics,
     compute_throughout_metrics,
     compute_timing_metrics,
+    pass_at_k,
     process_validation_metrics,
 )
 from verl.utils.metric import (
@@ -492,6 +493,59 @@ class TestBootstrapMetric(unittest.TestCase):
             bootstrap_metric([], subset_size=1, reduce_fns=[np.mean])
 
 
+class TestPassAtK(unittest.TestCase):
+    """Tests for the pass_at_k unbiased estimator (Codex/HumanEval)."""
+
+    def test_humaneval_reference_values(self):
+        """Match the closed-form reference values from the HumanEval paper."""
+        # n=5, c=2: pass@1 = c/n = 0.4
+        self.assertAlmostEqual(pass_at_k(5, 2, 1), 0.4)
+        # n=5, c=2: pass@2 = 1 - C(3,2)/C(5,2) = 1 - 3/10 = 0.7
+        self.assertAlmostEqual(pass_at_k(5, 2, 2), 0.7)
+        # n=10, c=1: pass@1 = 0.1
+        self.assertAlmostEqual(pass_at_k(10, 1, 1), 0.1)
+
+    def test_reduces_to_any_correct_when_k_equals_n(self):
+        """pass@n is the exact 'any correct' indicator (this is true pass@N)."""
+        self.assertEqual(pass_at_k(4, 0, 4), 0.0)
+        self.assertEqual(pass_at_k(4, 1, 4), 1.0)
+        self.assertEqual(pass_at_k(4, 2, 4), 1.0)
+        self.assertEqual(pass_at_k(4, 4, 4), 1.0)
+
+    def test_partial_pass_intermediate_k(self):
+        """A prompt with 1 correct of 4: pass@1=0.25, pass@2=0.5, pass@3=0.75, pass@4=1.0."""
+        self.assertAlmostEqual(pass_at_k(4, 1, 1), 0.25)
+        self.assertAlmostEqual(pass_at_k(4, 1, 2), 0.5)  # 1 - C(3,2)/C(4,2) = 1 - 3/6
+        self.assertAlmostEqual(pass_at_k(4, 1, 3), 0.75)  # 1 - C(3,3)/C(4,3) = 1 - 1/4
+        self.assertAlmostEqual(pass_at_k(4, 1, 4), 1.0)
+
+    def test_all_correct_and_none_correct(self):
+        """Degenerate counts return 1.0 / 0.0 for every k."""
+        for k in (1, 2, 4):
+            self.assertEqual(pass_at_k(4, 4, k), 1.0)
+            self.assertEqual(pass_at_k(4, 0, k), 0.0)
+
+    def test_monotonic_non_decreasing_in_k(self):
+        """pass@k never decreases as k grows for fixed (n, c)."""
+        vals = [pass_at_k(8, 3, k) for k in range(1, 9)]
+        for lo, hi in zip(vals, vals[1:], strict=False):
+            self.assertLessEqual(lo, hi + 1e-12)
+
+    def test_k_greater_than_n_raises(self):
+        """k must not exceed n."""
+        with self.assertRaises(ValueError):
+            pass_at_k(4, 2, 5)
+
+    def test_bounded_unit_interval(self):
+        """Estimate always lies in [0, 1]."""
+        for n in range(1, 9):
+            for c in range(0, n + 1):
+                for k in range(1, n + 1):
+                    v = pass_at_k(n, c, k)
+                    self.assertGreaterEqual(v, 0.0)
+                    self.assertLessEqual(v, 1.0)
+
+
 class TestCalcMajVal(unittest.TestCase):
     """Tests for the calc_maj_val function."""
 
@@ -550,6 +604,44 @@ class TestProcessValidationMetrics(unittest.TestCase):
 
         # Check the value of mean@2 for source1/score
         self.assertAlmostEqual(result["source1"]["score"]["mean@2"], 0.85)
+
+        # pass@N is emitted alongside mean/std; both scores > 0 so pass@2 == 1.0
+        self.assertIn("pass@2", result["source1"]["score"])
+        self.assertAlmostEqual(result["source1"]["score"]["pass@2"], 1.0)
+
+    def test_process_validation_metrics_pass_at_k_values(self):
+        """pass@N reflects the exact fraction of prompts with >=1 correct sample.
+
+        One prompt with 1 correct of 4, contrasted against the biased bootstrap best@4:
+        pass@4 == 1.0 (the prompt did pass), pass@2 == 0.5, while mean@4 == 0.25.
+        The sparse {2, 4} ladder is emitted.
+        """
+        data_sources = ["src"] * 4
+        sample_uids = ["p1"] * 4
+        infos_dict = {"score": [1.0, 0.0, 0.0, 0.0]}
+
+        result = process_validation_metrics(data_sources, sample_uids, infos_dict, seed=42)
+        score = result["src"]["score"]
+
+        self.assertAlmostEqual(score["mean@4"], 0.25)
+        # sparse ladder: pass@{2, 4} only
+        self.assertEqual({"pass@2", "pass@4"}, {k for k in score if k.startswith("pass@")})
+        self.assertAlmostEqual(score["pass@2"], 0.5)
+        self.assertAlmostEqual(score["pass@4"], 1.0)  # exact "any correct", unlike best@4
+        # sanity: the biased bootstrap under-reports the passing prompt
+        self.assertLess(score["best@4/mean"], 1.0)
+
+    def test_process_validation_metrics_pass_at_k_aggregates_across_prompts(self):
+        """pass@N averages per-prompt values: one all-correct + one all-wrong -> 0.5."""
+        data_sources = ["src"] * 8
+        sample_uids = ["good"] * 4 + ["bad"] * 4
+        infos_dict = {"score": [1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]}
+
+        result = process_validation_metrics(data_sources, sample_uids, infos_dict, seed=42)
+        score = result["src"]["score"]
+
+        self.assertAlmostEqual(score["pass@4"], 0.5)
+        self.assertAlmostEqual(score["pass@2"], 0.5)
 
     def test_process_validation_metrics_with_pred(self):
         """Test process_validation_metrics with prediction data."""

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -857,6 +857,36 @@ def bootstrap_metric(
     return result
 
 
+def pass_at_k(n: int, c: int, k: int) -> float:
+    """
+    Unbiased estimator of pass@k from the Codex/HumanEval paper (Chen et al., 2021).
+
+    Estimates the probability that at least one of ``k`` samples drawn WITHOUT
+    replacement from the ``n`` generated samples is correct, given that ``c`` of the
+    ``n`` are correct::
+
+        pass@k = 1 - C(n - c, k) / C(n, k)
+
+    evaluated in the numerically stable product form. Unlike a with-replacement
+    bootstrap of ``max`` (see ``bootstrap_metric``), this is unbiased. When ``k == n``
+    it reduces to the exact "any correct" indicator (1.0 if ``c > 0`` else 0.0), i.e.
+    the true pass@N.
+
+    Args:
+        n: Total number of samples generated for the prompt.
+        c: Number of correct samples (e.g. reward > 0).
+        k: The k in pass@k. Must satisfy 1 <= k <= n.
+
+    Returns:
+        The unbiased pass@k estimate in [0, 1].
+    """
+    if k > n:
+        raise ValueError(f"pass@k requires k <= n, got k={k}, n={n}")
+    if n - c < k:
+        return 1.0
+    return float(1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1)))
+
+
 def calc_maj_val(data: list[dict[str, Any]], vote_key: str, val_key: str) -> float:
     """
     Calculate a value based on majority voting.
@@ -923,6 +953,9 @@ def process_validation_metrics(
         Where metric_name includes:
         - "mean@N": Mean value across N samples
         - "std@N": Standard deviation across N samples
+        - "pass@N": Unbiased pass@N estimate (Codex/HumanEval); pass@n_resps is the exact
+          fraction of prompts with at least one correct (reward > 0) sample, and pass@1
+          equals mean@n_resps for binary rewards
         - "best@N/mean": Mean of the best values in bootstrap samples of size N
         - "best@N/std": Standard deviation of the best values in bootstrap samples
         - "worst@N/mean": Mean of the worst values in bootstrap samples
@@ -950,7 +983,7 @@ def process_validation_metrics(
     reduce_fns_best_worst = [np.max, np.min]
     n_bootstrap = 1000
 
-    # 2. cache ns list
+    # 2. cache ns list — the @N ladder shared by every validation metric (best/worst/maj/pass).
     def gen_ns(n_resps: int) -> list[int]:
         if n_resps <= 1:
             return []
@@ -994,8 +1027,15 @@ def process_validation_metrics(
                         ns_cache[n_resps] = gen_ns(n_resps)
                     ns = ns_cache[n_resps]
 
-                    # compute best/worst metrics
+                    # count correct samples (reward > 0) for the unbiased pass@k estimator
+                    n_correct = int(np.sum(np.asarray(var_vals) > 0))
+
+                    # every @N metric uses the same ladder `ns`
                     for n in ns:
+                        # unbiased pass@n (Codex/HumanEval), no bootstrap; pass@n_resps is the exact
+                        # "any correct" fraction and pass@1 equals mean@n_resps for binary rewards
+                        metric[f"pass@{n}"] = pass_at_k(n_resps, n_correct, n)
+
                         # compute best/worst metrics
                         (bon_mean, bon_std), (won_mean, won_std) = bootstrap_metric(
                             data=var_vals,

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -857,6 +857,36 @@ def bootstrap_metric(
     return result
 
 
+def pass_at_k(n: int, c: int, k: int) -> float:
+    """
+    Unbiased estimator of pass@k from the Codex/HumanEval paper (Chen et al., 2021).
+
+    Estimates the probability that at least one of ``k`` samples drawn WITHOUT
+    replacement from the ``n`` generated samples is correct, given that ``c`` of the
+    ``n`` are correct::
+
+        pass@k = 1 - C(n - c, k) / C(n, k)
+
+    evaluated in the numerically stable product form. Unlike a with-replacement
+    bootstrap of ``max`` (see ``bootstrap_metric``), this is unbiased. When ``k == n``
+    it reduces to the exact "any correct" indicator (1.0 if ``c > 0`` else 0.0), i.e.
+    the true pass@N.
+
+    Args:
+        n: Total number of samples generated for the prompt.
+        c: Number of correct samples (e.g. reward > 0).
+        k: The k in pass@k. Must satisfy 1 <= k <= n.
+
+    Returns:
+        The unbiased pass@k estimate in [0, 1].
+    """
+    if k > n:
+        raise ValueError(f"pass@k requires k <= n, got k={k}, n={n}")
+    if n - c < k:
+        return 1.0
+    return float(1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1)))
+
+
 def calc_maj_val(data: list[dict[str, Any]], vote_key: str, val_key: str) -> float:
     """
     Calculate a value based on majority voting.
@@ -923,6 +953,8 @@ def process_validation_metrics(
         Where metric_name includes:
         - "mean@N": Mean value across N samples
         - "std@N": Standard deviation across N samples
+        - "pass@N": Unbiased pass@N estimate (Codex/HumanEval); pass@n_resps is the exact
+          fraction of prompts with at least one correct (reward > 0) sample
         - "best@N/mean": Mean of the best values in bootstrap samples of size N
         - "best@N/std": Standard deviation of the best values in bootstrap samples
         - "worst@N/mean": Mean of the worst values in bootstrap samples
@@ -994,8 +1026,14 @@ def process_validation_metrics(
                         ns_cache[n_resps] = gen_ns(n_resps)
                     ns = ns_cache[n_resps]
 
+                    # count correct samples (reward > 0) for the unbiased pass@k estimator
+                    n_correct = int(np.sum(np.asarray(var_vals) > 0))
+
                     # compute best/worst metrics
                     for n in ns:
+                        # unbiased pass@n (Codex/HumanEval), no bootstrap; pass@n_resps is exact "any correct"
+                        metric[f"pass@{n}"] = pass_at_k(n_resps, n_correct, n)
+
                         # compute best/worst metrics
                         (bon_mean, bon_std), (won_mean, won_std) = bootstrap_metric(
                             data=var_vals,

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -728,7 +728,7 @@ class RayPPOTrainer:
                 for metric_name, metric_val in metric2val.items():
                     if (
                         (var_name == core_var)
-                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])
+                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best", "pass"])
                         and (f"@{n_max}" in metric_name)
                     ):
                         metric_sec = "val-core"

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1272,7 +1272,7 @@ class PPOTrainer(ABC):
                 for metric_name, metric_val in metric2val.items():
                     if (
                         (var_name == core_var)
-                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])
+                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best", "pass"])
                         and (f"@{n_max}" in metric_name)
                     ):
                         metric_sec = "val-core"

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1258,7 +1258,7 @@ class PPOTrainer(ABC):
                 for metric_name, metric_val in metric2val.items():
                     if (
                         (var_name == core_var)
-                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])
+                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best", "pass"])
                         and (f"@{n_max}" in metric_name)
                     ):
                         metric_sec = "val-core"


### PR DESCRIPTION
### What does this PR do?

Adds an **unbiased pass@k** validation metric (the Codex/HumanEval estimator) and logs it next to the existing `mean@k` / `best@k` / `worst@k` metrics.

Today, `process_validation_metrics` reports `best@k` via `bootstrap_metric`, which subsamples `k` items **with replacement** and averages the max. When `k` equals the number of generations per prompt `n`, this is a biased-*low* estimate of true pass@k: a with-replacement resample of size `n` can miss a prompt's only correct sample, so a prompt that actually passed is scored below 1.0. Concretely, for a prompt with 1 correct of 4, `best@4` reports `1 - (3/4)^4 ≈ 0.684` instead of `1.0`. So `best@k` is not the pass@k practitioners expect, and it systematically under-reports.

This PR adds `pass_at_k(n, c, k) = 1 - C(n-c, k) / C(n, k)` (numerically stable product form) and emits `pass@k` for every `k` in the existing `ns` ladder. At `k == n` it reduces exactly to the "any correct" indicator, i.e. true pass@N. `best@k` is left untouched.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+pass%40k
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

CPU unit tests in `tests/trainer/ppo/test_metric_utils_on_cpu.py` (no GPU required):

- New `TestPassAtK`: HumanEval reference values (`pass@1=c/n`, `(5,2,2)=0.7`), the `k==n` reduction to any-correct, monotonicity in `k`, `[0,1]` bounds, and the `k>n` error.
- Extended `TestProcessValidationMetrics`: asserts `pass@k` is emitted, checks exact values on `[1,0,0,0]` (`pass@4=1.0`, `pass@2=0.5`, `mean@4=0.25`) contrasted against the biased `best@4/mean < 1.0`, and verifies cross-prompt aggregation.

```
$ pytest tests/trainer/ppo/test_metric_utils_on_cpu.py -v
...
======================= 45 passed, 2 warnings in 36.35s ========================
```

### API and Usage Example

No API changes. New metrics appear automatically in validation logs. On a run with `val_kwargs.n = 4`:

```
val-core/<data_source>/reward/mean@4:  0.2637   # unchanged
val-core/<data_source>/reward/best@4/mean: 0.3835   # unchanged (biased bootstrap of max)
val-core/<data_source>/reward/pass@4:  0.4336   # NEW: exact/unbiased pass@4
val-aux/<data_source>/reward/pass@2:   0.3516   # NEW: unbiased pass@2
```

### Design & Code Changes

- `verl/trainer/ppo/metric_utils.py`: add `pass_at_k`; emit `pass@{n}` per prompt in `process_validation_metrics` (`n_correct` counted as `reward > 0`); no bootstrap needed, so it's deterministic.
- `verl/trainer/ppo/ray_trainer.py` and `verl/trainer/ppo/v1/trainer_base.py`: add the `pass` prefix to the `val-core` classifier, so `pass@{n_max}` on the core reward variable surfaces under `val-core` alongside `mean@{n_max}` / `best@{n_max}` (lower `k` stay in `val-aux`, matching `best@k` behavior).
- `tests/trainer/ppo/test_metric_utils_on_cpu.py`: new `TestPassAtK` and extended `TestProcessValidationMetrics`.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (`ruff` / `ruff-format` clean on changed files).
- [x] Add / Update the documentation.
- [x] Add unit test(s) covering the new code.