### PR TITLE
[trainer, perf] refactor: avoid scalar tensor dispatch in batch balancing

### DIFF
--- a/tests/utils/test_seqlen_balancing.py
+++ b/tests/utils/test_seqlen_balancing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
@@ -20,12 +21,47 @@ from verl import DataProto
 from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device
 from verl.utils.model import create_random_mask
 from verl.utils.seqlen_balancing import (
+    calculate_workload,
+    calculate_workload_as_list,
     ceildiv,
     get_reverse_idx,
+    get_seqlen_balanced_partitions,
     prepare_dynamic_batch,
     rearrange_micro_batches,
     restore_dynamic_batch,
 )
+
+
+def test_calculate_workload_as_list_uses_host_scalars():
+    for dtype, scalar_type in ((torch.int64, int), (torch.float32, np.float32)):
+        seqlens = torch.tensor([64, 128, 256, 512, 1024, 2048, 4096, 8192], dtype=dtype)
+        workload_lst = calculate_workload_as_list(seqlens)
+
+        assert workload_lst == calculate_workload(seqlens).tolist()
+        assert all(type(workload) is scalar_type for workload in workload_lst)
+        assert get_seqlen_balanced_partitions(workload_lst, k_partitions=4, equal_size=True) == (
+            get_seqlen_balanced_partitions(calculate_workload(seqlens), k_partitions=4, equal_size=True)
+        )
+
+
+def test_calculate_workload_as_list_preserves_float32_partitioning():
+    seqlens = torch.tensor(
+        [3765, 30817, 14350, 9825, 28544, 25697, 7113, 20034, 14106, 13834, 10, 7534, 3612, 532, 32621, 15886],
+        dtype=torch.float32,
+    )
+    workload_tensor = calculate_workload(seqlens)
+    original_workloads = workload_tensor.clone()
+
+    for equal_size in (True, False):
+        expected = get_seqlen_balanced_partitions(workload_tensor, k_partitions=2, equal_size=equal_size)
+        assert (
+            get_seqlen_balanced_partitions(calculate_workload_as_list(seqlens), k_partitions=2, equal_size=equal_size)
+            == expected
+        )
+        assert torch.equal(workload_tensor, original_workloads)
+
+    expected = get_seqlen_balanced_partitions(workload_tensor, k_partitions=2, equal_size=True)
+    assert get_seqlen_balanced_partitions(workload_tensor.tolist(), k_partitions=2, equal_size=True) != expected
 
 
 def test_seqlen_balancing():

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -66,7 +66,11 @@ from verl.utils.debug import marked_timer
 from verl.utils.import_utils import deprecated, load_class_from_fqn
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
-from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
+from verl.utils.seqlen_balancing import (
+    calculate_workload_as_list,
+    get_seqlen_balanced_partitions,
+    log_seqlen_unbalance,
+)
 from verl.utils.skip.skip_manager import SkipManager
 from verl.utils.torch_functional import masked_mean
 from verl.utils.tracking import ValidationGenerationsLogger
@@ -1163,7 +1167,7 @@ class RayPPOTrainer:
         attention_mask = batch.batch["attention_mask"]
         batch_size = attention_mask.shape[0]
         global_seqlen_lst = batch.batch["attention_mask"].view(batch_size, -1).sum(-1)  # (train_batch_size,)
-        workload_lst = calculate_workload(global_seqlen_lst)
+        workload_lst = None
         # Get dp_size from dispatch info to correctly balance across data parallel ranks
         # Note: world_size may include tensor/pipeline parallel dimensions, but we only want DP
         dp_size = self._get_dp_size(self.actor_rollout_wg, "actor")
@@ -1194,6 +1198,7 @@ class RayPPOTrainer:
             )
 
         elif keep_minibatch:
+            workload_lst = calculate_workload_as_list(global_seqlen_lst)
             # Decouple the DP balancing and mini-batching.
             minibatch_size = self.config.actor_rollout_ref.actor.get("ppo_mini_batch_size")
             minibatch_num = len(workload_lst) // minibatch_size
