### PR TITLE
[ckpt] fix: parse resume step from checkpoint directory

### DIFF
--- a/tests/utils/checkpoint/test_checkpoint_handler_on_cpu.py
+++ b/tests/utils/checkpoint/test_checkpoint_handler_on_cpu.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from verl.utils.checkpoint.checkpoint_handler import extract_step
+
+
+def test_extract_step_uses_checkpoint_directory_not_parent():
+    path = os.path.join("/tmp", "global_step_900", "archive", "global_step_12")
+
+    assert extract_step(path) == 12
+
+
+def test_extract_step_accepts_trailing_path_separator():
+    path = os.path.join("/tmp", "run", "global_step_37", "")
+
+    assert extract_step(path) == 37
+
+
+def test_extract_step_rejects_non_checkpoint_directory():
+    path = os.path.join("/tmp", "run", "global_step_37", "actor")
+
+    assert extract_step(path) is None

--- a/verl/utils/checkpoint/checkpoint_handler.py
+++ b/verl/utils/checkpoint/checkpoint_handler.py
@@ -31,7 +31,8 @@ from verl.workers.engine import BaseEngine
 
 
 def extract_step(path):
-    match = re.search(r"global_step_(\d+)", path)
+    checkpoint_dir = os.path.basename(os.path.normpath(path))
+    match = re.fullmatch(r"global_step_(\d+)", checkpoint_dir)
     if match:
         return int(match.group(1))
     return None


### PR DESCRIPTION
### What does this PR do?

The SFT `CheckpointHandler` derives the resumed training counter with:

```python
re.search(r"global_step_(\d+)", path)
```

Because the search scans the complete path, an earlier marker in a parent
directory wins. For example:

```text
/tmp/global_step_900/archive/global_step_12 -> 900
```

The model and dataloader load checkpoint 12, while the trainer resumes its
counter at step 900. A child path such as `global_step_37/actor` is also
accepted even though it is not the checkpoint root.

This PR normalizes the path and extracts the step only when the final directory
name exactly matches `global_step_N`.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+CheckpointHandler+extract_step
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+resume_from_path+global_step+basename
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+checkpoint+parent+global_step
- [x] Audited 510 open PRs and changed files; no competing implementation was
  found.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Before the fix:

```text
expected checkpoint 12, got 900
expected child path rejection, got 37
2 failed, 1 passed
```

After the fix:

```text
python -m pytest -q \
  tests/utils/checkpoint/test_checkpoint_handler_on_cpu.py \
  tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py
8 passed

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed
```

The tests cover parent-directory markers, trailing path separators, and
non-checkpoint child directories.

### API and Usage Example

No public API or configuration changes. Valid checkpoint roots named
`global_step_N` continue to work.

### Design & Code Changes

- Normalize the supplied checkpoint path.
- Match `global_step_N` against its basename with `re.fullmatch`.
- Return `None` when the supplied path is not a checkpoint root.

### AI Assistance

TRAE AI assisted with repository discovery, implementation, and test drafting.
The human submitter reviewed every changed line, understood the resume-counter
risk and test evidence, and explicitly approved publication.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied all pre-commit checks with `pre-commit run --all-files`.
- [x] Documentation is not required because valid user-facing paths retain the
  same format and behavior.
- [x] Added CPU regression tests collected by `cpu_unit_tests.yml`.
- [ ] Request CI in the community channel after the PR is available.
- [x] This PR does not modify the `recipe` submodule.
