### PR TITLE
[rollout] FlexKV KV cache offload for dynamic resource

### DIFF
--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -445,9 +445,12 @@ class CheckpointEngineManager:
         self.replicas = [r for r in self.replicas if r not in replicas_set]
 
     @auto_await
-    async def sleep_replicas(self):
+    async def sleep_replicas(self, reset_connector: bool = True):
         """Sleep all rollout replicas: free weight and kv_cache device memory."""
-        await asyncio.gather(*[r.sleep() for r in self.replicas])
+        if reset_connector:
+            await asyncio.gather(*[r.sleep() for r in self.replicas])
+        else:
+            await asyncio.gather(*[r.sleep(reset_connector=False) for r in self.replicas])
 
     @auto_await
     async def wake_up_replicas(self):
@@ -455,9 +458,14 @@ class CheckpointEngineManager:
         await asyncio.gather(*[r.wake_up() for r in self.replicas])
 
     @auto_await
-    async def abort_replicas(self):
+    async def abort_replicas(self, checkpoint_kv: bool = False, timeout_s: float = 30.0):
         """Abort all in-flight requests on every replica."""
-        await asyncio.gather(*[r.abort_all_requests() for r in self.replicas])
+        if checkpoint_kv:
+            await asyncio.gather(
+                *[r.abort_all_requests(checkpoint_kv=True, timeout_s=timeout_s) for r in self.replicas]
+            )
+        else:
+            await asyncio.gather(*[r.abort_all_requests() for r in self.replicas])
 
     @auto_await
     async def resume_generation_replicas(self):

--- a/verl/experimental/fully_async_policy/dynamic_schedule/dynamic_resource_controller.py
+++ b/verl/experimental/fully_async_policy/dynamic_schedule/dynamic_resource_controller.py
@@ -70,6 +70,8 @@ class DynamicResourceController:
         num_standalone_replicas: int,
         num_hybrid_replicas: int,
         policy: DynamicSchedulePolicyBase | None = None,
+        abort_kv_reuse_enabled: bool = False,
+        abort_kv_reuse_timeout_s: float = 30.0,
     ):
         self.rollouter = rollouter
         self.hybrid_checkpoint_manager = hybrid_checkpoint_manager
@@ -79,6 +81,8 @@ class DynamicResourceController:
         self._only_hybrid: bool = num_standalone_replicas == 0
         self.activate_count: int = 0
         self.deactivate_count: int = 0
+        self.abort_kv_reuse_enabled = abort_kv_reuse_enabled
+        self.abort_kv_reuse_timeout_s = abort_kv_reuse_timeout_s
         self.policy: DynamicSchedulePolicyBase = (
             policy if policy is not None else DefaultDynamicSchedulePolicy(only_hybrid=self._only_hybrid)
         )
@@ -139,6 +143,7 @@ class DynamicResourceController:
         """Remove hybrid replicas from LB, abort in-flight requests, release GPU memory."""
         print(f"[DynamicResourceController] Deactivating hybrid replicas at step {global_steps}")
         start = time.time()
+        dynamic_cycle_id = self.deactivate_count + 1
 
         hybrid_replicas_dict = ray.get(self.rollouter.get_all_hybrid_replicas.remote())
         hybrid_resource_ids = list(hybrid_replicas_dict.keys())
@@ -147,10 +152,20 @@ class DynamicResourceController:
             self._hybrid_active = False
             return
 
-        # Order is critical: remove from LB first so retry loop can't re-route to dying replicas.
+        if self.abort_kv_reuse_enabled:
+            await self.rollouter.begin_abort_kv_reuse_cycle.remote(dynamic_cycle_id)
+
+        # Order is critical: remove from LB first so retry loop cannot re-route to dying replicas.
         await self.rollouter.remove_replicas.remote(hybrid_resource_ids)
-        await self.hybrid_checkpoint_manager.abort_replicas()
-        await self.hybrid_checkpoint_manager.sleep_replicas()
+        await self.hybrid_checkpoint_manager.abort_replicas(
+            checkpoint_kv=self.abort_kv_reuse_enabled,
+            timeout_s=self.abort_kv_reuse_timeout_s,
+        )
+        if self.abort_kv_reuse_enabled:
+            await self.rollouter.mark_abort_kv_reuse_ready.remote(dynamic_cycle_id)
+        await self.hybrid_checkpoint_manager.sleep_replicas(
+            reset_connector=not self.abort_kv_reuse_enabled
+        )
 
         self._hybrid_active = False
         self.deactivate_count += 1

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -215,6 +215,12 @@ class FullyAsyncTaskRunner:
                 ray.cancel(future)
             raise
         finally:
+            rollouter = self.components.get("rollouter")
+            if rollouter is not None:
+                try:
+                    ray.get(rollouter.shutdown_services.remote())
+                except Exception as e:
+                    print(f"[ASYNC MAIN] Rollout service cleanup failed: {e}")
             asyncio.run(self.components["message_queue_client"].clear_queue())
             print("[ASYNC MAIN] Training completed or interrupted")
 

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -1196,6 +1196,12 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """Return the worker group for hybrid replicas."""
         return self._hybrid_worker_group
 
+    async def begin_abort_kv_reuse_cycle(self, cycle_id: int) -> None:
+        await self.llm_server_manager.global_load_balancer.begin_abort_kv_reuse_cycle.remote(cycle_id)
+
+    async def mark_abort_kv_reuse_ready(self, cycle_id: int) -> None:
+        await self.llm_server_manager.global_load_balancer.mark_abort_kv_reuse_ready.remote(cycle_id)
+
     async def add_replicas(self, resource_ids: list[str]) -> int:
         n = await self.llm_server_manager.add_replicas(resource_ids)
         if n > 0:

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -645,6 +645,10 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """Stop rollout profiling on all replicas before the next weight sync."""
         await self.llm_server_manager.stop_profile()
 
+    async def shutdown_services(self):
+        if hasattr(self, "llm_server_manager"):
+            await self.llm_server_manager.shutdown()
+
     def do_validate(self):
         """Run validation and return metrics"""
         timing_raw = {}

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -337,6 +337,12 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             num_standalone_replicas=num_standalone,
             num_hybrid_replicas=num_hybrid,
             policy=policy,
