### PR TITLE
[sglang] fix: translate LoRA target_modules into SGLang's "all" sentinel

### DIFF
--- a/tests/workers/rollout/rollout_sglang/test_lora_target_modules_on_cpu.py
+++ b/tests/workers/rollout/rollout_sglang/test_lora_target_modules_on_cpu.py
@@ -1,0 +1,68 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for translating verl's LoRA ``target_modules`` into SGLang's spelling.
+
+``model.target_modules`` defaults to PEFT's ``"all-linear"`` shorthand, which PEFT resolves
+against the loaded model. SGLang has no such shorthand and coerces the value with
+``set(...)``, so forwarding the bare string tears it into characters and the LoRA memory
+pool dies on one of them (``get_hidden_dim not implemented for i``). The regression these
+tests guard is precisely that: the result must never be a set of single characters.
+
+They also pin the deliberate refusal to guess. PEFT reads any other bare string as a
+regex over the whole parameter key, and SGLang cannot express that, so it must fail
+loudly rather than quietly adapt a different set of modules than training did.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from verl.workers.rollout.sglang_rollout.utils import sglang_lora_target_modules
+
+SEVEN_PROJECTIONS = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
+
+
+class TestSGLangLoraTargetModules:
+    def test_all_linear_becomes_sglang_all_sentinel(self):
+        assert sglang_lora_target_modules("all-linear") == ["all"]
+
+    def test_explicit_list_passes_through(self):
+        assert sglang_lora_target_modules(SEVEN_PROJECTIONS) == SEVEN_PROJECTIONS
+
+    def test_set_is_materialized_as_list(self):
+        result = sglang_lora_target_modules({"q_proj", "v_proj"})
+        assert isinstance(result, list)
+        assert sorted(result) == ["q_proj", "v_proj"]
+
+    @pytest.mark.parametrize("regex", [r".*\.q_proj", "q_proj", r"model\.layers\.\d+\.mlp\..*"])
+    def test_regex_string_is_rejected_not_guessed(self, regex):
+        # PEFT would re.fullmatch these against the full key. Wrapping them into a
+        # one-element list would look like it worked while adapting the wrong modules.
+        with pytest.raises(ValueError, match="regex"):
+            sglang_lora_target_modules(regex)
+
+    def test_rejection_message_names_the_alternatives(self):
+        with pytest.raises(ValueError) as excinfo:
+            sglang_lora_target_modules(r".*\.q_proj")
+        message = str(excinfo.value)
+        assert "all-linear" in message
+        assert "q_proj" in message
+
+    def test_no_accepted_input_is_ever_split_into_characters(self):
+        # ServerArgs applies set() to whatever it receives; any single-character entry
+        # means the string was iterated instead of listed.
+        for value in ("all-linear", SEVEN_PROJECTIONS, {"q_proj"}):
+            result = sglang_lora_target_modules(value)
+            assert all(len(item) > 1 for item in result), f"{value!r} was split into {result!r}"

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -51,7 +51,11 @@ from verl.utils.tracking import RLInsightLogger
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.sglang_rollout.sglang_rollout import _set_envs_and_config
-from verl.workers.rollout.sglang_rollout.utils import SGLANG_LORA_NAME, lora_served_as_adapter
+from verl.workers.rollout.sglang_rollout.utils import (
+    SGLANG_LORA_NAME,
+    lora_served_as_adapter,
+    sglang_lora_target_modules,
+)
 from verl.workers.rollout.utils import get_max_position_embeddings, run_uvicorn
 
 logger = logging.getLogger(__file__)
@@ -327,7 +331,7 @@ class SGLangHttpServer:
                 {
                     "enable_lora": True,
                     "max_lora_rank": self.model_config.lora_rank,
-                    "lora_target_modules": self.model_config.target_modules,
+                    "lora_target_modules": sglang_lora_target_modules(self.model_config.target_modules),
                 }
             )
         # Only set dist_init_addr for multi-node; for single-node, let SGLang

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -42,6 +42,38 @@ def lora_served_as_adapter(model_config) -> bool:
     return lora_enabled and not model_config.lora.get("merge", False)
 
 
