### PR TITLE
[sglang] fix: make FSDP+LoRA adapter sync to SGLang work end-to-end

### DIFF
--- a/tests/workers/rollout/rollout_sglang/test_peft_config_normalize_on_cpu.py
+++ b/tests/workers/rollout/rollout_sglang/test_peft_config_normalize_on_cpu.py
@@ -1,0 +1,84 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for normalizing an engine's adapter config for SGLang's adapter loader.
+
+`BaseEngine.get_per_tensor_param` declares its second return value `Optional[dict]`. The
+fixtures here are built by the real producers rather than hand-written, so the tests
+break if either producer changes shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from peft import LoraConfig, TaskType
+
+from verl.utils.megatron_peft_utils import build_peft_config_for_vllm
+from verl.workers.rollout.sglang_rollout.utils import normalize_peft_config_for_sglang
+
+SEVEN_PROJECTIONS = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+
+
+def _fsdp_shape() -> dict:
+    """What verl/workers/engine/fsdp/transformer_impl.py returns."""
+    return LoraConfig(
+        r=32,
+        lora_alpha=32,
+        target_modules=SEVEN_PROJECTIONS,
+        task_type=TaskType.CAUSAL_LM,
+    ).to_dict()
+
+
+def _megatron_shape() -> dict:
+    """What verl/workers/engine/megatron/transformer_impl.py returns."""
+    return build_peft_config_for_vllm({"rank": 32, "alpha": 32})
+
+
+class TestNormalizePeftConfigForSGLang:
+    def test_result_is_json_serializable(self):
+        # The config crosses an HTTP boundary, so every value must survive json.dumps.
+        json.dumps(normalize_peft_config_for_sglang(_fsdp_shape()))
+
+    def test_enums_are_unwrapped_to_strings(self):
+        result = normalize_peft_config_for_sglang(_fsdp_shape())
+        assert result["task_type"] == "CAUSAL_LM"
+        assert result["peft_type"] == "LORA"
+
+    def test_target_modules_is_materialized_as_list(self):
+        result = normalize_peft_config_for_sglang({"target_modules": {"q_proj", "v_proj"}, "peft_type": "LORA"})
+        assert isinstance(result["target_modules"], list)
+        assert sorted(result["target_modules"]) == ["q_proj", "v_proj"]
+
+    def test_input_is_not_mutated(self):
+        original = _fsdp_shape()
+        before = dict(original)
+        normalize_peft_config_for_sglang(original)
+        assert original == before
+
+    def test_missing_peft_type_is_rejected_not_guessed(self):
+        # The megatron producer omits peft_type entirely. That pairing is out of scope
+        # here, so it must fail with something a reader can act on rather than be
+        # silently filled in with a plausible value.
+        assert "peft_type" not in _megatron_shape()
+        with pytest.raises(ValueError, match="peft_type"):
+            normalize_peft_config_for_sglang(_megatron_shape())
+
+    def test_rejection_names_the_producer_and_the_keys(self):
+        with pytest.raises(ValueError) as excinfo:
+            normalize_peft_config_for_sglang(_megatron_shape())
+        message = str(excinfo.value)
+        assert "build_peft_config_for_vllm" in message
+        assert "target_modules" in message  # the key listing, to orient the reader

--- a/verl/workers/rollout/sglang_rollout/http_server_engine.py
+++ b/verl/workers/rollout/sglang_rollout/http_server_engine.py
@@ -70,6 +70,8 @@ DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_RETRY_DELAY = 2.0
 DEFAULT_MAX_CONNECTIONS = 2000
 DEFAULT_MAX_WAIT_TIME = 300.0
+# Cap on how much of a failed response body reaches the log.
+_ERROR_BODY_CHARS = 2000
 
 
 def _read_response(response: requests.Response):
@@ -82,6 +84,16 @@ def _read_response(response: requests.Response):
             "content_type": response.headers.get("Content-Type", ""),
             "text": response.text,
         }