+            abort_kv_reuse_enabled=bool(
+                self.config.actor_rollout_ref.rollout.abort_kv_reuse.enabled
+            ),
+            abort_kv_reuse_timeout_s=float(
+                self.config.actor_rollout_ref.rollout.abort_kv_reuse.timeout_s
+            ),
         )
         print(
             f"[FullyAsyncTrainer] DynamicResourceController initialised "

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -530,6 +530,12 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             except TrainingStopException:
                 print("[FullyAsyncTrainer] Training stopped by queue termination signal")
                 break
+            if self.current_param_version >= self.total_train_steps:
+                print(
+                    f"[FullyAsyncTrainer] Reached total_train_steps={self.total_train_steps}, "
+                    "stopping training"
+                )
+                break
 
         self.progress_bar.close()
         if self.current_param_version % self.config.trainer.test_freq != 0 or self.local_trigger_step > 1:

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -69,6 +69,24 @@ abort_kv_reuse:
 # External KV backend used by abort_kv_reuse.
 kv_backend: null
 
+# Optional Ray-managed FlexKV services. When enabled, VERL starts two Redis
+# metadata services and one external FlexKV server per rollout node.
+flexkv_service:
+  auto_start: false
+  redis_server_path: redis-server
+  expected_gpus_per_node: null
+  cpu_cache_gb: 16
+  flexkv_redis_port: 6393
+  mooncake_redis_port: 6395
+  local_zmq_port_base: 56800
+  transfer_engine_port_base: 56900
+  tokens_per_block: 16
+  protocol: tcp
+  device_name: ""
+  node_ttl_seconds: 3600
+  startup_timeout_s: 120.0
+  log_dir: /tmp/verl_flexkv
+
 # TP size for rollout. Not effective for hf
 tensor_model_parallel_size: 2
 

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -79,6 +79,7 @@ flexkv_service:
   flexkv_redis_port: 6393
   mooncake_redis_port: 6395
   local_zmq_port_base: 56800
+  rpc_port_base: 12841
   transfer_engine_port_base: 56900
   tokens_per_block: 16
   protocol: tcp

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -60,6 +60,15 @@ cudagraph_capture_sizes: null
 # Whether to free engine KVCache after generation.
 free_cache_engine: True
 
+abort_kv_reuse:
+  enabled: false
+  timeout_s: 30.0
+  require_global_visibility: true
+  fallback: recompute
+
+# External KV backend used by abort_kv_reuse.
+kv_backend: null
+
 # TP size for rollout. Not effective for hf
 tensor_model_parallel_size: 2
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -142,6 +142,16 @@ class CheckpointEngineConfig(BaseConfig):
 
 
 @dataclass
+class AbortKVReuseConfig(BaseConfig):
+    """Checkpoint aborted rollout KV before a dynamic hybrid replica sleeps."""
+
+    enabled: bool = False
+    timeout_s: float = 30.0
+    require_global_visibility: bool = True
+    fallback: str = "recompute"
+
+
+@dataclass
 class RolloutConfig(BaseConfig):
     _mutable_fields = {
         "max_model_len",
@@ -188,6 +198,8 @@ class RolloutConfig(BaseConfig):
     enforce_eager: bool = False
     cudagraph_capture_sizes: Optional[list] = None
     free_cache_engine: bool = True
+    abort_kv_reuse: AbortKVReuseConfig = field(default_factory=AbortKVReuseConfig)
+    kv_backend: Optional[str] = None
     data_parallel_size: int = 1
     expert_parallel_size: int = 1
     tensor_model_parallel_size: int = 2

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -30,6 +30,7 @@ __all__ = [
     "TraceConfig",
     "ServerConfig",
     "PrometheusConfig",
+    "FlexKVServiceConfig",
     "RolloutConfig",
     "CheckpointEngineConfig",
 ]
@@ -152,6 +153,26 @@ class AbortKVReuseConfig(BaseConfig):
 
 
 @dataclass
+class FlexKVServiceConfig(BaseConfig):
+    """Ray-managed distributed FlexKV service configuration."""
+
+    auto_start: bool = False
+    redis_server_path: str = "redis-server"
+    expected_gpus_per_node: Optional[int] = None
+    cpu_cache_gb: int = 16
+    flexkv_redis_port: int = 6393
+    mooncake_redis_port: int = 6395
+    local_zmq_port_base: int = 56800
+    transfer_engine_port_base: int = 56900
+    tokens_per_block: int = 16
+    protocol: str = "tcp"
+    device_name: str = ""
+    node_ttl_seconds: int = 3600
+    startup_timeout_s: float = 120.0
+    log_dir: str = "/tmp/verl_flexkv"
+
+
+@dataclass
 class RolloutConfig(BaseConfig):
     _mutable_fields = {
         "max_model_len",
@@ -199,6 +220,7 @@ class RolloutConfig(BaseConfig):
     cudagraph_capture_sizes: Optional[list] = None
     free_cache_engine: bool = True
     abort_kv_reuse: AbortKVReuseConfig = field(default_factory=AbortKVReuseConfig)
+    flexkv_service: FlexKVServiceConfig = field(default_factory=FlexKVServiceConfig)
     kv_backend: Optional[str] = None
     data_parallel_size: int = 1
     expert_parallel_size: int = 1

--- a/verl/workers/rollout/flexkv_service.py
+++ b/verl/workers/rollout/flexkv_service.py
@@ -168,6 +168,7 @@ class FlexKVNodeService:
                 "MC_LEGACY_RPC_PORT_BINDING": "1",
             }
         )
+        packed_kv = bool(cfg.get("packed_kv", True))
         cmd = [
             sys.executable,
             "-m",
@@ -187,8 +188,9 @@ class FlexKVNodeService:
             cfg["model_path"],
             "--tokens-per-block",
             str(cfg["tokens_per_block"]),
-            "--packed-kv",
         ]
+        if packed_kv:
+            cmd.append("--packed-kv")
         self.process = subprocess.Popen(
             cmd,
             env=env,
@@ -242,11 +244,12 @@ class FlexKVNodeService:
 
 
 class FlexKVServiceManager:
-    """Driver-side coordinator shared by all vLLM replicas."""
+    """Driver-side coordinator shared by vLLM or SGLang rollout replicas."""
 
     def __init__(self, rollout_config, model_config):
         self.config = OmegaConf.to_container(rollout_config.flexkv_service, resolve=True)
         self.model_path = getattr(model_config, "path")
+        self.rollout_name = str(rollout_config.name)
         self.tp_size = int(rollout_config.tensor_model_parallel_size)
         self.expected_gpus = int(self.config["expected_gpus_per_node"] or rollout_config.n_gpus_per_node)
         if self.expected_gpus % self.tp_size:
@@ -298,6 +301,7 @@ class FlexKVServiceManager:
                         "instance_num": self.expected_gpus // self.tp_size,
                         "tp_size": self.tp_size,
                         "model_path": self.model_path,
+                        "packed_kv": self.rollout_name == "vllm",
                         "metadata_host": self.metadata["host"],
                     }
                 )

--- a/verl/workers/rollout/flexkv_service.py
+++ b/verl/workers/rollout/flexkv_service.py
@@ -113,6 +113,7 @@ class FlexKVNodeService:
         gpu_register_path = f"{server_path}_gpu_register"
         config_path = f"/tmp/verl_fk_{run_id}.yaml"
         mooncake_path = f"/tmp/verl_fk_{run_id}_mte.json"
+        rpc_port = int(cfg["rpc_port_base"]) + node_index
         for path in (
             server_path,
             gpu_register_path,
@@ -165,7 +166,7 @@ class FlexKVNodeService:
                 "FLEXKV_SERVER_RECV_PORT": f"ipc://{server_path}",
                 "VLLM_CUMEM_ENABLE_SHAREABLE_HANDLE": "1",
                 "FLEXKV_ENABLE_MPS": "0",
-                "MC_LEGACY_RPC_PORT_BINDING": "1",
+                "MC_LEGACY_RPC_PORT_BINDING": str(rpc_port),
             }
         )
         packed_kv = bool(cfg.get("packed_kv", True))
@@ -215,7 +216,7 @@ class FlexKVNodeService:
             "MOONCAKE_CONFIG_PATH": mooncake_path,
             "VLLM_CUMEM_ENABLE_SHAREABLE_HANDLE": "1",
             "FLEXKV_ENABLE_MPS": "0",
