### PR TITLE
[algo, cfg] feat: allow standard PPO without dual clipping

### DIFF
--- a/tests/trainer/ppo/test_standard_ppo_on_cpu.py
+++ b/tests/trainer/ppo/test_standard_ppo_on_cpu.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU coverage for selecting standard PPO instead of dual-clip PPO."""
+
+import pytest
+import torch
+
+from verl.trainer.ppo.core_algos import compute_policy_loss_vanilla
+from verl.workers.config.actor import ActorConfig, PolicyLossConfig
+
+
+def _actor_config(*, clip_ratio_c) -> ActorConfig:
+    return ActorConfig(
+        strategy="fsdp",
+        rollout_n=1,
+        ppo_micro_batch_size_per_gpu=1,
+        clip_ratio=0.2,
+        clip_ratio_low=0.2,
+        clip_ratio_high=0.2,
+        clip_ratio_c=clip_ratio_c,
+        loss_agg_mode="token-mean",
+        policy_loss=PolicyLossConfig(loss_mode="vanilla"),
+    )
+
+
+def test_vanilla_without_dual_clip_matches_standard_ppo():
+    old_log_prob = torch.tensor([[0.0]])
+    log_prob = torch.tensor([[torch.log(torch.tensor(10.0))]])
+    advantages = torch.tensor([[-1.0]])
+    response_mask = torch.ones_like(advantages)
+
+    standard_loss, standard_metrics = compute_policy_loss_vanilla(
+        old_log_prob,
+        log_prob,
+        advantages,
+        response_mask,
+        "token-mean",
+        _actor_config(clip_ratio_c=None),
+    )
+    dual_clip_loss, _ = compute_policy_loss_vanilla(
+        old_log_prob,
+        log_prob,
+        advantages,
+        response_mask,
+        "token-mean",
+        _actor_config(clip_ratio_c=3.0),
+    )
+
+    assert standard_loss.item() == pytest.approx(10.0)
+    assert dual_clip_loss.item() == pytest.approx(3.0)
+    assert standard_metrics["actor/pg_clipfrac_lower"] == 0.0

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -75,7 +75,8 @@ policy_loss:
   # KL divergence penalty coefficient
   ppo_kl_coef: 0.1
 
-# Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C
+# Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C.
+# Set to null to use standard PPO without the additional dual-clipping branch.
 clip_ratio_c: 3.0
 
 # Loss aggregation mode: "token-mean", "seq-mean-token-sum", "seq-mean-token-mean", or "seq-mean-token-sum-norm"
@@ -332,4 +333,3 @@ qat:
 
   # Path to vLLM quantization config JSON file
   quantization_config_path: null
-

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1239,10 +1239,11 @@ def compute_policy_loss(
         loss_agg_mode (str, optional):
             Aggregation mode for `agg_loss`. Defaults to "token-mean".
     """
-    assert clip_ratio_c > 1.0, (
-        "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
-        + f" but get the value: {clip_ratio_c}."
-    )
+    if clip_ratio_c is not None:
+        assert clip_ratio_c > 1.0, (
+            "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
+            + f" but get the value: {clip_ratio_c}."
+        )
 
     negative_approx_kl = log_prob - old_log_prob
     # Clamp negative_approx_kl for stability
@@ -1263,13 +1264,18 @@ def compute_policy_loss(
     )  # max(-ratio * A, -clip(ratio, 1-cliprange, 1+cliprange) * A)
     pg_clipfrac = verl_F.masked_mean(torch.gt(pg_losses2, pg_losses1).float(), response_mask)
 
