### PR TITLE
[reward] feat: batch-capable RewardManager for experimental reward_loop

### DIFF
--- a/docs/advance/reward_loop.rst
+++ b/docs/advance/reward_loop.rst
@@ -137,8 +137,9 @@ The ``RewardManager`` maintains a reward function and defines its computation lo
 - **dapo**: DAPO implementation with an overlong reward penalty.
 - **limit**: Restricts the concurrency of the reward function, useful when external API calls are rate-limited.
 - **remote**: Runs in a separate process, effective for CPU-intensive tasks such as ``Math-Verify``.
+- **batch**: Forwards the whole chunk to a single ``compute_score`` call with plural kwargs (``data_sources`` / ``solution_strs`` / ``ground_truths`` / ``extra_infos``). Useful when the user reward function can amortize per-sample work (e.g. batched tokenization, one-shot remote inference).
 
-Users can also customize their own ``RewardManager``, inheriting from ``RewardManagerBase``, and implementing the ``run_single`` function.
+Users can also customize their own ``RewardManager``, inheriting from ``RewardManagerBase``, and implementing the ``run_single`` function. Custom managers may additionally override ``run_batch`` to receive the whole chunk in one call; the base class provides a default ``run_batch`` that fans out to ``run_single`` per sample, so existing managers keep their behavior with no changes.
 
 .. code:: python
 

