### PR TITLE
[trainer] fix: isolate validation bootstrap randomness

### DIFF
--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -491,6 +491,17 @@ class TestBootstrapMetric(unittest.TestCase):
         with self.assertRaises(ValueError):
             bootstrap_metric([], subset_size=1, reduce_fns=[np.mean])
 
+    def test_bootstrap_metric_does_not_reset_global_numpy_rng(self):
+        """Bootstrap sampling must not perturb unrelated NumPy randomness."""
+        np.random.seed(1234)
+        expected = np.random.random(3)
+
+        np.random.seed(1234)
+        bootstrap_metric([1, 2, 3], subset_size=2, reduce_fns=[np.mean], n_bootstrap=5, seed=42)
+        actual = np.random.random(3)
+
+        np.testing.assert_array_equal(actual, expected)
+
 
 class TestCalcMajVal(unittest.TestCase):
     """Tests for the calc_maj_val function."""

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -832,12 +832,12 @@ def bootstrap_metric(
         >>> bootstrap_metric(data, 3, reduce_fns)
         [(3.0, 0.5), (4.5, 0.3)]  # Example values
     """
-    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
     data_np = np.array(data, dtype=object)
     n_data = len(data_np)
 
     # generate bootstrap indices, shape: (n_bootstrap, subset_size)
-    bootstrap_idxs = np.random.choice(n_data, size=(n_bootstrap, subset_size), replace=True)
+    bootstrap_idxs = rng.choice(n_data, size=(n_bootstrap, subset_size), replace=True)
 
     # pre-allocate result array, shape: (n_fns, n_bootstrap)
     n_fns = len(reduce_fns)


### PR DESCRIPTION
### What does this PR do?

`bootstrap_metric()` currently calls `np.random.seed(seed)` before drawing
bootstrap indices. Validation therefore resets the process-wide NumPy random
stream every time these metrics are computed.

A minimal reproduction shows unrelated random values changing after a metric
call:

```text
expected [0.191519, 0.622109, 0.437728]
actual   [0.058084, 0.866176, 0.601115]
```

This PR uses a local `np.random.RandomState(seed)` for bootstrap sampling.
Results remain reproducible for the same seed and retain the legacy
`RandomState` sampling sequence, while unrelated NumPy users keep their state.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+bootstrap_metric+np.random.seed
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+validation+metrics+global+numpy+rng
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+bootstrap+local+rng+metric_utils
- [x] Audited 512 open PRs and changed files; no competing implementation was
  found.
- [x] PR #7240 modifies the same metric file to add pass@k but does not change
  bootstrap RNG ownership.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Before the fix, the new RNG-isolation assertion failed for all three sampled
values.

```text
python -m pytest -q tests/trainer/ppo/test_metric_utils_on_cpu.py
37 passed

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed
```

The regression test seeds the global RNG, calls `bootstrap_metric`, and verifies
that the next values are exactly those expected without the metric call.

### API and Usage Example

No public API or metric-name changes. The `seed` argument remains deterministic
and maps to the same legacy bootstrap samples.

### Design & Code Changes

- Instantiate a local `np.random.RandomState(seed)`.
- Draw bootstrap indices from that local generator.
- Leave the global NumPy random state untouched.

### AI Assistance

TRAE AI assisted with repository discovery, implementation, and test drafting.
The human submitter reviewed every changed line, understood the RNG isolation
and compatibility choice, and explicitly approved publication.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied all pre-commit checks with `pre-commit run --all-files`.
- [x] Documentation is not required because metric APIs and names are
  unchanged.
- [x] Added CPU regression coverage to the existing metric test suite.
- [ ] Request CI in the community channel after the PR is available.
- [x] This PR does not modify the `recipe` submodule.
