### PR TITLE
fix: set sleep_level before first resume on LoRA adapter path (#7289)

### DIFF
--- a/tests/workers/test_lora_resume_ordering.py
+++ b/tests/workers/test_lora_resume_ordering.py
@@ -1,0 +1,90 @@
+"""Tests for LoRA adapter resume ordering fix (#7289).
+
+Verifies that:
+1. sleep_level is set at init time (before first resume)
+2. update_weights skips resuming "weights" when sleep_level=1
+3. wake_up mirrors sleep in the COLOCATED path
+"""
+
+import pathlib
+
+
+def _read_source(relpath):
+    return pathlib.Path(relpath).read_text()
+
+
+def test_sleep_level_set_at_init():
+    """sleep_level must be set during __init__, before update_weights runs."""
+    src = _read_source("verl/workers/engine_workers.py")
+    assert "lora_as_adapter" in src
+    assert "self.rollout.sleep_level = 1" in src
+    peft_merge_pos = src.index("self.peft_merge")
+    first_sleep_level_pos = src.index("self.rollout.sleep_level = 1")
+    assert first_sleep_level_pos > peft_merge_pos
+    assert first_sleep_level_pos - peft_merge_pos < 600
+
+
+def test_resume_skips_weights_at_sleep_level_1():
+    """update_weights must not resume 'weights' when sleep_level=1."""
+    src = _read_source("verl/workers/engine_workers.py")
+    resume_start = src.index("# 1. resume rollout memory")
+    resume_end = src.index("# 2. determine")
+    resume_section = src[resume_start:resume_end]
+    assert "sleep_level" in resume_section
+
+
+def test_wake_up_mirrors_sleep():
+    """wake_up COLOCATED must branch on lora_as_adapter like sleep does."""
+    src = _read_source("verl/workers/rollout/sglang_rollout/async_sglang_server.py")
+    wake_up_start = src.index("async def wake_up")
+    # Find next method or property
+    rest = src[wake_up_start + 20:]
+    for marker in ["\n    @", "\n    async def ", "\nclass "]:
+        try:
+            end = rest.index(marker)
+            break
+        except ValueError:
+            end = len(rest)
+    wake_up_src = rest[:end]
+    assert "lora_as_adapter" in wake_up_src
+
+
+def test_sleep_and_wake_up_tag_symmetry():
+    """sleep and wake_up must both reference lora_as_adapter."""
+    src = _read_source("verl/workers/rollout/sglang_rollout/async_sglang_server.py")
+
+    sleep_start = src.index("async def sleep")
+    rest = src[sleep_start + 20:]
+    for marker in ["\n    async def ", "\n    @", "\nclass "]:
+        try:
+            end = rest.index(marker)
+            break
+        except ValueError:
+            end = len(rest)
+    sleep_src = rest[:end]
+
+    wake_up_start = src.index("async def wake_up")
+    rest2 = src[wake_up_start + 20:]
+    for marker in ["\n    @", "\n    async def ", "\nclass "]:
+        try:
+            end2 = rest2.index(marker)
+            break
+        except ValueError:
+            end2 = len(rest2)
+    wake_up_src = rest2[:end2]
+
+    assert "lora_as_adapter" in sleep_src, "sleep must check lora_as_adapter"
+    assert "lora_as_adapter" in wake_up_src, "wake_up must check lora_as_adapter"
+
+
+def test_no_unconditional_weights_resume():
+    """engine_workers must not unconditionally resume weights tag."""
+    src = _read_source("verl/workers/engine_workers.py")
+    resume_start = src.index("# 1. resume rollout memory")
+    resume_end = src.index("# 2. determine")
+    resume_section = src[resume_start:resume_end]
+    lines = resume_section.split("\n")
+    for i, line in enumerate(lines):
+        if 'resume(tags=["weights"])' in line:
+            context = "\n".join(lines[max(0, i - 5):i + 1])
+            assert "sleep_level" in context

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -668,6 +668,14 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             self.layered_summon = self.config.rollout.get("layered_summon", False)
             self.peft_merge: bool = model_config.lora.get("merge", False)
 
+            # Determine sleep_level early so resume() knows what was released.
+            # sleep_level=1 (adapter path): only kv_cache is released during sleep,
+            # weights stay in GPU.  sleep_level=2 (default/merge): both released.
+            lora_rank = model_config.lora.get("rank", 0) or getattr(model_config, "lora_rank", 0)
+            lora_as_adapter = lora_rank > 0 and not self.peft_merge
+            if hasattr(self, "rollout") and lora_as_adapter:
+                self.rollout.sleep_level = 1
+
         # 4. build checkpoint engine
         if "actor" in self.role:
             checkpoint_engine_config = omega_conf_to_dataclass(self.config.rollout.checkpoint_engine)
@@ -762,8 +770,13 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         log_gpu_memory_usage("Before resume weights", logger=logger)
 
         # 1. resume rollout memory (weights were released during sleep)
+        # When sleep_level=1 (LoRA adapter path), only kv_cache was released,
+        # so resuming "weights" would fail with KeyError.
         if self.config.rollout.free_cache_engine:
-            await self.rollout.resume(tags=["weights"])
+            if getattr(self.rollout, "sleep_level", 2) == 1:
+                pass  # weights were never released; nothing to resume
+            else:
+                await self.rollout.resume(tags=["weights"])
         log_gpu_memory_usage("After resume weights", logger=logger)
 
         # 2. determine if we need a base weight sync (adapter path only)
@@ -773,7 +786,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         do_lora_base_sync = False
         if not self.peft_merge and peft_config is not None:
-            self.rollout.sleep_level = 1
+            self.rollout.sleep_level = 1  # reinforce for subsequent iterations
             do_lora_base_sync = not self.base_sync_done
 
         # 3. sync weights: For SGLang, we need base first (when needed), then adapter/merged

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -466,8 +466,12 @@ class SGLangHttpServer:
             # In hybrid mode, rollout is wake up in `update_weights`
             raise ValueError(f"wake_up not support rollout_mode {self.rollout_mode}")
         elif self.rollout_mode == RolloutMode.COLOCATED:
-            # Directly call engine to wake up without sync weights.
-            obj = ResumeMemoryOccupationReqInput(tags=["kv_cache", "weights"])
+            # Mirror sleep(): only resume what was actually released.
+            if self.lora_as_adapter:
+                tags = ["kv_cache"]
+            else:
+                tags = ["kv_cache", "weights"]
+            obj = ResumeMemoryOccupationReqInput(tags=tags)
             await self.tokenizer_manager.resume_memory_occupation(obj, None)
             await self.tokenizer_manager.flush_cache()
         elif self.rollout_mode == RolloutMode.STANDALONE:


### PR DESCRIPTION
## Summary

Fixes #7289 — LoRA adapter path resumes `weights` tag that was never released, causing `KeyError: 'weights'` in SGLang's `resume_memory_occupation` on the first weight sync.

## Root Cause

### Bug 1: Resume before sleep_level is known (`engine_workers.py`)

In `ActorRolloutRefWorker.update_weights()`:

```python
# Line 764-766: resume called UNCONDITIONALLY
if self.config.rollout.free_cache_engine:
    await self.rollout.resume(tags=["weights"])   # <-- always resumes weights

# Line 774-776: sleep_level set TEN LINES LATER
if not self.peft_merge and peft_config is not None:
    self.rollout.sleep_level = 1                  # <-- too late
```

The comment on line 764 states *"weights were released during sleep"* — but for `sleep_level=1` (LoRA adapter path), only `kv_cache` was released. Weights were never in `offload_tags`, so SGLang raises `KeyError("weights")`.

### Bug 2: sleep/wake_up asymmetry (`async_sglang_server.py`)

```python
# sleep() BRANCHES on lora_as_adapter:
if self.lora_as_adapter:
    tags = ["kv_cache"]           # only kv_cache for adapter path
else:
    tags = ["kv_cache", "weights"]

# wake_up() does NOT branch — hard-codes both tags:
obj = ResumeMemoryOccupationReqInput(tags=["kv_cache", "weights"])  # always!
```

So `wake_up()` tries to resume `weights` that `sleep()` never released.

### Symptom

First weight sync of a LoRA run with `free_cache_engine=true`:
```
KeyError: 'weights'
  sglang/srt/managers/scheduler_update_weights_mixin.py, in resume_memory_occupation
      self.offload_tags.remove(tag)
```

## Fix

### 1. Set `sleep_level` at init time (`engine_workers.py`)

Determine LoRA adapter mode during `__init__`, where `model_config` is already available:

```python
lora_rank = model_config.lora.get("rank", 0) or getattr(model_config, "lora_rank", 0)
lora_as_adapter = lora_rank > 0 and not self.peft_merge
if hasattr(self, "rollout") and lora_as_adapter:
    self.rollout.sleep_level = 1
```

This uses the same `lora_served_as_adapter` logic from `sglang_rollout/utils.py` but avoids adding a dependency.

### 2. Guard resume on `sleep_level` (`engine_workers.py`)

```python
if self.config.rollout.free_cache_engine:
    if getattr(self.rollout, "sleep_level", 2) == 1:
        pass  # weights were never released; nothing to resume
    else:
        await self.rollout.resume(tags=["weights"])
```

### 3. Mirror `sleep()` in `wake_up()` (`async_sglang_server.py`)

```python
elif self.rollout_mode == RolloutMode.COLOCATED:
    if self.lora_as_adapter:
        tags = ["kv_cache"]
    else:
        tags = ["kv_cache", "weights"]
    obj = ResumeMemoryOccupationReqInput(tags=tags)
```

### Files Changed

- `verl/workers/engine_workers.py` — early sleep_level, guarded resume
- `verl/workers/rollout/sglang_rollout/async_sglang_server.py` — wake_up mirrors sleep

## Tests

5 tests in `tests/workers/test_lora_resume_ordering.py`:

| Test | What it verifies |
|------|-----------------|
| `test_sleep_level_set_at_init` | `sleep_level=1` is set near `peft_merge` in `__init__`, before `update_weights` runs |
| `test_resume_skips_weights_at_sleep_level_1` | The resume section checks `sleep_level` before resuming weights |
| `test_wake_up_mirrors_sleep` | `wake_up` COLOCATED path branches on `lora_as_adapter` |
| `test_sleep_and_wake_up_tag_symmetry` | Both `sleep()` and `wake_up()` reference `lora_as_adapter` |
| `test_no_unconditional_weights_resume` | No `resume(tags=["weights"])` without a `sleep_level` guard |

```
tests/workers/test_lora_resume_ordering.py: 5 passed
```