### PR TITLE
[megatron, hardware] fix: pure-torch fast_hadamard_transform fallback for DSA on ROCm

### DIFF
--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -55,49 +55,41 @@ def apply_fast_hadamard_transform_shim():
 
     Register ``pure_torch_hadamard_transform`` under the real import name so any
     importer picks it up, and back-fill modules that already captured ``None``
-    (e.g. Megatron's ``dsa`` module at import time). When the real package is
-    installed its kernel is kept and only the back-fill runs.
+    (e.g. Megatron's ``dsa`` module at import time). This is a no-op once the name
+    imports, be it the real package or the stub an earlier call installed.
     """
     import importlib
     import logging
     import sys
     import types
 
-    # Import rather than probe ``sys.modules``: an entry under that name only means
-    # *something* is registered (a partially initialized module, a stub from another
-    # framework, an earlier run of this shim), which says nothing about whether a
-    # usable kernel is there. A broken CUDA extension can also fail the import with
-    # OSError/RuntimeError, not just ImportError.
+    # Catch every exception, not just ImportError: a CUDA extension built against
+    # another toolkit fails to load with OSError. An import that goes through means
+    # every importer of the name resolves to that same module, so none of them can
+    # be left holding a None binding.
     try:
-        module = importlib.import_module("fast_hadamard_transform")
+        importlib.import_module("fast_hadamard_transform")
+        return
     except Exception:
-        module = None
+        pass
 
-    hadamard_transform = getattr(module, "hadamard_transform", None)
-    use_fallback = hadamard_transform is None
-    if use_fallback:
-        hadamard_transform = pure_torch_hadamard_transform
-        if module is None:
-            module = types.ModuleType("fast_hadamard_transform")
-        module.hadamard_transform = hadamard_transform
-        sys.modules["fast_hadamard_transform"] = module
+    module = types.ModuleType("fast_hadamard_transform")
+    module.hadamard_transform = pure_torch_hadamard_transform
+    sys.modules["fast_hadamard_transform"] = module
 
     # Back-fill modules that already ran `from fast_hadamard_transform import
     # hadamard_transform` and captured None (e.g. Megatron's dsa.py at import).
-    # This must run even when the real package is importable now, because those
-    # importers ran at a point when it was not, and they keep their own binding.
     # Read `__dict__` directly: `getattr` would trigger PEP-562 module-level
     # `__getattr__` hooks, which can raise or force lazy imports.
     for mod in list(sys.modules.values()):
         mod_dict = getattr(mod, "__dict__", None)
         if mod_dict is not None and mod_dict.get("hadamard_transform", "keep") is None:
-            mod_dict["hadamard_transform"] = hadamard_transform
+            mod_dict["hadamard_transform"] = pure_torch_hadamard_transform
 
-    if use_fallback:
-        logging.getLogger(__name__).warning(
-            "fast_hadamard_transform is unavailable; falling back to a pure-torch Fast "
-            "Walsh-Hadamard transform. Results match the CUDA kernel but DSA forward will be slower."
-        )
+    logging.getLogger(__name__).warning(
+        "fast_hadamard_transform is unavailable; falling back to a pure-torch Fast "
+        "Walsh-Hadamard transform. Results match the CUDA kernel but DSA forward will be slower."
+    )
 
 
 def apply_patch():

--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -17,7 +17,89 @@
 # 1. `get_query_key_value_tensors` in `multi_latent_attention.py` works wrong when packed_seq_params is not None
 
 
+def apply_fast_hadamard_transform_shim():
+    """Provide a pure-torch ``fast_hadamard_transform`` when the CUDA package is absent.
+
+    DeepSeek-V4 / V3.2 sparse-attention (DSA) in Megatron-LM does
+    ``from fast_hadamard_transform import hadamard_transform`` at import time and
+    asserts it is not None inside the indexer's ``rotate_activation``. The upstream
+    Dao-AILab package only ships nvcc kernels and cannot be built on ROCm, so that
+    import yields ``None`` there and every DSA forward crashes.
+
+    Register a vectorized Fast Walsh-Hadamard Transform under the real import name
+    (fp32 butterfly accumulation, numerically equivalent to
+    ``F.linear(x, scipy.linalg.hadamard(dim)) * scale``) so any importer picks it
+    up, and back-fill modules that already captured ``None`` (e.g. Megatron's
+    ``dsa`` module at import time). No-op when the real package is installed.
+    """
+    import logging
+    import sys
+    import types
+
+    import torch
+
+    # Real CUDA package present and working -> leave it alone.
+    existing = sys.modules.get("fast_hadamard_transform")
+    if existing is not None and getattr(existing, "hadamard_transform", None) is not None:
+        return
+    if existing is None:
+        try:
+            import fast_hadamard_transform as existing
+
+            if getattr(existing, "hadamard_transform", None) is not None:
+                return
+        except Exception:
+            # A broken CUDA extension can fail with OSError/RuntimeError, not just ImportError.
+            existing = None
+
+    def hadamard_transform(x, scale=1.0):
+        """Fast Walsh-Hadamard transform along the last dim (size must be 2**k)."""
+        n = x.shape[-1]
+        if n < 1 or n & (n - 1) != 0:
+            raise ValueError(f"hadamard_transform requires last dim to be a power of 2, got {n}")
+        orig_dtype = x.dtype
+        orig_shape = x.shape
+        # Accumulate in fp32 for numerical stability, cast back at the end.
+        y = x.to(torch.float32).reshape(-1, n)
+        h = 1
+        while h < n:
+            y = y.view(-1, n // (2 * h), 2, h)
+            a = y[:, :, 0, :]
+            b = y[:, :, 1, :]
+            y = torch.stack((a + b, a - b), dim=2).reshape(-1, n)
+            h *= 2
+        y = y * scale
+        return y.reshape(orig_shape).to(orig_dtype)
+
+    module = existing if existing is not None else types.ModuleType("fast_hadamard_transform")
+    module.hadamard_transform = hadamard_transform
+    module.hadamard_transform_ref = hadamard_transform
+    sys.modules["fast_hadamard_transform"] = module
+
+    # Back-fill modules that already ran `from fast_hadamard_transform import
+    # hadamard_transform` and captured None (e.g. Megatron's dsa.py at import).
+    # Read `__dict__` directly: `getattr` would trigger PEP-562 module-level
+    # `__getattr__` hooks, which can raise or force lazy imports.
+    for mod in list(sys.modules.values()):
+        mod_dict = getattr(mod, "__dict__", None)
+        if mod_dict is not None and mod_dict.get("hadamard_transform", "keep") is None:
+            mod_dict["hadamard_transform"] = hadamard_transform
+
+    logging.getLogger(__name__).warning(
+        "fast_hadamard_transform is unavailable; falling back to a pure-torch Fast Walsh-Hadamard "
+        "transform. Results match the CUDA kernel but DSA forward will be slower."
+    )
+
+
 def apply_patch():
+    # DeepSeek sparse-attention (DSA) needs ``fast_hadamard_transform``, which
+    # cannot be built on ROCm (its setup requires nvcc). Install a pure-torch
+    # fallback from the central mcore patch entry so every DSA importer picks it
+    # up without engine-specific wiring. Callers run this both before model
+    # creation (hf_to_mcore_config_dpskv3) and after it (the mbridge path in
+    # megatron_utils.get_model), which is why the shim also back-fills importers.
+    apply_fast_hadamard_transform_shim()
+
     import megatron.core
     import torch
     import torch.nn.functional as F

--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -17,6 +17,33 @@
 # 1. `get_query_key_value_tensors` in `multi_latent_attention.py` works wrong when packed_seq_params is not None
 
 
+def pure_torch_hadamard_transform(x, scale=1.0):
+    """Fast Walsh-Hadamard transform along the last dim (size must be 2**k).
+
+    Vectorized butterfly accumulated in fp32, numerically equivalent to
+    ``F.linear(x, scipy.linalg.hadamard(dim)) * scale`` and bit-for-bit identical to
+    the Dao-AILab CUDA kernel it stands in for.
+    """
+    import torch
+
+    n = x.shape[-1]
+    if n < 1 or n & (n - 1) != 0:
+        raise ValueError(f"hadamard_transform requires last dim to be a power of 2, got {n}")
+    orig_dtype = x.dtype
+    orig_shape = x.shape
+    # Accumulate in fp32 for numerical stability, cast back at the end.
+    y = x.to(torch.float32).reshape(-1, n)
+    h = 1
+    while h < n:
+        y = y.view(-1, n // (2 * h), 2, h)
+        a = y[:, :, 0, :]
+        b = y[:, :, 1, :]
+        y = torch.stack((a + b, a - b), dim=2).reshape(-1, n)
+        h *= 2
+    y = y * scale
+    return y.reshape(orig_shape).to(orig_dtype)
+
+
 def apply_fast_hadamard_transform_shim():
     """Provide a pure-torch ``fast_hadamard_transform`` when the CUDA package is absent.
 
@@ -26,58 +53,39 @@ def apply_fast_hadamard_transform_shim():
     Dao-AILab package only ships nvcc kernels and cannot be built on ROCm, so that
     import yields ``None`` there and every DSA forward crashes.
 
-    Register a vectorized Fast Walsh-Hadamard Transform under the real import name
-    (fp32 butterfly accumulation, numerically equivalent to
-    ``F.linear(x, scipy.linalg.hadamard(dim)) * scale``) so any importer picks it
-    up, and back-fill modules that already captured ``None`` (e.g. Megatron's
-    ``dsa`` module at import time). No-op when the real package is installed.
+    Register ``pure_torch_hadamard_transform`` under the real import name so any
+    importer picks it up, and back-fill modules that already captured ``None``
+    (e.g. Megatron's ``dsa`` module at import time). When the real package is
+    installed its kernel is kept and only the back-fill runs.
     """
+    import importlib
     import logging
     import sys
     import types
 
-    import torch
+    # Import rather than probe ``sys.modules``: an entry under that name only means
+    # *something* is registered (a partially initialized module, a stub from another
+    # framework, an earlier run of this shim), which says nothing about whether a
+    # usable kernel is there. A broken CUDA extension can also fail the import with
+    # OSError/RuntimeError, not just ImportError.
+    try:
+        module = importlib.import_module("fast_hadamard_transform")
+    except Exception:
+        module = None
 
-    # Real CUDA package present and working -> leave it alone.
-    existing = sys.modules.get("fast_hadamard_transform")
-    if existing is not None and getattr(existing, "hadamard_transform", None) is not None:
-        return
-    if existing is None:
-        try:
-            import fast_hadamard_transform as existing
-
-            if getattr(existing, "hadamard_transform", None) is not None:
-                return
-        except Exception:
-            # A broken CUDA extension can fail with OSError/RuntimeError, not just ImportError.
-            existing = None
-
-    def hadamard_transform(x, scale=1.0):
-        """Fast Walsh-Hadamard transform along the last dim (size must be 2**k)."""
-        n = x.shape[-1]
-        if n < 1 or n & (n - 1) != 0:
-            raise ValueError(f"hadamard_transform requires last dim to be a power of 2, got {n}")
-        orig_dtype = x.dtype
-        orig_shape = x.shape
-        # Accumulate in fp32 for numerical stability, cast back at the end.
-        y = x.to(torch.float32).reshape(-1, n)
-        h = 1
-        while h < n:
-            y = y.view(-1, n // (2 * h), 2, h)
-            a = y[:, :, 0, :]
-            b = y[:, :, 1, :]
-            y = torch.stack((a + b, a - b), dim=2).reshape(-1, n)
-            h *= 2
-        y = y * scale
-        return y.reshape(orig_shape).to(orig_dtype)
-
-    module = existing if existing is not None else types.ModuleType("fast_hadamard_transform")
-    module.hadamard_transform = hadamard_transform
-    module.hadamard_transform_ref = hadamard_transform
-    sys.modules["fast_hadamard_transform"] = module
+    hadamard_transform = getattr(module, "hadamard_transform", None)
+    use_fallback = hadamard_transform is None
+    if use_fallback:
+        hadamard_transform = pure_torch_hadamard_transform
+        if module is None:
+            module = types.ModuleType("fast_hadamard_transform")
+        module.hadamard_transform = hadamard_transform
+        sys.modules["fast_hadamard_transform"] = module
 
     # Back-fill modules that already ran `from fast_hadamard_transform import
     # hadamard_transform` and captured None (e.g. Megatron's dsa.py at import).
+    # This must run even when the real package is importable now, because those
+    # importers ran at a point when it was not, and they keep their own binding.
     # Read `__dict__` directly: `getattr` would trigger PEP-562 module-level
     # `__getattr__` hooks, which can raise or force lazy imports.
     for mod in list(sys.modules.values()):
@@ -85,10 +93,11 @@ def apply_fast_hadamard_transform_shim():
         if mod_dict is not None and mod_dict.get("hadamard_transform", "keep") is None:
             mod_dict["hadamard_transform"] = hadamard_transform
 
-    logging.getLogger(__name__).warning(
-        "fast_hadamard_transform is unavailable; falling back to a pure-torch Fast Walsh-Hadamard "
-        "transform. Results match the CUDA kernel but DSA forward will be slower."
-    )
+    if use_fallback:
+        logging.getLogger(__name__).warning(
+            "fast_hadamard_transform is unavailable; falling back to a pure-torch Fast "
+            "Walsh-Hadamard transform. Results match the CUDA kernel but DSA forward will be slower."
+        )
 
 
 def apply_patch():

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -379,9 +379,7 @@ def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval
         # owned by another pipeline stage: pure lockstep row. The slot table
         # was pre-seeded from the owner stage (fail loud if not -- an
         # unsized entry would silently misalign the batched gather).
-        assert cached is not None, (
-            f"{rec.megatron_name}: slot table not pre-seeded for a non-owned PP param"
-        )
+        assert cached is not None, f"{rec.megatron_name}: slot table not pre-seeded for a non-owned PP param"
         assert lidx.numel() == 0, f"{rec.megatron_name}: delta reported for a param this rank does not own"
     if lidx.numel() == 0 and cached is not None:
         # empty delta: the slot table froze after the first probe, so the


### PR DESCRIPTION
DeepSeek sparse-attention (DSA) in Megatron-LM binds `from fast_hadamard_transform import hadamard_transform` at import time and asserts it is not None inside the indexer's `rotate_activation`. The Dao-AILab package only ships nvcc kernels and its setup.py hard-requires nvcc, so it cannot be built on ROCm: there the import yields None and every DSA forward crashes.

Register a vectorized Fast Walsh-Hadamard Transform under the real import name so any importer picks it up, and back-fill modules that already captured None. The back-fill is required, not defensive: Megatron's dsa.py binds the symbol at import time, and the mbridge path in megatron_utils.get_model() calls apply_patch() after the model has been built. No-op when the real CUDA package is installed.

Split out of #7050 so it can be reviewed independently of the ROCm Dockerfile and FP8/rollout changes there.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
