### PR TITLE
[reward] fix: clean up PRIME code worker processes

### DIFF
--- a/tests/utils/reward_score/test_prime_code_process_cleanup_on_cpu.py
+++ b/tests/utils/reward_score/test_prime_code_process_cleanup_on_cpu.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.utils.reward_score.prime_code import utils
+
+
+def test_check_correctness_returns_plain_metadata_list():
+    sample = {"inputs": [[1]], "outputs": [[1]], "fn_name": "solve"}
+    generation = "def solve(x):\n    return x"
+
+    result, metadata = utils.check_correctness(sample, generation, timeout=1, debug=False)
+
+    assert type(result) is list
+    assert type(metadata) is list
+
+
+def test_timeout_reaps_worker_and_shuts_down_manager(monkeypatch):
+    managers = []
+    processes = []
+
+    class FakeManager:
+        def __init__(self):
+            self.entered = False
+            self.exited = False
+            managers.append(self)
+
+        def __enter__(self):
+            self.entered = True
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.exited = True
+
+        def list(self):
+            return []
+
+    class FakeProcess:
+        def __init__(self, target, args):
+            self.join_calls = []
+            self.killed = False
+            processes.append(self)
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            self.join_calls.append(timeout)
+
+        def is_alive(self):
+            return not self.killed
+
+        def kill(self):
+            self.killed = True
+
+    monkeypatch.setattr(utils.multiprocessing, "Manager", FakeManager)
+    monkeypatch.setattr(utils.multiprocessing, "Process", FakeProcess)
+
+    sample = {"inputs": [[1]], "outputs": [[1]]}
+    result, metadata = utils.check_correctness(sample, "while True: pass", timeout=0.1, debug=False)
+
+    assert result == [-1]
+    assert metadata == []
+    assert managers[0].entered
+    assert managers[0].exited
+    assert processes[0].killed
+    assert len(processes[0].join_calls) == 2
+    assert processes[0].join_calls[0] == pytest.approx(1.1)
+    assert processes[0].join_calls[1] is None

--- a/verl/utils/reward_score/prime_code/utils.py
+++ b/verl/utils/reward_score/prime_code/utils.py
@@ -43,18 +43,21 @@ def check_correctness(in_outs: Optional[dict], generation, timeout=10, debug=Tru
     The global timeout is to catch some extreme/rare cases not handled by the timeouts
     inside `run_test`"""
 
-    manager = multiprocessing.Manager()
-    result = manager.list()
-    metadata_list = manager.list()
-    p = multiprocessing.Process(target=_temp_run, args=(in_outs, generation, debug, result, metadata_list, timeout))
-    p.start()
-    p.join(timeout=timeout + 1)
-    if p.is_alive():
-        p.kill()
-        # p.terminate()
-    if not result:
-        # consider that all tests failed
-        result = [[-1 for i in range(len(in_outs["inputs"]))]]
-        if debug:
-            print("global timeout")
-    return result[0], metadata_list
+    with multiprocessing.Manager() as manager:
+        result = manager.list()
+        metadata_list = manager.list()
+        p = multiprocessing.Process(target=_temp_run, args=(in_outs, generation, debug, result, metadata_list, timeout))
+        p.start()
+        p.join(timeout=timeout + 1)
+        if p.is_alive():
+            p.kill()
+            p.join()
+        if result:
+            result_value = result[0]
+        else:
+            # consider that all tests failed
+            result_value = [-1 for _ in range(len(in_outs["inputs"]))]
+            if debug:
+                print("global timeout")
+        metadata_value = list(metadata_list)
+    return result_value, metadata_value


### PR DESCRIPTION
### What does this PR do?

`prime_code.check_correctness()` creates a `multiprocessing.Manager` for every
code-reward evaluation and returns its `ListProxy` metadata directly. Keeping
that return value alive also keeps the manager server process alive:

```text
metadata_type=ListProxy
new_children_while_metadata_alive=[<manager pid>]
```

The global-timeout path also calls `kill()` without a subsequent `join()`, so
the killed worker is not explicitly reaped.

This PR scopes the manager with a context manager, copies metadata into a
plain Python list before shutdown, and joins a worker after killing it.
Code execution, scoring, and timeout thresholds are unchanged.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+prime_code+check_correctness+Manager
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+metadata_list+ListProxy
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+code+reward+manager+process+cleanup
- [x] Repeated the searches immediately before publication; no competing PR
  was found among 507 open PRs.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Before:

```text
result_type=list
metadata_type=ListProxy
new_children_while_metadata_alive=[75797]
new_children_after_metadata_release=[]
```

After:

```text
result_type=list
metadata_type=list
new_children_while_metadata_alive=[]
new_children_after_metadata_release=[]
```

Regression and existing PRIME code tests:

```text
python -m pytest -q \
  tests/utils/reward_score/test_prime_code_process_cleanup_on_cpu.py \
  tests/utils/reward_score/test_sandbox_on_cpu.py \
  -k 'process_cleanup or prime_code or check_correctness'
4 passed, 1 skipped

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed
```

The new tests verify both the real return type and the timeout lifecycle:
manager context exit, worker kill, and post-kill join.

### API and Usage Example

No signature change. The metadata return value is now a regular `list` rather
than a manager-backed `ListProxy`.

### Design & Code Changes

- Keep manager proxies inside a `with multiprocessing.Manager()` scope.
- Materialize result metadata before leaving that scope.
- Reap a killed timeout worker with an unconditional second `join()`.

### AI Assistance

TRAE AI assisted with repository discovery, implementation, and test drafting.
The human submitter reviewed every changed line, understood the process
lifecycle and test evidence, and explicitly approved publication.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied all pre-commit checks with `pre-commit run --all-files`.
- [x] Documentation is not required because the public function signature and
  scoring semantics do not change.
- [x] Added CPU regression tests collected by `cpu_unit_tests.yml`.
- [ ] Request CI in the community channel after the PR is available.
- [x] This PR does not modify the `recipe` submodule.