-            "MC_LEGACY_RPC_PORT_BINDING": "1",
+            "MC_LEGACY_RPC_PORT_BINDING": str(rpc_port),
         }
 
     def stop(self) -> None:

--- a/verl/workers/rollout/flexkv_service.py
+++ b/verl/workers/rollout/flexkv_service.py
@@ -1,0 +1,395 @@
+# Copyright 2026 Nvidia Corporation
+# Licensed under the Apache License, Version 2.0.
+
+"""Ray-managed metadata and node-local FlexKV services."""
+
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import ray
+from omegaconf import OmegaConf
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+def _wait_tcp(host: str, port: int, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except OSError:
+            time.sleep(0.2)
+    raise TimeoutError(f"timed out waiting for {host}:{port}")
+
+
+def _wait_socket(path: str, process: subprocess.Popen, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if Path(path).is_socket():
+            return
+        rc = process.poll()
+        if rc is not None:
+            raise RuntimeError(f"FlexKV node server exited during startup (rc={rc})")
+        time.sleep(0.2)
+    raise TimeoutError(f"timed out waiting for {path}")
+
+
+class FlexKVMetadataService:
+    def __init__(self, config: dict[str, Any]):
+        self.config = config
+        self.processes: list[subprocess.Popen] = []
+        self.log_files = []
+
+    def start(self) -> dict[str, Any]:
+        host = ray.util.get_node_ip_address().strip("[]")
+        log_dir = Path(self.config["log_dir"])
+        log_dir.mkdir(parents=True, exist_ok=True)
+        for name, port in (
+            ("flexkv", int(self.config["flexkv_redis_port"])),
+            ("mooncake", int(self.config["mooncake_redis_port"])),
+        ):
+            log = open(log_dir / f"redis-{name}.log", "a", encoding="utf-8")
+            cmd = [
+                self.config["redis_server_path"],
+                "--bind",
+                host,
+                "--protected-mode",
+                "no",
+                "--port",
+                str(port),
+                "--save",
+                "",
+                "--appendonly",
+                "no",
+            ]
+            process = subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT)
+            self.processes.append(process)
+            self.log_files.append(log)
+            _wait_tcp(host, port, float(self.config["startup_timeout_s"]))
+            if process.poll() is not None:
+                raise RuntimeError(f"redis-server for {name} exited during startup; see {log.name}")
+        print(
+            f"VERL_FLEXKV_SERVICE phase=METADATA_READY node_id={self.config['node_id']} host={host} "
+            f"flexkv_redis={self.config['flexkv_redis_port']} "
+            f"mooncake_redis={self.config['mooncake_redis_port']}",
+            flush=True,
+        )
+        return {
+            "host": host,
+            "flexkv_redis_port": int(self.config["flexkv_redis_port"]),
+            "mooncake_redis_port": int(self.config["mooncake_redis_port"]),
+        }
+
+    def stop(self) -> None:
+        for process in reversed(self.processes):
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+        for log in self.log_files:
+            log.close()
+
+
+class FlexKVNodeService:
+    def __init__(self, config: dict[str, Any]):
+        self.config = config
+        self.process: subprocess.Popen | None = None
+        self.log_file = None
+
+    def start(self) -> dict[str, str]:
+        node_ip = ray.util.get_node_ip_address().strip("[]")
+        cfg = self.config
+        run_id = cfg["run_id"]
+        node_index = int(cfg["node_index"])
+        server_path = f"/tmp/verl_fk_{run_id}"
+        gpu_register_path = f"{server_path}_gpu_register"
+        config_path = f"/tmp/verl_fk_{run_id}.yaml"
+        mooncake_path = f"/tmp/verl_fk_{run_id}_mte.json"
+        for path in (
+            server_path,
+            gpu_register_path,
+            f"{gpu_register_path}_control",
+        ):
+            Path(path).unlink(missing_ok=True)
+
+        Path(config_path).write_text(
+            "enable_p2p_cpu: true\n"
+            "enable_p2p_ssd: false\n"
+            f"cpu_cache_gb: {int(cfg['cpu_cache_gb'])}\n"
+            "ssd_cache_gb: 0\n"
+            f"local_zmq_ip: \"{node_ip}\"\n"
+            f"local_zmq_port: {int(cfg['local_zmq_port_base']) + node_index}\n"
+            f"redis_host: \"{cfg['metadata_host']}\"\n"
+            f"redis_port: {int(cfg['flexkv_redis_port'])}\n"
+            f"local_ip: \"{node_ip}\"\n"
+            "redis_password: null\n"
+            f"node_ttl_seconds: {int(cfg['node_ttl_seconds'])}\n",
+            encoding="utf-8",
+        )
+        Path(mooncake_path).write_text(
+            json.dumps(
+                {
+                    "engine_ip": node_ip,
+                    "engine_port": int(cfg["transfer_engine_port_base"]) + node_index,
+                    "metadata_backend": "redis",
+                    "metadata_server": f"redis://{cfg['metadata_host']}:{cfg['mooncake_redis_port']}",
+                    "metadata_server_auth": "",
+                    "protocol": cfg["protocol"],
+                    "device_name": cfg["device_name"],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        log_dir = Path(cfg["log_dir"])
+        log_dir.mkdir(parents=True, exist_ok=True)
+        self.log_file = open(log_dir / f"flexkv-node-{run_id}-{node_index}.log", "a", encoding="utf-8")
+        env = os.environ.copy()
+        env.update(
+            {
+                "CUDA_VISIBLE_DEVICES": ",".join(cfg["gpu_ids"]),
+                "FLEXKV_CONFIG_PATH": config_path,
+                "MOONCAKE_CONFIG_PATH": mooncake_path,
+                "FLEXKV_ENABLE_P2P": "1",
+                "FLEXKV_SERVER_CLIENT_MODE": "1",
+                "FLEXKV_SERVER_RECV_PORT": f"ipc://{server_path}",
+                "VLLM_CUMEM_ENABLE_SHAREABLE_HANDLE": "1",
+                "FLEXKV_ENABLE_MPS": "0",
+                "MC_LEGACY_RPC_PORT_BINDING": "1",
+            }
+        )
+        cmd = [
+            sys.executable,
+            "-m",
+            "verl.workers.rollout.flexkv_service",
+            "serve",
+            "--server-recv-port",
+            f"ipc://{server_path}",
+            "--gpu-register-port",
+            f"ipc://{gpu_register_path}",
+            "--expected-gpus",
+            str(cfg["expected_gpus"]),
+            "--instance-num",
+            str(cfg["instance_num"]),
+            "--tp-size",
+            str(cfg["tp_size"]),
+            "--model-path",
+            cfg["model_path"],
+            "--tokens-per-block",
+            str(cfg["tokens_per_block"]),
+            "--packed-kv",
+        ]
+        self.process = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=self.log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        _wait_socket(server_path, self.process, float(cfg["startup_timeout_s"]))
+        print(
+            f"VERL_FLEXKV_SERVICE phase=NODE_READY node_id={cfg['node_id']} "
+            f"node_ip={node_ip} gpus={cfg['gpu_ids']} socket={server_path}",
+            flush=True,
+        )
+        return {
+            "FLEXKV_ENABLE_P2P": "1",
+            "FLEXKV_SERVER_CLIENT_MODE": "1",
+            "FLEXKV_SERVER_LAUNCH_MODE": "external",
+            "FLEXKV_SERVER_RECV_PORT": f"ipc://{server_path}",
+            "FLEXKV_INSTANCE_NUM": str(cfg["instance_num"]),
+            "FLEXKV_CPU_CACHE_GB": str(cfg["cpu_cache_gb"]),
+            "FLEXKV_CONFIG_PATH": config_path,
+            "MOONCAKE_CONFIG_PATH": mooncake_path,
+            "VLLM_CUMEM_ENABLE_SHAREABLE_HANDLE": "1",
+            "FLEXKV_ENABLE_MPS": "0",
+            "MC_LEGACY_RPC_PORT_BINDING": "1",
+        }
+
+    def stop(self) -> None:
+        if self.process is not None:
+            import psutil
+
+            try:
+                root = psutil.Process(self.process.pid)
+                processes = root.children(recursive=True) + [root]
+            except psutil.NoSuchProcess:
+                processes = []
+            for process in reversed(processes):
+                try:
+                    process.terminate()
+                except psutil.NoSuchProcess:
+                    pass
+            _, alive = psutil.wait_procs(processes, timeout=5)
+            for process in alive:
+                try:
+                    process.kill()
+                except psutil.NoSuchProcess:
+                    pass
+            psutil.wait_procs(alive, timeout=5)
+        if self.log_file is not None:
+            self.log_file.close()
+
+
+class FlexKVServiceManager:
+    """Driver-side coordinator shared by all vLLM replicas."""
+
+    def __init__(self, rollout_config, model_config):
+        self.config = OmegaConf.to_container(rollout_config.flexkv_service, resolve=True)
+        self.model_path = getattr(model_config, "path")
+        self.tp_size = int(rollout_config.tensor_model_parallel_size)
+        self.expected_gpus = int(self.config["expected_gpus_per_node"] or rollout_config.n_gpus_per_node)
+        if self.expected_gpus % self.tp_size:
+            raise ValueError("expected_gpus_per_node must be divisible by rollout TP")
+        self.metadata_node_id = str(ray.get_runtime_context().get_node_id())
+        self.run_id = str(ray.get_runtime_context().get_job_id()).replace(":", "")[:8]
+        self.lock = asyncio.Lock()
+        self.nodes: dict[str, dict[str, Any]] = {}
+        self.metadata_actor = None
+        self.metadata = None
+
+    async def _ensure_metadata(self) -> None:
+        if self.metadata is not None:
+            return
+        actor_cls = ray.remote(num_cpus=0.1)(FlexKVMetadataService)
+        metadata_config = dict(self.config)
+        metadata_config["node_id"] = self.metadata_node_id
+        self.metadata_actor = actor_cls.options(
+            scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=self.metadata_node_id, soft=False)
+        ).remote(metadata_config)
+        self.metadata = await self.metadata_actor.start.remote()
+
+    async def register_node(self, node_id: str, gpu_ids: list[str]) -> dict[str, str]:
+        async with self.lock:
+            await self._ensure_metadata()
+            state = self.nodes.setdefault(
+                node_id,
+                {
+                    "gpus": set(),
+                    "event": asyncio.Event(),
+                    "env": None,
+                    "actor": None,
+                    "error": None,
+                    "index": len(self.nodes),
+                },
+            )
+            state["gpus"].update(gpu_ids)
+            if len(state["gpus"]) > self.expected_gpus:
+                raise RuntimeError(f"node {node_id} reported too many GPUs: {state['gpus']}")
+            if len(state["gpus"]) == self.expected_gpus and state["actor"] is None:
+                node_cfg = dict(self.config)
+                node_cfg.update(
+                    {
+                        "run_id": self.run_id,
+                        "node_id": node_id,
+                        "node_index": state["index"],
+                        "gpu_ids": sorted(state["gpus"], key=int),
+                        "expected_gpus": self.expected_gpus,
+                        "instance_num": self.expected_gpus // self.tp_size,
+                        "tp_size": self.tp_size,
+                        "model_path": self.model_path,
+                        "metadata_host": self.metadata["host"],
+                    }
+                )
+                actor_cls = ray.remote(num_cpus=0.1)(FlexKVNodeService)
+                state["actor"] = actor_cls.options(
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=node_id, soft=False)
+                ).remote(node_cfg)
+                try:
+                    state["env"] = await state["actor"].start.remote()
+                except Exception as e:
+                    state["error"] = e
+                finally:
+                    state["event"].set()
+            event = state["event"]
+        try:
+            await asyncio.wait_for(event.wait(), timeout=float(self.config["startup_timeout_s"]))
+        except asyncio.TimeoutError as e:
+            observed = sorted(self.nodes[node_id]["gpus"])
+            raise TimeoutError(
+                f"timed out waiting for {self.expected_gpus} FlexKV GPUs on node {node_id}; observed {observed}"
+            ) from e
+        state = self.nodes[node_id]
+        if state["error"] is not None:
+            raise RuntimeError(f"failed to start FlexKV service on node {node_id}") from state["error"]
+        return dict(state["env"])
+
+    async def shutdown(self) -> None:
+        actors = [state["actor"] for state in self.nodes.values() if state["actor"] is not None]
+        if actors:
+            await asyncio.gather(*(actor.stop.remote() for actor in actors), return_exceptions=True)
+        if self.metadata_actor is not None:
+            await self.metadata_actor.stop.remote()
+
+
+def _run_node_server() -> None:
+    import argparse
+
+    import torch
+    from transformers import AutoConfig
+    from mooncake.engine import TransferEngine
+
+    from flexkv.common.config import (
+        CacheConfig,
+        ModelConfig,
+        RankInfo,
+        load_user_config_from_file,
+        update_default_config_from_user_config,
+    )
+    from flexkv.server.server import KVServer
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("serve")
+    parser.add_argument("--server-recv-port", required=True)
+    parser.add_argument("--gpu-register-port", required=True)
+    parser.add_argument("--expected-gpus", type=int, required=True)
+    parser.add_argument("--instance-num", type=int, required=True)
+    parser.add_argument("--tp-size", type=int, required=True)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--tokens-per-block", type=int, default=16)
+    parser.add_argument("--packed-kv", action="store_true")
+    args = parser.parse_args()
+    assert TransferEngine is not None
+
+    hf = AutoConfig.from_pretrained(args.model_path, trust_remote_code=True)
+    text = getattr(hf, "text_config", hf)
+    head_dim = getattr(text, "head_dim", None) or text.hidden_size // text.num_attention_heads
+    if args.packed_kv:
+        head_dim *= 2
+    model_config = ModelConfig(
+        num_layers=text.num_hidden_layers,
+        num_kv_heads=text.num_key_value_heads,
+        head_size=head_dim,
+        packed_kv=args.packed_kv,
+        dtype=torch.bfloat16,
+        tp_size=args.tp_size,
+        pp_size=1,
+        dp_size=1,
+        nnodes=1,
+        instance_num=args.instance_num,
+    )
+    model_config.freeze()
+    cache_config = CacheConfig(tokens_per_block=args.tokens_per_block)
+    user_config = load_user_config_from_file(os.environ["FLEXKV_CONFIG_PATH"])
+    update_default_config_from_user_config(RankInfo(model_config=model_config), cache_config, user_config)
+    server = KVServer(
+        model_config=model_config,
+        cache_config=cache_config,
+        gpu_register_port=args.gpu_register_port,
+        server_recv_port=args.server_recv_port,
+    )
+    server.run()
+
+
+if __name__ == "__main__":
+    _run_node_server()

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -475,8 +475,11 @@ class LLMServerManager:
 
         flexkv_service = self.rollout_config.get("flexkv_service", {})
         if bool(flexkv_service.get("auto_start", False)):
-            if self.rollout_config.name != "vllm" or self.rollout_config.get("kv_backend") != "flexkv":
-                raise ValueError("flexkv_service.auto_start requires rollout.name=vllm and kv_backend=flexkv")
+            supported_rollouts = {"vllm", "sglang"}
+            if self.rollout_config.name not in supported_rollouts or self.rollout_config.get("kv_backend") != "flexkv":
+                raise ValueError(
+                    "flexkv_service.auto_start requires rollout.name in {vllm, sglang} and kv_backend=flexkv"
+                )
             from verl.workers.rollout.flexkv_service import FlexKVServiceManager
 
             self.flexkv_service_manager = FlexKVServiceManager(self.rollout_config, self.model_config)

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -471,6 +471,15 @@ class LLMServerManager:
         self.worker_group = worker_group
         self.rollout_resource_pool = rollout_resource_pool
         self.start_rank = start_rank
+        self.flexkv_service_manager = None
+
+        flexkv_service = self.rollout_config.get("flexkv_service", {})
+        if bool(flexkv_service.get("auto_start", False)):
+            if self.rollout_config.name != "vllm" or self.rollout_config.get("kv_backend") != "flexkv":
+                raise ValueError("flexkv_service.auto_start requires rollout.name=vllm and kv_backend=flexkv")
+            from verl.workers.rollout.flexkv_service import FlexKVServiceManager
+
+            self.flexkv_service_manager = FlexKVServiceManager(self.rollout_config, self.model_config)
 
         assert worker_group is not None or self.rollout_config.nnodes > 0, "nnodes must be > 0 in standalone mode"
 
@@ -537,6 +546,8 @@ class LLMServerManager:
             )
             for replica_rank in range(num_replicas)
         ]