@@ -1207,10 +1212,12 @@ class RayPPOTrainer:
                 for j, part in enumerate(rearrange_minibatch_lst):
                     global_partition_lst[j].extend([x + minibatch_size * i for x in part])
         else:
+            workload_lst = calculate_workload_as_list(global_seqlen_lst)
             global_partition_lst = get_seqlen_balanced_partitions(workload_lst, k_partitions=dp_size, equal_size=True)
         # Place smaller micro-batches at both ends to reduce the bubbles in pipeline parallel.
         # Skip reordering within partitions for PrefixGrouper to maintain uid grouping
         if not getattr(self, "use_prefix_grouper", False):
+            assert workload_lst is not None
             for idx, partition in enumerate(global_partition_lst):
                 partition.sort(key=lambda x: (workload_lst[x], x))
                 ordered_partition = partition[::2] + partition[1::2][::-1]

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -82,7 +82,11 @@ from verl.utils.debug.metrics import calculate_debug_metrics
 from verl.utils.import_utils import load_extern_type
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
-from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
+from verl.utils.seqlen_balancing import (
+    calculate_workload_as_list,
+    get_seqlen_balanced_partitions,
+    log_seqlen_unbalance,
+)
 from verl.utils.skip import SkipManager
 from verl.utils.tracking import DapoFilteredRewardTableLogger, Tracking, ValidationGenerationsLogger
 from verl.workers.config import CriticConfig, DistillationConfig, HFModelConfig
@@ -1465,7 +1469,7 @@ class PPOTrainer(ABC):
         batch_multiple = self._get_required_batch_multiple(dp_size)
         batch = upsample_batch_to_divisible_size(batch, batch_multiple, self.tokenizer.eos_token_id)
         global_seqlen_lst = torch.tensor([tag["seq_len"] for tag in batch.tags], dtype=torch.int64)
-        workload_lst = calculate_workload(global_seqlen_lst)
+        workload_lst = calculate_workload_as_list(global_seqlen_lst)
 
         # reorder based on index. The data will be automatically equally partitioned by dispatch function
         global_partition_lst = get_seqlen_balanced_partitions(workload_lst, k_partitions=dp_size, equal_size=True)

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -38,7 +38,7 @@ from verl.utils.dataset.dataset_utils import SFTTensorCollator
 from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset
 from verl.utils.device import auto_set_device, get_device_name
 from verl.utils.logger import log_with_rank
-from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions
+from verl.utils.seqlen_balancing import calculate_workload_as_list, get_seqlen_balanced_partitions
 from verl.utils.tracking import Tracking
 from verl.workers.engine_workers import TrainingWorker
 
@@ -310,15 +310,15 @@ class SFTTrainer:
 
                 if self.config.trainer.balance_batch:
                     global_seqlen_lst = torch.Tensor([item.size()[0] for item in data["input_ids"]])
-                    global_seqlen_lst = calculate_workload(global_seqlen_lst)
+                    workload_lst = calculate_workload_as_list(global_seqlen_lst)
                     dp_size = max(self.training_client._query_dispatch_info("train")) + 1
 
                     global_partition_lst = get_seqlen_balanced_partitions(
-                        global_seqlen_lst, k_partitions=dp_size, equal_size=True
+                        workload_lst, k_partitions=dp_size, equal_size=True
                     )
                     # Place smaller micro-batches at both ends to reduce the bubbles in pipeline parallel.
                     for idx, partition in enumerate(global_partition_lst):
-                        partition.sort(key=lambda x: (global_seqlen_lst[x], x))
+                        partition.sort(key=lambda x: (workload_lst[x], x))
                         ordered_partition = partition[::2] + partition[1::2][::-1]
                         global_partition_lst[idx] = ordered_partition
 

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -15,6 +15,7 @@
 import copy
 import heapq
 from itertools import chain
+from numbers import Real
 
 import torch
 from torch import distributed as dist
