### PR TITLE
[fully_async, fsdp] fix: preserve FSDP1 policy snapshots

### DIFF
--- a/tests/experimental/fully_async_policy/test_engine_workers_on_cpu.py
+++ b/tests/experimental/fully_async_policy/test_engine_workers_on_cpu.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType
+
+from verl.experimental.separation.engine_workers import DetachActorWorker
+from verl.utils import fsdp_utils
+
+
+def _run_fsdp1_sharded_snapshot_roundtrip(rank, world_size, rendezvous_path):
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{rendezvous_path}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        torch.manual_seed(7)
+        model = FSDP(nn.Sequential(nn.Linear(4, 8), nn.Linear(8, 3)), device_id=torch.device("cpu"))
+        snapshot = fsdp_utils.fsdp1_sharded_save_to_cpu(model)
+        local_snapshot = {name: value.local_tensor().clone() for name, value in snapshot.items()}
+
+        with torch.no_grad():
+            for parameter in model.parameters():
+                parameter.add_(10)
+
+        fsdp_utils.fsdp1_sharded_load_from_cpu(model, snapshot)
+        restored = fsdp_utils.fsdp1_sharded_save_to_cpu(model)
+        for name, value in restored.items():
+            torch.testing.assert_close(value.local_tensor(), local_snapshot[name], rtol=0, atol=0)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_fsdp1_sharded_snapshot_roundtrip(tmp_path):
+    mp.spawn(
+        _run_fsdp1_sharded_snapshot_roundtrip,
+        args=(2, tmp_path / "rendezvous"),
+        nprocs=2,
+        join=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("strategy", "handler_names"),
+    [
+        ("fsdp", ("fsdp1_sharded_save_to_cpu", "fsdp1_sharded_load_from_cpu")),
+        ("fsdp2", ("fsdp2_sharded_save_to_cpu", "fsdp2_sharded_load_from_cpu")),
+        ("veomni", ("fsdp2_sharded_save_to_cpu", "fsdp2_sharded_load_from_cpu")),
+    ],
+)
+def test_detach_actor_worker_selects_matching_fsdp_handlers(monkeypatch, strategy, handler_names):
+    expected_handlers = (object(), object())
+    for name, handler in zip(handler_names, expected_handlers, strict=True):
+        monkeypatch.setattr(fsdp_utils, name, handler)
+
+    worker = object.__new__(DetachActorWorker)
+    worker._strategy_handlers = None
+    worker.config = SimpleNamespace(actor=SimpleNamespace(strategy=strategy))
+
+    assert worker._get_strategy_handlers() == expected_handlers
+
+
+def test_fsdp1_sharded_snapshot_uses_cpu_state_dict(monkeypatch):
+    snapshot = {"weight": object()}
+    model = SimpleNamespace(state_dict=lambda: snapshot)
+    captured = {}
+
+    @contextmanager
+    def fake_state_ctx(ctx_model, state_type, state_cfg, optim_cfg):
+        captured.update(
+            model=ctx_model,
+            state_type=state_type,
+            offload_to_cpu=state_cfg.offload_to_cpu,
+            optim_cfg=optim_cfg,
+        )
+        yield
+
+    monkeypatch.setattr(fsdp_utils, "fsdp_version", lambda _: 1)
+    monkeypatch.setattr(fsdp_utils, "get_fsdp_state_ctx", fake_state_ctx)
+
+    assert fsdp_utils.fsdp1_sharded_save_to_cpu(model) is snapshot
+    assert captured == {
+        "model": model,
+        "state_type": StateDictType.SHARDED_STATE_DICT,
+        "offload_to_cpu": True,
+        "optim_cfg": None,
+    }
+
+
+def test_fsdp1_sharded_restore_uses_matching_state_dict_context(monkeypatch):
+    snapshot = {"weight": object()}
+    captured = {}
+
+    class Model:
+        def load_state_dict(self, state):
+            captured["state"] = state
+
+    model = Model()
+
+    @contextmanager
+    def fake_state_ctx(ctx_model, state_type, state_cfg, optim_cfg):
+        captured.update(
+            model=ctx_model,
+            state_type=state_type,
+            offload_to_cpu=state_cfg.offload_to_cpu,
+            optim_cfg=optim_cfg,
+        )
+        yield
+
+    monkeypatch.setattr(fsdp_utils, "fsdp_version", lambda _: 1)
+    monkeypatch.setattr(fsdp_utils, "get_fsdp_state_ctx", fake_state_ctx)
+
+    fsdp_utils.fsdp1_sharded_load_from_cpu(model, snapshot)
+    assert captured == {
+        "model": model,
+        "state_type": StateDictType.SHARDED_STATE_DICT,
+        "offload_to_cpu": True,
+        "optim_cfg": None,
+        "state": snapshot,
+    }

