### PR TITLE
[ci] chore: remove RAY_DEDUP_LOGS=0 from GSPO Qwen3-8B FSDP2 NPU nightly test

### DIFF
--- a/tests/special_npu/nightly_ci_ascend/run_gspo_qwen3_8b_fsdp2_npu.sh
+++ b/tests/special_npu/nightly_ci_ascend/run_gspo_qwen3_8b_fsdp2_npu.sh
@@ -3,7 +3,6 @@
 
 set -xeuo pipefail
 
-export RAY_DEDUP_LOGS=0
 export HYDRA_FULL_ERROR=1
 export TASK_QUEUE_ENABLE=1
 export HCCL_EXEC_TIMEOUT=3600


### PR DESCRIPTION
### What does this PR do?

Remove `export RAY_DEDUP_LOGS=0` from `tests/special_npu/nightly_ci_ascend/run_gspo_qwen3_8b_fsdp2_npu.sh` so the GSPO Qwen3-8B FSDP2 NPU nightly test uses Ray's default log dedup behavior (less noisy logs / avoid duplicate log flooding).

### Checklist Before Starting

- [ ] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=RAY_DEDUP_LOGS — no open PR found.
- [ ] Format the PR title as `[{modules}] {type}: {description}`.

### Test

- Ran pre-commit on the changed file (shellcheck passed).
- The change only removes one env var export from a CI test script; no training/algorithm behavior affected.

### API and Usage Example

No API change.

### Design & Code Changes

- Removed `export RAY_DEDUP_LOGS=0` from `tests/special_npu/nightly_ci_ascend/run_gspo_qwen3_8b_fsdp2_npu.sh`.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply pre-commit checks.
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s). Not needed: the change is to an existing nightly CI script.
- [ ] Send a message in the `ci-request` channel on Slack/Feishu once ready for CI.