--- a/tests/experimental/reward_loop/test_batch_reward_manager.py
+++ b/tests/experimental/reward_loop/test_batch_reward_manager.py
@@ -1,0 +1,397 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os.path
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import DictConfig
+from transformers import AutoTokenizer
+
+from verl import DataProto
+from verl.experimental.reward_loop.reward_loop import RewardLoopWorker
+from verl.experimental.reward_loop.reward_manager.batch import BatchRewardManager
+from verl.experimental.reward_loop.reward_manager.naive import NaiveRewardManager
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    # Match the convention used by sibling reward_loop tests
+    # (e.g. test_rate_limited_reward_manager_on_cpu.py): default to
+    # ~/models/Qwen/Qwen2.5-0.5B-Instruct so CI works out of the box, with
+    # env-var override for local runs where the model lives elsewhere.
+    path = os.environ.get("BATCH_REWARD_TOKENIZER_PATH") or os.path.expanduser("~/models/Qwen/Qwen2.5-0.5B-Instruct")
+    return AutoTokenizer.from_pretrained(path)
+
+
+def _make_data(
+    tokenizer,
+    responses: list[str],
+    ground_truths: list[str] | None = None,
+    data_sources: list[str] | None = None,
+    extra_infos: list[dict] | None = None,
+    prompt_len: int = 4,
+) -> DataProto:
+    n = len(responses)
+    if ground_truths is None:
+        ground_truths = ["gt"] * n
+    if data_sources is None:
+        data_sources = ["src"] * n
+    if extra_infos is None:
+        extra_infos = [{} for _ in range(n)]
+
+    encoded = [tokenizer.encode(r, add_special_tokens=False) for r in responses]
+    max_resp = max(len(ids) for ids in encoded)
+    response_ids = torch.zeros((n, max_resp), dtype=torch.long)
+    resp_mask = torch.zeros((n, max_resp), dtype=torch.long)
+    for i, ids in enumerate(encoded):
+        response_ids[i, : len(ids)] = torch.tensor(ids, dtype=torch.long)
+        resp_mask[i, : len(ids)] = 1
+
+    prompts = torch.zeros((n, prompt_len), dtype=torch.long)
+    prompt_mask = torch.ones((n, prompt_len), dtype=torch.long)
+    attention_mask = torch.cat([prompt_mask, resp_mask], dim=1)
+
+    data = DataProto.from_dict(
+        {
+            "prompts": prompts,
+            "responses": response_ids,
+            "attention_mask": attention_mask,
+        }
+    )
+    data.non_tensor_batch = {
+        "data_source": np.array(data_sources, dtype=object),
+        "reward_model": np.array([{"ground_truth": gt} for gt in ground_truths], dtype=object),
+        "extra_info": np.array(extra_infos, dtype=object),
+    }
+    return data
+
+
+def _make_config(*, custom_path: str | None = None, rm_enable: bool = False) -> DictConfig:
+    return DictConfig(
+        {
+            "reward": {
+                "custom_reward_function": {"path": custom_path},
+                "reward_model": {"enable": rm_enable},
+            }
+        }
+    )
+
+
+class TestBatchRewardManagerRunBatch:
+    @pytest.mark.asyncio
+    async def test_run_batch_sync_dict_result(self, tokenizer):
+        received: dict = {}
+
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            received["n_calls"] = received.get("n_calls", 0) + 1
+            received["data_sources"] = list(data_sources)
+            received["solution_strs"] = list(solution_strs)
+            return [{"score": 0.5, "custom_key": "v"} for _ in solution_strs]
+
+        config = _make_config(custom_path="dummy")
+        manager = BatchRewardManager(config=config, tokenizer=tokenizer, compute_score=compute_score)
+        data = _make_data(tokenizer, ["hello world", "answer here"])
+
+        result = await manager.run_batch(data)
+
+        assert len(result) == 2
+        assert received["n_calls"] == 1
+        assert all(r["reward_score"] == 0.5 for r in result)
+        assert all(r["reward_extra_info"].get("custom_key") == "v" for r in result)
+
+    @pytest.mark.asyncio
+    async def test_run_batch_sync_float_result(self, tokenizer):
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            return [0.75 for _ in solution_strs]
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=compute_score
+        )
+        data = _make_data(tokenizer, ["r1", "r2", "r3"])
+
+        result = await manager.run_batch(data)
+
+        assert len(result) == 3
+        for r in result:
+            assert r["reward_score"] == 0.75
+            assert r["reward_extra_info"]["acc"] == 0.75
+
+    @pytest.mark.asyncio
+    async def test_run_batch_async(self, tokenizer):
+        async def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            await asyncio.sleep(0)
+            return [1.0 for _ in solution_strs]
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=compute_score
+        )
+        data = _make_data(tokenizer, ["r1", "r2"])
+
+        result = await manager.run_batch(data)
+
+        assert manager.is_async_reward_score is True
+        assert [r["reward_score"] for r in result] == [1.0, 1.0]
+
+    @pytest.mark.asyncio
+    async def test_run_batch_length_mismatch_fails_downstream(self, tokenizer):
+        # compute_score returns fewer items than len(data). run_batch itself does not
+        # assert; downstream consumers (or manual indexing) surface the mismatch.
+        # This test locks the current no-assert behavior and matches naive parity.
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            return [0.5 for _ in solution_strs[:1]]  # length 1 instead of 2
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=compute_score
+        )
+        data = _make_data(tokenizer, ["r1", "r2"])
+
+        result = await manager.run_batch(data)
+        assert len(result) == 1  # matches compute_score output, not len(data)
+
+    @pytest.mark.asyncio
+    async def test_run_single_delegates_to_run_batch(self, tokenizer):
+        seen_lens: list = []
+
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            seen_lens.append((len(data_sources), len(solution_strs)))
+            return [0.42 for _ in solution_strs]
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=compute_score
+        )
+        data = _make_data(tokenizer, ["r1", "r2", "r3"])
+
+        result = await manager.run_single(data)
+
+        assert result["reward_score"] == 0.42
+        # run_single takes the last row via `data[-1:]`, so compute_score sees length 1.
+        assert seen_lens == [(1, 1)]
+
+    @pytest.mark.asyncio
+    async def test_run_batch_size_one(self, tokenizer):
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            assert len(solution_strs) == 1
+            return [0.9]
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=compute_score
+        )
+        data = _make_data(tokenizer, ["single"])
+
+        result = await manager.run_batch(data)
+        assert len(result) == 1
+        assert result[0]["reward_score"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_run_batch_multi_sample_no_truncation(self, tokenizer):
+        received_n: list = []
+
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            received_n.append(len(solution_strs))
+            return [i for i in range(len(solution_strs))]
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=compute_score
+        )
+        data = _make_data(tokenizer, ["a", "b", "c", "d"])
+
+        result = await manager.run_batch(data)
+
+        assert received_n == [4]
+        assert [r["reward_score"] for r in result] == [0, 1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_extra_info_batch_isolation(self, tokenizer):
+        # agent_loop.py broadcasts `extra_info` via `np.array([v] * n)`, so all rows
+        # share the same dict reference. Without the top-level shallow copy in
+        # _extract_sample, per-sample injection of `num_turns` overwrites earlier
+        # samples in the same batch.
+        seen: list = []
+
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            seen.extend(dict(e) for e in extra_infos)
+            return [0.0 for _ in solution_strs]
+
+        shared_extra = {"base": "shared"}
+        extra_infos = [shared_extra, shared_extra, shared_extra]
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=compute_score
+        )
+        data = _make_data(tokenizer, ["a", "b", "c"], extra_infos=extra_infos)
+        # Inject distinct __num_turns__ per row so isolation is observable.
+        data.non_tensor_batch["__num_turns__"] = np.array([1, 2, 3], dtype=object)
+
+        await manager.run_batch(data)
+
+        assert [e["num_turns"] for e in seen] == [1, 2, 3]
+        # Original shared dict was not mutated by us.
+        assert "num_turns" not in shared_extra
+
+
+class TestWorkerDispatch:
+    def _make_worker_stub(self, config: DictConfig, reward_manager) -> RewardLoopWorker:
+        worker = RewardLoopWorker.__new__(RewardLoopWorker)
+        worker.config = config
+        worker.reward_manager = reward_manager
+        worker.reward_router_address = None
+        worker.reward_model_tokenizer = None
+        return worker
+
+    @pytest.mark.asyncio
+    async def test_worker_unconditionally_calls_run_batch_naive(self, tokenizer):
+        # NaiveRewardManager does not override run_batch; default fan-out kicks in.
+        def compute_score(data_source, solution_str, ground_truth, extra_info, **kwargs):
+            return 0.3
+
+        config = _make_config(custom_path="dummy")
+        manager = NaiveRewardManager(config=config, tokenizer=tokenizer, compute_score=compute_score)
+        run_batch_calls = []
+        run_single_calls = []
+        original_run_batch = manager.run_batch
+        original_run_single = manager.run_single
+
+        async def spy_run_batch(data):
+            run_batch_calls.append(len(data))
+            return await original_run_batch(data)
+
+        async def spy_run_single(data):
+            run_single_calls.append(len(data))
+            return await original_run_single(data)
+
+        manager.run_batch = spy_run_batch  # type: ignore
+        manager.run_single = spy_run_single  # type: ignore
+
+        worker = self._make_worker_stub(config, manager)
+        data = _make_data(tokenizer, ["a", "b", "c"])
+
+        result = await worker.compute_score_batch(data)
+
+        assert len(result) == 3
+        assert run_batch_calls == [3]
+        assert run_single_calls == [1, 1, 1]
+
+    @pytest.mark.asyncio
+    async def test_worker_unconditionally_calls_run_batch_batch_manager(self, tokenizer):
+        n_compute_calls = 0
+        n_run_batch_calls = 0
+
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            nonlocal n_compute_calls
+            n_compute_calls += 1
+            return [0.5 for _ in solution_strs]
+
+        config = _make_config(custom_path="dummy")
+        manager = BatchRewardManager(config=config, tokenizer=tokenizer, compute_score=compute_score)
+        original_run_batch = manager.run_batch
+
+        async def spy_run_batch(data):
+            nonlocal n_run_batch_calls
+            n_run_batch_calls += 1
+            return await original_run_batch(data)
+
+        manager.run_batch = spy_run_batch  # type: ignore
+
+        worker = self._make_worker_stub(config, manager)
+        data = _make_data(tokenizer, ["a", "b", "c"])
+
+        result = await worker.compute_score_batch(data)
+
+        assert len(result) == 3
+        assert n_run_batch_calls == 1
+        assert n_compute_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_worker_dispatch_priority(self, tokenizer):
+        # custom_reward_function.path set AND reward_model.enable = True => run_batch wins.
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            return [1.0 for _ in solution_strs]
+
+        config = _make_config(custom_path="dummy", rm_enable=True)
+        manager = BatchRewardManager(config=config, tokenizer=tokenizer, compute_score=compute_score)
+        worker = self._make_worker_stub(config, manager)
+        worker.compute_score_disrm = AsyncMock(side_effect=AssertionError("disrm must not be called"))
+        run_batch_spy = MagicMock(wraps=manager.run_batch)
+
+        async def wrapped(data):
+            return await run_batch_spy(data)
+
+        manager.run_batch = wrapped  # type: ignore
+
+        data = _make_data(tokenizer, ["a", "b"])
+        result = await worker.compute_score_batch(data)
+
+        assert len(result) == 2
+        assert run_batch_spy.call_count == 1
+        worker.compute_score_disrm.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_worker_disrm_still_fan_outs(self, tokenizer):
+        # No custom path + reward_model.enable = True => per-sample disrm fan-out;
+        # run_batch must NOT be called.
+        config = _make_config(custom_path=None, rm_enable=True)
+
+        def compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, **kwargs):
+            raise AssertionError("compute_score must not be called on disrm path")
+
+        manager = BatchRewardManager(config=config, tokenizer=tokenizer, compute_score=compute_score)
+        run_batch_spy = MagicMock(side_effect=AssertionError("run_batch must not be called on disrm path"))
+        manager.run_batch = run_batch_spy  # type: ignore
+
+        worker = self._make_worker_stub(config, manager)
+        worker.compute_score_disrm = AsyncMock(return_value={"reward_score": 0.1})
+
+        data = _make_data(tokenizer, ["a", "b", "c"])
+        result = await worker.compute_score_batch(data)
+
+        assert len(result) == 3
+        assert worker.compute_score_disrm.call_count == 3
+        run_batch_spy.assert_not_called()
+
+
+class TestCustomRewardFunctionKwargs:
+    @pytest.mark.asyncio
+    async def test_custom_reward_function_kwargs_pass_through(self, tokenizer):
+        # Verifies _call_with_kwargs threading: user-supplied reward_kwargs land
+        # in the batch compute_score alongside the plural fields.
+        from functools import partial
+
+        from verl.trainer.ppo.reward import _call_with_kwargs
+
+        received: dict = {}
+
+        def raw_compute_score(*, data_sources, solution_strs, ground_truths, extra_infos, my_hp, **kwargs):
+            received["my_hp"] = my_hp
+            received["n"] = len(solution_strs)
+            return [0.0 for _ in solution_strs]
+
+        wrapped = partial(_call_with_kwargs, raw_compute_score, {"my_hp": 42})
+
+        manager = BatchRewardManager(
+            config=_make_config(custom_path="dummy"), tokenizer=tokenizer, compute_score=wrapped
+        )
+        data = _make_data(tokenizer, ["a", "b"])
+
+        await manager.run_batch(data)
+
+        assert received["my_hp"] == 42
+        assert received["n"] == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -136,11 +136,14 @@ class RewardLoopWorker:
         )
 
     async def compute_score_batch(self, data: DataProto) -> list[dict]:
-        tasks = []
-        for i in range(len(data)):
-            tasks.append(asyncio.create_task(self.compute_score(data[i : i + 1])))
-        outputs = await asyncio.gather(*tasks)
-        return outputs
+        if self.config.reward.custom_reward_function.path is not None:
+            # custom reward function takes precedence over disrm
+            return await self.reward_manager.run_batch(data)
+        if self.config.reward.reward_model.enable:
+            # disrm: keep per-sample HTTP fan-out, do not batch
+            tasks = [asyncio.create_task(self.compute_score_disrm(data[i : i + 1])) for i in range(len(data))]
+            return list(await asyncio.gather(*tasks))
+        return await self.reward_manager.run_batch(data)
 
     async def compute_score(self, data: DataProto) -> dict:
         if self.config.reward.custom_reward_function.path is not None:

--- a/verl/experimental/reward_loop/reward_manager/__init__.py
+++ b/verl/experimental/reward_loop/reward_manager/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .registry import get_reward_manager_cls, register  # noqa: I001
+from .batch import BatchRewardManager
 from .dapo import DAPORewardManager
 from .gdpo import GDPORewardManager
 from .naive import NaiveRewardManager
@@ -20,6 +21,7 @@ from .limited import RateLimitedRewardManager
 from .remote import RemoteRewardManager
 
 __all__ = [
+    "BatchRewardManager",
     "DAPORewardManager",
     "GDPORewardManager",
     "NaiveRewardManager",

--- a/verl/experimental/reward_loop/reward_manager/base.py
+++ b/verl/experimental/reward_loop/reward_manager/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -57,6 +58,20 @@ class RewardManagerBase(ABC):
     @abstractmethod
     async def run_single(self, data: DataProto):
         raise NotImplementedError
+
+    async def run_batch(self, data: DataProto) -> list[dict]:
+        """Compute reward for every sample in ``data`` and return a list aligned
+        with the input order.
+
+        Default implementation fans out to :meth:`run_single` per sample, so
+        subclasses that only implement ``run_single`` inherit batch semantics
+        equivalent to the legacy ``RewardLoopWorker.compute_score_batch``
+        per-sample fan-out. Subclasses can override this to consume the full
+        batch in one call (e.g. to leverage ``tokenizer.batch_decode`` and a
+        batched user ``compute_score``).
+        """
+        tasks = [asyncio.create_task(self.run_single(data[i : i + 1])) for i in range(len(data))]
+        return list(await asyncio.gather(*tasks))
 
     @classmethod
     def assemble_rm_scores(cls, data: DataProto, scores: list[float]) -> torch.Tensor:

--- a/verl/experimental/reward_loop/reward_manager/batch.py
+++ b/verl/experimental/reward_loop/reward_manager/batch.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+
+from verl import DataProto
+from verl.experimental.reward_loop.reward_manager import register
+from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
+from verl.utils.reward_score import default_compute_score
+
+
+@register("batch")
+class BatchRewardManager(RewardManagerBase):
+    """Batch-friendly reward manager: forwards the whole chunk to a single
+    ``compute_score`` call with plural kwargs (``data_sources`` /
+    ``solution_strs`` / ``ground_truths`` / ``extra_infos``).
+
+    Field naming is aligned with ``verl/workers/reward_manager/batch.py`` so
+    users have a single batch contract across both codepaths.
+    """
+
+    def __init__(self, config, tokenizer, compute_score, reward_router_address=None, reward_model_tokenizer=None):
+        super().__init__(config, tokenizer, compute_score)
+        self.compute_score = compute_score or default_compute_score
+        self.is_async_reward_score = inspect.iscoroutinefunction(self.compute_score)
+        self.reward_router_address = reward_router_address
+        self.reward_model_tokenizer = reward_model_tokenizer
+
+    @staticmethod
+    def _extract_sample(data_item):
+        response_ids = data_item.batch["responses"]
+        response_length = response_ids.shape[-1]
+        valid_response_length = data_item.batch["attention_mask"][-response_length:].sum()
+        valid_response_ids = response_ids[:valid_response_length]
+
+        data_source = data_item.non_tensor_batch["data_source"]
+        ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
+        # Top-level shallow copy is required for batch correctness: agent_loop broadcasts
+        # `extra_info` via `np.array([v] * n)`, so every sample in the chunk shares the same
+        # dict reference. Without this copy, per-sample injection of `num_turns` /
+        # `rollout_reward_scores` overwrites earlier samples within the same batch.
+        extra_info = dict(data_item.non_tensor_batch.get("extra_info") or {})
+        tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)
+        if tool_extra_fields is not None:
+            extra_info.update(tool_extra_fields.items())
+
+        num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
+        rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})
+        extra_info["num_turns"] = num_turns
+        extra_info["rollout_reward_scores"] = rollout_reward_scores
+
+        return valid_response_ids, data_source, ground_truth, extra_info
+
+    async def run_batch(self, data: DataProto) -> list[dict]:
+        valid_ids_list: list = []
+        data_sources: list = []
+        ground_truths: list = []
+        extra_infos: list = []
+        for i in range(len(data)):
+            valid_ids, data_source, ground_truth, extra_info = self._extract_sample(data[i])
+            valid_ids_list.append(valid_ids)
+            data_sources.append(data_source)
+            ground_truths.append(ground_truth)
+            extra_infos.append(extra_info)
+
+        solution_strs = await self.loop.run_in_executor(
+            None, lambda: self.tokenizer.batch_decode(valid_ids_list, skip_special_tokens=True)
+        )
+
+        extra_reward_kwargs = (
+            {
+                "reward_router_address": self.reward_router_address,
+                "reward_model_tokenizer": self.reward_model_tokenizer,
+            }
+            if self.reward_router_address is not None
+            else {}
+        )
+
+        if self.is_async_reward_score:
+            result = await self.compute_score(
+                data_sources=data_sources,
+                solution_strs=solution_strs,
+                ground_truths=ground_truths,
+                extra_infos=extra_infos,
+                **extra_reward_kwargs,
+            )
+        else:
+            result = await self.loop.run_in_executor(
+                None,
+                lambda: self.compute_score(
+                    data_sources=data_sources,
+                    solution_strs=solution_strs,
+                    ground_truths=ground_truths,
+                    extra_infos=extra_infos,
+                    **extra_reward_kwargs,
+                ),
+            )
+
+        outputs: list[dict] = []
+        for item in result:
+            reward_extra_info: dict = {}
+            if isinstance(item, dict):
+                score = item["score"]
+                for key, value in item.items():
+                    reward_extra_info[key] = value
+            else:
+                score = item
+                reward_extra_info["acc"] = score
+            outputs.append({"reward_score": score, "reward_extra_info": reward_extra_info})
+        return outputs
+
+    async def run_single(self, data: DataProto) -> dict:
+        # Preserve `naive.run_single`'s multi-sequence fallback: take only the last row.
+        return (await self.run_batch(data[-1:]))[0]