+        for replica in self.rollout_replicas:
+            replica.flexkv_service_manager = self.flexkv_service_manager
 
         if self.worker_group and self.rollout_config.name != "trtllm":
             await asyncio.gather(*[server.init_hybrid(self.worker_group) for server in self.rollout_replicas])
@@ -550,6 +561,11 @@ class LLMServerManager:
             )
         else:
             await asyncio.gather(*[server.init_standalone() for server in self.rollout_replicas])
+
+        # Replicas only need the manager while launching servers. Keeping it
+        # attached would make their later serialization capture asyncio state.
+        for replica in self.rollout_replicas:
+            replica.flexkv_service_manager = None
 
         self.server_handles = [server._server_handle for server in self.rollout_replicas]
         self.server_addresses = [server._server_address for server in self.rollout_replicas]
@@ -592,6 +608,10 @@ class LLMServerManager:
             load_balancer_handle=self.global_load_balancer,
             **kwargs,
         )
+
+    async def shutdown(self) -> None:
+        if self.flexkv_service_manager is not None:
+            await self.flexkv_service_manager.shutdown()
 
     def get_addresses(self) -> list[str]:
         """Get the OpenAI chat completion API http addresses of the LLM server replicas."""

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -76,6 +76,25 @@ class GlobalRequestLoadBalancer:
         self._inflight_requests: dict[str, int] = {sid: 0 for sid in servers}
         self._request_id_to_server: LRUCache = LRUCache(maxsize=max_cache_size)
         self._full_determinism = full_determinism
