### PR TITLE
fix: pass repetition_penalty from config to GenerationConfig in HFRollout

### DIFF
--- a/tests/workers/rollout/test_hf_rollout_repetition_penalty.py
+++ b/tests/workers/rollout/test_hf_rollout_repetition_penalty.py
@@ -1,0 +1,137 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for repetition_penalty support in HFRollout.
+
+Verifies that _generate_minibatch reads repetition_penalty from the
+rollout config and passes it into GenerationConfig for all sampling modes.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from omegaconf import OmegaConf
+from transformers import GenerationConfig
+
+from verl.workers.rollout.hf_rollout import HFRollout
+from verl.workers.rollout.base import BaseRollout
+
+
+def _make_config(**overrides):
+    """Build an OmegaConf rollout config with sensible defaults."""
+    base = {
+        "temperature": 1.0,
+        "top_k": -1,
+        "top_p": 1.0,
+        "prompt_length": 16,
+        "response_length": 16,
+        "do_sample": True,
+        "repetition_penalty": 1.0,
+        "micro_batch_size": 128,
+        "val_kwargs": {
+            "top_k": -1,
+            "top_p": 1.0,
+            "temperature": 1.0,
+            "n": 1,
+            "do_sample": True,
+        },
+    }
+    base.update(overrides)
+    return OmegaConf.create(base)
+
+
+def _make_rollout(config):
+    """Create an HFRollout instance, bypassing abstract method checks
+    and the parent __init__ (which requires distributed setup)."""
+    with patch.multiple(HFRollout, __abstractmethods__=frozenset()), \
+         patch.object(BaseRollout, "__init__", lambda self, *a, **kw: None):
+        return HFRollout(module=MagicMock(), config=config)
+
+
+def _capture_generation_config(rollout, meta_info):
+    """Call _generate_minibatch and capture the GenerationConfig kwargs.
+
+    We intercept GenerationConfig.__init__ to record what HFRollout passes,
+    avoiding the need for a real model or GPU.
+    """
+    captured = {}
+    original_init = GenerationConfig.__init__
+
+    def spy_init(self, **kwargs):
+        captured.update(kwargs)
+        original_init(self, **kwargs)
+
+    prompts = MagicMock()
+    prompts.meta_info = meta_info
+    prompts.batch = {
+        "input_ids": MagicMock(),
+        "attention_mask": MagicMock(),
+        "position_ids": MagicMock(),
+    }
+    prompts.batch["input_ids"].size.return_value = 2
+
+    with patch.object(GenerationConfig, "__init__", spy_init):
+        try:
+            rollout._generate_minibatch(prompts)
+        except Exception:
+            pass  # Expected: no real model to call generate() on
+
+    return captured
+
+
+class TestRepetitionPenaltyInConfig:
+    """Verify repetition_penalty is read from config and passed through."""
+
+    def test_default_repetition_penalty(self):
+        """Default config (1.0) should pass repetition_penalty=1.0."""
+        rollout = _make_rollout(_make_config())
+        captured = _capture_generation_config(
+            rollout, {"do_sample": True, "validate": False, "eos_token_id": 0, "pad_token_id": 0}
+        )
+        assert "repetition_penalty" in captured
+        assert captured["repetition_penalty"] == 1.0
+
+    def test_custom_repetition_penalty_from_config(self):
+        """Setting repetition_penalty=1.15 in config should propagate."""
+        rollout = _make_rollout(_make_config(repetition_penalty=1.15))
+        captured = _capture_generation_config(
+            rollout, {"do_sample": True, "validate": False, "eos_token_id": 0, "pad_token_id": 0}
+        )
+        assert captured["repetition_penalty"] == 1.15
+
+    def test_meta_info_overrides_config(self):
+        """meta_info repetition_penalty should override the config value."""
+        rollout = _make_rollout(_make_config(repetition_penalty=1.0))
+        captured = _capture_generation_config(
+            rollout,
+            {"do_sample": True, "validate": False, "repetition_penalty": 1.3, "eos_token_id": 0, "pad_token_id": 0},
+        )
+        assert captured["repetition_penalty"] == 1.3
+
+    def test_validate_mode_includes_repetition_penalty(self):
+        """Validation sampling should also include repetition_penalty."""
+        rollout = _make_rollout(_make_config(repetition_penalty=1.1))
+        captured = _capture_generation_config(
+            rollout, {"do_sample": True, "validate": True, "eos_token_id": 0, "pad_token_id": 0}
+        )
+        assert "repetition_penalty" in captured
+        assert captured["repetition_penalty"] == 1.1
+
+    def test_greedy_mode_omits_repetition_penalty(self):
+        """Greedy decoding (do_sample=False) should not set repetition_penalty."""
+        rollout = _make_rollout(_make_config(repetition_penalty=1.2))
+        captured = _capture_generation_config(
+            rollout, {"do_sample": False, "validate": False, "eos_token_id": 0, "pad_token_id": 0}
+        )
+        assert "repetition_penalty" not in captured