-    pg_losses3 = -advantages * clip_ratio_c
-    clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
-    pg_clipfrac_lower = verl_F.masked_mean(
-        torch.gt(clip_pg_losses1, pg_losses3) * (advantages < 0).float(), response_mask
-    )
-
-    pg_losses = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
+    if clip_ratio_c is None:
+        # Standard PPO has only the clipped and unclipped objectives. VERL's
+        # historical default keeps dual clipping enabled with clip_ratio_c=3.
+        pg_losses = clip_pg_losses1
+        pg_clipfrac_lower = torch.zeros((), device=log_prob.device)
+    else:
+        pg_losses3 = -advantages * clip_ratio_c
+        clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
+        pg_clipfrac_lower = verl_F.masked_mean(
+            torch.gt(clip_pg_losses1, pg_losses3) * (advantages < 0).float(), response_mask
+        )
+        pg_losses = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
     pg_loss = agg_loss(loss_mat=pg_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
 
     return pg_loss, pg_clipfrac, ppo_kl, pg_clipfrac_lower
@@ -1321,10 +1327,11 @@ def compute_policy_loss_vanilla(
     cliprange_low = clip_ratio_low
     cliprange_high = clip_ratio_high
 
-    assert clip_ratio_c > 1.0, (
-        "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
-        + f" but get the value: {clip_ratio_c}."
-    )
+    if clip_ratio_c is not None:
+        assert clip_ratio_c > 1.0, (
+            "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
+            + f" but get the value: {clip_ratio_c}."
+        )
 
     negative_approx_kl = log_prob - old_log_prob
     # Clamp negative_approx_kl for stability
@@ -1345,13 +1352,18 @@ def compute_policy_loss_vanilla(
     )  # max(-ratio * A, -clip(ratio, 1-cliprange, 1+cliprange) * A)
     pg_clipfrac = verl_F.masked_mean(torch.gt(pg_losses2, pg_losses1).float(), response_mask)
 
-    pg_losses3 = -advantages * clip_ratio_c
-    clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
-    pg_clipfrac_lower = verl_F.masked_mean(
-        torch.gt(clip_pg_losses1, pg_losses3) * (advantages < 0).float(), response_mask
-    )
-
-    pg_losses = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
+    if clip_ratio_c is None:
+        # Standard PPO has only the clipped and unclipped objectives. VERL's
+        # historical default keeps dual clipping enabled with clip_ratio_c=3.
+        pg_losses = clip_pg_losses1
+        pg_clipfrac_lower = torch.zeros((), device=log_prob.device)
+    else:
+        pg_losses3 = -advantages * clip_ratio_c
+        clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
+        pg_clipfrac_lower = verl_F.masked_mean(
+            torch.gt(clip_pg_losses1, pg_losses3) * (advantages < 0).float(), response_mask
+        )
+        pg_losses = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
 
     # Apply rollout correction weights if provided
     if rollout_is_weights is not None:

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -118,7 +118,7 @@ class ActorConfig(BaseConfig):
         clip_ratio_low (float): Lower bound for PPO clipping ratio.
         clip_ratio_high (float): Upper bound for PPO clipping ratio.
         policy_loss (PolicyLossConfig): Configuration for policy loss computation.
-        clip_ratio_c (float): Clipping ratio for critic loss.
+        clip_ratio_c (Optional[float]): Dual-clip PPO bound. Set to None to use standard PPO clipping only.
         loss_agg_mode (str): Loss aggregation mode. Options: 'token-mean', 'sample-mean'.
         loss_scale_factor (Optional[int]): Scale factor for 'seq-mean-token-sum-norm' loss aggregation mode.
             If None, uses response_length. Set to a constant to ensure consistent normalization.
@@ -160,7 +160,7 @@ class ActorConfig(BaseConfig):
     clip_ratio_high: float = 0.2
     freeze_vision_tower: bool = False
     policy_loss: PolicyLossConfig = field(default_factory=PolicyLossConfig)
-    clip_ratio_c: float = 3.0
+    clip_ratio_c: Optional[float] = 3.0
     loss_agg_mode: str = "token-mean"
     loss_scale_factor: Optional[int] = None
     entropy_coeff: float = 0


### PR DESCRIPTION
### What does this PR do?

Allows `clip_ratio_c=null` to select standard PPO without VERL's additional dual-clipping branch. The historical default remains `3.0`, so existing configurations retain dual-clip PPO behavior.

This is the third part of the former mixed #7197 scope. It is intentionally independent of PRs 1 and 2, but should remain a draft until those two are merged and this behavior receives additional review.

This is not a duplicate of another open PR: the [open-PR search for standard PPO and dual clipping](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22standard+PPO%22+%22dual+clip%22) found no PR implementing this configuration switch.

AI assistance disclosure: OpenAI Codex was used to split the original commit, isolate the standard-PPO behavior, add focused regression coverage, run checks, and compose this draft PR. The human submitter must review every changed line and rerun the focused tests in a working PyTorch environment before marking it ready for review.

### Checklist Before Starting

- [x] Search for similar PRs. Query: [standard PPO and dual clipping](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22standard+PPO%22+%22dual+clip%22)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `pre-commit run --all-files --show-diff-on-failure --color=always` — passed.
- `python -m pytest -q tests/trainer/ppo/test_standard_ppo_on_cpu.py tests/workers/config/test_actor_config_on_cpu.py` — blocked before collection because the current Python environment does not have pytest installed. The available system PyTorch is also unusable because `libnvshmem_host.so.3` is missing.

### API and Usage Example

```bash
# Standard PPO
actor_rollout_ref.actor.clip_ratio_c=null

# Existing dual-clip PPO behavior
actor_rollout_ref.actor.clip_ratio_c=3.0
```

### Design & Code Changes

- Make `ActorConfig.clip_ratio_c` optional.
- Skip the dual-clip lower branch when `clip_ratio_c` is null in both the registered and deprecated PPO loss paths.
- Return a zero lower-clip fraction metric for standard PPO.
- Preserve the existing default and add a focused standard-versus-dual-clip regression test.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). The actor configuration reference is updated inline.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Focused CPU tests were added to the existing test suite; local execution is blocked as described above.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).