### PR TITLE
[fully_async] fix: report compute score timing metrics

### DIFF
--- a/tests/experimental/fully_async_policy/test_async_genrm_config_on_cpu.py
+++ b/tests/experimental/fully_async_policy/test_async_genrm_config_on_cpu.py
@@ -12,17 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for async GenRM config validation logic (no GPU required).
+"""CPU unit tests for fully async policy utilities and GenRM config validation.
 
-Tests the config parsing and assertion logic added to FullyAsyncRollouter
-to support GenRM/DisRM in fully async training mode.
+Tests GenRM/DisRM config validation and rollout metric aggregation.
 """
 
 import unittest
 
+import numpy as np
 import pytest
+import torch
 from omegaconf import OmegaConf
+from tensordict import TensorDict
 
+from verl import DataProto
+from verl.experimental.fully_async_policy.detach_utils import (
+    MetricsAggregator,
+    RolloutSample,
+    assemble_batch_from_rollout_samples,
+)
 from verl.trainer.ppo.utils import need_reward_model
 
 
@@ -100,6 +108,48 @@ class TestAsyncRollouterRMAssert(unittest.TestCase):
         config = _make_config(reward_model_enable=True, enable_resource_pool=False)
         with pytest.raises(AssertionError, match="standalone mode"):
             self._validate_async_rm_config(config)
+
+
+def test_compute_score_metrics_are_preserved_and_aggregated():
+    compute_score_times = [0.25, 0.75]
+    full_batch = DataProto(
+        batch=TensorDict(
+            {"response_mask": torch.ones(2, 1, dtype=torch.long)},
+            batch_size=[2],
+        ),
+        non_tensor_batch={
+            "min_global_steps": np.array([1, 1]),
+            "max_global_steps": np.array([1, 2]),
+        },
+        meta_info={
+            "metrics": [
+                {"generate_sequences": 1.0, "tool_calls": 0.0, "compute_score": value} for value in compute_score_times
+            ]
+        },
+    )
+    rollout_sample = RolloutSample(full_batch, sample_id="sample-0", epoch=0, rollout_status={})
+
+    result = assemble_batch_from_rollout_samples([rollout_sample], tokenizer=None, config=None)
+
+    assert result.non_tensor_batch["compute_score_times"] == pytest.approx(compute_score_times)
+    assert result.meta_info["timing_s/agent_loop/compute_score/min"] == pytest.approx(0.25)
+    assert result.meta_info["timing_s/agent_loop/compute_score/mean"] == pytest.approx(0.5)
+    assert result.meta_info["timing_s/agent_loop/compute_score/max"] == pytest.approx(0.75)
+
+    aggregator = MetricsAggregator(total_gpus=1)
+    aggregator.add_step_metrics(result.meta_info, sample_count=2)
+    aggregator.add_step_metrics(
+        {
+            "timing_s/agent_loop/compute_score/min": 0.5,
+            "timing_s/agent_loop/compute_score/mean": 1.0,
+            "timing_s/agent_loop/compute_score/max": 1.5,
+        },
+        sample_count=2,
+    )
+    aggregated = aggregator.get_aggregated_metrics()
+    assert aggregated["timing_s/agent_loop/compute_score/min"] == pytest.approx(0.25)
+    assert aggregated["timing_s/agent_loop/compute_score/mean"] == pytest.approx(0.75)
+    assert aggregated["timing_s/agent_loop/compute_score/max"] == pytest.approx(1.5)
 
 
 if __name__ == "__main__":

--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -76,8 +76,10 @@ def addition_process(output: DataProto):
     metrics = output.meta_info.pop("metrics")  # List[Dict[str, str]]
     processing_times_list = [item["generate_sequences"] for item in metrics]
     tool_calls_times_list = [item["tool_calls"] for item in metrics]
+    compute_score_times_list = [item["compute_score"] for item in metrics]
     output.non_tensor_batch["processing_times"] = processing_times_list
     output.non_tensor_batch["tool_calls_times"] = tool_calls_times_list
+    output.non_tensor_batch["compute_score_times"] = compute_score_times_list
     return output
 
 