+def sglang_lora_target_modules(target_modules: Any) -> list[str]:
+    """Render verl's ``model.target_modules`` as SGLang's ``lora_target_modules``.
+
+    Following PEFT, verl overloads this field by type: a list names modules matched
+    exactly or by suffix, while a bare string is either the ``"all-linear"`` shorthand
+    or a *regex* matched against the whole parameter key -- see
+    :func:`verl.utils.model.check_target_modules`, which dispatches on exactly that.
+
+    SGLang supports neither form. It normalizes the field with ``set(...)``, so a bare
+    string is torn into its characters and the LoRA memory pool later dies on one of
+    them::
+
+        NotImplementedError: get_hidden_dim not implemented for i
+
+    ``"all-linear"`` translates to SGLang's own ``"all"`` sentinel, which it expands
+    itself. A regex has no SGLang equivalent, and reading it as a literal module name
+    would silently adapt a different set of modules than training did, so it is
+    rejected with an actionable message instead.
+    """
+    if target_modules == "all-linear":
+        return ["all"]
+    if isinstance(target_modules, str):
+        raise ValueError(
+            f"SGLang cannot serve a regex `target_modules` ({target_modules!r}). PEFT matches a "
+            f"string against the full parameter key, which SGLang's LoRA pool has no equivalent "
+            f"of, and reading it as a literal module name would adapt different modules than "
+            f"training did. Use `all-linear`, or list the module names explicitly, e.g. "
+            f"[q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]."
+        )
+    return list(target_modules)
+
+
 def broadcast_pyobj(
     data: list[Any],
     rank: int,


### PR DESCRIPTION

### What does this PR do?

`verl/workers/config/model.py:126` defaults `target_modules` to PEFT's `"all-linear"`
shorthand. `async_sglang_server.py:330` forwards that value verbatim into
`ServerArgs.lora_target_modules`. SGLang has no such shorthand:
`ServerArgs.check_lora_server_args()`, which the engine reaches via
`check_server_args()` at launch (`entrypoints/engine.py:955`), normalizes the field with
`set(...)` — and that iterates a bare string character by character. The LoRA memory
pool then tries to look up the hidden dim of a module named after one of those
characters:

```
NotImplementedError: get_hidden_dim not implemented for i
```

`'i'` is the sixth character of `"all-linear"`. Every FSDP+LoRA+SGLang run started with
the default config dies at server launch.

SGLang spells the same intent `"all"`, which the same check expands to
`SUPPORTED_LORA_TARGET_MODULES` (and, for the `csgmv` backend, prunes `embed_tokens` /
`lm_head` itself). So the fix is a translation, not a reimplementation of PEFT's
resolution logic.

**On the other string form.** Following PEFT, verl overloads this field by type: a list
names modules matched exactly or by suffix, while a bare string that is *not*
`"all-linear"` is a regex matched against the whole parameter key — see
`verl.utils.model.check_target_modules`, which dispatches on exactly that with
`re.fullmatch`. SGLang cannot express a regex. Rather than wrap such a string into a
one-element list — which would look like it worked while adapting a different set of
modules than training did — the helper rejects it with a message naming the two
spellings that do work. A loud failure at launch is the only reading that keeps
training and serving in agreement.

Note this is specifically the *engine-launch* path. The adapter-load path
(`wrap_lora_params`) is unaffected, because PEFT rewrites the shorthand on the config
object itself during `get_peft_model`, so by the time anything calls `to_dict()` the
string is gone:

```
before get_peft_model : target_modules = 'all-linear'
after  get_peft_model : type = set value = ['model.layers.0.mlp.down_proj',
                                            'model.layers.0.self_attn.q_proj', ...]
to_dict()[target_modules] type = set
```

(A resolved set of fully qualified module paths, not the bare names SGLang's server
args use — but that path only has to round-trip what PEFT produced, and this PR makes
no change there.)

### Checklist Before Starting

- [x] Search for similar PRs:
      https://github.com/verl-project/verl/issues?q=repo%3Averl-project%2Fverl+is%3Aopen+lora_target_modules+all-linear

  One hit, **#5220** (open, last touched 2026-02-06), which works around the same
  problem downstream inside its own new adapter-loading path — it parses the value and
  falls back to a hard-coded seven-projection list with the comment *"SGLang needs
  explicit module names to infer LoRA hidden dims"*. It does not fix the forwarding at
  `async_sglang_server.py:330`, so the engine still fails at launch before its code is
  reached. Independent confirmation of the bug; different layer; no conflict.

  **#7187** (open, 2026-08-04) also edits `sglang_rollout/utils.py`, reworking
  `lora_served_as_adapter`; this PR adds a separate helper beside it and the two merge
  cleanly in either order. **#7234** (merged 2026-08-04) is adjacent — it keeps SGLang
  LoRA-free when `model.lora.merge=True` — but does not touch the forwarding fixed here.

- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

New CPU unit test, `tests/workers/rollout/rollout_sglang/test_lora_target_modules_on_cpu.py`,
picked up by `cpu_unit_tests.yml` via the `_on_cpu.py` suffix convention. Run locally
against this branch:

```
$ python -m pytest tests/workers/rollout/rollout_sglang/test_lora_target_modules_on_cpu.py -q
........                                                                 [100%]
8 passed, 1 warning in 4.15s
```

Confirmed against a real sglang 0.5.8, by passing each value through the same
`ServerArgs` construction the launcher does and then the `check_server_args()` the engine
runs at `entrypoints/engine.py:955` — note the expansion lives in
`check_lora_server_args()`, which `__post_init__` does *not* call, so constructing
`ServerArgs` alone exercises none of this:

```
sglang vocabulary (11): ['down_proj', 'embed_tokens', 'gate_proj', 'gate_up_proj',
                         'k_proj', 'lm_head', 'o_proj', 'q_proj', 'qkv_proj',
                         'up_proj', 'v_proj']

verl main sends the raw config value: 'all-linear'
  -> type=set n=7 value=['-', 'a', 'e', 'i', 'l', 'n', 'r']
     TORN INTO CHARACTERS   'i' present: True

this PR sends: ['all']
  -> type=set n=9 value=['down_proj', 'gate_proj', 'gate_up_proj', 'k_proj', 'o_proj',
                         'q_proj', 'qkv_proj', 'up_proj', 'v_proj']

explicit list (what we fell back to): ['q_proj', 'k_proj', 'v_proj', 'o_proj',
                                      'gate_proj', 'up_proj', 'down_proj']
  -> type=set n=7 value=['down_proj', 'gate_proj', 'k_proj', 'o_proj', 'q_proj',
                         'up_proj', 'v_proj']
```

Nine rather than eleven, because the default `csgmv` backend cannot yet adapt
`embed_tokens` or `lm_head` and SGLang discards them itself with a warning. That is a
good argument for translating to the sentinel rather than expanding on verl's side:
verl would have to mirror backend-specific pruning it has no business knowing about.

The helper's own behaviour, including the regex refusal (script below):

```
patched helper returns: ['all']
no single-character entries; SGLang will expand the sentinel itself.

regex rejected, not guessed:
  SGLang cannot serve a regex `target_modules` ('.*\\.q_proj'). [...] Use `all-linear`,
  or list the module names explicitly, e.g. [q_proj, k_proj, ...].
```

Originally hit on `verl 0.8.0 × sglang 0.5.8`, single A800-80G, FSDP + LoRA rank 32,
colocated. The workaround at the time was to spell the seven projections out in the
run config — the same list #5220 hard-codes — which is what confirmed the diagnosis.

Lint: `ruff==0.12.2 check` and `ruff format --check` clean on all three files.

**Not covered by the above:** a full training run from this branch. The argument
handling is exercised against the real sglang 0.5.8 through the same validation the
engine runs at launch, but no SGLang server was actually started and no adapter served.

<details>
<summary>Repro script (stdlib only; uses sglang and verl if importable)</summary>

```python
#!/usr/bin/env python3
"""Minimal repro: verl's "all-linear" shorthand torn into characters by SGLang.

Two halves. The first needs nothing but the stdlib and shows the mechanism; the
second needs `sglang==0.5.8` installed and shows SGLang doing it for real:

    python pr04_all_linear_char_split.py

`verl/workers/config/model.py` defaults `target_modules` to PEFT's `"all-linear"`,
and `async_sglang_server.py` forwards it verbatim into
`ServerArgs.lora_target_modules`. `ServerArgs.check_lora_server_args()` -- reached from
`check_server_args()` at engine launch, not from `__post_init__` -- normalizes that
field with `set(...)`, which iterates a string character by character. The LoRA memory
pool then asks for the hidden dim of a module named "i".
"""

import sys

VERL_DEFAULT = "all-linear"  # verl/workers/config/model.py


def show_mechanism() -> set:
    """What ServerArgs.__post_init__ does to a bare string."""
    splat = set(VERL_DEFAULT)
    print(f"set({VERL_DEFAULT!r}) = {sorted(splat)}")
    singles = sorted(c for c in splat if len(c) == 1)
    print(f"  -> {len(singles)} single-character 'module names', including {'i' in splat and 'i' or '?'!r}")
    print("     which is the 'i' in: NotImplementedError: get_hidden_dim not implemented for i")
    return splat


def show_sglang_agrees() -> int:
    try:
        from sglang.srt.server_args import SUPPORTED_LORA_TARGET_MODULES
    except ImportError:
        print("\nsglang not installed -- skipping the live half (mechanism above still holds).")
        return 0

    print(f"\nsglang's own vocabulary: {sorted(SUPPORTED_LORA_TARGET_MODULES)}")
    bogus = set(VERL_DEFAULT) - set(SUPPORTED_LORA_TARGET_MODULES)
    print(f"  none of verl's default survives it: {len(bogus)}/{len(set(VERL_DEFAULT))} entries are unknown")

    # The value the patch sends instead.
    print(f"\nsglang spells the same intent 'all' -> expands to {len(SUPPORTED_LORA_TARGET_MODULES)} real modules")
    assert "all" not in SUPPORTED_LORA_TARGET_MODULES, "'all' is a sentinel, not a module name"
    return 0


def main() -> int:
    show_mechanism()
    rc = show_sglang_agrees()

    # What the patched helper returns.
    from verl.workers.rollout.sglang_rollout.utils import sglang_lora_target_modules

    patched = sglang_lora_target_modules(VERL_DEFAULT)
    print(f"\npatched helper returns: {patched!r}")
    assert patched == ["all"], patched
    assert all(len(m) > 1 for m in patched), "still splitting into characters"
    print("no single-character entries; SGLang will expand the sentinel itself.")

    # And it refuses to guess at PEFT's other string form. `verl.utils.model.
    # check_target_modules` reads any other string as a regex over the full parameter
    # key; wrapping it into a one-element list would silently adapt the wrong modules.
    try:
        sglang_lora_target_modules(r".*\.q_proj")
    except ValueError as e:
        print(f"\nregex rejected, not guessed:\n  {e}")
    else:
        print("\nregex was NOT rejected -- the helper is guessing again.")
        return 2
    return rc


if __name__ == "__main__":
    sys.exit(main())
```

</details>

### API and Usage Example

No config change. `model.target_modules: all-linear` — already the default — now works
with the SGLang rollout instead of crashing at launch.

```yaml
actor_rollout_ref:
  model:
    lora_rank: 32
    target_modules: all-linear    # previously required spelling out all seven projections
  rollout:
    name: sglang
```

### Design & Code Changes

- `verl/workers/rollout/sglang_rollout/utils.py` — new `sglang_lora_target_modules()`
  next to `lora_served_as_adapter()`, documenting the translation and why it exists.
- `verl/workers/rollout/sglang_rollout/async_sglang_server.py` — call it at the
  `lora_target_modules` assignment.
- `tests/.../test_lora_target_modules_on_cpu.py` — new.

One deliberate choice worth flagging: rejecting a regex `target_modules` turns what is
today a confusing crash deep inside SGLang's memory pool into an early `ValueError`.
That is a behaviour change for anyone currently passing a regex — though today they
cannot get past server launch either, so nobody is losing a working configuration. If
you would rather it warned and fell through, that is a one-line change.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] `ruff` and `ruff-format` clean (pinned to the repo's `v0.12.2`)
- [x] Docs — no user-facing change, so nothing to update
- [x] Unit test added to `cpu_unit_tests`
- [ ] `ci-request` Slack message
- [x] Not related to the `recipe` submodule, so no submodule reference to update

### AI assistance disclosure

AI assistance (Claude) was used to pin the root cause to the forwarding site, confirm
SGLang's `"all"` sentinel against the pinned 0.5.8 source, write the patch, the test
and the repro, and draft this description.

