### PR TITLE
[megatron] fix: make DeepSeek-V4 context parallelism actually runnable

### DIFF
--- a/examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh
+++ b/examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh
@@ -137,6 +137,29 @@ ACTOR=(
     "++actor_rollout_ref.actor.megatron.override_transformer_config.pipeline_model_parallel_layout='${PIPELINE_MODEL_PARALLEL_LAYOUT}'"
 )
 
+# Context parallelism needs three extra transformer-config settings for DeepSeek-V4 on top of
+# `context_parallel_size`. Each of them is enforced by Megatron-Core, so without them the run
+# aborts at model build or in the first attention forward. They are appended only when CP > 1.
+#
+#   cp_partition_mode=contiguous
+#     DSv4 attention requires every CP rank to own ONE consecutive interval of the packed THD
+#     buffer. Megatron-Core defaults to "zigzag" and raises
+#     "DSv4 Hybrid with CP requires cp_partition_mode='contiguous'."
+#   sequence_packing_scheduler=dp_balanced
+#     Megatron-Core asserts "DSv4 Hybrid with CP requires a sequence_packing_scheduler for THD
+#     inputs." Needs Transformer Engine >= 2.9.
+#   max_seqlen_per_dp_cp_rank
+#     Documented as max sequence length / cp_size; it drives how sub-samples are assigned to
+#     each DPxCP rank.
+CP_ARGS=()
+if [ "${ACTOR_CP}" -gt 1 ]; then
+    CP_ARGS=(
+        ++actor_rollout_ref.actor.megatron.override_transformer_config.cp_partition_mode=contiguous
+        ++actor_rollout_ref.actor.megatron.override_transformer_config.sequence_packing_scheduler=dp_balanced
+        ++actor_rollout_ref.actor.megatron.override_transformer_config.max_seqlen_per_dp_cp_rank=$(((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH) / ACTOR_CP))
+    )
+fi
+
 ROLLOUT=(
     actor_rollout_ref.rollout.name=vllm
     actor_rollout_ref.rollout.tensor_model_parallel_size=1
@@ -193,6 +216,7 @@ python3 -m verl.trainer.main_ppo \
     "${DATA[@]}" \
     "${MODEL[@]}" \
     "${ACTOR[@]}" \
+    "${CP_ARGS[@]}" \
     "${ROLLOUT[@]}" \
     "${REWARD[@]}" \
     "${TRAINER[@]}" \

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -510,6 +510,11 @@ def preprocess_thd_engine(
 
     packed_seq_params = PackedSeqParams(
         qkv_format="thd",
+        # Tell the attention kernels how the rows above were sharded across CP ranks. The rows
+        # are already split according to `cp_layout`, but PackedSeqParams defaults to "zigzag",
+        # so without this an attention variant that requires a contiguous split (DeepSeek-V4)
+        # raises "DSv4 THD CP requires a contiguous CP partition." on every forward.
+        cp_partition_mode=cp_layout,
         cu_seqlens_q=cu_seqlens_padded,
         max_seqlen_q=max_seqlen_in_batch,
         cu_seqlens_kv=cu_seqlens_padded,

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import logging
 import math
 import os
@@ -29,6 +30,12 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 ContextParallelLayout = Literal["zigzag", "contiguous"]
+
+# Older Megatron-core releases have no ``cp_partition_mode`` field on PackedSeqParams; they
+# support only the zigzag CP layout.
+_PACKED_SEQ_PARAMS_HAS_CP_PARTITION_MODE = any(
+    f.name == "cp_partition_mode" for f in dataclasses.fields(PackedSeqParams)
+)
 
 
 def _compute_fp8_thd_align_size(align_size: int) -> tuple[int, int]:
@@ -508,13 +515,20 @@ def preprocess_thd_engine(
                 for k, v in saved_position_roll_dict.items():
                     position_ids_rmpad[k] = v
 
-    packed_seq_params = PackedSeqParams(
-        qkv_format="thd",
+    if _PACKED_SEQ_PARAMS_HAS_CP_PARTITION_MODE:
         # Tell the attention kernels how the rows above were sharded across CP ranks. The rows
         # are already split according to `cp_layout`, but PackedSeqParams defaults to "zigzag",
         # so without this an attention variant that requires a contiguous split (DeepSeek-V4)
         # raises "DSv4 THD CP requires a contiguous CP partition." on every forward.
-        cp_partition_mode=cp_layout,
+        extra_packed_args["cp_partition_mode"] = cp_layout
+    elif cp_layout != "zigzag" and cp_size > 1:
+        raise ValueError(
+            f"cp_layout='{cp_layout}' requires PackedSeqParams.cp_partition_mode, which this "
+            "Megatron-core version does not provide. Upgrade Megatron-core or use the zigzag layout."
+        )
+
+    packed_seq_params = PackedSeqParams(
+        qkv_format="thd",
         cu_seqlens_q=cu_seqlens_padded,
         max_seqlen_q=max_seqlen_in_batch,
         cu_seqlens_kv=cu_seqlens_padded,

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
+import inspect
 import logging
 import math
 import os
@@ -32,9 +32,11 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 ContextParallelLayout = Literal["zigzag", "contiguous"]
 
 # Older Megatron-core releases have no ``cp_partition_mode`` field on PackedSeqParams; they
-# support only the zigzag CP layout.
-_PACKED_SEQ_PARAMS_HAS_CP_PARTITION_MODE = any(
-    f.name == "cp_partition_mode" for f in dataclasses.fields(PackedSeqParams)
+# support only the zigzag CP layout. Inspect ``__init__`` rather than dataclass fields so that
+# duck-typed replacements (e.g. test stubs taking ``**kwargs``) also count as supporting it.
+_PACKED_SEQ_PARAMS_INIT_PARAMS = inspect.signature(PackedSeqParams.__init__).parameters
+_PACKED_SEQ_PARAMS_HAS_CP_PARTITION_MODE = "cp_partition_mode" in _PACKED_SEQ_PARAMS_INIT_PARAMS or any(
+    p.kind is inspect.Parameter.VAR_KEYWORD for p in _PACKED_SEQ_PARAMS_INIT_PARAMS.values()
 )
 
 

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -216,6 +216,19 @@ def get_moe_num_layers_to_build(
     return num_moe_layers
 
 
+def _context_parallel_layout(tf_config) -> str:
+    """Return the CP row layout used for THD packing, matching MegatronEngine.
+
+    Router-replay tensors must be sharded exactly like the model's own token rows; otherwise the
+    replayed routes are attached to the wrong tokens (or the shapes disagree outright, since the
+    zigzag layout doubles the alignment). Keep this in sync with
+    ``MegatronEngine._get_context_parallel_layout``.
+    """
+    if getattr(tf_config, "experimental_attention_variant", None) == "dsv4_hybrid":
+        return "contiguous"
+    return "zigzag"
+
+
 def merge_router_topk_indices(attention_mask, input_ids, mini_layer_topk_idx_list, tf_config, vp_rank=None):
     """
     Merge recorded router top-k indices across sequence-parallel ranks for all router instances,
@@ -259,6 +272,8 @@ def merge_router_topk_indices(attention_mask, input_ids, mini_layer_topk_idx_lis
             else None
         )
 
+        cp_layout = _context_parallel_layout(tf_config)
+
         if input_ids.is_nested:
             batch_size = input_ids.shape[0]
             _, packed_seq_params, _ = preprocess_thd_engine(
@@ -266,9 +281,15 @@ def merge_router_topk_indices(attention_mask, input_ids, mini_layer_topk_idx_lis
                 pre_process=True,
                 use_fp8_padding=use_fp8_padding,
                 min_local_rows=min_local_rows,
+                cp_layout=cp_layout,
             )
             layers_topk_idx = postprocess_thd_engine(
-                layers_topk_idx, packed_seq_params, input_ids, batch_size, post_process=True
+                layers_topk_idx,
+                packed_seq_params,
+                input_ids,
+                batch_size,
+                post_process=True,
+                cp_layout=cp_layout,
             )
         else:
             batch_size, seq_len = attention_mask.shape[:2]
@@ -336,6 +357,8 @@ def set_router_replay_data(
             else None
         )
 
+        cp_layout = _context_parallel_layout(tf_config)
+
         replay_mask_rmpad = None
         if layers_topk_idx.is_nested:
             layers_topk_idx_rmpad, _, _ = preprocess_thd_engine(
@@ -343,6 +366,7 @@ def set_router_replay_data(
                 pre_process=True,
                 use_fp8_padding=use_fp8_padding,
                 min_local_rows=min_local_rows,
+                cp_layout=cp_layout,
             )
             if replay_mask is not None:
                 replay_mask_rmpad, _, _ = preprocess_thd_engine(
@@ -350,6 +374,7 @@ def set_router_replay_data(
                     pre_process=True,
                     use_fp8_padding=use_fp8_padding,
                     min_local_rows=min_local_rows,
+                    cp_layout=cp_layout,
                 )
         else:
             layers_topk_idx_rmpad, _ = preprocess_packed_seqs(


### PR DESCRIPTION
### What does this PR do?

#7221 added the `contiguous` context-parallel (CP) row layout that DeepSeek-V4 requires and wired it into `MegatronEngine`. Turning on `context_parallel_size > 1` for DeepSeek-V4 still fails, because the chosen layout is never communicated to the attention kernels or to the router-replay tensors, and the example script does not set the transformer-config flags that Megatron-Core enforces for this model.

This PR completes that path with three changes, plus the example-script wiring:

1. `PackedSeqParams` now carries `cp_partition_mode`, so the attention kernels are told how the rows were actually sharded.
2. Router-replay tensors are packed with the same CP layout as the model's token rows.
3. `examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh` appends the transformer-config settings Megatron-Core requires when `ACTOR_CP > 1`.

Follow-up to #7221 (contiguous CP layout for DeepSeek V4).

### Checklist Before Starting

- [x] Search for similar PRs.
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+cp_partition_mode
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+context+parallel+deepseek
  - #7221 introduced the `cp_layout` plumbing this PR builds on; no open PR sets
    `cp_partition_mode` on `PackedSeqParams`, threads `cp_layout` into router replay, or adds the
    CP flags to the DeepSeek-V4 example.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

**Unit (CPU), on this branch:**

```bash
pytest tests/utils/test_megatron_bshd_preprocess.py \
       tests/workers/test_megatron_value_head_cp_layout_on_cpu.py -q
# 15 passed
```

**End-to-end**, DeepSeek-V4-Flash-Base, GRPO + vLLM rollout + Megatron training, 40 GPUs
(10 nodes x 4 x GB200), `PP=5`, `EP=8`, `TP=1`, response length 1024, R3 router replay enabled:

| | CP=1 | CP=2 |
|---|---|---|
| completes a training step | yes (`EXIT_CODE=0`) | yes (`EXIT_CODE=0`) |
| `training/rollout_probs_diff_mean` | 0.009243 | 0.009768 |
| `training/rollout_probs_diff_max` | 0.2348 | 0.1825 |
| `training/rollout_actor_probs_pearson_corr` | 0.998795 | 0.998569 |
| `actor/ppo_kl` | 4.8e-08 | -2.2e-09 |

The first three rows compare vLLM's rollout log-probs (computed on **whole** sequences, no CP) with the Megatron actor's log-probs (computed with the sequence **split across 2 CP ranks and gathered back**). CP=2 tracks CP=1 to ~3 decimal places, so the contiguous split/gather is numerically consistent, not merely crash-free. `ppo_kl ≈ 0` on both is expected at step 1, where the actor still equals the rollout policy.

Without the changes in this PR the same CP=2 configuration fails before producing any of the above, at three different points:

| missing piece | failure |
|---|---|
| `cp_partition_mode` on `TransformerConfig` | `ValueError: DSv4 Hybrid with CP requires cp_partition_mode='contiguous'.` at model build |
| `cp_partition_mode` on `PackedSeqParams` | `ValueError: DSv4 THD CP requires a contiguous CP partition.` on every attention forward |
| `sequence_packing_scheduler` | `AssertionError: DSv4 Hybrid with CP requires a sequence_packing_scheduler for THD inputs.` at model build |

**Scope of validation.** The comparison above is a forward-level equivalence check. In these runs every sampled response scored identically (a base model on DAPO math), so GRPO's group std was 0, advantages vanished, and `grad_norm` was 0 — the backward completed without producing NaN/inf, but gradient *values* were not compared between CP=1 and CP=2. CP sizes > 2 were not exercised.

### API and Usage Example

No API change. `context_parallel_size > 1` simply works for DeepSeek-V4 now; the example script adds the required flags automatically:

```bash
# 2-way context parallelism ACTOR_CP=2 bash examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh
```

which appends, only when `ACTOR_CP > 1`:

```
++actor_rollout_ref.actor.megatron.override_transformer_config.cp_partition_mode=contiguous
++actor_rollout_ref.actor.megatron.override_transformer_config.sequence_packing_scheduler=dp_balanced
++actor_rollout_ref.actor.megatron.override_transformer_config.max_seqlen_per_dp_cp_rank=$(((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH) / ACTOR_CP))
```

At `ACTOR_CP=1` the array expands to nothing, so the default path is byte-for-byte unchanged. `sequence_packing_scheduler` requires Transformer Engine >= 2.9.

### Design & Code Changes

**`verl/models/mcore/util.py`** — `preprocess_thd_engine` already splits rows according to `cp_layout`, but the `PackedSeqParams` it returns left `cp_partition_mode` at its default (`"zigzag"`). Pass `cp_layout` through, so the description of the rows matches how they were produced.

**`verl/utils/megatron/router_replay_utils.py`** — `merge_router_topk_indices` and `set_router_replay_data` called `preprocess_thd_engine` / `postprocess_thd_engine` without `cp_layout`, so replay tensors were packed `zigzag` while the model's rows were packed `contiguous`. The layouts also use different alignment (`zigzag` doubles it), so this either raises on a shape mismatch or silently attaches replayed routes to the wrong tokens. Both call sites now use a small `_context_parallel_layout()` helper rather than a third copy of the layout rule; its docstring points at `MegatronEngine._get_context_parallel_layout`, which must stay in sync.

**`examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh`** — adds a `CP_ARGS` array, appended after `ACTOR`, populated only when `ACTOR_CP > 1`. Each entry is commented with the exact Megatron-Core error it prevents.

### Checklist Before Submitting

- [ ] Read the Contribute Guide.
- [ ] Apply pre-commit checks.
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to the CI workflow. *The CPU tests from #7221 cover the
      layout maths and pass unchanged; the CP>1 path itself needs a multi-GPU DeepSeek-V4 model,
      which is out of reach for CI.*
- [ ] Send a message in the `ci-request` channel.

---