+        self._abort_kv_reuse_event: asyncio.Event | None = None
+        self._abort_kv_reuse_cycle_id: int | None = None
+
+    def begin_abort_kv_reuse_cycle(self, cycle_id: int) -> None:
+        self._abort_kv_reuse_cycle_id = int(cycle_id)
+        self._abort_kv_reuse_event = asyncio.Event()
+
+    async def wait_abort_kv_reuse_ready(self) -> int | None:
+        event = self._abort_kv_reuse_event
+        cycle_id = self._abort_kv_reuse_cycle_id
+        if event is None or cycle_id is None:
+            return None
+        await event.wait()
+        return cycle_id
+
+    def mark_abort_kv_reuse_ready(self, cycle_id: int) -> None:
+        if self._abort_kv_reuse_event is None or self._abort_kv_reuse_cycle_id != int(cycle_id):
+            raise RuntimeError(f"abort KV reuse cycle {cycle_id} was not initialized")
+        self._abort_kv_reuse_event.set()
 
     def acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
         """Acquire a server for the given request (sticky + least-loaded).
@@ -414,6 +433,9 @@ class FullyAsyncLLMServerClient(LLMServerClient):
             if output.stop_reason not in ("aborted", "abort") or not should_retry:
                 break
 
+            abort_kv_cfg = self.config.actor_rollout_ref.rollout.get("abort_kv_reuse", {})
+            if bool(abort_kv_cfg.get("enabled", False)):
+                await self._load_balancer.wait_abort_kv_reuse_ready.remote()
             await asyncio.sleep(1)
 
         final_output.extra_fields["global_steps"] = global_steps

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -266,13 +266,23 @@ class RolloutReplica(ABC):
         """Wake up each rollout server."""
         await asyncio.gather(*[server.wake_up.remote() for server in self.servers])
 
-    async def sleep(self):
+    async def sleep(self, reset_connector: bool = True):
         """Sleep each rollout server."""
-        await asyncio.gather(*[server.sleep.remote() for server in self.servers])
+        if reset_connector:
+            await asyncio.gather(*[server.sleep.remote() for server in self.servers])
+        else:
+            await asyncio.gather(
+                *[server.sleep.remote(reset_connector=False) for server in self.servers]
+            )
 
-    async def abort_all_requests(self):
-        """Partial rollout: abort and save all unfinished requests in each rollout server."""
-        await asyncio.gather(*[server.abort_all_requests.remote() for server in self.servers])
+    async def abort_all_requests(self, checkpoint_kv: bool = False, timeout_s: float = 30.0):
+        """Abort requests and optionally wait for external KV checkpointing."""
+        await asyncio.gather(
+            *[
+                server.abort_all_requests.remote(checkpoint_kv=checkpoint_kv, timeout_s=timeout_s)
+                for server in self.servers
+            ]
+        )
 
     async def resume_generation(self):
         """Resume generation on all servers after abort_all_requests."""

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -128,6 +128,13 @@ class RolloutReplica(ABC):
         self._server_address: str = None
         self._server_handle: ActorHandle = None
 
+    async def _get_flexkv_service_env(self, node_id: str, gpu_ids: list[str]) -> dict[str, str]:
+        """Register a rollout node with the shared FlexKV service, when enabled."""
+        manager = getattr(self, "flexkv_service_manager", None)
+        if manager is None:
+            return {}
+        return await manager.register_node(node_id, gpu_ids)
+
     async def init_hybrid(self, worker_group: RayWorkerGroup):
         """Init hybrid rollout server, rollout engine and training engine(fsdp/megatron) fused in same process.
 

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -44,7 +44,7 @@ from sglang.srt.managers.tokenizer_manager import ServerStatus
 
 from verl.plugin.platform import get_platform
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import get_visible_devices_keyword
+from verl.utils.device import get_resource_name, get_visible_devices_keyword
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler, build_sglang_profiler_args
 from verl.utils.tracking import RLInsightLogger