--- a/verl/workers/rollout/hf_rollout.py
+++ b/verl/workers/rollout/hf_rollout.py
@@ -60,6 +60,7 @@ class HFRollout(BaseRollout):
         response_length = prompts.meta_info.get("response_length", self.config.response_length)
         top_p = prompts.meta_info.get("top_p", self.config.get("top_p", 1.0))
         top_k = max(0, prompts.meta_info.get("top_k", self.config.get("top_k", 0)))  # to be compatible with vllm
+        repetition_penalty = prompts.meta_info.get("repetition_penalty", self.config.get("repetition_penalty", 1.0))
 
         if not do_sample:
             # do_sample==False -> greedy decoding
@@ -75,6 +76,7 @@ class HFRollout(BaseRollout):
                 "top_k": max(0, self.config.val_kwargs.top_k),  # to be compatible with vllm
                 "top_p": self.config.val_kwargs.top_p,
                 "temperature": self.config.val_kwargs.temperature,
+                "repetition_penalty": repetition_penalty,
                 "num_return_sequences": 1,  # if validate, already repeat in ray_trainer
             }
         else:
@@ -85,6 +87,7 @@ class HFRollout(BaseRollout):
                 "top_p": top_p,
                 "top_k": top_k,
                 "temperature": temperature,
+                "repetition_penalty": repetition_penalty,
                 # already repeat in ray_trainer
                 # https://github.com/verl-project/verl/blob/2fdfbdcba6f2e076f64bc47922d8fe6cf7dc7da5/verl/trainer/ppo/ray_trainer.py#L1117
                 "num_return_sequences": 1,


### PR DESCRIPTION
## Summary

Closes #7270

## Problem

`HFRollout._generate_minibatch` reads `top_p`, `top_k`, and `temperature` from the rollout config and passes them to `GenerationConfig`, but omits `repetition_penalty`. Because `GenerationConfig` back-fills unset fields from the model's `generation_config.json`, HF rollouts silently inherit the **checkpoint's** value instead of the configured default (`1.0`).

For Qwen2.5-Instruct checkpoints this means rollouts are generated with `repetition_penalty=1.05`–`1.1` while the training forward pass applies none — a silent train/inference mismatch.

The vLLM rollout path already reads this field correctly (`vllm_async_server.py:576`).

## Changes

**`verl/workers/rollout/hf_rollout.py`** (+3 lines)
- Extract `repetition_penalty` from `meta_info` with fallback to config (matching the pattern for `top_p`/`top_k`)
- Pass it into `GenerationConfig` kwargs for both normal sampling and validation modes
- Greedy mode (`do_sample=False`) is unchanged — only `do_sample` and `num_beams` are set

**`tests/workers/rollout/test_hf_rollout_repetition_penalty.py`** (new, 5 tests)
- Default config passes `repetition_penalty=1.0`
- Custom config value propagates correctly
- `meta_info` override takes precedence over config
- Validation mode includes `repetition_penalty`
- Greedy mode correctly omits it

## Testing

```
$ python -m pytest tests/workers/rollout/test_hf_rollout_repetition_penalty.py -v
5 passed in 2.00s
```