@@ -44,6 +45,17 @@ def calculate_workload(seqlen_list: torch.Tensor) -> torch.Tensor:
         Useful for balancing computation across data parallel ranks.
     """
     return 24576 * seqlen_list + seqlen_list**2
+
+
+def calculate_workload_as_list(seqlen_list: torch.Tensor) -> list[Real]:
+    """Calculate workloads as host scalars for Python-native partitioning."""
+    workloads = calculate_workload(seqlen_list)
+    if workloads.is_floating_point():
+        # Keep floating-point accumulation in the source dtype. Converting to
+        # Python float would silently promote float32 sums to float64 and can
+        # change Karmarkar-Karp tie-breaking for nearly balanced partitions.
+        return list(workloads.detach().cpu().numpy())
+    return workloads.tolist()
 
 
 def karmarkar_karp(seqlen_list: list[int], k_partitions: int, equal_size: bool) -> list[list[int]]:
@@ -77,12 +89,22 @@ def karmarkar_karp(seqlen_list: list[int], k_partitions: int, equal_size: bool) 
 
         def add(self, idx: int, val: int):
             self.items.append((idx, val))
-            self.sum += val
+            # NumPy 1.x promotes ``0 + np.float32`` to float64, while NumPy 2.x
+            # preserves float32. Seed NumPy floating sums from their first
+            # scalar so partition tie-breaking is version-independent.
+            if len(self.items) == 1 and getattr(getattr(val, "dtype", None), "kind", None) == "f":
+                self.sum = val
+            else:
+                self.sum += val
 
         def merge(self, other):
             for idx, val in other.items:
+                # Keep the same first-scalar rule inline in this hot loop.
+                if not self.items and getattr(getattr(val, "dtype", None), "kind", None) == "f":
+                    self.sum = val
+                else:
+                    self.sum += val
                 self.items.append((idx, val))
-                self.sum += val
 
         def __lt__(self, other):
             if self.sum != other.sum:


### PR DESCRIPTION
### What does this PR do?

Removes repeated scalar tensor dispatch from controller-side batch balancing in classic PPO, V1 PPO, and SFT.

The Karmarkar-Karp partitioner and subsequent ordering are pure Python, but the three trainers passed a workload tensor into them. The patch adds a small `calculate_workload_as_list()` boundary helper and converts the workload tensor once before heap/sort work. `calculate_workload()` remains tensor-native for tensor consumers.

Closes #7279.

### Checklist Before Starting

- [x] Searched open issues and PRs with exact function/path terms on 2026-08-06. No matching report or implementation was found.
- [x] Search links: [issues](https://github.com/verl-project/verl/issues?q=is%3Aopen+calculate_workload+balance_batch+tensor), [pull requests](https://github.com/verl-project/verl/pulls?q=is%3Aopen+Karmarkar+Karp+tensor+tolist)
- [x] PR title: `[trainer, perf] refactor: avoid scalar tensor dispatch in batch balancing`

The searches covered `calculate_workload balance_batch tensor`, `get_seqlen_balanced_partitions tensor tolist`, and `Karmarkar Karp scalar tensor`. Issue #4152 concerns a DP-size divisibility error, and PR #6025 concerns grouped mini-batches; neither addresses scalar tensor dispatch. Open work on padding/sequence balancing does not convert these three default trainer paths at the Python boundary.

### Test

#### Correctness and regression

```bash
python -m pytest tests/utils/test_seqlen_balancing.py -q -k 'not distributed'
# 8 passed, 1 deselected

python -m pytest tests/utils/test_seqlen_balancing.py -q
# 9 passed (CUDA/NCCL environment)

python -m pytest tests/trainer/ppo/*_on_cpu.py -q
# 110 passed, 4 pre-existing warnings
```

The added tests check that workloads become host scalar lists, preserve floating-point accumulation semantics, and produce partition output identical to the previous tensor-scalar input. The focused suite also passed with NumPy 1.26.4 and 2.5.1.

```bash
pre-commit run --all-files --show-diff-on-failure --color=never
# All 13 configured hooks passed, including Ruff, mypy, config generation, and compile-all.
```

#### CPU microbenchmark

CPU-only microbenchmark, pinned to one Xeon Gold 6133 core with one Torch thread. Timings include workload conversion, partitioning, and within-partition sort; five warmups were excluded, execution order was randomized, and exact outputs were asserted.

```bash
taskset -c 2 .venv/bin/python /tmp/benchmark_balance.py
```

`/tmp/benchmark_balance.py` is the benchmark harness included in the linked issue reproduction.

| Batch | Repetitions | Before | After | Speedup | Reduction |
|---:|---:|---:|---:|---:|---:|
| 256 | 30 | 35.572 ± 0.736 ms | 1.598 ± 0.070 ms | 22.26× | 95.51% |
| 1,024 | 20 | 188.412 ± 1.437 ms | 7.569 ± 0.183 ms | 24.89× | 95.98% |
| 4,096 | 10 | 925.286 ± 5.659 ms | 33.940 ± 0.678 ms | 27.26× | 96.33% |

These measurements directly cover the Python partitioning path and are not end-to-end training throughput. The benchmark exercises the integer sequence-length path used by PPO.

#### Four-GPU Qwen3.5-0.8B SFT benchmark

The post-publication training benchmark used four RTX 3090 GPUs, BF16 FSDP2, global batch size 256, dynamic micro-batch size 1/GPU, a 2048-token/GPU budget, and seed 20260806. The environment was Python 3.12.13, PyTorch 2.11.0+cu128, CUDA 12.8, NCCL 2.28.9, Transformers 5.10.4, and Ray 2.56.1.

Four complete runs were measured in baseline → candidate → candidate → baseline order. Each run used two warm-up steps followed by eight measured steps. Values below are means of the two run means; `±` is the run-level standard deviation.

| Metric | Baseline | After | Absolute delta | Relative delta |
|---|---:|---:|---:|---:|
| Controller balance stage | 89.568 ± 0.114 ms | 28.557 ± 3.169 ms | **-61.011 ms** | **-68.12% (3.136×)** |
| Timed train step | 7492.403 ms | 7530.990 ms | +38.588 ms | +0.52% |
| Token throughput | 2591.3 tokens/s | 2576.0 tokens/s | -15.4 tokens/s | -0.59% |

The two independently ordered pairs reduced balance time by 70.59% and 65.65%. Input, index, ordered-length, partition-workload, partition-size, and token fingerprints matched exactly at every compared step. Maximum loss and gradient-norm differences were both zero. No NaN/Inf, OOM, NCCL error, traceback, or worker crash occurred; per-run PyTorch peaks were identical at 10.583 GiB allocated and 15.232 GiB reserved.

Immutable inputs:

- Qwen Hub revision: `2fc06364715b967f1860aea9cf38778875588b17`
- Qwen weight SHA-256: `04b1c301231dd422b8860db31311ab2721511346a32cb1e079c4c4e5f1fe4696`
- Dataset SHA-256: `78d52b1b7c3f16252305386d87d5eaacc3256f7831cd0e0237d2d0489e1eebfe`

### API and Usage Example

No user-facing API or configuration change. Internal tensor consumers can continue using `calculate_workload`; Python-native algorithms can use `calculate_workload_as_list`.

### Design & Code Changes

- Add a focused tensor-to-list workload helper.
- Use it in classic PPO, V1 PPO, and SFT balancing.
- Avoid computing/converting workloads on the separate PrefixGrouper path, where they are unused.
- Keep SFT sequence lengths and calculated workloads in separately named variables.
- Preserve float32 accumulation and tie-breaking across NumPy 1.x and 2.x.
- Cover host scalar types and exact partition equivalence on CPU.

### Checklist Before Submitting

- [x] Read the contribution guide and repository AI-agent instructions.
- [x] Added focused unit coverage in an existing CPU test file.
- [x] Ran targeted tests, a repeated benchmark, and all configured pre-commit hooks.
- [x] No user-facing documentation change is needed; behavior and configuration are unchanged.
- [x] Human submitter reviewed every changed line, reran the tests, and reproduced the benchmark on representative hardware.
- [ ] Request CI in the project's Slack or Feishu channel after opening the PR.

### AI assistance disclosure

OpenAI Codex assisted with repository auditing, reproduction, implementation, test design, validation and duplicate searches.
