### PR TITLE
[algo] fix: preserve REINFORCE++ returns across observations

### DIFF
--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -14,6 +14,7 @@
 
 import random
 import unittest
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -24,6 +25,7 @@ from verl.trainer.ppo.core_algos import (
     compute_gae_advantage_return,
     compute_grpo_outcome_advantage,
     compute_grpo_vectorized_outcome_advantage,
+    compute_reinforce_plus_plus_outcome_advantage,
     compute_rloo_outcome_advantage,
     compute_rloo_vectorized_outcome_advantage,
     get_adv_estimator_fn,
@@ -196,6 +198,55 @@ def test_multi_turn_compute_gae_advantage_return():
     assert torch.equal(adv1, adv2), f"{adv1=}, {adv2=}"
     assert torch.equal(ret1, ret2), f"{ret1=}, {ret2=}"
     print(f" [CORRECT] \n\n{adv1=}, \n\n{ret1=}")
+
+
+@pytest.mark.parametrize("gamma", [1.0, 0.5])
+def test_multi_turn_compute_reinforce_plus_plus_advantage(gamma):
+    """Observation tokens must not interrupt returns between assistant turns."""
+    config = SimpleNamespace(gamma=gamma)
+    compact_rewards = torch.tensor([[0.0, 0.0, 0.0, 1.0]])
+    compact_mask = torch.ones_like(compact_rewards)
+    expanded_rewards = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]])
+    expanded_mask = torch.tensor([[1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]])
+
+    compact_advantages, compact_returns = compute_reinforce_plus_plus_outcome_advantage(
+        compact_rewards, compact_mask, config=config
+    )
+    expanded_advantages, expanded_returns = compute_reinforce_plus_plus_outcome_advantage(
+        expanded_rewards, expanded_mask, config=config
+    )
+
+    expected_returns = torch.tensor([[gamma**3, gamma**2, gamma, 1.0]])
+    torch.testing.assert_close(compact_returns, expected_returns)
+    torch.testing.assert_close(expanded_returns[expanded_mask.bool()], compact_returns.flatten())
+    torch.testing.assert_close(expanded_advantages[expanded_mask.bool()], compact_advantages.flatten())
+    torch.testing.assert_close(expanded_returns[:, -2:], torch.zeros(1, 2))
+
+
+def test_batched_reinforce_plus_plus_handles_observations_and_padding():
+    rewards = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.5, 0.0, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    response_mask = torch.tensor(
+        [
+            [1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+
+    advantages, returns = compute_reinforce_plus_plus_outcome_advantage(
+        rewards, response_mask, config=SimpleNamespace(gamma=0.5)
+    )
+
+    torch.testing.assert_close(returns[0][response_mask[0].bool()], torch.tensor([0.125, 0.25, 0.5, 1.0]))
+    torch.testing.assert_close(returns[1][response_mask[1].bool()], torch.tensor([0.5, 1.0, 1.0]))
+    torch.testing.assert_close(returns[2], torch.zeros(8))
+    torch.testing.assert_close(advantages * (1 - response_mask), torch.zeros_like(advantages))
 
 
 def _make_group_index(batch_size: int, num_groups: int) -> np.ndarray:

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -718,10 +718,16 @@ def compute_reinforce_plus_plus_outcome_advantage(
         running_return = 0
 
         for t in reversed(range(token_level_rewards.shape[1])):
-            running_return = token_level_rewards[:, t] + gamma * running_return
+            # Observation tokens use the same zero mask as trailing padding. Because
+            # the scan starts from zero, padding naturally keeps a zero return, while
+            # observation spans must preserve the return from later assistant turns.
+            is_response_token = response_mask[:, t].bool()
+            running_return = torch.where(
+                is_response_token,
+                token_level_rewards[:, t] + gamma * running_return,
+                running_return,
+            )
             returns[:, t] = running_return
-            # Reset after EOS
-            running_return = running_return * response_mask[:, t]
 
         advantages = verl_F.masked_whiten(returns, response_mask)
         advantages = advantages * response_mask


### PR DESCRIPTION
### What does this PR do?

Fixes REINFORCE++ return propagation for multi-turn trajectories containing tool observations.

`response_mask=0` represents both internal observation tokens and trailing padding. The previous reverse scan reset its running return at every zero, so an outcome reward reached only the final assistant turn. This change updates returns only on assistant tokens: internal observations preserve the later-turn return, while trailing padding stays zero because each row's reverse scan starts at zero.

Closes #7278.

### Checklist Before Starting

- [x] Searched open issues and PRs with exact code and symptom terms on 2026-08-06. No matching report or fix was found.
- [x] Search links: [issues](https://github.com/verl-project/verl/issues?q=is%3Aopen+reinforce%2B%2B+observation+mask), [pull requests](https://github.com/verl-project/verl/pulls?q=is%3Aopen+running_return+response_mask)
- [x] PR title: `[algo] fix: preserve REINFORCE++ returns across observations`

The searches covered `reinforce++ observation mask`, `running_return response_mask`, and `multi-turn reward-to-go advantage`. Adjacent discussions about per-turn reward design do not change this existing estimator's mask handling.

### Test

```bash
.venv/bin/python -m pytest tests/trainer/ppo/test_core_algos_on_cpu.py -q
# 26 passed
```

The new tests cover:

- invariance when observation spans are inserted;
- analytic discounted returns for `gamma=1.0` and `gamma=0.5`;
- heterogeneous batched masks, internal observations, trailing padding, and an all-masked row;
- zero advantages outside `response_mask`.

```bash
pre-commit run \
  --files verl/trainer/ppo/core_algos.py tests/trainer/ppo/test_core_algos_on_cpu.py \
  --show-diff-on-failure --color=never
# All 13 configured hooks passed, including Ruff, mypy, config generation, and compile-all.
```

The standalone reproducer changed from:

```text
compact=[1.0, 1.0, 1.0, 1.0] with_observation=[0.0, 0.0, 1.0, 1.0]
```

to:

```text
compact=[1.0, 1.0, 1.0, 1.0] with_observation=[1.0, 1.0, 1.0, 1.0]
```

### API and Usage Example

No API or configuration changes.

### Design & Code Changes

- Use an elementwise `torch.where` recurrence so valid response tokens update `G_t = r_t + gamma * G`, while masked observation/padding tokens retain the current row's `G`.
- Add CPU regression coverage beside the existing multi-turn GAE test.

### Checklist Before Submitting

- [x] Read the contribution guide and repository AI-agent instructions.
- [x] Added focused unit coverage in an existing CPU CI test file.
- [x] Ran targeted tests and all configured pre-commit hooks.
- [x] No user-facing documentation change is needed; behavior now matches the documented `response_mask` contract.
- [x] Human submitter reviewed every changed line and reran the commands above.
- [ ] Request CI in the project's Slack or Feishu channel after opening the PR.

### AI assistance disclosure

OpenAI Codex assisted with repository auditing, reproduction, implementation, test design, validation and duplicate searches.