@@ -144,6 +144,10 @@ class SGLangHttpServer:
             f"{nnodes=}, {cuda_visible_devices=}, role={disaggregation_role}"
         )
         os.environ[visible_devices_keyword] = cuda_visible_devices
+        os.environ["VERL_REPLICA_RANK"] = str(replica_rank)
+        flexkv_instance_num = int(os.getenv("FLEXKV_INSTANCE_NUM", "1"))
+        if flexkv_instance_num > 1:
+            os.environ["FLEXKV_INSTANCE_ID"] = str(replica_rank % flexkv_instance_num)
 
         assert disaggregation_role in ("null", "prefill", "decode"), (
             f"disaggregation_role must be 'null'|'prefill'|'decode', got {disaggregation_role!r}"
@@ -255,6 +259,17 @@ class SGLangHttpServer:
                 self._master_port = master_port
 
         engine_kwargs = self.config.get("engine_kwargs", {}).get("sglang", {}) or {}
+        abort_kv_config = self.config.get("abort_kv_reuse", {}) or {}
+        kv_backend = self.config.get("kv_backend")
+        if bool(abort_kv_config.get("enabled", False)) and kv_backend != "flexkv":
+            raise ValueError(
+                "SGLang abort_kv_reuse requires kv_backend=flexkv, "
+                f"got {kv_backend!r}"
+            )
+        if kv_backend == "flexkv":
+            engine_kwargs["enable_flexkv"] = True
+            engine_kwargs["flexkv_config_file"] = os.environ.get("FLEXKV_CONFIG_PATH")
+            engine_kwargs.setdefault("page_size", int(self.config.flexkv_service["tokens_per_block"]))
         attention_backend = engine_kwargs.pop("attention_backend", None)
         mm_attention_backend = engine_kwargs.pop("mm_attention_backend", None)
         # Delta checkpoint engines apply sparse weight updates in place through SGLang's
@@ -403,10 +418,9 @@ class SGLangHttpServer:
         sglang.srt.entrypoints.engine._set_envs_and_config = _set_envs_and_config
         os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"
         server_args = ServerArgs(**args)
-        # For SGLang main branch or version >= 0.5.10
-        # The latest main branch of SGLang has wrapped the _launch_subprocesses function inside the Engine class
-        if version.parse(sglang.__version__) >= version.parse("0.5.10"):
-            from sglang.srt.entrypoints.http_server import Engine
+        # Prefer feature detection because development branches may retain an older version string.
+        if hasattr(sglang.srt.entrypoints.engine.Engine, "_launch_subprocesses"):
+            from sglang.srt.entrypoints.engine import Engine
 
             self.tokenizer_manager, self.template_manager, self.scheduler_info, *_ = Engine._launch_subprocesses(
                 server_args=server_args,
@@ -482,7 +496,7 @@ class SGLangHttpServer:
             self.model_config.lora_rank > 0 or self.model_config.lora.get("rank", 0) > 0
         ) and not self.model_config.lora.get("merge", False)
 
-    async def sleep(self):
+    async def sleep(self, reset_connector: bool = True):
         if self.node_rank != 0 or not self.config.free_cache_engine:
             return
 
@@ -495,14 +509,14 @@ class SGLangHttpServer:
             tags = ["kv_cache", "weights"]
 
         if self.rollout_mode == RolloutMode.HYBRID:
-            obj = ReleaseMemoryOccupationReqInput(tags=tags)
+            obj = ReleaseMemoryOccupationReqInput(tags=tags, reset_connector=reset_connector)
             await self.tokenizer_manager.release_memory_occupation(obj, None)
         elif self.rollout_mode == RolloutMode.COLOCATED:
-            obj = ReleaseMemoryOccupationReqInput(tags=tags)
+            obj = ReleaseMemoryOccupationReqInput(tags=tags, reset_connector=reset_connector)
             await self.tokenizer_manager.release_memory_occupation(obj, None)
         elif self.rollout_mode == RolloutMode.STANDALONE:
             # In standalone mode, resume kv_cache if free_cache_engine is enabled
-            obj = ReleaseMemoryOccupationReqInput(tags=["kv_cache"])
+            obj = ReleaseMemoryOccupationReqInput(tags=["kv_cache"], reset_connector=reset_connector)
             await self.tokenizer_manager.release_memory_occupation(obj, None)
 
     async def clear_kv_cache(self):
@@ -706,10 +720,14 @@ class SGLangHttpServer:
         """Set the global steps of the model weights."""
         self.global_steps = global_steps
 
-    async def abort_all_requests(self):
+    async def abort_all_requests(self, checkpoint_kv: bool = False, timeout_s: float = 30.0):
         if self.node_rank != 0:
             return
-        await self.tokenizer_manager.pause_generation(PauseGenerationReqInput(mode="abort"))
+        await self.tokenizer_manager.pause_generation(
+            PauseGenerationReqInput(
+                mode="abort", checkpoint_aborted_kv=checkpoint_kv, checkpoint_timeout_s=timeout_s
+            )
+        )
 
     async def resume_generation(self):
         if self.node_rank != 0:
@@ -768,13 +786,18 @@ class SGLangReplica(RolloutReplica):
         worker_infos = await asyncio.gather(
             *[
                 worker.__ray_call__.remote(
-                    lambda self: (ray.get_runtime_context().get_node_id(), os.environ[visible_devices_keyword])
+                    lambda self: (
+                        ray.get_runtime_context().get_node_id(),
+                        os.environ[visible_devices_keyword],
+                        ray.get_runtime_context().get_accelerator_ids()[get_resource_name()][0],
+                    )
                 )
                 for worker in self.workers
             ]
         )
         worker_cuda_visible_devices = [worker_info[1] for worker_info in worker_infos]
         worker_node_ids = [worker_info[0] for worker_info in worker_infos]
+        worker_service_gpu_ids = [worker_info[2] for worker_info in worker_infos]
         base_gpu_id = 0
         infer_tp = self.config.tensor_model_parallel_size * self.config.data_parallel_size
         replica_world_size = infer_tp * self.config.pipeline_model_parallel_size
@@ -804,6 +827,10 @@ class SGLangReplica(RolloutReplica):
             )
 
             node_id = worker_node_ids[node_rank * self.gpus_per_replica_node]
+            node_gpu_ids = worker_service_gpu_ids[
+                node_rank * self.gpus_per_replica_node : (node_rank + 1) * self.gpus_per_replica_node
+            ]
+            service_env = await self._get_flexkv_service_env(node_id, node_gpu_ids)
             if self.is_reward_model:
                 name = f"sglang_server_reward_{self.replica_rank}_{node_rank}{self.name_suffix}"
             elif self.is_teacher_model:
@@ -819,6 +846,7 @@ class SGLangReplica(RolloutReplica):
                     "env_vars": {
                         **{var: "1" for var in get_platform().ray_noset_envvars()},
                         **get_platform().rollout_env_vars(),
+                        **service_env,
                     }
                 },
                 name=name,
@@ -856,13 +884,13 @@ class SGLangReplica(RolloutReplica):
             else f"{server_address}:{server_port}"
         )
 
-    async def abort_all_requests(self):
+    async def abort_all_requests(self, checkpoint_kv: bool = False, timeout_s: float = 30.0):
         """Abort all ongoing generation requests on the primary server.
 
         SGLang control RPCs are only served by the node-rank 0 server for a
         multi-node replica, so avoid broadcasting this call to every server.
         """
-        await self.servers[0].abort_all_requests.remote()
+        await self.servers[0].abort_all_requests.remote(checkpoint_kv=checkpoint_kv, timeout_s=timeout_s)
 
     async def resume_generation(self):
         """Resume generation on the primary server after abort_all_requests."""

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -125,6 +125,9 @@ class vLLMHttpServer:
 
         os.environ[get_visible_devices_keyword()] = cuda_visible_devices
         os.environ["VERL_REPLICA_RANK"] = str(replica_rank)
+        flexkv_instance_num = int(os.getenv("FLEXKV_INSTANCE_NUM", "1"))
+        if flexkv_instance_num > 1:
+            os.environ["FLEXKV_INSTANCE_ID"] = str(replica_rank % flexkv_instance_num)
         # Forward the Ray job id into the vLLM worker subprocess so the
         # colocated weight-transfer IPC socket path is unique per Ray job.
         # Without this, two concurrent verl jobs on the same node both bind

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -250,6 +250,38 @@ class vLLMHttpServer:
         # 1. setup vllm serve cli args
         engine_kwargs = self.config.get("engine_kwargs", {}).get(self._get_engine_kwargs_key(), {}) or {}
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
+        abort_kv_config = self.config.get("abort_kv_reuse", {}) or {}
+        if bool(abort_kv_config.get("enabled", False)):
+            kv_backend = self.config.get("kv_backend")
+            kv_transfer_config = engine_kwargs.get("kv_transfer_config") or {}
+            kv_connector = (
+                kv_transfer_config.get("kv_connector")
+                if isinstance(kv_transfer_config, dict)
+                else getattr(kv_transfer_config, "kv_connector", None)
+            )
+            kv_role = (
+                kv_transfer_config.get("kv_role")
+                if isinstance(kv_transfer_config, dict)
+                else getattr(kv_transfer_config, "kv_role", None)
+            )
+            expected_connectors = {"mooncake_store": "MooncakeStoreConnector"}
+            if kv_backend not in expected_connectors:
+                raise ValueError(
+                    "abort_kv_reuse requires kv_backend=mooncake_store in the first version; "
+                    f"got {kv_backend!r}"
+                )
+            expected_connector = expected_connectors[kv_backend]
+            if kv_connector != expected_connector or kv_role != "kv_both":
+                raise ValueError(
+                    "abort_kv_reuse configuration mismatch: "
+                    f"backend={kv_backend!r}, connector={kv_connector!r}, kv_role={kv_role!r}"
+                )
+            logger.info(
+                "abort KV reuse backend validated: backend=%s connector=%s role=%s",
+                kv_backend,
+                kv_connector,
+                kv_role,
+            )
         if self.config.get("limit_images", None):  # support for multi-image data
             engine_kwargs["limit_mm_per_prompt"] = {"image": self.config.get("limit_images")}
 

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -264,10 +264,14 @@ class vLLMHttpServer:
                 if isinstance(kv_transfer_config, dict)
                 else getattr(kv_transfer_config, "kv_role", None)
             )
-            expected_connectors = {"mooncake_store": "MooncakeStoreConnector"}
+            expected_connectors = {
+                "mooncake_store": "MooncakeStoreConnector",
+                "flexkv": "FlexKVConnectorV1",
+            }
             if kv_backend not in expected_connectors:
                 raise ValueError(
-                    "abort_kv_reuse requires kv_backend=mooncake_store in the first version; "
+                    "abort_kv_reuse requires a supported external KV backend; "
+                    f"supported={sorted(expected_connectors)}, "
                     f"got {kv_backend!r}"
                 )
             expected_connector = expected_connectors[kv_backend]

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -17,6 +17,7 @@ import inspect
 import json
 import logging
 import os
+import time
 import uuid
 from pprint import pprint
 from typing import Any, Callable, Optional
@@ -788,14 +789,14 @@ class vLLMHttpServer:
         elif self.rollout_mode == RolloutMode.STANDALONE:
             logger.info("skip wake_up in standalone mode")
 
-    async def sleep(self):
+    async def sleep(self, reset_connector: bool = True):
         if self.node_rank != 0 or not self.config.free_cache_engine:
             return
 
         if self.rollout_mode == RolloutMode.HYBRID:
-            await self._sleep_hybrid()
+            await self._sleep_hybrid(reset_connector=reset_connector)
         elif self.rollout_mode == RolloutMode.COLOCATED:
-            await self.engine.sleep(level=1)
+            await self.engine.sleep(level=1, reset_connector=reset_connector)
         elif self.rollout_mode == RolloutMode.STANDALONE:
             logger.info("skip sleep in standalone mode")
 
@@ -849,7 +850,12 @@ class vLLMHttpServer:
     async def wait_for_requests_to_drain(self):
         await self.engine.wait_for_requests_to_drain()
 
-    async def abort_all_requests(self, reset_prefix_cache: bool = True) -> dict[str, Any]:
+    async def abort_all_requests(
+        self,
+        reset_prefix_cache: bool = True,
+        checkpoint_kv: bool = False,
+        timeout_s: float = 30.0,
+    ) -> dict[str, Any]:
         """Abort all ongoing generation requests.
 
         On vLLM >= 0.12.0, uses AsyncLLM.pause_generation() to abort in-flight
@@ -868,26 +874,51 @@ class vLLMHttpServer:
             # Snapshot request IDs before pausing for reporting
             request_ids = list(self.engine.output_processor.request_states.keys())
 
-            # pause_generation with wait_for_inflight_requests=False will:
-            # 1. Set engine to paused state (blocks new generate calls)
-            # 2. Abort all in-flight requests
-            # 3. Wait for requests to drain
-            # 4. Clear prefix and mm caches if clear_cache=True.
-            #    EngineCore._reset_caches defaults reset_connector=True
-            #    on this path, so any attached external KV store (e.g.
-            #    MooncakeStoreConnector) is invalidated along with the
-            #    local prefix cache — RL-correct hard-reset at every
-            #    weight update boundary, no extra kwargs needed.
+            if checkpoint_kv:
+                print(
+                    "VERL_ABORT_KV_EVENT "
+                    + json.dumps(
+                        {
+                            "phase": "BARRIER_WAIT_START",
+                            "replica_id": self.replica_rank,
+                            "node_rank": self.node_rank,
+                            "request_count": len(request_ids),
+                            "timeout_s": timeout_s,
+                            "wall_ns": time.time_ns(),
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
+            # pause_generation() waits for delayed-free connector work to finish.
             await self.engine.pause_generation(
+                mode="abort",
                 wait_for_inflight_requests=False,
-                clear_cache=reset_prefix_cache,
+                clear_cache=(reset_prefix_cache and not checkpoint_kv),
             )
+            if checkpoint_kv:
+                print(
+                    "VERL_ABORT_KV_EVENT "
+                    + json.dumps(
+                        {
+                            "phase": "BARRIER_VISIBLE",
+                            "replica_id": self.replica_rank,
+                            "node_rank": self.node_rank,
+                            "request_count": len(request_ids),
+                            "wall_ns": time.time_ns(),
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
 
             logger.info(f"Aborted {len(request_ids)} requests: {request_ids}")
             return {"aborted_count": len(request_ids), "request_ids": request_ids}
 
         except Exception as e:
             logger.error(f"Error aborting requests: {e}")
+            if checkpoint_kv:
+                raise
             return {"aborted_count": 0, "request_ids": [], "error": str(e)}
 
     async def resume_generation(self):
@@ -1073,7 +1104,7 @@ class vLLMHttpServer:
         """Return the tags passed to engine.wake_up(). Default includes kv_cache."""
         return ["kv_cache", "weights"]
 
-    async def _sleep_hybrid(self):
+    async def _sleep_hybrid(self, reset_connector: bool = True):
         """HYBRID sleep: adapters and MTP need level=1; full weights need level=2.
 
         Uses engine.sleep() instead of engine.collective_rpc("sleep") to ensure
