### PR TITLE
[ckpt] feat: Node-local multi-sender broadcast in NCCL checkpoint engine

### DIFF
--- a/tests/checkpoint_engine/test_correctness_on_gpu.py
+++ b/tests/checkpoint_engine/test_correctness_on_gpu.py
@@ -32,10 +32,12 @@ _ngpus = torch.cuda.device_count()
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("rebuild_group", [False, True])
+@pytest.mark.parametrize("multi_sender", [False, True])
 @pytest.mark.parametrize("num_trainer, num_rollout", [(2, _ngpus - 2)])
 @auto_await
 async def test_nccl_checkpoint_engine(
     rebuild_group,
+    multi_sender,
     num_trainer,
     num_rollout,
     num_nodes=1,
@@ -60,7 +62,7 @@ async def test_nccl_checkpoint_engine(
     checkpoint_engine_config = CheckpointEngineConfig(
         backend="nccl",
         update_weights_bucket_megabytes=bucket_size_mb,
-        engine_kwargs={"nccl": {"rebuild_group": rebuild_group}},
+        engine_kwargs={"nccl": {"rebuild_group": rebuild_group, "multi_sender": multi_sender}},
     )
     model_config = HFModelConfig(path=model_path, use_remove_padding=True)
     rollout_config = RolloutConfig(name="vllm", checkpoint_engine=checkpoint_engine_config)
@@ -191,6 +193,7 @@ async def test_kimi_checkpoint_engine(
 if __name__ == "__main__":
     test_nccl_checkpoint_engine(
         rebuild_group=False,
+        multi_sender=False,
         num_trainer=2,
         num_rollout=30,
         num_nodes=4,

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -539,8 +539,8 @@ class CheckpointEngineManager:
 
 
 async def split_weight_chunks(
-    weights: Generator[tuple[str, torch.Tensor], None, None], bucket_size: int
-) -> AsyncGenerator[tuple[TensorMeta, torch.Tensor], None]:
+    weights: Generator[tuple[str, torch.Tensor], None, None], bucket_size: int, meta_only: bool = False
+) -> AsyncGenerator[tuple[TensorMeta, torch.Tensor | None], None]:
     """Split the weight into chunks.
 
     Args:
@@ -563,30 +563,7 @@ async def split_weight_chunks(
                 chunk_size=chunk_size,
                 offset=None,
             )
-            yield (tensor_meta, buffer[chunk_offset : chunk_offset + chunk_size])
-            chunk_offset += chunk_size
-
-
-async def get_weight_chunks_size(
-    weights: Generator[tuple[str, torch.Tensor], None, None], bucket_size: int
-) -> AsyncGenerator[int, None]:
-    """Yield the size of each weight chunk, without slicing the chunk itself.
-
-    Splits on exactly the same boundaries as `split_weight_chunks`, so a caller that only needs to
-    keep in step with a peer walking that generator can use this instead and skip the buffers.
-
-    Args:
-        weights: The weights generator.
-        bucket_size: Max bucket size in bytes.
-
-    Yields:
-        The size of the weight chunks.
-    """
-    async for _name, weight in ensure_async_iterator(weights):
-        chunk_offset = 0
-        while chunk_offset < weight.nbytes:
-            chunk_size = min(bucket_size, weight.nbytes - chunk_offset)
-            yield chunk_size
+            yield (tensor_meta, None if meta_only else buffer[chunk_offset : chunk_offset + chunk_size])
             chunk_offset += chunk_size
 
 

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -567,6 +567,29 @@ async def split_weight_chunks(
             chunk_offset += chunk_size
 
 
+async def get_weight_chunks_size(
+    weights: Generator[tuple[str, torch.Tensor], None, None], bucket_size: int
+) -> AsyncGenerator[int, None]:
+    """Yield the size of each weight chunk, without slicing the chunk itself.
+
+    Splits on exactly the same boundaries as `split_weight_chunks`, so a caller that only needs to
+    keep in step with a peer walking that generator can use this instead and skip the buffers.
+
+    Args:
+        weights: The weights generator.
+        bucket_size: Max bucket size in bytes.
+
+    Yields:
+        The size of the weight chunks.
+    """
+    async for _name, weight in ensure_async_iterator(weights):
+        chunk_offset = 0
+        while chunk_offset < weight.nbytes:
+            chunk_size = min(bucket_size, weight.nbytes - chunk_offset)
+            yield chunk_size
+            chunk_offset += chunk_size
+
+
 async def merge_weight_chunks(
     chunks: Generator[tuple[TensorMeta, torch.Tensor], None, None], bucket_size: int
 ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -63,7 +63,7 @@ from .base import CheckpointEngineRegistry
 from .delta_sync.encode import DeltaFlush, DeltaParam
 from .delta_sync.encode import checksum as _checksum
 from .delta_sync.sparse_gather import gather_slot_entries_to_rank0
-from .nccl_checkpoint_engine import MasterMetadata, NCCLCheckpointEngine
+from .nccl_checkpoint_engine import MasterMetadata, NCCLCheckpointEngine, WorkerMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -246,11 +246,17 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
 
     wire_format = "delta_flush"
 
-    def prepare(self) -> MasterMetadata | None:
+    def prepare(self) -> WorkerMetadata:
         # Delta broadcasts small per-flush buffers directly, so skip the parent's
         # 2 * bucket_size fixed buffers. Still hand back the master zmq endpoint
         # that build_topology() distributes to the rollout workers.
-        return MasterMetadata(zmq_ip=self.ip, zmq_port=self.listen_port) if self.is_master else None
+        #
+        # Only rank 0 broadcasts here (see the assert in send_weights) and this engine has no relay
+        # path, so it always takes the parent's single-sender topology.
+        master = (
+            MasterMetadata(zmq_ip=self.ip, zmq_port=self.listen_port, multi_sender=False) if self.is_master else None
+        )
+        return WorkerMetadata(node_id=self.get_node_id(), master=master)
 
     # ---- trainer side ----
     # ---- shared STREAMING wire ----

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -31,6 +31,7 @@ from verl.checkpoint_engine.base import (
     CheckpointEngine,
     CheckpointEngineRegistry,
     TensorMeta,
+    get_weight_chunks_size,
     merge_weight_chunks,
     split_weight_chunks,
 )
@@ -42,8 +43,23 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 @dataclass
 class MasterMetadata:
+    """Endpoint of the broadcast source (actor rank 0), handed to every worker in the group."""
+
     zmq_ip: str
     zmq_port: int
+    multi_sender: bool
+
+
+@dataclass
+class WorkerMetadata:
+    """What each worker reports from `prepare()` for `build_topology` to place it in the group.
+
+    Only the source rank fills `master`; every worker reports `node_id` so it can be matched
+    against the source's.
+    """
+
+    node_id: str
+    master: MasterMetadata | None = None
 
 
 class BroadcastOperation:
@@ -85,6 +101,7 @@ class BroadcastOperation:
         else:
             self.socket.recv_string()
             self.metadata = self.socket.recv_pyobj()
+            self.bucket = self.bucket[: self.metadata["length"]]
 
         # broadcast tensor via NCCL
         collective.broadcast(self.bucket, src_rank=0, group_name=self.group_name)
@@ -111,6 +128,9 @@ class NCCLCheckpointEngine(CheckpointEngine):
         rebuild_group (bool): Whether to rebuild the NCCL process group in each update. Defaults to False.
         is_master (bool): Whether the current process is the master process. Defaults to False.
         rollout_dtype (torch.dtype): The dtype of the weights received from rollout workers. Defaults to torch.bfloat16.
+        multi_sender (bool): Whether to also admit the source's NVLink-local actor workers into the
+            broadcast group as relays, widening the fan-out at the root. Defaults to False, which
+            keeps the group at one sender (actor rank 0) plus the rollout workers.
     """
 
     def __init__(
@@ -120,11 +140,13 @@ class NCCLCheckpointEngine(CheckpointEngine):
         rebuild_group: bool = False,
         is_master: bool = False,
         rollout_dtype: torch.dtype = torch.bfloat16,
+        multi_sender: bool = False,
     ) -> None:
         self.bucket_size = bucket_size
         self.group_name = group_name
         self.rebuild_group = rebuild_group
         self.rollout_dtype = rollout_dtype
+        self.multi_sender = multi_sender
 
         # start zeromq server for broadcasting bucket tensor metadata
         self.is_master = is_master
@@ -132,7 +154,16 @@ class NCCLCheckpointEngine(CheckpointEngine):
         if self.is_master:
             self._start_zmq_server()
 
-    def prepare(self) -> MasterMetadata:
+    @staticmethod
+    def get_node_id() -> str:
+        """Identity of the node this GPU belongs to, used as a proxy for NVLink reachability.
+
+        GPUs on the same node are NVLink-reachable, and a node never spans more than one NVLink
+        domain, so matching on node id can only ever under-select peers, never over-select them.
+        """
+        return ray.get_runtime_context().get_node_id()
+
+    def prepare(self) -> WorkerMetadata:
         # For master process, use cupy instead of torch to avoid memory register error
         # when `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
         if self.is_master:
@@ -142,7 +173,12 @@ class NCCLCheckpointEngine(CheckpointEngine):
             self.send_buf = torch.zeros(self.bucket_size, dtype=torch.uint8, device="cuda")
             self.recv_buf = torch.zeros(self.bucket_size, dtype=torch.uint8, device="cuda")
 
-        return MasterMetadata(zmq_ip=self.ip, zmq_port=self.listen_port) if self.is_master else None
+        master = (
+            MasterMetadata(zmq_ip=self.ip, zmq_port=self.listen_port, multi_sender=self.multi_sender)
+            if self.is_master
+            else None
+        )
+        return WorkerMetadata(node_id=self.get_node_id(), master=master)
 
     def finalize(self):
         """Destroy the NCCL process group if rebuild_group is True."""
@@ -157,17 +193,60 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
         torch.cuda.empty_cache()
 
+    @staticmethod
+    def _single_sender_ranks(actor_wg_world_size: int) -> list[int]:
+        """Only actor rank 0 joins the group; every other actor worker sits the broadcast out."""
+        return [0] + [-1] * (actor_wg_world_size - 1)
+
+    @staticmethod
+    def _multi_sender_ranks(actor_wg_world_size: int, metadata: list[WorkerMetadata]) -> list[int]:
+        """Actor rank 0 joins, plus every actor worker on its node, which are its NVLink peers.
+
+        Those peers carry no data the rollout needs. They join so NCCL has somewhere to fan a
+        bucket out to over NVLink, from which it can push on over each peer's own NIC. A peer on
+        any other node would have to pull a full copy over the fabric to contribute nothing, so it
+        gets rank -1 instead.
+        """
+        source_node = metadata[0].node_id
+
+        # Ranks must stay contiguous, so number the survivors as we walk the actor workers.
+        ranks, next_rank = [], 0
+        for i in range(actor_wg_world_size):
+            if i == 0 or metadata[i].node_id == source_node:
+                ranks.append(next_rank)
+                next_rank += 1
+            else:
+                ranks.append(-1)
+        return ranks
+
     @classmethod
-    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[dict]):
+    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[WorkerMetadata]):
+        master = metadata[0].master
+        assert master is not None, "actor rank 0 must be the checkpoint engine master"
+
+        if master.multi_sender:
+            actor_ranks = cls._multi_sender_ranks(actor_wg_world_size, metadata)
+        else:
+            actor_ranks = cls._single_sender_ranks(actor_wg_world_size)
+
+        # Multi-sender degrades to a single sender when rank 0 has no actor peers on its node.
+        num_senders = sum(rank >= 0 for rank in actor_ranks)
+        world_size = num_senders + rollout_world_size
+        logger.info(
+            f"build_topology: {num_senders} of {actor_wg_world_size} actor workers send, world_size {world_size}"
+        )
+
         actor_wg_kwargs = {
-            "rank": [0] + [-1] * (actor_wg_world_size - 1),
-            "world_size": [rollout_world_size + 1] * actor_wg_world_size,
-            "master_metadata": [metadata[0]] * actor_wg_world_size,
+            "rank": actor_ranks,
+            "world_size": [world_size] * actor_wg_world_size,
+            "master_metadata": [master] * actor_wg_world_size,
+            "num_senders": [num_senders] * actor_wg_world_size,
         }
         rollout_kwargs = {
-            "rank": list(range(1, rollout_world_size + 1)),
-            "world_size": [rollout_world_size + 1] * rollout_world_size,
-            "master_metadata": [metadata[0]] * rollout_world_size,
+            "rank": list(range(num_senders, world_size)),
+            "world_size": [world_size] * rollout_world_size,
+            "master_metadata": [master] * rollout_world_size,
+            "num_senders": [num_senders] * rollout_world_size,
         }
         return actor_wg_kwargs, rollout_kwargs
 
@@ -198,14 +277,19 @@ class NCCLCheckpointEngine(CheckpointEngine):
         self.socket.connect(address)
         self.socket.setsockopt_string(zmq.SUBSCRIBE, self.topic)
 
-    def init_process_group(self, rank: int, world_size: int, master_metadata: MasterMetadata):
+    def init_process_group(self, rank: int, world_size: int, master_metadata: MasterMetadata, num_senders: int):
         """Initialize the NCCL process group.
 
         Args:
             rank (int): The rank of the current process.
             world_size (int): The total number of processes.
+            master_metadata (MasterMetadata): The endpoint of the broadcast source.
+            num_senders (int): How many actor-side ranks the group starts with. Ranks below this
+                send or relay weights; ranks at or above it consume them.
         """
-        # For actor workers other than rank 0, their rank should be -1.
+        self.num_senders = num_senders
+
+        # Actor workers left out of the group are given rank -1.
         if rank < 0:
             self.rank = rank
             self.world_size = world_size
@@ -221,7 +305,8 @@ class NCCLCheckpointEngine(CheckpointEngine):
                 f"world_size {world_size} is not equal to self.world_size {self.world_size}"
             )
 