+
+
+def _log_error_body(endpoint: str, status: int, body: str) -> None:
+    """Log a failed response's body.
+
+    `raise_for_status()` reports only the status line, but SGLang returns the actual
+    reason -- a pydantic validation report, a scheduler traceback -- in the body, so
+    without this a 400 is indistinguishable from any other 400.
+    """
+    logger.error(f"HTTP {status} from {endpoint}: {body[:_ERROR_BODY_CHARS]}")
 
 
 async def _read_async_response(resp: aiohttp.ClientResponse) -> dict[str, Any]:
@@ -325,6 +337,8 @@ class HttpServerAdapter(EngineBase):
                 else:
                     response = requests.post(url, json=payload or {}, timeout=self.timeout)
 
+                if response.status_code >= 400:
+                    _log_error_body(endpoint, response.status_code, response.text)
                 response.raise_for_status()
                 return _read_response(response)
 
@@ -691,10 +705,14 @@ class AsyncHttpServerAdapter(HttpServerAdapter):
                 async with self._get_session() as session:
                     if method.upper() == "GET":
                         async with session.get(url, timeout=timeout) as response:
+                            if response.status >= 400:
+                                _log_error_body(endpoint, response.status, await response.text())
                             response.raise_for_status()
                             return await _read_async_response(response)
                     else:
                         async with session.post(url, json=payload or {}, timeout=timeout) as response:
+                            if response.status >= 400:
+                                _log_error_body(endpoint, response.status, await response.text())
                             response.raise_for_status()
                             return await _read_async_response(response)
 

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -18,13 +18,11 @@ from __future__ import annotations
 import logging
 import multiprocessing as mp
 import os
-from dataclasses import asdict
 from typing import Generator
 
 import ray
 import sglang.srt.entrypoints.engine
 import torch
-from peft import LoraConfig
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import (
     MultiprocessingSerializer,
@@ -44,6 +42,7 @@ from verl.workers.rollout.sglang_rollout.http_server_engine import AsyncHttpServ
 from verl.workers.rollout.sglang_rollout.utils import (
     SGLANG_LORA_NAME,
     get_named_tensor_buckets,
+    normalize_peft_config_for_sglang,
 )
 
 logger = logging.getLogger(__file__)
@@ -433,22 +432,17 @@ class ServerAdapter(BaseRollout):
         )
         await self._engine.update_weights_from_tensor(req)
 
-    def wrap_lora_params(self, peft_config: LoraConfig, weights: Generator[tuple[str, torch.Tensor]]):
+    def wrap_lora_params(self, peft_config: dict, weights: Generator[tuple[str, torch.Tensor]]):
         # peft config
-        peft_config_json = asdict(peft_config)
-        peft_config_json["task_type"] = peft_config_json["task_type"].value
-        peft_config_json["peft_type"] = peft_config_json["peft_type"].value
-        peft_config_json["target_modules"] = list(peft_config_json["target_modules"])
+        peft_config_json = normalize_peft_config_for_sglang(peft_config)
 
         # lora weights
         processed_weights: dict[str, torch.Tensor] = {
             name: _preprocess_tensor_for_update_weights(tensor.detach()) for name, tensor in weights
         }
 
-        infer_tp_size = self.device_mesh["infer_tp"].mesh.size()[0]
-        serialized_named_tensors = []
-        for i in range(infer_tp_size):
-            serialized_tensors = MultiprocessingSerializer.serialize(processed_weights, output_str=True)
-            serialized_named_tensors.append(serialized_tensors)
+        # `LoadLoRAAdapterFromTensorsReqInput.serialized_tensors` is a single `str`: SGLang's
+        # LoRA path shards the adapter across TP ranks internally, so one payload serves all.
+        serialized_named_tensors = MultiprocessingSerializer.serialize(processed_weights, output_str=True)
 
         return peft_config_json, serialized_named_tensors

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -26,6 +26,33 @@ from verl.workers.rollout.utils import ensure_async_iterator
 SGLANG_LORA_NAME = "verl_actor_lora_name"
 
 
