### PR TITLE
[misc] fix: preserve variable-length generation chats

### DIFF
--- a/tests/trainer/test_main_generation_server_on_cpu.py
+++ b/tests/trainer/test_main_generation_server_on_cpu.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from verl.trainer.main_generation_server import _chat_list_to_object_array
+
+
+def test_chat_list_to_object_array_preserves_varying_turn_counts():
+    chats = [
+        [{"role": "user", "content": "one"}],
+        [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+        ],
+    ]
+
+    chat_array = _chat_list_to_object_array(chats)
+
+    assert chat_array.shape == (2,)
+    assert chat_array.dtype == object
+    assert chat_array.tolist() == chats
+
+
+def test_chat_list_to_object_array_does_not_add_a_turn_axis():
+    chats = [
+        [{"role": "user", "content": "one"}],
+        [{"role": "user", "content": "two"}],
+    ]
+
+    chat_array = _chat_list_to_object_array(chats)
+
+    assert chat_array.shape == (2,)
+    assert chat_array.tolist() == chats
+
+
+def test_chat_object_array_splits_without_changing_order():
+    chats = [[{"role": "user", "content": str(i)}] for i in range(5)]
+
+    chat_array = _chat_list_to_object_array(chats)
+    splits = [split.tolist() for split in np.array_split(chat_array, 3)]
+
+    assert splits == [chats[:2], chats[2:4], chats[4:]]

--- a/verl/trainer/main_generation_server.py
+++ b/verl/trainer/main_generation_server.py
@@ -37,6 +37,13 @@ from verl.utils.hdfs_io import makedirs
 from verl.workers.rollout.replica import get_rollout_replica_class
 
 
+def _chat_list_to_object_array(chat_list: list) -> np.ndarray:
+    """Build a one-dimensional object array without coercing nested chat turns."""
+    chat_array = np.empty(len(chat_list), dtype=object)
+    chat_array[:] = chat_list
+    return chat_array
+
+
 async def start_server(config):
     tp_size = config.actor_rollout_ref.rollout.tensor_model_parallel_size
     num_replicas = (config.trainer.n_gpus_per_node * config.trainer.nnodes) // tp_size
@@ -156,7 +163,7 @@ def main(config):
     dataset = pd.concat(datasets, axis=0, ignore_index=True)
     chat_lst = dataset[config.data.prompt_key].tolist()
     chat_lst = [chat.tolist() for chat in chat_lst]
-    chat_numpy = np.array(chat_lst)
+    chat_numpy = _chat_list_to_object_array(chat_lst)
 
     # start native server
     server_handles, server_addresses = asyncio.run(start_server(config))


### PR DESCRIPTION
### What does this PR do?

`main_generation_server` converts parquet chat rows with `np.array(chat_lst)`.
With NumPy 2.x, valid chats containing different numbers of turns raise:

```text
ValueError: setting an array element with a sequence
```

Even when every chat has the same turn count, NumPy can add an unintended
second axis instead of preserving one chat object per dataset row.

This PR builds a one-dimensional object array by assigning each chat row
element-wise. `np.array_split` can then distribute rows across rollout
replicas without coercing or reshaping the nested message lists.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+main_generation_server+ragged+chat
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+np.array+chat_lst
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+varying+turns+generation
- [x] Repeated the searches immediately before publication; no competing PR
  was found among 507 open PRs.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Minimal reproduction before the fix:

```python
np.array([
    [{"role": "user", "content": "one"}],
    [
        {"role": "user", "content": "one"},
        {"role": "assistant", "content": "two"},
        {"role": "user", "content": "three"},
    ],
])
# ValueError: ... inhomogeneous shape ...
```

Regression and related CPU tests:

```text
python -m pytest -q \
  tests/trainer/test_main_generation_server_on_cpu.py \
  tests/trainer/ppo/v1/test_compute_reward_colocate_on_cpu.py
14 passed

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed
```

The new tests cover varying turn counts, equal turn counts, and stable
ordering across `np.array_split`.

### API and Usage Example

No public API or configuration changes.

### Design & Code Changes

- Add `_chat_list_to_object_array()` to create a strictly one-dimensional
  object array.
- Use it before splitting chats across rollout replicas.
- Keep chat messages, sampling, and server request behavior unchanged.

### AI Assistance

TRAE AI assisted with repository discovery, implementation, and test drafting.
The human submitter reviewed every changed line, understood the NumPy object
array behavior and test evidence, and explicitly approved publication.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied all pre-commit checks with `pre-commit run --all-files`.
- [x] Documentation is not required because there is no user-facing API or
  configuration change.
- [x] Added CPU regression tests collected by `cpu_unit_tests.yml`.
- [ ] Request CI in the community channel after the PR is available.
- [x] This PR does not modify the `recipe` submodule.