### PR DESCRIPTION
### What does this PR do?

Existing reward managers under verl/experimental/reward_loop only expose run_single, so RewardLoopWorker.compute_score_batch has to fan out N tasks per chunk and calls the user compute_score N times. For rule-based rewards that can be evaluated in one shot (e.g. batched tokenizer decoding + a single compute_score call), this is a straight throughput loss.

Introduce a `run_batch` contract without breaking existing managers:

* RewardManagerBase now defines `async run_batch(data)` with a default fan-out implementation (asyncio.create_task + asyncio.gather over run_single per sample). `run_single` stays `@abstractmethod`. Legacy managers (naive/dapo/gdpo/limited/remote) inherit the default and behave exactly like the previous per-sample fan-out.
* RewardLoopWorker.compute_score_batch now dispatches by priority `custom_reward_function.path > reward_model.enable > default rule-based`. Custom and rule-based branches call run_batch(data) unconditionally; the disrm branch keeps per-sample compute_score_disrm fan-out. The single-sample compute_score entry point is unchanged so callers like agent_loop.py aren't affected.
* New BatchRewardManager (registered as "batch") consumes the whole chunk in one call using the plural signature that already exists in verl/workers/reward_manager/batch.py (data_sources / solution_strs / ground_truths / extra_infos). It shallow-copies extra_info at the top level so per-sample num_turns / rollout_reward_scores injection doesn't overwrite sibling rows that share the same dict reference from agent_loop's np.array([v] * n) broadcast. The `**kwargs` surface (reward_router_address /  reward_model_tokenizer when the router is configured) mirrors NaiveRewardManager exactly, so users can move a reward function between the two managers by only switching to the plural signature.
* BatchRewardManager.run_single delegates to run_batch(data[-1:])[0], keeping naive.run_single's multi-sequence fallback semantics.

Default reward_manager.name stays "naive"; the new "batch" value is opt-in.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: batch reward loop 
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Tests in tests/experimental/reward_loop/test_batch_reward_manager.py cover sync/async user functions, dict/float returns, run_single delegation, batch=1 and batch>1 paths, cur_steps propagation, worker dispatch priority (custom > disrm > default), disrm still fanning out per sample, kwargs threading through _call_with_kwargs, and same-batch extra_info isolation.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
