### PR TITLE
[misc] fix: reap stubborn timeout processes

### DIFF
--- a/tests/utils/test_timeout_decorator_cpu.py
+++ b/tests/utils/test_timeout_decorator_cpu.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import multiprocessing
+import os
+import signal
 import sys
 import threading
 import time
@@ -38,6 +40,14 @@ def slow_task(x):
     """A task that takes longer than the timeout."""
     time.sleep(LONG_TASK_DURATION)
     return "slow_finished"  # This return value indicates it didn't time out
+
+
+def task_ignores_sigterm(pid_queue):
+    """Keep running after SIGTERM so timeout cleanup must escalate."""
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    pid_queue.put(os.getpid())
+    while True:
+        time.sleep(0.1)
 
 
 # REMOVE global decorator here
@@ -108,6 +118,33 @@ def test_slow_task_timeout():  # Renamed from test_multiprocessing_slow_task_tim
         slow_task(1)
     # Check the error message from the multiprocessing implementation
     assert f"timed out after {TEST_TIMEOUT_SECONDS} seconds" in str(excinfo.value)  # Use pytest assert
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires POSIX signal handling")
+def test_timeout_kills_task_that_ignores_sigterm():
+    """A timed-out child must not survive after ignoring graceful termination."""
+    pid_queue = multiprocessing.Queue()
+    task = timeout(seconds=0.2)(task_ignores_sigterm)
+    pid = None
+
+    try:
+        with pytest.raises(TimeoutError):
+            task(pid_queue)
+        pid = pid_queue.get(timeout=1)
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
+    finally:
+        pid_queue.close()
+        pid_queue.join_thread()
+        if pid is not None:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
 
 
 def test_internal_exception():  # Renamed from test_multiprocessing_internal_exception

--- a/verl/utils/py_functional.py
+++ b/verl/utils/py_functional.py
@@ -113,10 +113,15 @@ def timeout_limit(seconds: float, use_signals: bool = False):
                 process.join(timeout=seconds)
 
                 if process.is_alive():
-                    process.terminate()
-                    process.join(timeout=0.5)  # Give it a moment to terminate
-                    if process.is_alive():
-                        print(f"Warning: Process {process.pid} did not terminate gracefully after timeout.")
+                    try:
+                        process.terminate()
+                        process.join(timeout=0.5)  # Give it a moment to terminate
+                        if process.is_alive():
+                            process.kill()
+                            process.join()
+                    finally:
+                        q.close()
+                        q.join_thread()
                     # Update function name in error message if needed (optional but good practice)
                     raise TimeoutError(f"Function {func.__name__} timed out after {seconds} seconds (multiprocessing)!")
 


### PR DESCRIPTION
### What does this PR do?

The multiprocessing timeout path currently stops cleanup after `terminate()` and a short join. A child that ignores `SIGTERM` therefore survives after the decorated call raises `TimeoutError`.

This change escalates cleanup to `Process.kill()` when graceful termination fails, waits for the child to exit, and closes the result queue on the timeout path. A POSIX regression test uses a child that ignores `SIGTERM` and verifies that its PID no longer exists when the timeout returns.

### Checklist Before Starting

- [x] Searched for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+timeout_limit
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22ignores+SIGTERM%22
- [x] This does not duplicate PR #5600, whose `py_functional.py` change only updates metric aggregation.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

```text
.venv/bin/python -m pytest -q tests/utils/test_timeout_decorator_cpu.py
7 passed, 1 skipped

pre-commit run --all-files --show-diff-on-failure --color=never
All hooks passed
```

Before the fix, the timeout returned after warning that the child did not terminate and the PID remained signalable. After the fix, the same stubborn child is killed and reaped before `TimeoutError` is raised.

### API and Usage Example

No API or configuration changes.

### Design & Code Changes

- Keep the existing graceful `terminate()` attempt and 0.5-second grace period.
- Escalate to `kill()` only when the process remains alive.
- Join without a timeout after `kill()` so the function does not return with an unreaped child.
- Close and join the multiprocessing queue on this failure path.
- Add POSIX-only regression coverage for a child that ignores `SIGTERM`.

### AI Assistance

TRAE AI was used to investigate the process-lifecycle failure, implement the focused change, add the regression test, and draft this description. The human submitter reviewed every changed line and ran the relevant tests.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [x] Applied all pre-commit checks.
- [x] Added a focused CPU regression test.
- [x] No documentation update is needed because this fixes internal cleanup without changing the API.
- [ ] Request project CI in Slack/Feishu when maintainers are ready to run it.
- [x] Recipe submodule update is not applicable.
