### PR TITLE
[fsdp] fix: route FSDP1 to dedicated save/load handlers in DetachActorWorker (#7249)

### DIFF
--- a/tests/experimental/separation/test_detach_actor_fsdp1.py
+++ b/tests/experimental/separation/test_detach_actor_fsdp1.py
@@ -1,0 +1,110 @@
+"""Tests for DetachActorWorker FSDP1 handler routing (#7249).
+
+Verifies that FSDP1 strategy uses fsdp1_sharded_save/load_to_cpu
+instead of the FSDP2-only DTensor variants, and that the FSDP1
+save/load round-trip preserves parameter values.
+"""
+
+import torch
+
+
+def test_fsdp1_save_load_round_trip():
+    """fsdp1_sharded_save_to_cpu / fsdp1_sharded_load_from_cpu preserves values."""
+    from verl.utils.fsdp_utils import (
+        fsdp1_sharded_save_to_cpu,
+        fsdp1_sharded_load_from_cpu,
+    )
+
+    model = torch.nn.Linear(8, 4, bias=True)
+    orig_weight = model.weight.data.clone()
+    orig_bias = model.bias.data.clone()
+
+    cpu_state = fsdp1_sharded_save_to_cpu(model)
+    assert isinstance(cpu_state, dict)
+    assert all(t.device == torch.device("cpu") for t in cpu_state.values())
+
+    # Corrupt the model
+    model.weight.data.fill_(999.0)
+    model.bias.data.fill_(-999.0)
+    assert not torch.equal(model.weight.data, orig_weight)
+
+    # Restore from CPU
+    fsdp1_sharded_load_from_cpu(model, cpu_state)
+    assert torch.equal(model.weight.data, orig_weight)
+    assert torch.equal(model.bias.data, orig_bias)
+
+
+def test_fsdp1_save_is_detached_copy():
+    """Saved state must be a detached copy, not a reference to live parameters."""
+    from verl.utils.fsdp_utils import fsdp1_sharded_save_to_cpu
+
+    model = torch.nn.Linear(4, 2)
+    cpu_state = fsdp1_sharded_save_to_cpu(model)
+
+    saved_weight = cpu_state["weight"].clone()
+    model.weight.data.fill_(0.0)
+    assert torch.equal(cpu_state["weight"], saved_weight), (
+        "Saved state was mutated when model parameters changed"
+    )
+
+
+def test_fsdp1_handler_routing_in_source():
+    """engine_workers.py must route 'fsdp' to fsdp1 functions, not fsdp2."""
+    import pathlib
+
+    src = pathlib.Path("verl/experimental/separation/engine_workers.py").read_text()
+
+    # FSDP1 should get its own branch
+    assert "fsdp1_sharded_save_to_cpu" in src
+    assert "fsdp1_sharded_load_from_cpu" in src
+
+    # 'fsdp' must NOT be in the same list as 'fsdp2'
+    # The old bug: if strategy in ["fsdp", "fsdp2", "veomni"]:
+    assert '["fsdp", "fsdp2", "veomni"]' not in src, (
+        "'fsdp' must not be grouped with 'fsdp2' in strategy routing"
+    )
+
+
+def test_fsdp2_routing_preserved_in_source():
+    """'fsdp2' and 'veomni' must still route to fsdp2 functions."""
+    import pathlib
+
+    src = pathlib.Path("verl/experimental/separation/engine_workers.py").read_text()
+    assert '["fsdp2", "veomni"]' in src
+    assert "fsdp2_sharded_save_to_cpu" in src
+    assert "fsdp2_sharded_load_from_cpu" in src
+
+
+def test_multi_layer_save_restore():
+    """Round-trip works for models with multiple named parameter groups."""
+    from verl.utils.fsdp_utils import (
+        fsdp1_sharded_save_to_cpu,
+        fsdp1_sharded_load_from_cpu,
+    )
+
+    model = torch.nn.Sequential(
+        torch.nn.Linear(8, 4),
+        torch.nn.LayerNorm(4),
+        torch.nn.Linear(4, 2),
+    )
+    originals = {name: p.data.clone() for name, p in model.named_parameters()}
+
+    cpu_state = fsdp1_sharded_save_to_cpu(model)
+    assert len(cpu_state) == len(originals)
+
+    for p in model.parameters():
+        p.data.fill_(0.0)
+
+    fsdp1_sharded_load_from_cpu(model, cpu_state)
+    for name, p in model.named_parameters():
+        assert torch.equal(p.data, originals[name]), f"Mismatch for {name}"
+
+
+def test_restore_from_cpu_branches_fsdp1():
+    """restore_model_from_cpu must NOT unpack (state, spec) tuple for fsdp strategy."""
+    import pathlib
+
+    src = pathlib.Path("verl/experimental/separation/engine_workers.py").read_text()
+    # For FSDP1, the saved state is a plain dict (not a tuple of (state, spec))
+    # so restore_model_from_cpu must not destructure it as a tuple
+    assert 'strategy == "fsdp"' in src or "strategy == 'fsdp'" in src

--- a/verl/experimental/separation/engine_workers.py
+++ b/verl/experimental/separation/engine_workers.py
@@ -72,6 +72,13 @@ class DetachActorWorker(ActorRolloutRefWorker):
 
         strategy = self.config.actor.strategy
 
+        if strategy == "fsdp":
+            from verl.utils.fsdp_utils import (
+                fsdp1_sharded_load_from_cpu,
+                fsdp1_sharded_save_to_cpu,
+            )
+
+            self._strategy_handlers = (fsdp1_sharded_save_to_cpu, fsdp1_sharded_load_from_cpu)
         # NOTE: VeOmni internally uses FSDP2 for data parallelism (VeOmniEngine inherits from
         # FSDPEngine and sets data_parallel_mode="fsdp2"), so its model parameters are DTensors
         # that are compatible with FSDP2's sharded save/load utilities.
@@ -80,7 +87,7 @@ class DetachActorWorker(ActorRolloutRefWorker):
         # save/restore. The current fsdp2_sharded_save_to_cpu / fsdp2_sharded_load_from_cpu
         # assume parameters are on GPU. Callers should ensure the model is loaded back to GPU
         # before calling save_model_to_cpu / restore_model_from_cpu in offload scenarios.
-        if strategy in ["fsdp", "fsdp2", "veomni"]:
+        elif strategy in ["fsdp2", "veomni"]:
             from verl.utils.fsdp_utils import (
                 fsdp2_sharded_load_from_cpu,
                 fsdp2_sharded_save_to_cpu,
@@ -141,9 +148,11 @@ class DetachActorWorker(ActorRolloutRefWorker):
         if n in self.cpu_saved_models:
             strategy = self.config.actor.strategy
 
-            if strategy in ["fsdp", "fsdp2", "veomni"]:
+            if strategy in ["fsdp2", "veomni"]:
                 cpu_sharded_state, global_spec = self.cpu_saved_models[n]
                 self.restore_handler(self.actor.engine.module, cpu_sharded_state, global_spec)
+            elif strategy == "fsdp":
+                self.restore_handler(self.actor.engine.module, self.cpu_saved_models[n])
             else:
                 self.restore_handler(self.actor.engine.module, self.cpu_saved_models[n])
 

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -1188,3 +1188,41 @@ def fsdp2_sharded_load_from_cpu(
 
     # Process synchronization: ensure all processes complete loading before proceeding
     dist.barrier()
+
+
+@torch.no_grad()
+def fsdp1_sharded_save_to_cpu(
+    model: torch.nn.Module,
+) -> dict[str, torch.Tensor]:
+    """Save FSDP1 model parameters to CPU memory.
+
+    Each process saves its local shard (the flat_param data visible to it)
+    to CPU. Unlike the FSDP2 variant, FSDP1 parameters are regular tensors
+    managed by FlatParamHandle, not DTensors.
+
+    Args:
+        model: FSDP1-wrapped model.
+
+    Returns:
+        cpu_state: dict mapping parameter names to CPU tensor copies.
+    """
+    cpu_state: dict[str, torch.Tensor] = {}
+    for name, param in model.named_parameters():
+        cpu_state[name] = param.data.detach().clone().cpu()
+    return cpu_state
+
+
+@torch.no_grad()
+def fsdp1_sharded_load_from_cpu(
+    model: torch.nn.Module,
+    cpu_state: dict[str, torch.Tensor],
+) -> None:
+    """Restore FSDP1 model parameters from CPU memory.
+
+    Args:
+        model: FSDP1 model to restore (must have the same structure as when saved).
+        cpu_state: dict produced by fsdp1_sharded_save_to_cpu.
+    """
+    for name, param in model.named_parameters():
+        if name in cpu_state:
+            param.data.copy_(cpu_state[name].to(param.data.device))


### PR DESCRIPTION
## Summary

Fixes #7249 — `DetachActorWorker` crashes on FSDP1 when recomputing `old_log_prob` with `bypass_mode=False`.

## Root Cause

`DetachActorWorker._get_strategy_handlers()` grouped `"fsdp"` (FSDP1), `"fsdp2"`, and `"veomni"` together, routing all three to `fsdp2_sharded_save_to_cpu`. That function requires DTensor parameters (`param._local_tensor`, `param._spec`), but FSDP1 wraps regular `torch.nn.Parameter` tensors managed by `FlatParamHandle`.

```python
# Before (broken):
if strategy in ["fsdp", "fsdp2", "veomni"]:
    self._strategy_handlers = (fsdp2_sharded_save_to_cpu, fsdp2_sharded_load_from_cpu)
```

Result: `AssertionError: No DTensor-type parameters found in the model.`

## Fix

**New FSDP1 handlers** in `verl/utils/fsdp_utils.py`:
- `fsdp1_sharded_save_to_cpu(model)` — saves each parameter's data as a detached clone to CPU
- `fsdp1_sharded_load_from_cpu(model, cpu_state)` — restores from the saved dict

**Updated routing** in `verl/experimental/separation/engine_workers.py`:
```python
# After (fixed):
if strategy == "fsdp":
    self._strategy_handlers = (fsdp1_sharded_save_to_cpu, fsdp1_sharded_load_from_cpu)
elif strategy in ["fsdp2", "veomni"]:
    self._strategy_handlers = (fsdp2_sharded_save_to_cpu, fsdp2_sharded_load_from_cpu)
```

**Updated `restore_model_from_cpu`**: FSDP1 state is a plain dict (not a `(state, spec)` tuple), so the restore path no longer destructures it as one.

## Tests

6 tests in `tests/experimental/separation/test_detach_actor_fsdp1.py`:
- FSDP1 save/load round-trip preserves parameter values
- saved state is a detached copy (not aliased to live parameters)
- source code routes `"fsdp"` to fsdp1 handlers
- source code routes `"fsdp2"`/`"veomni"` to fsdp2 handlers
- multi-layer model save/restore
- `restore_model_from_cpu` branches correctly for FSDP1