### PR TITLE
[megatron] fix: pad multidimensional THD tensors along the sequence dimension

### DIFF
--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -150,6 +150,27 @@ def test_preprocess_thd_engine_pads_to_minimum_rows(monkeypatch):
     torch.testing.assert_close(local_positions[0, 100:], torch.zeros(28, dtype=torch.long))
 
 
+@pytest.mark.parametrize("cp_rank", [0, 1])
+def test_preprocess_thd_engine_pads_multidimensional_router_data(monkeypatch, cp_rank):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(
+        monkeypatch,
+        tp_size=1,
+        cp_size=2,
+        cp_rank=cp_rank,
+    )
+    route = torch.arange(48 * 8, dtype=torch.long).reshape(1, 48, 8)
+    routed_experts = _nested_tensor([route])
+
+    local_routes, packed_seq_params, _ = mcore_util.preprocess_thd_engine(routed_experts)
+
+    expected = torch.zeros((2, 48, 8), dtype=torch.long)
+    if cp_rank == 0:
+        expected[0] = route[0]
+    assert local_routes.shape == (1, 2, 48, 8)
+    assert packed_seq_params.cu_seqlens_q_padded.tolist() == [0, 4]
+    torch.testing.assert_close(local_routes[0], expected)
+
+
 @pytest.mark.parametrize(
     ("cp_rank", "expected_ids", "expected_positions"),
     [

--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -172,6 +172,28 @@ def test_preprocess_thd_engine_pads_multidimensional_router_data(monkeypatch, cp
 
 
 @pytest.mark.parametrize(
+    ("cp_rank", "expected"),
+    [
+        (0, [2, 3, 1, 1]),
+        (1, [4, 5, 6, 7]),
+    ],
+)
+def test_preprocess_thd_engine_preserves_1d_zigzag_roll_alignment(monkeypatch, cp_rank, expected):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(
+        monkeypatch,
+        tp_size=1,
+        cp_size=2,
+        cp_rank=cp_rank,
+    )
+    labels = _nested_tensor([torch.arange(1, 8, dtype=torch.long)])
+
+    local_labels, packed_seq_params, _ = mcore_util.preprocess_thd_engine(labels, need_roll=True)
+
+    assert packed_seq_params.cu_seqlens_q_padded.tolist() == [0, 8]
+    torch.testing.assert_close(local_labels[0], torch.tensor(expected, dtype=torch.long))
+
+
+@pytest.mark.parametrize(
     ("cp_rank", "expected_ids", "expected_positions"),
     [
         (0, [10, 11, 12, 13, 14], [0, 1, 2, 3, 4]),

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -446,9 +446,6 @@ def preprocess_thd_engine(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i]
-            # Keep the legacy 1-D padding boundary used by need_roll below.
-            # Dense per-token metadata must instead pad the sequence dimension
-            # while preserving its trailing dimensions.
             pad_target = align_size if d.dim() == 1 else seqlen_padded_i
             if d.shape[0] < pad_target:
                 original_seqlen = d.shape[0]

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -446,17 +446,14 @@ def preprocess_thd_engine(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i]
-            # If the number of elements in `d` is smaller than the required
-            # alignment size, pad the tensor with zeros so that its total
-            # length matches `align_size`. This ensures size alignment for
-            # downstream operations (e.g., communication or memory alignment).
-            if d.numel() < align_size:
-                original_size = d.numel()
-                pad = torch.zeros(align_size - d.numel(), dtype=d.dtype, device=d.device)
+            if d.shape[0] < seqlen_padded_i:
+                original_seqlen = d.shape[0]
+                pad_shape = (seqlen_padded_i - original_seqlen, *d.shape[1:])
+                pad = torch.zeros(pad_shape, dtype=d.dtype, device=d.device)
                 d = torch.cat([d, pad], dim=0)
                 logger.warning_once(
-                    f"Padding tensor for context parallel alignment, original_size={original_size}, "
-                    f"align_size={align_size}"
+                    f"Padding tensor for context parallel alignment, original_seqlen={original_seqlen}, "
+                    f"padded_seqlen={seqlen_padded_i}"
                 )
 
             input_ids_rmpad[start_idx : start_idx + half_seqlen] = d[

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -446,15 +446,17 @@ def preprocess_thd_engine(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i]
-            pad_target = align_size if d.dim() == 1 else seqlen_padded_i
-            if d.shape[0] < pad_target:
-                original_seqlen = d.shape[0]
-                pad_shape = (pad_target - original_seqlen, *d.shape[1:])
+            # If the number of elements in `d` is smaller than the required
+            # alignment size, pad the tensor with zeros so that its total
+            # length matches `align_size`. This ensures size alignment for
+            # downstream operations (e.g., communication or memory alignment).
+            if d.shape[0] < align_size:
+                pad_shape = (align_size - d.shape[0], *d.shape[1:])
                 pad = torch.zeros(pad_shape, dtype=d.dtype, device=d.device)
                 d = torch.cat([d, pad], dim=0)
                 logger.warning_once(
-                    f"Padding tensor for context parallel alignment, original_seqlen={original_seqlen}, "
-                    f"padded_seqlen={pad_target}"
+                    f"Padding tensor for context parallel alignment, original_size={d.shape[0]}, "
+                    f"align_size={align_size}"
                 )
 
             input_ids_rmpad[start_idx : start_idx + half_seqlen] = d[

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -446,14 +446,18 @@ def preprocess_thd_engine(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i]
-            if d.shape[0] < seqlen_padded_i:
+            # Keep the legacy 1-D padding boundary used by need_roll below.
+            # Dense per-token metadata must instead pad the sequence dimension
+            # while preserving its trailing dimensions.
+            pad_target = align_size if d.dim() == 1 else seqlen_padded_i
+            if d.shape[0] < pad_target:
                 original_seqlen = d.shape[0]
-                pad_shape = (seqlen_padded_i - original_seqlen, *d.shape[1:])
+                pad_shape = (pad_target - original_seqlen, *d.shape[1:])
                 pad = torch.zeros(pad_shape, dtype=d.dtype, device=d.device)
                 d = torch.cat([d, pad], dim=0)
                 logger.warning_once(
                     f"Padding tensor for context parallel alignment, original_seqlen={original_seqlen}, "
-                    f"padded_seqlen={seqlen_padded_i}"
+                    f"padded_seqlen={pad_target}"
                 )
 
             input_ids_rmpad[start_idx : start_idx + half_seqlen] = d[


### PR DESCRIPTION
### What does this PR do?

Fix a context-parallel shape mismatch in `preprocess_thd_engine` when processing multidimensional nested tensors such as Router Replay data.

The observed error was:

    RuntimeError: The expanded size of the tensor (1) must match
    the existing size (0) at non-singleton dimension 0.
    Target sizes: [1, 48, 8].
    Tensor sizes: [0, 48, 8].

### Root cause

The existing padding logic was introduced with one-dimensional inputs in mind:

    d.shape = [seq_len]

For a one-dimensional tensor:

    d.numel() == d.shape[0] == seq_len

However, the same function is also used for multidimensional per-token metadata, including Router Replay tensors:

    d.shape = [seq_len, num_layers, topk]

For the failing case:

    d.shape    = [1, 48, 8]
    d.shape[0] = 1
    d.numel()  = 384

Context-parallel alignment and chunk slicing operate along dimension 0, but the previous condition compared the total number of scalar elements with the sequence alignment size:

    if d.numel() < align_size:

With `tp_size=1`, `cp_size=2`, and zigzag CP:

    align_size       = 4
    original seq_len = 1
    padded seq_len   = 4

The old condition evaluates to `384 < 4`, so padding is skipped. A later CP rank then reads an empty sequence slice with shape `[0, 48, 8]` and assigns it into a destination with shape `[1, 48, 8]`, causing the RuntimeError.

The old padding tensor was also one-dimensional and therefore could not correctly pad tensors with dense trailing dimensions.

### Fix

Select the padding target according to the tensor layout:

    pad_target = align_size if d.dim() == 1 else seqlen_padded_i

For one-dimensional inputs, the existing `align_size` behavior is preserved. This is important because labels and MTP loss masks use `need_roll=True`, whose boundary handling depends on the existing one-dimensional padding behavior.

For multidimensional inputs, padding is applied along the sequence dimension up to `seqlen_padded_i`, while preserving all trailing dimensions:

    pad_shape = (
        pad_target - original_seqlen,
        *d.shape[1:],
    )

For the reported Router Replay tensor:

    input:   [1, 48, 8]
    padding: [3, 48, 8]
    result:  [4, 48, 8]

This gives every CP rank correctly shaped chunks while preserving the layer and top-k dimensions.

### Compatibility

The fix intentionally preserves all existing one-dimensional behavior, including zigzag CP label rolling.

A differential test compared the old and new implementations across:

- sequence lengths 1 through 64;
- TP sizes 1, 2, and 4;
- CP sizes 2 and 4;
- every CP rank;
- both `need_roll=False` and `need_roll=True`.

Result:

    2304 cases compared
    0 one-dimensional behavior differences

The following paths remain behaviorally unchanged:

- input IDs;
- labels;
- loss masks;
- replay masks;
- `need_roll=True` label processing;
- `cp_size <= 1`;
- contiguous CP layout.

Multidimensional Router Replay and teacher top-k tensors now receive shape-preserving sequence padding.

### Test

Added regression coverage for:

1. Multidimensional Router Replay data shaped `[1, 48, 8]` on both CP ranks.
2. One-dimensional zigzag label rolling with a non-aligned sequence length, ensuring legacy `need_roll` behavior remains unchanged.

Test command:

    PYTHONPATH="/opt/tiger/verl" pytest -q \
      tests/utils/test_megatron_bshd_preprocess.py \
      tests/workers/test_router_replay_engine_helpers_on_cpu.py \
      tests/utils/veomni/test_router_replay_on_cpu.py \
      tests/workers/test_megatron_distillation_only_on_cpu.py \
      tests/workers/test_distillation_topk_symmetry_on_cpu.py

Result:

    48 passed

Pre-commit checks for the changed files also passed.

### API and Usage Example

No public API or configuration changes are required. This only corrects internal THD padding for tensors with dense trailing dimensions.

### Related work

The original one-dimensional padding logic was introduced in #5410.

PR #6703 addresses a related one-dimensional FP8 + CP padding issue. This PR does not change the existing one-dimensional padding contract; it specifically removes the one-dimensional assumption for Router Replay and other multidimensional per-token metadata.

### AI assistance

AI assistance was used to investigate the failure, audit all `preprocess_thd_engine` call sites, perform differential testing, and draft this change. The human submitter reviewed the changed code and test coverage.