-        if self.rank > 0:
+        # Only consumers read the bucket metadata stream; relays never touch the payload.
+        if self.rank >= num_senders:
             self._connect_zmq_client(master_metadata)
         collective.barrier(self.group_name)
 
@@ -238,16 +323,27 @@ class NCCLCheckpointEngine(CheckpointEngine):
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
         """
-        assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
+        assert self.rank < self.num_senders, "Rollout workers should not send weights."
 
-        # For actor rank other than 0, consume weights without sending.
+        # Actor workers left out of the group still have to walk the generator: producing each
+        # weight is itself collective over the actor group.
         if self.rank < 0:
-            for name, weight in weights:
+            for _name, _weight in weights:
                 pass
+            return
+
+        if self.rank > 0:
+            await self._relay_weights(weights)
             return
 
         send_buf, recv_buf = self.send_buf, self.recv_buf
         broadcast_op = None
+
+        # In the case of multi senders, the broadcast and all-gather kernels must
+        # be queued in a deterministic order, otherwise the NCCL kernel may deadlock.
+        # Moreover the wait_for_complete() function only waits for the NCCL kernel to be enqueued,
+        # not for the kernel to finish.
+        pipelined = self.num_senders == 1
 
         start_time = time.time()
         bucket_meta: dict[str, TensorMeta] = {}
@@ -258,14 +354,14 @@ class NCCLCheckpointEngine(CheckpointEngine):
                 torch.cuda.synchronize()
 
                 # wait previous broadcast op finish
-                if broadcast_op is not None:
+                if pipelined and broadcast_op is not None:
                     await broadcast_op.wait_for_complete()
 
                 broadcast_op = BroadcastOperation(
                     rank=self.rank,
                     group_name=self.group_name,
-                    bucket=send_buf,
-                    metadata={"bucket_meta": bucket_meta, "is_last": False},
+                    bucket=send_buf[:offset],
+                    metadata={"bucket_meta": bucket_meta, "is_last": False, "length": offset},
                     socket=self.socket,
                     topic=self.topic,
                 )
@@ -283,16 +379,20 @@ class NCCLCheckpointEngine(CheckpointEngine):
             send_buf[offset : offset + tensor_meta.chunk_size] = cp.asarray(chunk)
             offset += tensor_meta.chunk_size
 
+            # keep the relays in step: no-op once the bucket's broadcast has already been drained
+            if not pipelined and broadcast_op is not None:
+                await broadcast_op.wait_for_complete()
+
         # broadcast last bucket
         torch.cuda.synchronize()
-        if broadcast_op is not None:
+        if pipelined and broadcast_op is not None:
             await broadcast_op.wait_for_complete()
 
         broadcast_op = BroadcastOperation(
             rank=self.rank,
             group_name=self.group_name,
-            bucket=send_buf,
-            metadata={"bucket_meta": bucket_meta, "is_last": True},
+            bucket=send_buf[:offset],
+            metadata={"bucket_meta": bucket_meta, "is_last": True, "length": offset},
             socket=self.socket,
             topic=self.topic,
         )
@@ -304,6 +404,35 @@ class NCCLCheckpointEngine(CheckpointEngine):
         torch.cuda.synchronize()
 
         logger.info(f"Rank {self.rank} send weights done, time cost: {time.time() - start_time:.2f}s")
+
+    async def _relay_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+        """Join every broadcast as an NVLink-local relay for rank 0, dropping the payload.
+
+        A relay holds nothing the rollout needs, so it only has to match the root bucket for
+        bucket. It recomputes the boundaries from its own copy of the weight stream under the same
+        rule `send_weights` uses above, which keeps the two in step without a round trip -- and it
+        has to be derived locally rather than read off the wire, because pulling a weight is itself
+        collective over the actor group, so blocking on the wire would deadlock against rank 0's
+        own gathers.
+        """
+        start_time = time.time()
+        offset = 0
+
+        # a single buffer suffices: nothing reads the bucket, so successive broadcasts can share it
+        async for chunk_size in get_weight_chunks_size(weights, self.bucket_size):
+            if offset + chunk_size > self.bucket_size:
+                collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)
+                offset = 0
+
+            offset += chunk_size
+
+        # relay last bucket
+        collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)
+
+        # wait for the enqueued NCCL kernels, so finalize() cannot free the buffer under them
+        torch.cuda.synchronize()
+
+        logger.info(f"Rank {self.rank} relay weights done, time cost: {time.time() - start_time:.2f}s")
 
     @torch.no_grad()
     async def receive_weights(
@@ -339,7 +468,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
             topic=self.topic,
         )
         metadata = await broadcast_op.wait_for_complete()
-        total_bytes += self.bucket_size
+        total_bytes += metadata["length"]
         total_params += len(metadata["bucket_meta"])
 
         # wait for the NCCL broadcast kernel to finish before we yield the tensors
@@ -367,7 +496,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
             # 3. wait for next bucket broadcast finish
             metadata = await broadcast_op.wait_for_complete()
-            total_bytes += self.bucket_size
+            total_bytes += metadata["length"]
             total_params += len(metadata["bucket_meta"])
 
             # 4. swap send_buf and recv_buf

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -31,7 +31,6 @@ from verl.checkpoint_engine.base import (
     CheckpointEngine,
     CheckpointEngineRegistry,
     TensorMeta,
-    get_weight_chunks_size,
     merge_weight_chunks,
     split_weight_chunks,
 )
@@ -140,7 +139,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
         rebuild_group: bool = False,
         is_master: bool = False,
         rollout_dtype: torch.dtype = torch.bfloat16,
-        multi_sender: bool = False,
+        multi_sender: bool = True,
     ) -> None:
         self.bucket_size = bucket_size
         self.group_name = group_name
@@ -419,12 +418,12 @@ class NCCLCheckpointEngine(CheckpointEngine):
         offset = 0
 
         # a single buffer suffices: nothing reads the bucket, so successive broadcasts can share it
-        async for chunk_size in get_weight_chunks_size(weights, self.bucket_size):
-            if offset + chunk_size > self.bucket_size:
+        async for tensor_meta, _ in split_weight_chunks(weights, self.bucket_size, meta_only=True):
+            if offset + tensor_meta.chunk_size > self.bucket_size:
                 collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)
                 offset = 0
 
-            offset += chunk_size
+            offset += tensor_meta.chunk_size
 
         # relay last bucket
         collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in `multi_sender` mode to the NCCL checkpoint engine that admits actor rank 0's node-local peers (and hence probably connected via high-speed interconnects) into the broadcast group as relays, so NCCL can drive more than one NIC per node during weight sync.

Addresses #7167. With a single sender, broadcast bandwidth is capped by the one NIC reachable from the source GPU (~25 GB/s on a GH200 node with 4 NICs and ~100 GB/s bisection). Admitting the source's NVLink peers gives NCCL's broadcast tree fan-out points it can reach over NVLink and push on from over their own NICs.

The relays carry no data the rollout needs — rank 0 remains the sole source, and there is still exactly one group and one broadcast per bucket. Actor workers on any other node are excluded (rank `-1`): they would have to pull a full copy over the fabric to contribute nothing.

Relationship to open PRs:
- **#7263** (`nccl_parallel`) targets the same issue by a different mechanism: a new backend where S actor ranks each send a stripe of the bucket sequence over S separate NCCL groups. This PR instead keeps the existing single-group broadcast and changes only group *membership*, as a flag on the existing `nccl` engine. The two are alternatives; see the discussion on #7167.
- **#7107** (bucket-size fix) is a prerequisite. Relays size each broadcast to match the root, so they depend on the root sending `send_buf[:offset]`. This PR is rebased on / assumes #7107; it does not restate that change.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+nccl+checkpoint+engine+broadcast and https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7167

### Test

**GPU correctness and latency:** 

The following measurements include the mean over 10 iterations run on the same hardware as #7167. The measurements include the time taken for all-reduce + broadcast + copy the tensors on a non-blocking stream on the receiver side. All my measurements are based on a 4-trainer (1 node)+ 4-rollout (1 node) configuration. 1 warm-up iteration was run before starting with the measurements, and the iterations were run with `rebuild_group: False`.

| Model | Mode | Mean (s) | Min–Max (s) |
|---|---|---:|---:|
| Qwen3.5-27B | single-sender | 5.026 | 5.02–5.04 |
| Qwen3.5-27B | **multi-sender** | **1.791** | 1.78–1.86 |
| Qwen3-30B-A3B | single-sender | 5.570 | 5.56–5.58 |
| Qwen3-30B-A3B | **multi-sender** | **1.892** | 1.86–1.92 |

Speedup: 2.81× on Qwen3.5-27B, 2.94× on Qwen3-30B-A3B.

**Effects of scaling out**

Scaling the rollout side out costs nothing measurable. A 4-trainer (1 node) + 12-rollout (3 nodes) configuration syncs Qwen3.5-27B in 1.82–1.88 s under multi-sender, within noise of the 1.78–1.86 s measured against 4 rollout workers on a single node.

Scaling the *trainer* side across nodes does cost, but the cost is not in the broadcast. An 8-trainer (2 nodes) + 8-rollout (2 nodes) configuration syncs the same model in 2.60–2.62 s under multi-sender versus 5.85–5.90 s single-sender — still a 2.25× speedup. Both modes slow by nearly the same absolute amount relative to their single-trainer-node numbers (+0.82 s and +0.85 s), which points at a fixed cost incurred ahead of the broadcast rather than anything in the transfer itself: gathering full parameters now crosses the 25 GB/s CXI fabric instead of staying on NVLink. Only rank-0 nodes contribute relays by design, so the second trainer node adds gather cost without adding senders.


### API and Usage Example

Off by default; existing behavior is unchanged.

```python
CheckpointEngineConfig(
    backend="nccl",
    update_weights_bucket_megabytes=2048,
    engine_kwargs={"nccl": {"multi_sender": True}},
)
```

The master's setting governs the whole group: it travels in `MasterMetadata`, so `build_topology` (a classmethod on the driver) resolves one mode for every worker.

### Design & Code Changes

Rank 0 stays the only source of weights. `multi_sender` changes only who else is in the group.

- **`WorkerMetadata`** — `prepare()` now reports each worker's Ray node id, since `build_topology` runs on the driver and cannot query worker placement itself. Only rank 0 fills the nested `master` field. Node id is the locality key: a node never spans more than one NVLink domain, so matching on it can under-select peers but never over-select them.
- **`build_topology`** dispatches to `_single_sender_ranks` (upstream behaviour, `[0, -1, …]`) or `_multi_sender_ranks` (rank 0 plus every actor worker on its node, others `-1`), then assembles the kwargs once. Senders take the low ranks.
- **`num_senders`** is passed to `init_process_group` and splits the group: ranks below it send or relay, ranks at or above it consume. It also fixes an incidental leak — only true consumers now subscribe to the zmq bucket-metadata topic, where previously every `rank > 0` did.
- **`_relay_weights`** walks the same weight stream as the root via the new `get_weight_chunks_size` helper, which splits on identical boundaries to `split_weight_chunks` without materializing buffers, and issues a matching broadcast per bucket while dropping the payload. Boundaries must be derived locally rather than read off the wire: producing a weight is itself collective over the actor group, so blocking on the wire would deadlock against rank 0's gathers.
- **Root wait placement** is now mode-dependent. Single sender waits just before enqueueing the next broadcast, preserving the fill/send overlap the `send_buf`/`recv_buf` swap exists for. With relays present the root waits as soon as the bucket is filled, so the root and the relays cannot issue the broadcast group's and the actor group's collectives in different orders, hence preventing a deadlock.

AI assistance (claude code) was used to refactor this code and build the PR.

**Why this makes sense after NCCL M2N**

This PR proposes a small change to the existing legacy NCCL backend without introducing new collectives or a completely new backend. Moreover, M2N currently relies on GIN for inter-NVL domain communication, which is not supported on certain backends such as CXI.