### PR TITLE
[reward] fix: do not drop a GSM8k answer that is followed by more text

### DIFF
--- a/tests/utils/reward_score/test_gsm8k_on_cpu.py
+++ b/tests/utils/reward_score/test_gsm8k_on_cpu.py
@@ -1,0 +1,105 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the GSM8k reward function.
+
+The response of an RL rollout does not reliably stop right after the ``#### N`` marker,
+so answer extraction must not depend on the answer landing inside a fixed-size tail
+window of the response.
+"""
+
+import pytest
+
+from verl.utils.reward_score.gsm8k import _SOLUTION_CLIP_CHARS, compute_score, extract_solution
+
+
+def _pad(n_chars: int) -> str:
+    """Filler that contains no digit, so it can never be mistaken for an answer."""
+    return ("the reasoning above confirms this result is consistent. " * (n_chars // 55 + 1))[:n_chars]
+
+
+@pytest.mark.parametrize("trailing_chars", [0, 1, _SOLUTION_CLIP_CHARS - 1, _SOLUTION_CLIP_CHARS, 4000])
+def test_strict_finds_answer_regardless_of_trailing_text(trailing_chars):
+    """A correct answer must score 1.0 however much the model keeps writing after it."""
+    solution_str = "2 + 40 = 42.\n#### 42\n" + _pad(trailing_chars)
+
+    assert extract_solution(solution_str, method="strict") == "42"
+    assert compute_score(solution_str, "42") == 1.0
+
+
+@pytest.mark.parametrize("trailing_chars", [0, _SOLUTION_CLIP_CHARS, 4000])
+def test_flexible_finds_last_number_regardless_of_trailing_text(trailing_chars):
+    solution_str = "the answer is 42 " + _pad(trailing_chars)
+
+    assert extract_solution(solution_str, method="flexible") == "42"
+
+
+@pytest.mark.parametrize("leading_chars", [0, _SOLUTION_CLIP_CHARS, 4000])
+def test_strict_takes_the_last_marker(leading_chars):
+    """Only the final ``####`` marker counts, whichever window it happens to fall in."""
+    solution_str = _pad(leading_chars) + "#### 7\nwait, let me redo that.\n#### 42\n" + _pad(leading_chars)
+
+    assert extract_solution(solution_str, method="strict") == "42"
+
+
+@pytest.mark.parametrize("method", ["strict", "flexible"])
+def test_long_answer_straddling_the_window_boundary_is_not_truncated(method):
+    """A number cut in half by the tail window must not be reported as the answer."""
+    answer = "1234567890123456789"
+    prefix = "#### " if method == "strict" else "the answer is "
+    # Place the answer so that the tail window starts in the middle of its digits.
+    tail = prefix + answer
+    solution_str = _pad(_SOLUTION_CLIP_CHARS + 10 - len(answer) // 2) + tail
+
+    assert extract_solution(solution_str, method=method) == answer
+
+
+def test_no_answer_returns_none():
+    for method in ("strict", "flexible"):
+        assert extract_solution("no number here at all", method=method) is None
+        assert extract_solution(_pad(4000), method=method) is None
+
+
+def test_flexible_rejects_bare_punctuation():
+    """Candidates the regex matches but that hold no digit are not answers.
+
+    ``extract_solution`` used to leak its loop variable and return ``"."`` here, which
+    ``compute_score`` then treated as a well formatted answer and paid ``format_score``
+    for instead of returning 0.
+    """
+    solution_str = "first sentence. second sentence. third sentence."
+
+    assert extract_solution(solution_str, method="flexible") is None
+    assert compute_score(solution_str, "42", method="flexible", format_score=0.5) == 0
+
+
+def test_missing_marker_scores_zero_even_when_a_number_is_present():
+    """strict mode still grades formatting: no ``####`` marker means no reward."""
+    solution_str = "the answer is 42"
+
+    assert extract_solution(solution_str, method="strict") is None
+    assert compute_score(solution_str, "42") == 0
+
+
+def test_wrong_answer_gets_format_score():
+    solution_str = "2 + 40 = 41.\n#### 41\n" + _pad(4000)
+
+    assert compute_score(solution_str, "42", format_score=0.1) == 0.1
+
+
+def test_thousands_separator_is_stripped():
+    solution_str = "#### 1,234\n" + _pad(4000)
+
+    assert extract_solution(solution_str, method="strict") == "1234"
+    assert compute_score(solution_str, "1234") == 1.0

--- a/verl/utils/reward_score/gsm8k.py
+++ b/verl/utils/reward_score/gsm8k.py
@@ -14,39 +14,59 @@
 
 import re
 
+# Size of the tail window that is searched before falling back to the whole response.
 _SOLUTION_CLIP_CHARS = 300
+
+_STRICT_ANSWER_RE = re.compile("#### (\\-?[0-9\\.\\,]+)")
+_FLEXIBLE_ANSWER_RE = re.compile("\\-?[0-9\\.\\,]+")
+_INVALID_ANSWERS = ("", ".")
+
+
+def _select_last(pattern, text, is_valid):
+    """Return the last match of ``pattern`` in ``text`` accepted by ``is_valid``, else None."""
+    selected = None
+    for match in pattern.finditer(text):
+        if is_valid(match):
+            selected = match
+    return selected
+
+
+def _find_answer_match(pattern, solution_str, is_valid):
+    """Locate the answer, searching only the tail of the response when that is safe.
+
+    Regular expression matching on very long strings can be slow, and for math problems
+    the final answer is usually at the end, so a short tail window is searched first.
+    The window result is only trusted when the selected match starts past the left edge
+    of the window, because a match touching that edge may be the tail half of a longer
+    one that the window cut in two. Otherwise the whole response is rescanned.
+
+    Clipping the response unconditionally, which this module used to do, silently dropped
+    a correct answer whenever the model kept generating for more than
+    ``_SOLUTION_CLIP_CHARS`` characters after writing it.
+    """
+    if len(solution_str) <= _SOLUTION_CLIP_CHARS:
+        return _select_last(pattern, solution_str, is_valid)
+
+    match = _select_last(pattern, solution_str[-_SOLUTION_CLIP_CHARS:], is_valid)
+    if match is not None and match.start() > 0:
+        return match
+    return _select_last(pattern, solution_str, is_valid)
 
 
 def extract_solution(solution_str, method="strict"):
     assert method in ["strict", "flexible"]
 
-    # Optimization: Regular expression matching on very long strings can be slow.
-    # For math problems, the final answer is usually at the end.
-    # We only match on the last 300 characters, which is a safe approximation for 300 tokens.
-    if len(solution_str) > _SOLUTION_CLIP_CHARS:
-        solution_str = solution_str[-_SOLUTION_CLIP_CHARS:]
-
     if method == "strict":
         # this also tests the formatting of the model
-        solutions = re.findall("#### (\\-?[0-9\\.\\,]+)", solution_str)
-        if len(solutions) == 0:
-            final_answer = None
-        else:
-            # take the last solution
-            final_answer = solutions[-1].replace(",", "").replace("$", "")
-    elif method == "flexible":
-        answer = re.findall("(\\-?[0-9\\.\\,]+)", solution_str)
-        final_answer = None
-        if len(answer) == 0:
-            # no reward is there is no answer
-            pass
-        else:
-            invalid_str = ["", "."]
-            # find the last number that is not '.'
-            for final_answer in reversed(answer):
-                if final_answer not in invalid_str:
-                    break
-    return final_answer
+        # take the last solution
+        match = _find_answer_match(_STRICT_ANSWER_RE, solution_str, lambda _: True)
+        # no reward if there is no answer
+        return None if match is None else match.group(1).replace(",", "").replace("$", "")
+
+    # find the last number that is not '.'
+    match = _find_answer_match(_FLEXIBLE_ANSWER_RE, solution_str, lambda m: m.group(0) not in _INVALID_ANSWERS)
+    # no reward if there is no answer
+    return None if match is None else match.group(0)
 
 
 def compute_score(solution_str, ground_truth, method="strict", format_score=0.0, score=1.0):


### PR DESCRIPTION
### What does this PR do?

`extract_solution()` in `verl/utils/reward_score/gsm8k.py` truncates the response to its last 300 characters before searching for the answer:

```python
if len(solution_str) > _SOLUTION_CLIP_CHARS:
    solution_str = solution_str[-_SOLUTION_CLIP_CHARS:]
```

A rollout does not reliably stop right after writing `#### N`. When it keeps generating for more than 300 characters past the marker, the marker falls outside the window, extraction returns `None`, and `compute_score()` pays 0 for an answer that was correct. On the current `main`:

```python
>>> from verl.utils.reward_score import default_compute_score
>>> tail = " and the reasoning above confirms this result is consistent." * 8
>>> default_compute_score("openai/gsm8k", "2+40=42\n#### 42\n" + tail, "42")
0                      # expected 1.0
>>> default_compute_score("openai/gsm8k", "2+40=42\n#### 42\n", "42")
1.0                    # same answer, nothing after it
```

This is a silent reward-signal loss, not a crash: the run trains against zeros for those samples. `openai/gsm8k` is the data source wired into `default_compute_score`, and GSM8k is the dataset used across the quickstart and e2e scripts, so the default path is the affected one.

A fixed-size tail window cannot be made safe by enlarging it, so this keeps the window as a fast path and adds a validity condition instead. The window result is trusted only when the selected match starts past the window's left edge, because a match touching that edge may be the tail half of a longer one that the window cut in two. Otherwise the whole response is rescanned. For `strict` the marker literal means a cut match cannot match at all, so the fallback is rare; for `flexible` the guard is what stops a truncated number such as `1234567890` being reported as `567890`.

The fallback is not a meaningful expense. Measured on this branch with the pinned pattern:

| response length | `strict` full scan | `rfind` |
|---|---|---|
| 4 000 chars | 0.8 us | 0.08 us |
| 32 000 chars | 6.8 us | 0.08 us |
| 131 000 chars | 26.8 us | 0.08 us |

32k characters is roughly a 8k-token response, so the default path costs single-digit microseconds even when it has to rescan.

Second defect in the same function: `flexible` mode leaked its loop variable.

```python
for final_answer in reversed(answer):
    if final_answer not in invalid_str:
        break
```

When no candidate is valid the loop never breaks and `final_answer` keeps the last value it was bound to, so the function returned `"."` instead of `None` even though `"."` is one of the strings it explicitly lists as invalid. `compute_score()` reads any non-`None` result as a well formatted answer and pays `format_score` rather than 0, contradicting the `# no reward is there is no answer` comment directly above.

```python
>>> extract_solution("first sentence. second sentence.", method="flexible")
'.'                    # expected None
```

Selecting the match inside the scan removes the leak.

Deliberately out of scope, to keep the diff to the actual defect: `strict` still accepts a trailing separator (`#### 42.` yields `"42."`), `flexible` still accepts a bare `","`, and the dead `.replace("$", "")` is left alone since the character class cannot match `$`.

### Checklist Before Starting

- [x] Search for similar PRs. Query link: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+gsm8k — plus:
  - `gh api "search/issues?q=repo:verl-project/verl+is:pr+is:open+extract_solution"` returns #2232 and #5470, neither of which touches `verl/utils/reward_score/gsm8k.py`
  - `+_SOLUTION_CLIP_CHARS` and `+clip+chars+reward` return nothing
  - `+reward_score+gsm8k` returns #7151 and #4241, both in the reward-manager plumbing, not in answer extraction
  - no open issue reports this

  Not a duplicate: no open PR modifies `verl/utils/reward_score/gsm8k.py`, and there is no existing test anywhere under `tests/` that calls `extract_solution` or the gsm8k `compute_score`.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

New file `tests/utils/reward_score/test_gsm8k_on_cpu.py`, 18 cases, CPU only, no GPU and no model download. It parametrizes the amount of text after the marker across 0, 1, `_SOLUTION_CLIP_CHARS - 1`, `_SOLUTION_CLIP_CHARS` and 4000 characters, covers the last-marker-wins rule, the window-boundary truncation case for both methods, the punctuation-only case, and the unchanged behaviours (missing marker still scores 0, wrong answer still gets `format_score`, thousands separators still stripped).

```
$ pytest tests/utils/reward_score/test_gsm8k_on_cpu.py -q
18 passed in 2.98s
```

Fail-before and pass-after, reverting only the source file and keeping the new test:

```
$ git checkout origin/main -- verl/utils/reward_score/gsm8k.py
$ pytest tests/utils/reward_score/test_gsm8k_on_cpu.py -q
11 failed, 7 passed in 3.67s

$ git checkout HEAD -- verl/utils/reward_score/gsm8k.py
$ pytest tests/utils/reward_score/test_gsm8k_on_cpu.py -q
18 passed in 2.98s
```

End to end through the registered data source, on this branch:

```
default_compute_score("openai/gsm8k", correct + 480 chars of trailing text, "42")  -> 1.0
default_compute_score("openai/gsm8k", correct, "42")                              -> 1.0
default_compute_score("openai/gsm8k", wrong + trailing text, "42")                -> 0.0
```

Lint, at the versions pinned in `.pre-commit-config.yaml`:

```
$ ruff --version
ruff 0.12.2
$ ruff check verl/utils/reward_score/gsm8k.py tests/utils/reward_score/test_gsm8k_on_cpu.py
All checks passed!
$ ruff format verl/utils/reward_score/gsm8k.py tests/utils/reward_score/test_gsm8k_on_cpu.py
```

The test file name ends in `_on_cpu.py` and sits under `tests/utils/` mirroring `verl/utils/`, so `cpu_unit_tests.yml` picks it up and `validate_structure.py` accepts its location. No workflow `paths` change is needed, since that job triggers on `**/*.py`.

### API and Usage Example

No API change. `extract_solution(solution_str, method=...)` and `compute_score(...)` keep their signatures and their return types. `_SOLUTION_CLIP_CHARS` keeps its name and value and is still the tail window size.

### Design & Code Changes

- `verl/utils/reward_score/gsm8k.py`
  - patterns precompiled at module scope, since they are now used from two places
  - `_select_last(pattern, text, is_valid)` returns the last match a per-mode predicate accepts, or `None`
  - `_find_answer_match(...)` searches the tail window and falls back to the full response when the selected match touches the window's left edge
  - `extract_solution` passes `lambda _: True` for `strict` and the invalid-candidate predicate for `flexible`, so neither mode's selection rule changes
- `tests/utils/reward_score/test_gsm8k_on_cpu.py`, new

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [x] Add / Update the documentation: not applicable, no user-facing option changes.
- [x] Add unit or end-to-end test(s) to the CI workflow to cover all the code.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] If your PR is related to the `recipe` submodule: not applicable.

### AI assistance disclosure

Per `AGENTS.md`: AI assistance was used to write this change. The reward-signal defect, the window-boundary truncation case and the loop-variable leak were each reproduced on `main` before any edit and re-verified after, the fail-before/pass-after transcripts above are real runs on this branch, and the perf numbers are measured rather than assumed. I have reviewed every changed line and am able to defend the change in review.
