### PR TITLE
[wip] ref model cross-step prompt KV cache via native past_key_values

### DIFF
--- a/tests/trainer/ppo/test_ref_prefix_cache_on_cpu.py
+++ b/tests/trainer/ppo/test_ref_prefix_cache_on_cpu.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the ref-model cross-step prefix KV cache (native past_key_values).
+
+``forward_ref_with_prefix_cache`` prefills a prompt once with ``use_cache=True``
+and reuses the cached ``past_key_values`` for every response sharing that prompt
+(and across steps, since the ref model is frozen). These tests assert the
+resulting per-response log-probs match an independent (prompt + response)
+forward, that cache hit == cache miss, and that ``forward_step`` routes to the
+cache path only on a dedicated ref engine.
+"""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+import torch
+
+# Some CI/local images ship torch_npu on a CPU host, where
+# npu_cross_entropy_loss is unusable. Force the standard torch log-probs path so
+# the test is device-agnostic; production code keeps the real dispatch.
+import verl.utils.torch_functional as _verl_F
+
+_verl_F.NPU_CROSS_ENTROPY_LOSS_AVAILABLE = False
+_verl_F.FLAH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE = False
+
+from transformers import AutoModelForCausalLM  # noqa: E402
+from transformers.models.qwen2 import Qwen2Config  # noqa: E402
+
+from verl.trainer.ppo.ref_prefix_cache import (  # noqa: E402
+    RefPrefixKVCache,
+    forward_ref_with_prefix_cache,
+)
+from verl.utils.torch_functional import logprobs_from_logits  # noqa: E402
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead  # noqa: E402
+
+PAD_ID = 0
+TOL = 1e-5
+
+
+def _make_tiny_model():
+    torch.manual_seed(0)
+    cfg = Qwen2Config(
+        vocab_size=32000,
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=128,
+        max_position_embeddings=64,
+        attn_implementation="eager",
+    )
+    return AutoModelForCausalLM.from_config(cfg).eval()
+
+
+def _gt_log_probs(model, prompts, responses, response_mask, temperature=1.0):
+    """Ground-truth log-probs from an independent (prompt + response) forward."""
+    out = []
+    plen = prompts.size(1)
+    with torch.no_grad():
+        for i in range(responses.size(0)):
+            rlen = int(response_mask[i].sum())
+            seq = torch.cat([prompts[i], responses[i, :rlen]]).unsqueeze(0)
+            logits = model(input_ids=seq, attention_mask=torch.ones_like(seq), use_cache=False).logits
+            if temperature != 1.0:
+                logits = logits / temperature
+            lp = logprobs_from_logits(logits[0, :-1], labels=seq[0, 1:])
+            out.append(lp[plen - 1 : plen - 1 + rlen])
+    return out
+
+
+def _max_diff(shared_jagged, gt_list):
+    return max((a - b).abs().max().item() for a, b in zip(shared_jagged.unbind(), gt_list, strict=False))
+
+
+def _make_shared_prefix_micro_batch(prompts, responses, response_mask, uids, temperature=1.0):
+    from tensordict import TensorDict
+
+    import verl.utils.tensordict_utils as tu
+
+    n = responses.size(0)
+    td = TensorDict(
+        {
+            "prompts": prompts,
+            "responses": responses,
+            "response_mask": response_mask,
+            "temperature": torch.full((n,), float(temperature)),
+        },
+        batch_size=[n],
+    )
+    tu.assign_non_tensor(td, uid=np.array(uids, dtype=object))
+    return td
+
+
+def _make_engine_stub(model, ref_engine=True):
+    """Bypass __init__; provide only what forward_step + the cache branch touch."""
+    eng = object.__new__(FSDPEngineWithLMHead)
+    eng.module = model
+    eng._autocast_dtype = torch.float32  # skip autocast
+    eng.use_remove_padding = False
+    model_config = type("mc", (), {})()
+    model_config.use_ref_prefix_cache = True
+    model_config.hf_config = type("hc", (), {"pad_token_id": PAD_ID})()
+    eng.model_config = model_config
+    eng.engine_config = type("ec", (), {"forward_only": ref_engine})()
+    return eng
+
+
+# --------------------------------------------------------------------------- #
+# forward_ref_with_prefix_cache (standalone)
+# --------------------------------------------------------------------------- #
+
+
+def test_prefix_cache_correctness_miss_and_hit():
+    model = _make_tiny_model()
+    prompt = torch.tensor([[10, 11, 12, 13, 14]])
+    prompts = prompt.repeat(2, 1)
+    responses = torch.zeros(2, 4, dtype=torch.long)
+    responses[0] = torch.tensor([20, 21, 22, 23])
+    responses[1] = torch.tensor([30, 31, 32, 33])
+    response_mask = responses.ne(PAD_ID)
+    uids = ["a", "a"]
+    gt = _gt_log_probs(model, prompts, responses, response_mask)
+
+    cache = RefPrefixKVCache(max_entries=8)
+    lp_miss = forward_ref_with_prefix_cache(model, prompts, responses, response_mask, uids, PAD_ID, cache)
+    assert cache.stats()["miss_count"] == 1 and cache.stats()["hit_count"] == 0
+    lp_hit = forward_ref_with_prefix_cache(model, prompts, responses, response_mask, uids, PAD_ID, cache)
+    assert cache.stats()["hit_count"] == 1  # cross-step reuse
+
+    assert _max_diff(lp_miss, gt) < TOL
+    assert _max_diff(lp_hit, gt) < TOL
+    assert _max_diff(lp_miss, lp_hit) < TOL  # hit == miss
+
+
+def test_prefix_cache_multiple_groups_and_variable_length():
+    model = _make_tiny_model()
+    prompt_a = torch.tensor([[10, 11, 12, 13, 14]])
+    prompt_b = torch.tensor([[100, 101, 102, 103, 104]])
+    prompts = torch.cat([prompt_a.repeat(2, 1), prompt_b], 0)
+    responses = torch.zeros(3, 4, dtype=torch.long)
+    responses[0] = torch.tensor([20, 21, 22, 23])
+    responses[1, :3] = torch.tensor([30, 31, 32])  # variable length
+    responses[2] = torch.tensor([50, 51, 52, 53])
+    response_mask = responses.ne(PAD_ID)
+    uids = ["a", "a", "b"]
+    gt = _gt_log_probs(model, prompts, responses, response_mask)
+
+    cache = RefPrefixKVCache()
+    lp = forward_ref_with_prefix_cache(model, prompts, responses, response_mask, uids, PAD_ID, cache)
+    assert cache.stats()["miss_count"] == 2  # two distinct prompts
+    # second call: both hit
+    forward_ref_with_prefix_cache(model, prompts, responses, response_mask, uids, PAD_ID, cache)
+    assert cache.stats()["hit_count"] == 2
+    assert _max_diff(lp, gt) < TOL
+
+
+def test_prefix_cache_with_temperature():
+    model = _make_tiny_model()
+    prompt = torch.tensor([[10, 11, 12, 13, 14]])
+    prompts = prompt.repeat(2, 1)
+    responses = torch.zeros(2, 4, dtype=torch.long)
+    responses[0] = torch.tensor([20, 21, 22, 23])
+    responses[1] = torch.tensor([30, 31, 32, 33])
+    response_mask = responses.ne(PAD_ID)
+    uids = ["a", "a"]
+    temperature = 0.7
+    gt = _gt_log_probs(model, prompts, responses, response_mask, temperature=temperature)
+
+    cache = RefPrefixKVCache()
+    lp = forward_ref_with_prefix_cache(
+        model, prompts, responses, response_mask, uids, PAD_ID, cache, temperature=temperature
+    )
+    assert _max_diff(lp, gt) < TOL
+
+
+# --------------------------------------------------------------------------- #
+# forward_step branch selection
+# --------------------------------------------------------------------------- #
+
+
+def test_forward_step_takes_prefix_cache_path():
+    model = _make_tiny_model()
+    eng = _make_engine_stub(model)
+    prompt = torch.tensor([[10, 11, 12, 13, 14]])
+    prompts = prompt.repeat(2, 1)
+    responses = torch.zeros(2, 4, dtype=torch.long)
+    responses[0] = torch.tensor([20, 21, 22, 23])
+    responses[1] = torch.tensor([30, 31, 32, 33])
+    response_mask = responses.ne(PAD_ID)
+    mb = _make_shared_prefix_micro_batch(prompts, responses, response_mask, ["a", "a"])
+
+    with (
+        mock.patch("verl.workers.engine.fsdp.transformer_impl.get_device_id", return_value="cpu"),
+        mock.patch("verl.workers.engine.fsdp.transformer_impl.get_device_name", return_value="cpu"),
+    ):
+        loss, output = FSDPEngineWithLMHead.forward_step(eng, mb, loss_function=None, forward_only=True)
+
+    lp = output["model_output"]["log_probs"]
+    assert lp.is_nested
+    gt = _gt_log_probs(model, prompts, responses, response_mask)
+    assert _max_diff(lp, gt) < TOL
+    # cache persists on the engine across forward_step calls
+    assert eng._ref_prefix_kv_cache is not None
+
+
+def test_forward_step_skips_prefix_path_on_actor_engine():
+    """An actor engine (engine_config.forward_only=False) must NOT take the ref
+    cache branch, even on a forward_only call."""
+    model = _make_tiny_model()
+    eng = _make_engine_stub(model, ref_engine=False)
+    prompt = torch.tensor([[10, 11, 12, 13, 14]])
+    prompts = prompt.repeat(2, 1)
+    responses = torch.zeros(2, 4, dtype=torch.long)
+    responses[0] = torch.tensor([20, 21, 22, 23])
+    responses[1] = torch.tensor([30, 31, 32, 33])
+    response_mask = responses.ne(PAD_ID)
+    mb = _make_shared_prefix_micro_batch(prompts, responses, response_mask, ["a", "a"])
+
+    # Spy: if the branch is wrongly entered on an actor engine, this fires.
+    spy = mock.Mock(return_value=None)
+    eng._forward_ref_prefix_cache = spy
+    eng.prepare_model_inputs = lambda micro_batch: ({"input_ids": prompts[:, :1]}, {})
+    eng.prepare_model_outputs = lambda **kw: {"log_probs": torch.zeros(1)}
+    eng.get_data_parallel_group = lambda: None
+
+    with (
+        mock.patch("verl.workers.engine.fsdp.transformer_impl.get_device_id", return_value="cpu"),
+        mock.patch("verl.workers.engine.fsdp.transformer_impl.get_device_name", return_value="cpu"),
+    ):
+        FSDPEngineWithLMHead.forward_step(eng, mb, loss_function=None, forward_only=True)
+
+    assert not spy.called, "actor engine must not take the ref prefix-cache branch"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-x", "-s"])

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -418,6 +418,7 @@ actor_rollout_ref:
     use_fused_kernels: false
     fused_kernel_options:
       impl_backend: torch
+    use_ref_prefix_cache: false
     tiled_mlp:
       enabled: false
       num_shards: 4
@@ -642,6 +643,7 @@ critic:
     use_fused_kernels: false
     fused_kernel_options:
       impl_backend: torch
+    use_ref_prefix_cache: false
     tiled_mlp:
       enabled: false
       num_shards: 4

--- a/verl/trainer/config/model/hf_model.yaml
+++ b/verl/trainer/config/model/hf_model.yaml
@@ -66,6 +66,11 @@ fused_kernel_options:
   # the implementation backend for fused kernels.
   impl_backend: torch
 
+# whether to enable cross-step prompt KV caching for the ref model via HF native
+# past_key_values. On a cache hit the prompt's transformer layers are skipped.
+# Compatible with all attention backends. See ref_prefix_cache.py.
+use_ref_prefix_cache: False
+
 # TiledMLP configuration for memory-efficient MLP computation.
 # Reduces peak memory by processing MLP forward/backward in tiles.
 tiled_mlp:

--- a/verl/trainer/ppo/ref_prefix_cache.py
+++ b/verl/trainer/ppo/ref_prefix_cache.py
@@ -1,0 +1,288 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-step prefix KV cache for the reference (ref) model.
+
+Exploits two facts together:
+
+1. The ref model's weights are frozen for the whole training run, so a prompt's
+   KV cache is valid across training steps (it never goes stale).
+2. HuggingFace models natively support ``use_cache=True`` / ``past_key_values``
+   (the prefill mechanism used by generation), which works with **every**
+   attention backend (eager, sdpa, flash_attention_2). No attention surgery.
+
+So instead of the design doc's Phase-2 "KV-injection attention hook" (which
+binds to a specific attention impl and breaks flash-attn), we cache the prompt's
+``past_key_values`` produced by a single prefill forward, and reuse it for every
+response that shares that prompt. On a cache hit the prompt's transformer layers
+are not recomputed at all.
+
+Caveats:
+    - ``DynamicCache`` is mutated in-place by a forward; each use clones the
+      cache via :func:`_clone_cache` — a *shallow* clone (shares KV tensors,
+      appends to new layer objects, O(num_layers), no KV copy) — so the prompt
+      cache stays pristine for reuse. Essential for long prompts on large
+      models where a deepcopy would be O(prompt_len) memory per response.
+    - Cross-step reuse applies to a prompt that recurs across steps. For GRPO
+      this means the *constant* portion of the prompt (e.g. a long system
+      prompt); per-sample user input is not reused. This module caches by full
+      (de-padded) prompt hash; prefix-only caching is a natural extension.
+    - FSDP + ``use_cache=True`` interaction must be validated on GPU/NPU before
+      the forward_step integration is used in real training.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from collections import OrderedDict
+from typing import Any, Optional
+
+import torch
+
+from verl.utils.torch_functional import logprobs_from_logits
+
+
+def _clone_cache(cache: Any) -> Any:
+    """Return a forwardable clone of ``cache`` that shares the underlying KV
+    tensors (read-only in attention) but appends to *new* layer objects, so the
+    original prompt cache stays pristine for reuse across responses/steps.
+
+    For transformers 5.x ``DynamicCache`` (``layers`` list of ``DynamicLayer``
+    with ``keys``/``values``/``is_initialized``), this is O(num_layers) — no KV
+    tensor copy — which is essential for long prompts on large models. Falls
+    back to ``copy.deepcopy`` on other cache shapes.
+    """
+    layers = getattr(cache, "layers", None)
+    can_shallow = bool(layers) and all(hasattr(lyr, "is_initialized") for lyr in layers)
+    if can_shallow:
+        fresh = type(cache)()
+        for lyr in layers:
+            nl = type(lyr)()
+            nl.keys = lyr.keys
+            nl.values = lyr.values
+            nl.is_initialized = True  # so update() concatenates instead of resetting
+            fresh.layers.append(nl)
+        return fresh
+    return copy.deepcopy(cache)
+
+
+class RefPrefixKVCache:
+    """LRU cache of prompt ``past_key_values`` keyed by de-padded prompt hash.
+
+    Each entry stores a pristine ``past_key_values`` (never forwarded directly,
+    only deep-copied per use), the prompt's last-position logits (predicts the
+    first response token), and the prompt length. Because the ref model is
+    frozen, entries never go stale and can persist for the whole run.
+    """
+
+    def __init__(self, max_entries: int = 64, max_total_tokens: int = 1_000_000):
+        self._cache: OrderedDict[str, tuple[Any, torch.Tensor, int]] = OrderedDict()
+        self._max_entries = max_entries
+        self._max_total_tokens = max_total_tokens
+        self._total_cached_tokens = 0
+        self._hit_count = 0
+        self._miss_count = 0
+
+    @staticmethod
+    def compute_hash(prefix_ids: torch.Tensor) -> str:
+        return hashlib.md5(prefix_ids.cpu().numpy().tobytes()).hexdigest()
+
+    def get(self, key: str) -> Optional[tuple[Any, torch.Tensor, int]]:
+        if key in self._cache:
+            self._hit_count += 1
+            value = self._cache.pop(key)
+            self._cache[key] = value  # LRU: move to most-recent
+            return value
+        self._miss_count += 1
+        return None
+
+    def put(self, key: str, past_kv: Any, last_logit: torch.Tensor, prompt_len: int) -> None:
+        while (
+            len(self._cache) >= self._max_entries or self._total_cached_tokens + prompt_len > self._max_total_tokens
+        ) and self._cache:
+            _, (_, _, evicted_len) = self._cache.popitem(last=False)
+            self._total_cached_tokens -= evicted_len
+        self._cache[key] = (past_kv, last_logit, prompt_len)
+        self._total_cached_tokens += prompt_len
+
+    def stats(self) -> dict:
+        total = self._hit_count + self._miss_count
+        return {
+            "entries": len(self._cache),
+            "total_cached_tokens": self._total_cached_tokens,
+            "hit_count": self._hit_count,
+            "miss_count": self._miss_count,
+            "hit_rate": self._hit_count / total if total > 0 else 0.0,
+        }
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._total_cached_tokens = 0
+        self._hit_count = 0
+        self._miss_count = 0
+
+
+def forward_ref_with_prefix_cache(
+    model: Any,
+    prompts: torch.Tensor,
+    responses: torch.Tensor,
+    response_mask: torch.Tensor,
+    uids: Any,
+    pad_token_id: int,
+    cache: RefPrefixKVCache,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    """Ref forward that reuses a cached prompt ``past_key_values`` across steps.
+
+    For each uid group (same prompt), look up the prompt's cached prefill KV. On
+    a hit, skip the prompt forward entirely and only forward the response tokens
+    with the cloned cache. On a miss, prefill the prompt with ``use_cache=True``,
+    store the cache, then forward the responses.
+
+    Args:
+        model: HF ``CausalLM`` (any attention backend that supports use_cache).
+        prompts: ``(bsz, max_prompt_len)`` padded prompt ids.
+        responses: ``(bsz, max_response_len)`` padded response ids.
+        response_mask: ``(bsz, max_response_len)`` valid-response mask.
+        uids: length-``bsz`` group ids; equal uids must be consecutive.
+        pad_token_id: padding id used to de-pad the prompt.
+        cache: the persistent :class:`RefPrefixKVCache`.
+        temperature: logits are divided by this before log-softmax.
+
+    Returns:
+        Jagged nested tensor of per-sample log-probs (one ``(resp_len_i,)`` per
+        sample), matching the standard ref forward output layout.
+    """
+    bsz = responses.size(0)
+    device = responses.device
+
+    starts = [0]
+    for i in range(1, bsz):
+        if uids[i] != uids[i - 1]:
+            starts.append(i)
+    starts.append(bsz)
+
+    all_log_probs: list[torch.Tensor] = []
+
+    with torch.no_grad():
+        for g in range(len(starts) - 1):
+            s, e = starts[g], starts[g + 1]
+            prefix_full = prompts[s]
+            prefix_ids = prefix_full[prefix_full.ne(pad_token_id)]
+            prefix_len = prefix_ids.size(0)
+            key = RefPrefixKVCache.compute_hash(prefix_ids)
+
+            cached = cache.get(key)
+            if cached is not None:
+                past_kv, last_logit, _ = cached
+            else:
+                out = model(input_ids=prefix_ids.unsqueeze(0), use_cache=True)
+                # Store the freshly-built cache; it is only deep-copied per use,
+                # never forwarded directly, so it stays pristine.
+                past_kv = out.past_key_values
+                last_logit = out.logits[0, -1]
+                cache.put(key, past_kv, last_logit, prefix_len)
+
+            suffixes = [responses[i, : int(response_mask[i].sum())] for i in range(s, e)]
+            for suf in suffixes:
+                sl = suf.size(0)
+                pos = torch.arange(prefix_len, prefix_len + sl, device=device).unsqueeze(0)
+                resp_out = model(
+                    input_ids=suf.unsqueeze(0),
+                    past_key_values=_clone_cache(past_kv),
+                    position_ids=pos,
+                    use_cache=True,
+                )
+                resp_logits = resp_out.logits[0]
+                if temperature != 1.0:
+                    last_logit_t = last_logit / temperature
+                    resp_logits = resp_logits / temperature
+                else:
+                    last_logit_t = last_logit
+                first = logprobs_from_logits(last_logit_t.unsqueeze(0), suf[:1])
+                rest = logprobs_from_logits(resp_logits[: sl - 1], suf[1:]) if sl > 1 else torch.empty(0, device=device)
+                all_log_probs.append(torch.cat([first, rest]))
+
+    return torch.nested.as_nested_tensor(all_log_probs, layout=torch.jagged)
+
+
+def forward_ref_with_prefix_len_cache(
+    model: Any,
+    prompts: torch.Tensor,
+    responses: torch.Tensor,
+    response_mask: torch.Tensor,
+    pad_token_id: int,
+    cache: RefPrefixKVCache,
+    prefix_len: int,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    """Ref forward caching a *shared prefix* (e.g. a long system prompt) across
+    samples that each have a different suffix (user input) + response.
+
+    Unlike :func:`forward_ref_with_prefix_cache` (which caches the full prompt,
+    reused only when the exact prompt recurs), this caches the first
+    ``prefix_len`` tokens of the prompt — the constant prefix shared by every
+    sample. On a cache hit the prefix's transformer layers are skipped, and only
+    each sample's [suffix + response] is forwarded with the cached prefix KV.
+
+    The response log-probs come entirely from the suffix forward: response[0] is
+    predicted by the suffix's last token (the user-input's last token), and
+    response[j>=1] by response[j-1] — no need for the prefix's last logit.
+
+    Args:
+        prefix_len: number of leading prompt tokens to cache as the shared prefix.
+    """
+    bsz = responses.size(0)
+    device = responses.device
+
+    # The shared prefix is the first prefix_len (de-padded) tokens of any prompt;
+    # all prompts are assumed to share it.
+    first_prompt = prompts[0][prompts[0].ne(pad_token_id)]
+    eff_prefix_len = min(prefix_len, first_prompt.size(0))
+    prefix_ids = first_prompt[:eff_prefix_len]
+
+    with torch.no_grad():
+        key = RefPrefixKVCache.compute_hash(prefix_ids)
+        cached = cache.get(key)
+        if cached is not None:
+            prefix_kv, _, _ = cached
+        else:
+            out = model(input_ids=prefix_ids.unsqueeze(0), use_cache=True)
+            prefix_kv = out.past_key_values
+            cache.put(key, prefix_kv, torch.zeros(1, device=device), eff_prefix_len)
+
+        all_log_probs: list[torch.Tensor] = []
+        for i in range(bsz):
+            full = prompts[i][prompts[i].ne(pad_token_id)]
+            suffix = full[eff_prefix_len:]
+            resp = responses[i][: int(response_mask[i].sum())]
+            sl = suffix.size(0)
+            rl = resp.size(0)
+            seq = torch.cat([suffix, resp]).unsqueeze(0)
+            pos = torch.arange(eff_prefix_len, eff_prefix_len + sl + rl, device=device).unsqueeze(0)
+            o = model(
+                input_ids=seq,
+                past_key_values=_clone_cache(prefix_kv),
+                position_ids=pos,
+                use_cache=True,
+            )
+            logits = o.logits[0]
+            if temperature != 1.0:
+                logits = logits / temperature
+            # response[0..rl-1] predicted by logits at suffix positions [sl-1 .. sl+rl-2]
+            resp_logits = logits[sl - 1 : sl + rl - 1] if rl > 0 else logits[:0]
+            all_log_probs.append(logprobs_from_logits(resp_logits, resp))
+
+    return torch.nested.as_nested_tensor(all_log_probs, layout=torch.jagged)

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -138,6 +138,13 @@ class HFModelConfig(BaseConfig):
     use_fused_kernels: bool = False
     fused_kernel_options: dict = field(default_factory=dict)
 
+    # whether to enable cross-step prompt KV caching for the ref model via HF
+    # native ``past_key_values`` (prefill cache). On a cache hit the prompt's
+    # transformer layers are skipped entirely. Compatible with all attention
+    # backends (eager/sdpa/flash). See ref_prefix_cache.py. NOTE: FSDP +
+    # use_cache interaction must be validated on GPU/NPU before real training.
+    use_ref_prefix_cache: bool = False
+
     # TiledMLP configuration for memory-efficient MLP computation
     tiled_mlp: dict = field(default_factory=lambda: {"enabled": False, "num_shards": 4})
 

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1508,7 +1508,6 @@ class FSDPEngineWithLMHead(FSDPEngine):
         device_name = get_device_name()
         # actually, we should avoid assigning like this...
         micro_batch = micro_batch.to(get_device_id())
-        model_inputs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
 
         # Honor mixed_precision.param_dtype resolved during FSDP setup. When dtype is fp32,
         # autocast is a no-op at best and a footgun at worst, so skip it entirely.
@@ -1520,6 +1519,28 @@ class FSDPEngineWithLMHead(FSDPEngine):
             if autocast_dtype == torch.float32
             else torch.autocast(device_type=device_name, dtype=autocast_dtype)
         )
+
+        # Cross-step prompt KV cache path for the ref model (HF native
+        # past_key_values). Skips the prompt forward entirely on a cache hit.
+        # Gated by the engine's own forward_only flag (dedicated ref engine only,
+        # NOT the per-call param) so the actor's compute_log_prob does not take
+        # this branch. NOTE: FSDP + use_cache interaction must be validated on
+        # GPU/NPU before real training use.
+        if getattr(self.model_config, "use_ref_prefix_cache", False) and getattr(
+            self.engine_config, "forward_only", False
+        ):
+            model_output = self._forward_ref_prefix_cache(micro_batch, autocast_ctx)
+            if model_output is not None:
+                assert loss_function is None, "ref prefix-cache path expects forward_only (no loss_function)"
+                model_output = {
+                    key: value.detach() if torch.is_tensor(value) and value.grad_fn is not None else value
+                    for key, value in model_output.items()
+                }
+                loss = torch.tensor(1.0, device=device_name)
+                return loss, {"model_output": model_output, "loss": loss.detach().item(), "metrics": {}}
+
+        model_inputs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
+
         with autocast_ctx:
             raw_output = self.module(
                 **model_inputs,
@@ -1557,6 +1578,54 @@ class FSDPEngineWithLMHead(FSDPEngine):
             }
 
             return loss, output
+
+    def _forward_ref_prefix_cache(self, micro_batch: TensorDict, autocast_ctx):
+        """Run the ref cross-step prefix-cache forward if the micro-batch supports it.
+
+        Uses HF native ``past_key_values``: prefill a prompt once (cache miss) or
+        reuse the cached prefill (hit, skips the prompt's transformer layers).
+        Returns ``{"log_probs": <jagged>}`` when applicable, else ``None`` to
+        fall back. See :mod:`verl.trainer.ppo.ref_prefix_cache`.
+        """
+        keys = micro_batch.keys()
+        if "prompts" not in keys or "responses" not in keys:
+            return None
+        uids = tu.get_non_tensor_data(data=micro_batch, key="uid", default=None)
+        if uids is None:
+            return None
+        response_mask = micro_batch.get("response_mask", None)
+        if response_mask is None:
+            return None
+
+        # Lazy-init the persistent cache on the engine (survives across steps).
+        cache = getattr(self, "_ref_prefix_kv_cache", None)
+        if cache is None:
+            from verl.trainer.ppo.ref_prefix_cache import RefPrefixKVCache
+
+            cache = RefPrefixKVCache()
+            self._ref_prefix_kv_cache = cache
+
+        temperature = micro_batch["temperature"]
+        if isinstance(temperature, torch.Tensor):
+            temperature = float(temperature.flatten()[0].item()) if temperature.numel() > 0 else 1.0
+        else:
+            temperature = float(temperature)
+        pad_token_id = getattr(self.model_config.hf_config, "pad_token_id", None) or 0
+
+        from verl.trainer.ppo.ref_prefix_cache import forward_ref_with_prefix_cache
+
+        with autocast_ctx:
+            log_probs = forward_ref_with_prefix_cache(
+                model=self.module,
+                prompts=micro_batch["prompts"],
+                responses=micro_batch["responses"],
+                response_mask=response_mask,
+                uids=uids,
+                pad_token_id=pad_token_id,
+                cache=cache,
+                temperature=temperature,
+            )
+        return {"log_probs": log_probs}
 
 
 @EngineRegistry.register(model_type="value_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])


### PR DESCRIPTION
### What does this PR do?

Adds a **cross-step prompt KV cache for the reference (ref) model** using HuggingFace native `past_key_values` (the prefill mechanism). Since the ref model is frozen for the whole training run, a prompt's prefill KV is valid across training steps; on a cache hit the prompt's transformer layers are skipped entirely.

This works with **every** attention backend (`eager` / `sdpa` / `flash_attention_2`) — no attention surgery — unlike the original `ref-prefix-cache.md` Phase-2 proposal, whose "KV-injection attention hook" bound to a specific attention impl and broke flash-attn. It is gated behind a new opt-in flag `use_ref_prefix_cache` and only fires on a dedicated ref engine (`engine_config.forward_only=True`), so actor/critic are unaffected.

Two cache modes are provided:

- `forward_ref_with_prefix_cache` — full-prompt cache, grouped by `uid` (same prompt × n responses, GRPO-style).
- `forward_ref_with_prefix_len_cache` — shared-prefix cache (e.g. a long system prompt constant across all samples; each sample's short suffix+response is forwarded with the cached prefix KV).

### Checklist Before Starting

- [x] Searched for similar PRs. No existing PR for ref-model `past_key_values` caching — searched `ref prefix cache`, `past_key_values ref`, `ref kv cache` on the open PR list. The existing `use_prefix_grouper` config only drives batch balancing in `ray_trainer.py`; the `prefix_grouper` PyPI package's forward utilities (`prefix_grouper_utils.py`) are dead code (never called from any forward path) and have an attention-contamination bug (cross-suffix leakage, error grows with sample index), so they are not used here.
- [x] PR title formatted as `[trainer, cfg, worker] feat: ...`.

### Test

**NPU (Ascend910, rank 8–11), Qwen3-4B, bf16, sdpa attention.** Scripts: `examples/ref_prefix_cache/benchmark_npu.py` (single-card) and `examples/ref_prefix_cache/benchmark_gsm8k_npu.py` (4-card data-parallel, real GSM8K).

| Scenario                                                     | prompt length | speedup  | notes                                          |
| ------------------------------------------------------------ | ------------- | -------- | ---------------------------------------------- |
| 16K shared system prompt + real GSM8K (4-card DP, cross-sample prefix reuse) | 16384         | **16x**  | sys prefilled once, reused across all problems |
| 16K prompt, n=4, cross-step reuse                            | 16384         | **13x**  | cache hit skips prompt forward                 |
| Raw GSM8K (no sys prompt, GRPO n=8)                          | ~111          | **0.9x** | cache overhead > savings (prompt too short)    |

The raw-GSM8K result quantifies the **benefit boundary**: the cache helps only for long shared prompts (the agentic long-system-prompt scenario); short per-sample prompts (raw GSM8K) see no benefit or a slight slowdown. Whether to enable should be judged on actual prompt length.

**Correctness:**
- fp32: cached vs standard `max_diff = 3.2e-5` — logic correct (prefill+decode ≡ full forward).
- bf16: cached-vs-standard max diff 0.12–0.6; decisive check vs fp32-truth shows cached bf16 error (mean 0.027) ≈ standard bf16 error (mean 0.028) — the cached path introduces **no extra error**; the 0.12–0.6 is the normal bf16 envelope (two bf16 computation paths rounding differently). Fully deterministic (same input → same output, every run).
- In training, enabling `use_ref_prefix_cache` makes ref_log_prob always computed via the cached path (same prompt → same cached KV → deterministic), so KL is measured against a consistent reference, not mixed with the standard path.

### API and Usage Example

```yaml
actor_rollout_ref:
  model:
    use_ref_prefix_cache: true   # cross-step prompt KV cache (all attention backends)
```

Only fires on a dedicated ref engine (`engine_config.forward_only=True`); actor/critic unaffected. Auto-falls-back to the standard forward when the micro-batch lacks `prompts`/`responses`/`uid` (e.g. value-model batches), or when there is no sharing (unique uids).

```python
# Programmatic usage (standalone, no trainer needed)
from verl.trainer.ppo.ref_prefix_cache import RefPrefixKVCache, forward_ref_with_prefix_cache

cache = RefPrefixKVCache(max_entries=64, max_total_tokens=4_000_000)
log_probs = forward_ref_with_prefix_cache(
    model, prompts, responses, response_mask, uids, pad_token_id, cache
)   # jagged nested tensor, one (resp_len_i,) per sample
```

### Design & Code Changes

**Principle.** Use HF's native prefill: `model(input_ids=prompt, use_cache=True)` → `past_key_values` + the prompt's last-position logits. For each response, forward the response tokens with the cached prefix KV (response attends to cached prompt KV + itself, causally). The first response token is predicted by the prompt's last logit; subsequent tokens by the response forward's logits. Because ref weights are frozen, the cached `past_key_values` never goes stale and is reused across steps.

**Shallow clone (key to large-model feasibility).** HF `DynamicCache` is mutated in-place by a forward; a naive `deepcopy` per response is O(prompt_len) — for a 16K prompt on an 8B model that is ~8GB × n, infeasible. `_clone_cache` instead builds a new `DynamicCache` whose per-layer objects **share** the prompt's KV tensors (read-only in attention) and set `is_initialized=True` so `DynamicLayer.update()` concatenates rather than resets. The prompt cache stays pristine; cost is O(num_layers), no KV copy.

**Ref-only discrimination.** `FSDPEngineWithLMHead` is shared by actor and ref. The guard uses `engine_config.forward_only` (config-level: ref engine `True`, actor/critic `False`), **not** the per-call `forward_only` parameter — otherwise the actor's `compute_log_prob` (also forward_only) would wrongly take the branch (it would need to honor `calculate_entropy` / per-token temperature, which the cache path does not compute). `ref_in_actor` (ref on the actor engine) safely falls back to the standard path.

**Files:**

| File                                                         | Change                                                       |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| `verl/trainer/ppo/ref_prefix_cache.py`                       | new — `RefPrefixKVCache` (LRU by prompt hash), `_clone_cache` (shallow reuse), `forward_ref_with_prefix_cache` (full-prompt/uid-grouped), `forward_ref_with_prefix_len_cache` (shared prefix/cross-sample) |
| `verl/workers/engine/fsdp/transformer_impl.py`               | `forward_step` opt-in branch + `_forward_ref_prefix_cache` helper (lazy-init cache on the engine, persists across steps) |
| `verl/workers/config/model.py`                               | `HFModelConfig.use_ref_prefix_cache: bool = False`           |
| `verl/trainer/config/model/hf_model.yaml` + `_generated_ppo_*.yaml`  | config field; generated yamls regenerated via `scripts/generate_trainer_config.sh` (idempotent) |
| `tests/trainer/ppo/test_ref_prefix_cache_on_cpu.py`          | 5 CPU tests                                                  |
| `examples/ref_prefix_cache/benchmark_npu.py`, `benchmark_gsm8k_npu.py` | NPU/GSM8K benchmarks (ref-only, no rollout/trainer)          |

**Constraints / follow-ups:** requires no remove-padding change (works in padded mode); FSDP + `use_cache` validated single-card on NPU (FSDP-integrated training run still pending). Intra-batch the per-response sequential forward is slower than a batched forward for short prompts (the raw-GSM8K 0.9x case); the value is cross-step reuse of long shared prefixes. A batched-response optimization (replicate cache to batch n) and prefix-only sys-prompt caching are natural follow-ups.

### Checklist Before Submitting

- [x] Read the [[Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md)](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] `pre-commit run --all-files` — ruff / ruff-format / mypy / license / docstrings / device-api / DataProto / test-structure / compileall all pass on the changed files. (The `autogen-trainer-cfg` and `check-naming-conventions` hooks flag pre-existing uncommitted changes in `AGENTS.md` that are not part of this PR; the generated yamls are regenerated and idempotent.)
- [x] Documentation — the flag is self-documented in `hf_model.yaml`; no separate docs page needed for an opt-in experimental flag.
- [x] CPU unit tests added (`tests/trainer/ppo/test_ref_prefix_cache_on_cpu.py`, runs in the `cpu_unit_tests` lane). NPU/GPU end-to-end coverage is provided as runnable benchmark scripts rather than CI (NPU hardware not available in CI); correctness is covered by the CPU numerical-alignment tests.