@@ -1096,7 +1127,7 @@ class vLLMHttpServer:
             sleep_level = 1
         else:
             sleep_level = 2
-        await self.engine.sleep(level=sleep_level)
+        await self.engine.sleep(level=sleep_level, reset_connector=reset_connector)
         await self.engine.reset_encoder_cache()
 
 
@@ -1198,19 +1229,30 @@ class vLLMReplica(RolloutReplica):
             else f"{server_address}:{server_port}"
         )
 
-    async def sleep(self):
+    async def sleep(self, reset_connector: bool = True):
         """Sleep each rollout server."""
         # Drain DP engines for safe sleep.
         await self.servers[0].wait_for_requests_to_drain.remote()
-        await asyncio.gather(*[server.sleep.remote() for server in self.servers])
+        await asyncio.gather(
+            *[server.sleep.remote(reset_connector=reset_connector) for server in self.servers]
+        )
 
-    async def abort_all_requests(self) -> dict[str, Any]:
+    async def abort_all_requests(
+        self, checkpoint_kv: bool = False, timeout_s: float = 30.0
+    ) -> dict[str, Any]:
         """Abort all ongoing generation requests across all servers.
 
         Returns:
             dict[str, Any]: Combined abort results from all servers.
         """
-        results = await asyncio.gather(*[server.abort_all_requests.remote() for server in self.servers])
+        results = await asyncio.gather(
+            *[
+                server.abort_all_requests.remote(
+                    checkpoint_kv=checkpoint_kv, timeout_s=timeout_s
+                )
+                for server in self.servers
+            ]
+        )
 
         total_aborted = sum(r.get("aborted_count", 0) for r in results)
         all_request_ids = []

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1215,6 +1215,13 @@ class vLLMReplica(RolloutReplica):
                 worker_cuda_visible_devices[node_rank * gpus_per_replica_node : (node_rank + 1) * gpus_per_replica_node]
             )
             node_id = worker_node_ids[node_rank * gpus_per_replica_node]
+            service_env = {}
+            flexkv_service_manager = getattr(self, "flexkv_service_manager", None)
+            if flexkv_service_manager is not None:
+                node_gpu_ids = worker_cuda_visible_devices[
+                    node_rank * gpus_per_replica_node : (node_rank + 1) * gpus_per_replica_node
+                ]
+                service_env = await flexkv_service_manager.register_node(node_id, node_gpu_ids)
             prefix = self._get_server_name_prefix()
             if self.is_reward_model:
                 name = f"{prefix}server_reward_{self.replica_rank}_{node_rank}{self.name_suffix}"
@@ -1225,6 +1232,7 @@ class vLLMReplica(RolloutReplica):
             env_vars = {
                 **{var: "1" for var in get_platform().ray_noset_envvars()},
                 **get_platform().rollout_env_vars(),
+                **service_env,
             }
 
             server = self.server_class.options(

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1215,13 +1215,10 @@ class vLLMReplica(RolloutReplica):
                 worker_cuda_visible_devices[node_rank * gpus_per_replica_node : (node_rank + 1) * gpus_per_replica_node]
             )
             node_id = worker_node_ids[node_rank * gpus_per_replica_node]
-            service_env = {}
-            flexkv_service_manager = getattr(self, "flexkv_service_manager", None)
-            if flexkv_service_manager is not None:
-                node_gpu_ids = worker_cuda_visible_devices[
-                    node_rank * gpus_per_replica_node : (node_rank + 1) * gpus_per_replica_node
-                ]
-                service_env = await flexkv_service_manager.register_node(node_id, node_gpu_ids)
+            node_gpu_ids = worker_cuda_visible_devices[
+                node_rank * gpus_per_replica_node : (node_rank + 1) * gpus_per_replica_node
+            ]
+            service_env = await self._get_flexkv_service_env(node_id, node_gpu_ids)
             prefix = self._get_server_name_prefix()
             if self.is_reward_model:
                 name = f"{prefix}server_reward_{self.replica_rank}_{node_rank}{self.name_suffix}"


### PR DESCRIPTION
### What does this PR do?

Add a backend-neutral lifecycle for reusing KV cache from requests aborted during fully asynchronous dynamic resource transitions.

Before a hybrid rollout replica is deactivated, VERL now:

1. removes the replica from the load balancer;
2. aborts in-flight requests and asks the configured KV backend to checkpoint their KV;
3. waits for the checkpoint barrier;
4. sleeps the rollout engine without clearing the current policy's external KV namespace; and
5. retries aborted requests only after the checkpoint is ready.

The implementation supports:

- vLLM with Mooncake or FlexKV;
- SGLang with FlexKV;
- Ray-managed FlexKV metadata and per-node services, so a normal VERL launch remains the only user entry point.

This PR contains the VERL-side lifecycle, configuration, service ownership, and vLLM/SGLang adapters. It depends on the following companion branches for the corresponding engine/backend behavior:

- SGLang: [https://github.com/DylanChen-NV/sglang/tree/dynamic-kv-sglang-flexkv-functional](https://github.com/DylanChen-NV/sglang/tree/dynamic-kv-sglang-flexkv-functional)
- FlexKV: [https://github.com/DylanChen-NV/FlexKV/tree/dynamic-kv-flexkv-functional](https://github.com/DylanChen-NV/FlexKV/tree/dynamic-kv-flexkv-functional)
- torch_memory_saver: [https://github.com/DylanChen-NV/torch_memory_saver/tree/dynamic-kv-sglang-flexkv-functional](https://github.com/DylanChen-NV/torch_memory_saver/tree/dynamic-kv-sglang-flexkv-functional) 

### Checklist Before Starting

- [x] Search for similar PRs. Query: [https://github.com/verl-project/verl/pulls?q=is%3Apr+dynamic+resource+KV+reuse](https://github.com/verl-project/verl/pulls?q=is%3Apr+dynamic+resource+KV+reuse)
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