--- a/verl/experimental/separation/engine_workers.py
+++ b/verl/experimental/separation/engine_workers.py
@@ -80,7 +80,14 @@ class DetachActorWorker(ActorRolloutRefWorker):
         # save/restore. The current fsdp2_sharded_save_to_cpu / fsdp2_sharded_load_from_cpu
         # assume parameters are on GPU. Callers should ensure the model is loaded back to GPU
         # before calling save_model_to_cpu / restore_model_from_cpu in offload scenarios.
-        if strategy in ["fsdp", "fsdp2", "veomni"]:
+        if strategy == "fsdp":
+            from verl.utils.fsdp_utils import (
+                fsdp1_sharded_load_from_cpu,
+                fsdp1_sharded_save_to_cpu,
+            )
+
+            self._strategy_handlers = (fsdp1_sharded_save_to_cpu, fsdp1_sharded_load_from_cpu)
+        elif strategy in ["fsdp2", "veomni"]:
             from verl.utils.fsdp_utils import (
                 fsdp2_sharded_load_from_cpu,
                 fsdp2_sharded_save_to_cpu,
@@ -114,9 +121,8 @@ class DetachActorWorker(ActorRolloutRefWorker):
         """
         Save the current model state to CPU memory.
 
-        For FSDP/FSDP2/VeOmni strategies, this uses fsdp2_sharded_save_to_cpu which
-        expects model parameters to be on GPU (as DTensors). If VeOmni param_offload
-        is enabled, ensure the model has been reloaded to GPU before calling this method.
+        FSDP1 uses its sharded state-dict API. FSDP2 and VeOmni use local DTensor
+        shards, which must be on GPU before saving.
 
         Args:
             n: Identifier/Key for the saved model state.
@@ -131,9 +137,8 @@ class DetachActorWorker(ActorRolloutRefWorker):
         """
         Restore the model state from CPU memory.
 
-        For FSDP/FSDP2/VeOmni strategies, the saved state is a tuple of
-        (cpu_sharded_state, global_spec) produced by fsdp2_sharded_save_to_cpu.
-        For Megatron, the saved state is passed directly to the restore handler.
+        FSDP2 and VeOmni states include both local shards and their DTensor spec.
+        FSDP1 and Megatron states are passed directly to their restore handlers.
 
         Args:
             n: Identifier/Key for the saved model state to restore.
@@ -141,7 +146,7 @@ class DetachActorWorker(ActorRolloutRefWorker):
         if n in self.cpu_saved_models:
             strategy = self.config.actor.strategy
 
-            if strategy in ["fsdp", "fsdp2", "veomni"]:
+            if strategy in ["fsdp2", "veomni"]:
                 cpu_sharded_state, global_spec = self.cpu_saved_models[n]
                 self.restore_handler(self.actor.engine.module, cpu_sharded_state, global_spec)
             else:

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -1090,6 +1090,36 @@ def merged_lora_context(actor, backup_adapters=False):
             fsdp_merge_unmerge(actor, do_merge=False)
 
 
+def fsdp1_sharded_save_to_cpu(model: FSDP) -> dict[str, object]:
+    """Save each rank's FSDP1 model shard to CPU memory."""
+    from torch.distributed.fsdp import ShardedStateDictConfig, StateDictType
+
+    assert fsdp_version(model) == 1, "fsdp1_sharded_save_to_cpu requires an FSDP1 model"
+    state_dict_config = ShardedStateDictConfig(offload_to_cpu=True)
+    with get_fsdp_state_ctx(
+        model,
+        state_type=StateDictType.SHARDED_STATE_DICT,
+        state_cfg=state_dict_config,
+        optim_cfg=None,
+    ):
+        return model.state_dict()
+
+
+def fsdp1_sharded_load_from_cpu(model: FSDP, cpu_sharded_state: dict[str, object]) -> None:
+    """Restore each rank's FSDP1 model shard from CPU memory."""
+    from torch.distributed.fsdp import ShardedStateDictConfig, StateDictType
+
+    assert fsdp_version(model) == 1, "fsdp1_sharded_load_from_cpu requires an FSDP1 model"
+    state_dict_config = ShardedStateDictConfig(offload_to_cpu=True)
+    with get_fsdp_state_ctx(
+        model,
+        state_type=StateDictType.SHARDED_STATE_DICT,
+        state_cfg=state_dict_config,
+        optim_cfg=None,
+    ):
+        model.load_state_dict(cpu_sharded_state)
+
+
 def fsdp2_sharded_save_to_cpu(
     model: torch.nn.Module,
 ) -> tuple[dict[str, tuple[torch.Tensor, DTensorSpec]], DTensorSpec]:


### PR DESCRIPTION
### What does this PR do?

Closes #7249.

`DetachActorWorker` previously routed the `fsdp` strategy through
`fsdp2_sharded_save_to_cpu()` and `fsdp2_sharded_load_from_cpu()`. Those
helpers require DTensor parameters, so fully async FSDP1 training crashed when
`bypass_mode=False` recomputed `old_log_prob`.

This change:

- adds FSDP1-specific in-memory snapshot helpers based on
  `StateDictType.SHARDED_STATE_DICT` with CPU offload;
- routes only FSDP2 and VeOmni through the existing DTensor helpers;
- adds handler-selection tests and a real two-rank Gloo roundtrip test that
  saves, mutates, restores, and compares FSDP1 parameter shards.

The change does not alter trainer control flow, configuration, or the existing
FSDP2, VeOmni, and Megatron snapshot formats.

### Checklist Before Starting

- [x] Search for similar PRs. Queries:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7249
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+DetachActorWorker+FSDP1+old_log_prob
- [x] No open PR among the current 508 open PRs references #7249 or matches
  the `DetachActorWorker` FSDP1 snapshot fix.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Regression test before the fix:

```text
python -m pytest -q tests/experimental/fully_async_policy/test_engine_workers_on_cpu.py
3 failed, 2 passed
```

After the fix:

```text
python -m pytest -q tests/experimental/fully_async_policy/test_engine_workers_on_cpu.py
6 passed

python -m pytest -q \
  tests/experimental/fully_async_policy/test_async_genrm_config_on_cpu.py \
  tests/experimental/fully_async_policy/test_engine_workers_on_cpu.py
11 passed

python -m pytest -q tests/utils/test_fsdp_wrap_policy_on_cpu.py
3 passed

python -m pytest -q tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
6 passed

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed
```

The two-rank regression uses actual FSDP1 sharded state dictionaries rather
than mocked parameter objects.

### API and Usage Example

No public API or configuration changes.

### Design & Code Changes

- `fsdp1_sharded_save_to_cpu()` enters the FSDP1 sharded state-dict context
  and returns each rank's CPU-offloaded local state.
- `fsdp1_sharded_load_from_cpu()` restores that state under the matching
  context.
- `DetachActorWorker` selects handlers by actual representation:
  FSDP1 sharded state dictionaries, FSDP2/VeOmni DTensor shards, or Megatron
  model copies.

### AI Assistance

TRAE AI assisted with repository discovery, implementation, and test drafting.
The human submitter reviewed every changed line, understood the FSDP1 state
lifecycle and test evidence, and explicitly approved publication.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [x] Applied all pre-commit checks with `pre-commit run --all-files`.
- [x] Documentation is not required because this fixes internal strategy
  dispatch without changing user-facing configuration or APIs.
- [x] Added CPU regression tests automatically collected by
  `cpu_unit_tests.yml`.
- [ ] Request CI in the community channel after the PR is available.
- [x] This PR does not modify the `recipe` submodule.
