### PR TITLE
[algo] fix: carry running_return through observation spans in REINFORCE++ (#7278)

### DIFF
--- a/tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py
+++ b/tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py
@@ -1,0 +1,147 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for REINFORCE++ advantage computation with multi-turn observation spans.
+
+Verifies that masked observation tokens (response_mask=0) are correctly
+skipped during the reverse return scan, so that outcome rewards propagate
+past observation spans to earlier assistant turns.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from verl.trainer.ppo.core_algos import compute_reinforce_plus_plus_outcome_advantage
+
+
+def _config(gamma=1.0):
+    return SimpleNamespace(gamma=gamma)
+
+
+class TestReinforcePPMultiTurn:
+    """Regression tests for #7278: observation spans must not block reward propagation."""
+
+    def test_observation_span_does_not_block_returns(self):
+        """Core regression test from the issue: inserting observation tokens
+        between assistant tokens should not change valid-token returns."""
+        config = _config(gamma=1.0)
+
+        # Compact: 4 assistant tokens, reward=1.0 at the end
+        compact_mask = torch.ones(1, 4)
+        compact_rewards = torch.tensor([[0.0, 0.0, 0.0, 1.0]])
+
+        # Expanded: same 4 assistant tokens with 2 observation tokens (mask=0) in the middle
+        expanded_mask = torch.tensor([[1.0, 1.0, 0.0, 0.0, 1.0, 1.0]])
+        expanded_rewards = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
+
+        _, compact_returns = compute_reinforce_plus_plus_outcome_advantage(
+            compact_rewards, compact_mask, config=config
+        )
+        _, expanded_returns = compute_reinforce_plus_plus_outcome_advantage(
+            expanded_rewards, expanded_mask, config=config
+        )
+
+        # Valid-token returns should match
+        compact_valid = compact_returns[compact_mask.bool()]
+        expanded_valid = expanded_returns[expanded_mask.bool()]
+        torch.testing.assert_close(compact_valid, expanded_valid)
+
+    def test_observation_positions_have_zero_returns(self):
+        """Observation tokens (mask=0) should have returns=0."""
+        config = _config(gamma=1.0)
+        mask = torch.tensor([[1.0, 1.0, 0.0, 0.0, 1.0, 1.0]])
+        rewards = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
+
+        _, returns = compute_reinforce_plus_plus_outcome_advantage(rewards, mask, config=config)
+
+        # Observation positions (indices 2, 3) should be zero
+        assert returns[0, 2].item() == 0.0
+        assert returns[0, 3].item() == 0.0
+
+    def test_trailing_padding_stays_zero(self):
+        """Trailing padding (mask=0 at the end) should have returns=0 and
+        should correctly reset running_return for EOS behavior."""
+        config = _config(gamma=1.0)
+        mask = torch.tensor([[1.0, 1.0, 1.0, 0.0, 0.0]])
+        rewards = torch.tensor([[0.0, 0.0, 1.0, 0.0, 0.0]])
+
+        _, returns = compute_reinforce_plus_plus_outcome_advantage(rewards, mask, config=config)
+
+        # Valid tokens should all see the reward
+        assert returns[0, 0].item() == 1.0
+        assert returns[0, 1].item() == 1.0
+        assert returns[0, 2].item() == 1.0
+        # Padding should be zero
+        assert returns[0, 3].item() == 0.0
+        assert returns[0, 4].item() == 0.0
+
+    def test_gamma_discount_across_observation_span(self):
+        """Gamma discount should only apply across valid tokens, not
+        observation tokens — observations are skipped, not discounted."""
+        config = _config(gamma=0.5)
+        # 2 valid tokens, then 2 observations, then 1 valid token with reward
+        mask = torch.tensor([[1.0, 1.0, 0.0, 0.0, 1.0]])
+        rewards = torch.tensor([[0.0, 0.0, 0.0, 0.0, 2.0]])
+
+        _, returns = compute_reinforce_plus_plus_outcome_advantage(rewards, mask, config=config)
+
+        # Position 4: reward=2.0 -> return=2.0
+        assert returns[0, 4].item() == 2.0
+        # Observations (2,3): skipped, return=0
+        assert returns[0, 2].item() == 0.0
+        assert returns[0, 3].item() == 0.0
+        # Position 1: gamma * running_return from position 4 = 0.5 * 2.0 = 1.0
+        assert returns[0, 1].item() == pytest.approx(1.0)
+        # Position 0: gamma * 1.0 = 0.5
+        assert returns[0, 0].item() == pytest.approx(0.5)
+
+    def test_batch_dimension(self):
+        """Verify correct behavior across a batch of sequences."""
+        config = _config(gamma=1.0)
+        mask = torch.tensor([
+            [1.0, 0.0, 1.0, 1.0],  # observation at position 1
+            [1.0, 1.0, 1.0, 0.0],  # padding at position 3
+        ])
+        rewards = torch.tensor([
+            [0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ])
+
+        _, returns = compute_reinforce_plus_plus_outcome_advantage(rewards, mask, config=config)
+
+        # Sequence 0: positions 0,2,3 are valid; observation at 1 is skipped
+        assert returns[0, 0].item() == 1.0  # reward propagated past observation
+        assert returns[0, 1].item() == 0.0  # observation -> zero
+        assert returns[0, 2].item() == 1.0
+        assert returns[0, 3].item() == 1.0
+
+        # Sequence 1: positions 0,1,2 are valid; padding at 3
+        assert returns[1, 0].item() == 1.0
+        assert returns[1, 1].item() == 1.0
+        assert returns[1, 2].item() == 1.0
+        assert returns[1, 3].item() == 0.0
+
+    def test_no_observation_tokens_unchanged(self):
+        """Without observation tokens, behavior should be identical to before."""
+        config = _config(gamma=1.0)
+        mask = torch.ones(1, 5)
+        rewards = torch.tensor([[0.0, 0.0, 0.0, 0.0, 3.0]])
+
+        _, returns = compute_reinforce_plus_plus_outcome_advantage(rewards, mask, config=config)
+
+        # All positions should see the cumulative return
+        for t in range(5):
+            assert returns[0, t].item() == 3.0

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -718,10 +718,12 @@ def compute_reinforce_plus_plus_outcome_advantage(
         running_return = 0
 
         for t in reversed(range(token_level_rewards.shape[1])):
-            running_return = token_level_rewards[:, t] + gamma * running_return
-            returns[:, t] = running_return
-            # Reset after EOS
-            running_return = running_return * response_mask[:, t]
+            new_running_return = token_level_rewards[:, t] + gamma * running_return
+            # For valid tokens (mask=1): update returns and running_return.
+            # For observation tokens (mask=0): skip — carry running_return
+            # through unchanged so rewards propagate past observation spans.
+            returns[:, t] = new_running_return * response_mask[:, t]
+            running_return = new_running_return * response_mask[:, t] + running_return * (1 - response_mask[:, t])
 
         advantages = verl_F.masked_whiten(returns, response_mask)
         advantages = advantages * response_mask


### PR DESCRIPTION
## Summary

Fixes #7278 — REINFORCE++ drops outcome rewards assigned before multi-turn observation spans, producing incorrect advantage estimates in multi-turn RL training.

## Root Cause

In `compute_reinforce_plus_plus_outcome_advantage` (`verl/trainer/ppo/core_algos.py`, line ~718), the reverse return scan zeros out `running_return` at observation tokens:

```python
# Before (broken):
for t in reversed(range(token_level_rewards.shape[1])):
    running_return = token_level_rewards[:, t] + gamma * running_return
    returns[:, t] = running_return
    # Reset after EOS
    running_return = running_return * response_mask[:, t]  # <-- BUG
```

In multi-turn RL, **observation tokens** (tool responses, environment feedback) have `response_mask = 0`. The multiplication `running_return * response_mask[:, t]` zeros `running_return` at these positions, preventing rewards from propagating past observation spans to earlier action tokens.

### Example from the issue

Consider a sequence: `[action, action, observation, observation, action, action]` with a reward of 1.0 at the final token.

| Position | response_mask | Expected return | Actual return (buggy) |
|----------|--------------|-----------------|----------------------|
| action 1 | 1 | 1.0 | **0.0** |
| action 2 | 1 | 1.0 | **0.0** |
| obs 1    | 0 | 0.0 | 0.0 |
| obs 2    | 0 | 0.0 | 0.0 |
| action 3 | 1 | 1.0 | 1.0 |
| action 4 | 1 | 1.0 | 1.0 |

The reward signal is completely lost for actions before the observation span.

### Why GAE works correctly

The GAE implementation at lines 254-256 already handles this correctly using a carry-through pattern:

```python
# GAE (correct):
new_val = delta[:, t] + gamma * lam * running_gae
running_gae = new_val * response_mask[:, t] + running_gae * (1 - response_mask[:, t])
```

REINFORCE++ should have used the same pattern.

## Fix

Apply the GAE carry-through pattern: at observation tokens (`mask=0`), carry `running_return` through unchanged instead of zeroing it:

```python
# After (fixed):
for t in reversed(range(token_level_rewards.shape[1])):
    new_running_return = token_level_rewards[:, t] + gamma * running_return
    # Valid tokens (mask=1): update returns and running_return normally.
    # Observation tokens (mask=0): skip — carry running_return through
    # unchanged so rewards propagate past observation spans.
    returns[:, t] = new_running_return * response_mask[:, t]
    running_return = (new_running_return * response_mask[:, t]
                    + running_return * (1 - response_mask[:, t]))
```

This is a 4-line change that:
- **Preserves behavior for single-turn**: When `response_mask` is all 1s, the formula reduces to the original
- **Fixes multi-turn**: Rewards propagate correctly through observation spans
- **Matches GAE**: Uses the same pattern that already works at lines 254-256

### Verification with issue reproducer

The exact reproducer from the issue now outputs correct results:

| Scenario | Before | After |
|----------|--------|-------|
| Compact (no obs) | `[1.0, 1.0, 1.0, 1.0]` | `[1.0, 1.0, 1.0, 1.0]` |
| Expanded (with obs) | `[0.0, 0.0, 1.0, 1.0]` | `[1.0, 1.0, 1.0, 1.0]` |

### Files Changed

- `verl/trainer/ppo/core_algos.py` — 4-line fix in `compute_reinforce_plus_plus_outcome_advantage`

## Tests

6 new tests in `tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py`:

| Test | What it verifies |
|------|-----------------|
| `test_observation_span_does_not_block_returns` | Rewards propagate past observation spans to earlier action tokens |
| `test_observation_positions_have_zero_returns` | Observation tokens themselves still have zero returns |
| `test_trailing_padding_stays_zero` | Padding tokens (beyond sequence length) remain zero |
| `test_gamma_discount_across_observation_span` | Gamma discount is correctly applied across observation gaps |
| `test_batch_dimension` | Each batch element is processed independently |
| `test_no_observation_tokens_unchanged` | Single-turn (all mask=1) produces identical results to before |

**No regressions**: All 23 existing tests in `tests/trainer/ppo/test_core_algos_on_cpu.py` still pass.

```
tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py: 6 passed
tests/trainer/ppo/test_core_algos_on_cpu.py: 23 passed
```