@@ -130,6 +132,7 @@ def assemble_batch_from_rollout_samples(
 
     processing_times = final_batch.non_tensor_batch["processing_times"]
     tool_calls = final_batch.non_tensor_batch["tool_calls_times"]
+    compute_score = final_batch.non_tensor_batch["compute_score_times"]
     # Collect statistics
     processing_time_stats = {
         "processing_time/avg": np.mean(processing_times),
@@ -145,6 +148,13 @@ def assemble_batch_from_rollout_samples(
             "timing_s/agent_loop/tool_calls/max": np.max(tool_calls),
             "timing_s/agent_loop/tool_calls/min": np.min(tool_calls),
             "timing_s/agent_loop/tool_calls/mean": np.mean(tool_calls),
+        }
+    compute_score_stats = {}
+    if len(compute_score) > 0:
+        compute_score_stats = {
+            "timing_s/agent_loop/compute_score/max": np.max(compute_score),
+            "timing_s/agent_loop/compute_score/min": np.min(compute_score),
+            "timing_s/agent_loop/compute_score/mean": np.mean(compute_score),
         }
     processing_time_stats = {f"fully_async/{key}": value for key, value in processing_time_stats.items()}
 
@@ -168,6 +178,7 @@ def assemble_batch_from_rollout_samples(
             **rollout_status,
             **partial_stats,
             **tool_calls_stats,
+            **compute_score_stats,
         }
     )
 
@@ -207,9 +218,18 @@ class MetricsAggregator:
         return {
             # Time-Based metrics, can add metrics here
             "time_sum": ["perf/time_per_step"],
-            "min": ["timing_s/agent_loop/tool_calls/min"],
-            "avg": ["timing_s/agent_loop/tool_calls/mean"],
-            "max": ["timing_s/agent_loop/tool_calls/max"],
+            "min": [
+                "timing_s/agent_loop/tool_calls/min",
+                "timing_s/agent_loop/compute_score/min",
+            ],
+            "avg": [
+                "timing_s/agent_loop/tool_calls/mean",
+                "timing_s/agent_loop/compute_score/mean",
+            ],
+            "max": [
+                "timing_s/agent_loop/tool_calls/max",
+                "timing_s/agent_loop/compute_score/max",
+            ],
             "last": [
                 "fully_async/count/total_generated_samples",
                 "fully_async/count/stale_samples_processed",


### PR DESCRIPTION
### What does this PR do?

Fully async training currently drops `AgentLoopMetrics.compute_score` in `addition_process()`, so reward-scoring latency is absent from its step metrics even though synchronous PPO already reports it.

This PR preserves the per-sample timing and reports:

- `timing_s/agent_loop/compute_score/min`
- `timing_s/agent_loop/compute_score/mean`
- `timing_s/agent_loop/compute_score/max`

It also registers explicit cross-step aggregation rules. Without them, the generic `timing_s/` rule would sum all three statistics across micro-steps.

Duplicate search: [open PRs for `fully_async compute_score metric`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fully_async+compute_score+metric). No matching open PR or issue was found; the existing synchronous implementation is the precedent for the metric names and statistics.

AI assistance disclosure: OpenAI Codex helped inspect the synchronous and fully async metric paths, implement the patch and tests, and draft this PR. The submitter reviewed the final diff and test results.

### Checklist Before Starting

- [x] Search for similar PRs. Query linked above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Validated the patch in the existing verl 0.8.0.dev server environment:

```text
python -m pytest /tmp/test_async_genrm_config_on_cpu.py -q
6 passed, 29 warnings in 9.63s

ruff check --config /opt/verl/pyproject.toml <changed files>
All checks passed!

ruff format --config /opt/verl/pyproject.toml --check <changed files>
2 files already formatted
```

The added case is integrated into the existing fully async CPU test file. It covers preservation and batch-level min/mean/max metrics, plus correct min/average/max aggregation across fully async micro-steps.

### API and Usage Example

No API or configuration changes. The three timing metrics appear automatically when fully async training logs step metrics.

### Design & Code Changes

- Carry `compute_score` timing from agent-loop metadata into the assembled rollout batch.
- Compute min, mean and max with the same names used by synchronous PPO.
- Add explicit `MetricsAggregator` rules so each statistic is combined correctly across micro-steps.
- Extend the existing fully async CPU test with coverage for batch assembly and cross-step aggregation.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Run targeted Ruff checks and formatting checks on all changed files.
- [x] Documentation is not required because this does not change an API or configuration.
- [x] Extend existing CPU unit tests to cover the changed behavior.
- [ ] Request CI in the verl community channel after maintainer triage.