+def normalize_peft_config_for_sglang(peft_config: dict) -> dict:
+    """Normalize an engine's adapter config into what SGLang's adapter loader accepts.
+
+    ``BaseEngine.get_per_tensor_param`` declares this value ``Optional[dict]``, and the
+    FSDP engine honours that with ``LoraConfig.to_dict()`` -- which leaves ``task_type``
+    and ``peft_type`` as enum members rather than the strings the wire format needs, so
+    unwrap them. The input is not mutated.
+
+    The megatron engine returns a differently shaped dict: ``build_peft_config_for_vllm()``
+    carries no ``peft_type`` key at all. Rather than guess a value for a path that has not
+    been exercised, reject it with a message that says so. Nothing regresses -- that
+    combination cannot reach SGLang today either, since the caller crashes further up.
+    """
+    normalized = dict(peft_config)
+    for key in ("task_type", "peft_type"):
+        if key in normalized:
+            normalized[key] = getattr(normalized[key], "value", normalized[key])
+    if "peft_type" not in normalized:
+        raise ValueError(
+            "adapter config has no 'peft_type', which SGLang's adapter loader requires. "
+            "The megatron engine's build_peft_config_for_vllm() omits it; that pairing is "
+            "not covered by this code path. Keys present: " + ", ".join(sorted(normalized))
+        )
+    normalized["target_modules"] = list(normalized["target_modules"])
+    return normalized
+
+
 def lora_served_as_adapter(model_config) -> bool:
     """Whether SGLang should serve LoRA as a hot-swappable adapter.
 


### PR DESCRIPTION

### What does this PR do?

Three defects sit on the single code path that pushes a LoRA adapter from an FSDP
trainer into a colocated SGLang server. They fire in sequence — each is only reachable
once the previous one is fixed — so they are submitted together. Split up, none of them
makes that path work on its own.

**1. `wrap_lora_params` calls `asdict()` on something that is already a dict.**
`BaseEngine.get_per_tensor_param` declares its second return value `Optional[dict]`
(`verl/workers/engine/base.py:151`), and the FSDP engine honours that by returning
`peft_config.to_dict()` (`engine/fsdp/transformer_impl.py:1032`). Its consumer,
`SGLangRollout.wrap_lora_params` (`sglang_rollout.py:438`), calls `asdict(peft_config)`,
which accepts dataclass *instances* only. Every FSDP+LoRA+SGLang weight sync raises:

```
TypeError: asdict() should be called on dataclass instances
```

Fixed on the consuming side, since that is the side disagreeing with the declared base
contract — and the vLLM rollout, the other consumer, already treats the value as a dict
and passes it straight into `TensorLoRARequest`.

The normalization moves into a `normalize_peft_config_for_sglang` helper so the
wire-format conversion is documented and unit tested. `to_dict()` does not flatten the
enums, so `task_type` and `peft_type` still need unwrapping before the config crosses an
HTTP boundary.

**2. `serialized_tensors` is built as a list, but the field is a `str`.**
`LoadLoRAAdapterFromTensorsReqInput.serialized_tensors` is typed `str` in sglang 0.5.8
(`python/sglang/srt/managers/io_struct.py`), while verl builds a list with one entry per
TP rank. The request fails pydantic validation:

```
{'type': 'string_type', 'loc': ('body', 'serialized_tensors'),
 'msg': 'Input should be a valid string'}
```

The loop was already dead code — its body ignores the loop index and appends the same
string `infer_tp_size` times. It is not needed, because the receiving end deserializes
the field as one payload and shards internally
(`sglang/srt/managers/tp_worker.py:184-189`):

```python
def load_lora_adapter_from_tensors(self, recv_req: LoadLoRAAdapterFromTensorsReqInput):
    # The LoRA code handles TP sharding internally using slice_lora_a_weights
    # and slice_lora_b_weights methods (see lora/layers.py:46-49, mem_pool.py:437-440).
    tensors = MultiprocessingSerializer.deserialize(recv_req.serialized_tensors)
```

Deleting the loop is simultaneously the fix and a simplification.

**3. `raise_for_status()` discards the body that says which field was wrong.**
`_make_request` / `_make_async_request` raise on 4xx/5xx without reading the response,
so defect 2 surfaced as a bare `400 Bad Request` and cost a full debugging round before
the pydantic report above was recovered by hand. Log the body on any 4xx/5xx before
raising. No behaviour change on success — checked against a real aiohttp server
returning that same 400:

```
LOG ERROR HTTP 400 from load_lora_adapter_from_tensor: {"detail": [{"type":
  "string_type", "loc": ["body", "serialized_tensors"], "msg": "Input should be
  a valid string"}]}
RESULT: still raises after reading body -> ClientResponseError 400
```

**Scope: the FSDP path only.** The megatron engine returns a differently shaped config —
`build_peft_config_for_vllm()` carries no `peft_type` key at all — and I have no megatron
setup to test against, so the helper rejects that shape with a message naming the
producer rather than inventing a plausible value. Nothing regresses: that pairing cannot
reach SGLang today either, since defect 1 above crashes first. The shape difference is
reported separately as #7290, since the right fix is a one-liner whose location
depends on which side you consider authoritative, and that call is not mine.

### Checklist Before Starting

- [x] Search for similar PRs:
      https://github.com/verl-project/verl/issues?q=repo%3Averl-project%2Fverl+is%3Aopen+serialized_tensors+lora

  Zero hits for defects 1 and 3. For the general area, **#5220
  `[sglang_rollout] feat: enable dynamic LoRA refresh for SGLang rollout`** (open, last
  touched 2026-02-06) overlaps in intent but not in mechanism: it takes the
  write-adapter-to-`/dev/shm`-and-load-from-disk route and adds its own parallel code
  path, rather than fixing the tensor-serialization path that `main` uses today. It
  does not touch `wrap_lora_params`, the `serialized_tensors` construction, or
  `raise_for_status`. Worth noting that its inline comment — *"SGLang needs explicit
  module names to infer LoRA hidden dims"* — and its hard-coded seven-projection
  fallback are independent corroboration of the sibling bug fixed in #7288.

  For provenance: this code arrived in **#5564** (`[sglang,fsdp] feat: LoRA support for
  SGLang rollouts`, merged 2026-03-20). **#7187** (`support full-rank VLM modules with
  LoRA`, open, 2026-08-04) also edits `sglang_rollout/utils.py` — it reworks
  `lora_served_as_adapter`, which this PR does not touch; I checked the two merge
  cleanly in either order. Searching `serialized_tensors` across the repo returns
  nothing else, open or closed.

- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

Encountered on `verl 0.8.0 × sglang 0.5.8 × torch 2.9.1+cu128 × peft 0.20.0`, single
A800-80G, FSDP + LoRA rank 32 + colocated SGLang, multi-turn agent rollout. Note that
this is exactly the combination `setup.py` pins: `SGLANG_REQUIRES` specifies
`sglang[srt,openai]==0.5.8` and `torch==2.9.1`. Defects 1 and 2 fire on 100% of weight
syncs in that configuration, i.e. the first one, i.e. before step 1 completes.

New CPU unit test, `tests/workers/rollout/rollout_sglang/test_peft_config_normalize_on_cpu.py`,
picked up by `cpu_unit_tests.yml`. Its fixtures are built by the real producers rather
than hand-written, so it breaks if either changes shape — including the two cases that
pin the scope boundary: the FSDP shape normalizes, the megatron shape is rejected.

```
$ python -m pytest tests/workers/rollout/rollout_sglang/test_peft_config_normalize_on_cpu.py -q
......                                                                   [100%]
6 passed, 1 warning in 4.88s
```

`wrap_lora_params` itself was exercised against the real config shapes. A full round
trip needs a GPU, a model and a live SGLang server, so the harness below gets as close
as a CPU box can: it lifts the actual function body out of a checkout with `inspect`,
stubs only the two SGLang serialization symbols — not what is under test — and feeds it
configs from the producers. On `main` it raises `TypeError: asdict()…`; on this branch
it returns a config with `task_type='CAUSAL_LM' peft_type='LORA'` and a `str` payload.

Defect 1's mismatch also reproduces standalone, with only `peft` installed:

```
FSDP engine returns: dict
consumer raises: TypeError: asdict() should be called on dataclass instances

after to_dict(), these are still enum members, not strings:
  task_type: TaskType
  peft_type: PeftType
```

Defect 2 confirmed against a real sglang 0.5.8, by running that dataclass through the
same pydantic validation FastAPI applies to it. Same rejection as the server gave in the
field; the live one is nested under `body` because FastAPI wraps the request model, this
one validates the model directly:

```
declared type of serialized_tensors: 'str'

verl main (list, one per TP rank)
  -> rejected: {'type': 'string_type', 'loc': ('serialized_tensors',),
                'msg': 'Input should be a valid string'}
the patch (single str)
  -> accepted
```

Lint: `ruff==0.12.2 check` and `ruff format --check` clean on all files.

**Not covered by the above:** a live round trip. All three defects were fixed in place
on a running box and each gate confirmed to open, but that was against 0.8.0 rather than
this branch, and the GPU tests under `tests/workers/rollout/rollout_sglang/` have not
been run. Both ends of defect 2 are pinned — the harness shows the request is built with
a `str`, and sglang 0.5.8 accepts a `str` and rejects a list — but not in one process
talking to a live server.

Megatron is out of scope by choice, not oversight: it is rejected rather than handled,
and the shape difference is filed as #7290.

<details>
<summary>Harness: runs verl's real wrap_lora_params against both engines' config shapes</summary>

```python
#!/usr/bin/env python3
"""Runs verl's real `wrap_lora_params` against both engines' real peft_config shapes.

