### PR TITLE
[cfg] fix: validate per-GPU static micro batches

### DIFF
--- a/tests/utils/test_config_on_cpu.py
+++ b/tests/utils/test_config_on_cpu.py
@@ -14,11 +14,14 @@
 
 import unittest
 from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from omegaconf import OmegaConf
 
 from verl.base_config import BaseConfig
 from verl.utils import omega_conf_to_dataclass
+from verl.utils.config import validate_config
 
 
 @dataclass
@@ -91,6 +94,60 @@ class TestPrintCfgCommand(unittest.TestCase):
         # Verify the output contains expected config information
         self.assertIn("critic", result.stdout)
         self.assertIn("profiler", result.stdout)
+
+
+class TestStaticMicroBatchValidation(unittest.TestCase):
+    @staticmethod
+    def _config(train_batch_size, sp_size=1):
+        return OmegaConf.create(
+            {
+                "trainer": {"n_gpus_per_node": 8, "nnodes": 1},
+                "data": {"train_batch_size": train_batch_size},
+                "actor_rollout_ref": {
+                    "actor": {
+                        "strategy": "fsdp",
+                        "use_dynamic_bsz": False,
+                        "ppo_micro_batch_size": None,
+                        "ppo_micro_batch_size_per_gpu": 3,
+                        "ulysses_sequence_parallel_size": sp_size,
+                        "fsdp_config": {"ulysses_sequence_parallel_size": sp_size},
+                        "use_kl_loss": False,
+                    },
+                    "rollout": {
+                        "n": 1,
+                        "name": "sglang",
+                        "log_prob_micro_batch_size": None,
+                        "log_prob_micro_batch_size_per_gpu": 1,
+                        "val_kwargs": {"do_sample": False},
+                    },
+                    "ref": {
+                        "log_prob_micro_batch_size": None,
+                        "log_prob_micro_batch_size_per_gpu": 1,
+                    },
+                    "model": {"lora": {}, "lora_rank": 0},
+                },
+                "algorithm": {"use_kl_in_reward": False},
+            }
+        )
+
+    @patch("verl.utils.config.omega_conf_to_dataclass")
+    def test_rejects_batch_smaller_than_per_gpu_micro_batch_product(self, to_dataclass):
+        to_dataclass.return_value = SimpleNamespace(validate=lambda *args: None)
+
+        with self.assertRaisesRegex(AssertionError, r"minimal possible batch size \(24\)"):
+            validate_config(self._config(train_batch_size=8), use_reference_policy=False, use_critic=False)
+
+    @patch("verl.utils.config.omega_conf_to_dataclass")
+    def test_accepts_batch_divisible_by_per_gpu_micro_batch_product(self, to_dataclass):
+        to_dataclass.return_value = SimpleNamespace(validate=lambda *args: None)
+
+        validate_config(self._config(train_batch_size=24), use_reference_policy=False, use_critic=False)
+
+    @patch("verl.utils.config.omega_conf_to_dataclass")
+    def test_accounts_for_ulysses_sequence_parallel_size(self, to_dataclass):
+        to_dataclass.return_value = SimpleNamespace(validate=lambda *args: None)
+
+        validate_config(self._config(train_batch_size=12, sp_size=2), use_reference_policy=False, use_critic=False)
 
 
 if __name__ == "__main__":

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -103,7 +103,17 @@ def validate_config(
             )
             minimal_bsz = megatron_dp * config.actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu
         else:
-            minimal_bsz = n_gpus
+            micro_batch_size_per_gpu = config.actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu
+            if micro_batch_size_per_gpu is None:
+                minimal_bsz = n_gpus
+            else:
+                sp_size = config.actor_rollout_ref.actor.get("ulysses_sequence_parallel_size", 1)
+                fsdp_config = config.actor_rollout_ref.actor.get("fsdp_config", {})
+                sp_size = max(sp_size, fsdp_config.get("ulysses_sequence_parallel_size", 1))
+                assert n_gpus % sp_size == 0, (
+                    f"n_gpus ({n_gpus}) must be divisible by ulysses_sequence_parallel_size ({sp_size})"
+                )
+                minimal_bsz = n_gpus // sp_size * micro_batch_size_per_gpu
 
         # 1. Check total batch size for data correctness
         real_train_batch_size = config.data.train_batch_size * config.actor_rollout_ref.rollout.n


### PR DESCRIPTION
### What does this PR do?

For static actor batching, `validate_config()` checks that:

```text
train_batch_size * rollout.n
```

is divisible by the smallest batch the workers can consume. The Megatron path
already uses `DP size * ppo_micro_batch_size_per_gpu`, but other backends only
use the GPU count and ignore the configured per-GPU micro-batch size.

For example, 8 FSDP workers with
`ppo_micro_batch_size_per_gpu=3` incorrectly accept a global batch of 8.
Each DP worker then receives one sample and fails later in
`prepare_micro_batches()`, which requires divisibility by 3.

This PR validates against:

```text
(n_gpus / ulysses_sequence_parallel_size) * ppo_micro_batch_size_per_gpu
```

when the new per-GPU option is used. The deprecated global micro-batch path
keeps its existing behavior.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ppo_micro_batch_size_per_gpu+validate_config+minimal_bsz
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+real_train_batch_size+per+gpu+micro+batch
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+FSDP+micro+batch+divisibility+validation
- [x] Audited 512 open PRs and changed files; no competing implementation was
  found.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Before the fix, the invalid 8-sample batch printed:

```text
[validate_config] All configuration checks passed successfully!
```

After the fix:

```text
PATH=.venv/bin:$PATH python -m pytest -q \
  tests/utils/test_config_on_cpu.py \
  tests/workers/config/test_actor_config_on_cpu.py
16 passed

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed
```

The tests cover an invalid 8 GPU x 3 micro-batch configuration, a valid global
batch of 24, and Ulysses SP=2 where the valid minimum is 12.

### API and Usage Example

No public API or configuration changes. Invalid static configurations now fail
during startup instead of after worker dispatch.

### Design & Code Changes

- Use the per-GPU actor micro-batch size when present.
- Reduce the effective DP size by the configured Ulysses SP size.
- Preserve the legacy global micro-batch validation path.

### AI Assistance

TRAE AI assisted with repository discovery, implementation, and test drafting.
The human submitter reviewed every changed line, understood the batch
divisibility rule and test evidence, and explicitly approved publication.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied all pre-commit checks with `pre-commit run --all-files`.
- [x] Documentation is not required because the configuration schema is
  unchanged.
- [x] Added CPU regression tests collected by `cpu_unit_tests.yml`.
- [ ] Request CI in the community channel after the PR is available.
- [x] This PR does not modify the `recipe` submodule.
