### PR TITLE
[reward] fix: restore PRIME scoring event loop

### DIFF
--- a/tests/workers/reward_manager/test_prime_on_cpu.py
+++ b/tests/workers/reward_manager/test_prime_on_cpu.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from verl.workers.reward_manager import prime
+
+
+async def _fake_parallel_compute_score_async(*args, **kwargs):
+    return [0.5]
+
+
+def test_run_reward_scoring_restores_previous_event_loop(monkeypatch):
+    monkeypatch.setattr(prime, "parallel_compute_score_async", _fake_parallel_compute_score_async)
+    previous_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(previous_loop)
+
+    try:
+        scores = prime.run_reward_scoring(
+            evaluation_func=None,
+            completions=["completion"],
+            references=["reference"],
+            tasks=["task"],
+            num_processes=1,
+        )
+
+        assert scores == [0.5]
+        assert asyncio.get_event_loop() is previous_loop
+        assert not previous_loop.is_closed()
+    finally:
+        asyncio.set_event_loop(None)
+        previous_loop.close()

--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -89,6 +89,11 @@ async def parallel_compute_score_async(
 
 
 def run_reward_scoring(evaluation_func, completions, references, tasks, extra_info=None, num_processes=64):
+    try:
+        previous_loop = asyncio.get_event_loop()
+    except RuntimeError:
+        previous_loop = None
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
@@ -97,6 +102,7 @@ def run_reward_scoring(evaluation_func, completions, references, tasks, extra_in
         )
     finally:
         loop.close()
+        asyncio.set_event_loop(previous_loop)
 
 
 @register("prime")


### PR DESCRIPTION
### What does this PR do?

`run_reward_scoring` installs a temporary asyncio event loop and closes it after PRIME scoring, but it leaves that closed loop as the thread's current loop. Callers that previously owned an open loop then observe the wrong, closed loop after scoring.

This change captures the caller's current loop, restores it after the temporary scoring loop is closed, and adds a CPU regression test proving that the caller loop remains current and open.

### Checklist Before Starting

- [x] Searched for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22run_reward_scoring%22+%22event+loop%22
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22PRIME%22+%22closed+event+loop%22
- [x] This does not duplicate PR #4939, which only changes the vLLM rollout path.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

```text
.venv/bin/python -m pytest -q tests/workers/reward_manager/test_prime_on_cpu.py
1 passed

pre-commit run --all-files --show-diff-on-failure --color=never
All hooks passed
```

Before the fix, scoring returned successfully but `asyncio.get_event_loop()` resolved to the closed temporary loop. After the fix, it resolves to the original open caller loop.

### API and Usage Example

No API or configuration changes.

### Design & Code Changes

- Capture the current event loop before installing PRIME's temporary loop.
- Preserve the existing behavior when no current loop is configured.
- Close the temporary loop in `finally`, then restore the caller's previous loop.
- Add a focused CPU test with the async scoring function stubbed to avoid multiprocessing or external dependencies.

### AI Assistance

TRAE AI was used to investigate event-loop ownership, implement the focused restoration, add the regression test, and draft this description. The human submitter reviewed every changed line and ran the relevant tests.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [x] Applied all pre-commit checks.
- [x] Added a focused CPU regression test.
- [x] No documentation update is needed because this fixes internal loop ownership without changing the API.
- [ ] Request project CI in Slack/Feishu when maintainers are ready to run it.
- [x] Recipe submodule update is not applicable.