The full FSDP+LoRA+SGLang round trip needs a GPU, a model and a live SGLang server. This
harness gets as close as a CPU box can: it lifts the actual function body out of a verl
checkout with `inspect`, stubs only the two SGLang symbols it calls (serialization, which
is not what is under test), and feeds it configs built by the actual producers.

    python pr03_wrap_lora_params_harness.py <path-to-verl-checkout>

Expected, and what makes the case for the patch:

    main            -> TypeError on both shapes         (defect 1)
    naive fix       -> works on fsdp, KeyError on megatron   <- the trap
    patched         -> works on both
"""

from __future__ import annotations

import ast
import sys
import textwrap
from dataclasses import asdict
from pathlib import Path

import torch
from peft import LoraConfig, TaskType

SEVEN_PROJECTIONS = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]


class _FakeSerializer:
    @staticmethod
    def serialize(obj, output_str=False):
        return "<serialized>" if output_str else b"<serialized>"


class _FakeMesh:
    def __getitem__(self, _key):
        return self

    @property
    def mesh(self):
        return self

    def size(self):
        return [1]


class _StubSelf:
    device_mesh = _FakeMesh()


def extract_function(source_path: Path, name: str):
    """Compile just one function out of a source file, with SGLang symbols stubbed."""
    tree = ast.parse(source_path.read_text())
    for node in ast.walk(tree):
        if isinstance(node, ast.FunctionDef) and node.name == name:
            src = textwrap.dedent(ast.get_source_segment(source_path.read_text(), node))
            break
    else:
        raise SystemExit(f"{name} not found in {source_path}")

    namespace = {
        "asdict": asdict,
        "torch": torch,
        "MultiprocessingSerializer": _FakeSerializer,
        "_preprocess_tensor_for_update_weights": lambda t: t,
        "Generator": object,
    }
    # The patched build imports its helper from verl; make it resolvable if present.
    try:
        from verl.workers.rollout.sglang_rollout.utils import normalize_peft_config_for_sglang

        namespace["normalize_peft_config_for_sglang"] = normalize_peft_config_for_sglang
    except ImportError:
        pass

    exec(compile(src, str(source_path), "exec"), namespace)  # noqa: S102
    return namespace[name]


def fsdp_shape() -> dict:
    """verl/workers/engine/fsdp/transformer_impl.py -> LoraConfig.to_dict()"""
    return LoraConfig(r=32, lora_alpha=32, target_modules=SEVEN_PROJECTIONS, task_type=TaskType.CAUSAL_LM).to_dict()


def megatron_shape() -> dict:
    """verl/workers/engine/megatron/transformer_impl.py -> build_peft_config_for_vllm()"""
    from verl.utils.megatron_peft_utils import build_peft_config_for_vllm

    return build_peft_config_for_vllm({"rank": 32, "alpha": 32})


def main() -> int:
    if len(sys.argv) != 2:
        print(__doc__)
        return 2
    checkout = Path(sys.argv[1])
    source = checkout / "verl/workers/rollout/sglang_rollout/sglang_rollout.py"
    if not source.is_file():
        print(f"not a verl checkout: {source} missing")
        return 2

    wrap_lora_params = extract_function(source, "wrap_lora_params")
    weights = [("base_model.model.layers.0.self_attn.q_proj.lora_A.weight", torch.zeros(32, 8))]

    print(f"checkout: {checkout}")
    print(f"function: {source.name}:wrap_lora_params\n")

    failures = 0
    for label, producer in (("fsdp", fsdp_shape), ("megatron", megatron_shape)):
        try:
            cfg, tensors = wrap_lora_params(_StubSelf(), producer(), iter(weights))
        except Exception as e:  # noqa: BLE001
            print(f"  {label:9s} -> {type(e).__name__}: {e}")
            failures += 1
            continue
        kind = type(tensors).__name__
        print(
            f"  {label:9s} -> ok   task_type={cfg['task_type']!r} peft_type={cfg['peft_type']!r} "
            f"serialized_tensors={kind}"
        )
        if kind != "str":
            print(f"  {'':9s}    NOTE: SGLang types this field `str`, got {kind}")

    print()
    print("2 failures = unpatched main; 1 = the naive fix's megatron trap; 0 = patched.")
    return 0


if __name__ == "__main__":
    sys.exit(main())
```

</details>

### API and Usage Example

`wrap_lora_params`'s annotation changes from `LoraConfig` to `dict`, and its second
return value from `list[str]` to `str`. It is an internal method with exactly one
caller (`SGLangRollout.update_weights`, same file), so no public API moves. Not marked
`[BREAKING]` for that reason — say the word if you would rather it were.

### Design & Code Changes

- `verl/workers/rollout/sglang_rollout/utils.py` — new `normalize_peft_config_for_sglang`,
  documenting the FSDP shape and unwrapping its enums. Does not mutate its input; rejects
  a config with no `peft_type` rather than guessing one.
- `verl/workers/rollout/sglang_rollout/sglang_rollout.py` — `wrap_lora_params` calls it;
  drop the dead per-TP-rank loop; drop the now-unused `asdict` and `LoraConfig` imports.
- `verl/workers/rollout/sglang_rollout/http_server_engine.py` — add `_log_error_body`,
  call it from the sync and async request paths before `raise_for_status()`. Body is
  truncated to 2000 chars.
- `tests/.../test_peft_config_normalize_on_cpu.py` — new.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] `ruff` and `ruff-format` clean (pinned to the repo's `v0.12.2`)
- [x] Docs — no user-facing change, so nothing to update
- [x] Unit test added to `cpu_unit_tests` for the config normalization. A full
      round-trip test still needs a GPU runner with sglang — happy to add one if you can
      point me at the right workflow.
- [ ] `ci-request` Slack message
- [x] Not related to the `recipe` submodule, so no submodule reference to update

### AI assistance disclosure

AI assistance (Claude) was used to re-verify each defect against `main`, write the
patch and the peft repro, and draft this description.

