### PR TITLE
[rollout] feat: multi-teacher shared GPU group 

### DIFF
--- a/examples/on_policy_distillation_trainer/README.md
+++ b/examples/on_policy_distillation_trainer/README.md
@@ -22,3 +22,10 @@ the single-teacher scripts. The MOPD script exposes per-teacher overrides.
 - `distillation.distillation_loss.loss_mode={k1, k3, forward_kl_topk, ...}`
 - `distillation.distillation_loss.use_policy_gradient=True|False`
 - `distillation.distillation_loss.topk=64`
+- `distillation.share_gpu_group=True` (multi-teacher): place all teachers on the SAME
+  GPUs and wake/sleep teacher engines on demand, so the teacher pool only needs to fit
+  one teacher (requires equal per-teacher world sizes and
+  `inference.free_cache_engine=True` + `inference.enable_sleep_mode=True`).
+  `distillation.max_awake_teachers=N` optionally caps how many teachers stay awake at
+  once (LRU eviction, vLLM sleep level 1). Enabled by default in
+  `run_qwen3_8b_mopd_fsdp.sh` via `TEACHER_SHARE_GPU_GROUP=True`.

--- a/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_fsdp.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_fsdp.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 # On-policy distillation | multi-teacher (gsm8k text + geo3k VL) | vLLM rollout | FSDP training | NVIDIA GPUs
+#
+# By default this script enables the multi-teacher shared GPU group
+# (TEACHER_SHARE_GPU_GROUP=True): BOTH teachers are placed on the SAME GPUs instead of
+# disjoint sub-pools, so the teacher pool only needs to fit ONE teacher
+# (TEACHER_WORLD_SIZE = teacher_tp * num_replicas). Teacher engines sleep when idle
+# (vLLM sleep level 1: weights offloaded to CPU, KV cache freed) and are woken on
+# demand by the TeacherSleepController. With both teachers at
+# gpu_memory_utilization=0.4 both can stay awake simultaneously, so
+# distillation.max_awake_teachers is left unset (null = unlimited).
+# Set TEACHER_SHARE_GPU_GROUP=False to fall back to disjoint per-teacher pools
+# (teacher pool = sum of both teachers' world sizes).
 
 set -xeuo pipefail
 
@@ -11,12 +22,27 @@ GEO3K_TEACHER_MODEL=${GEO3K_TEACHER_MODEL:-Qwen/Qwen3-VL-32B-Instruct}
 NNODES=${NNODES:-1}
 NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
 
-# Per-teacher replicas; total teacher GPUs = sum(num_replicas) * teacher_tp
+# Per-teacher replicas; total teacher GPUs depend on TEACHER_SHARE_GPU_GROUP (see header).
 TEACHER_NNODES=${TEACHER_NNODES:-1}
 TEACHER_NUM_REPLICAS_GSM8K=${TEACHER_NUM_REPLICAS_GSM8K:-1}
 TEACHER_NUM_REPLICAS_GEO3K=${TEACHER_NUM_REPLICAS_GEO3K:-1}
 teacher_tp=${TEACHER_TP:-2}
-TEACHER_WORLD_SIZE=$(( (TEACHER_NUM_REPLICAS_GSM8K + TEACHER_NUM_REPLICAS_GEO3K) * teacher_tp ))
+
+TEACHER_SHARE_GPU_GROUP=${TEACHER_SHARE_GPU_GROUP:-True}
+if [ "$TEACHER_SHARE_GPU_GROUP" = "True" ]; then
+    # Shared mode places both teachers on the same GPUs, so per-teacher world sizes
+    # must be equal; the teacher pool only needs to fit one teacher.
+    if [ "$TEACHER_NUM_REPLICAS_GSM8K" != "$TEACHER_NUM_REPLICAS_GEO3K" ]; then
+        echo "ERROR: TEACHER_SHARE_GPU_GROUP=True requires equal per-teacher world sizes, but " >&2
+        echo "TEACHER_NUM_REPLICAS_GSM8K ($TEACHER_NUM_REPLICAS_GSM8K) != TEACHER_NUM_REPLICAS_GEO3K ($TEACHER_NUM_REPLICAS_GEO3K)." >&2
+        echo "Set them equal, or set TEACHER_SHARE_GPU_GROUP=False to use disjoint teacher pools." >&2
+        exit 1
+    fi
+    TEACHER_WORLD_SIZE=$(( teacher_tp * TEACHER_NUM_REPLICAS_GSM8K ))
+else
+    # Disjoint pools: total teacher GPUs = sum(num_replicas) * teacher_tp
+    TEACHER_WORLD_SIZE=$(( (TEACHER_NUM_REPLICAS_GSM8K + TEACHER_NUM_REPLICAS_GEO3K) * teacher_tp ))
+fi
 
 distillation_loss_mode=${DISTILLATION_LOSS_MODE:-k1}
 use_policy_gradient=${USE_POLICY_GRADIENT:-True}
@@ -138,6 +164,10 @@ EXTRA=(
     distillation.distillation_loss.loss_max_clamp=10.0
     distillation.distillation_loss.log_prob_min_clamp=-10.0
 )
+
+if [ "$TEACHER_SHARE_GPU_GROUP" = "True" ]; then
+    EXTRA+=(distillation.share_gpu_group=True)
+fi
 
 ########################### launch ###########################
 # uv (set VERL_USE_UV=0 for system python): on GPU, the driver and every Ray worker

--- a/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_fsdp.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_fsdp.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 # On-policy distillation | multi-teacher (gsm8k text + geo3k VL) | vLLM rollout | FSDP training | NVIDIA GPUs
+#
+# By default this script enables the multi-teacher shared GPU group
+# (TEACHER_SHARE_GPU_GROUP=True): BOTH teachers are placed on the SAME GPUs instead of
+# disjoint sub-pools, so the teacher pool only needs to fit ONE teacher
+# (TEACHER_WORLD_SIZE = teacher_tp * num_replicas). Teacher engines sleep when idle
+# (vLLM sleep level 1: weights offloaded to CPU, KV cache freed) and are woken on
+# demand by the TeacherSleepController. With both teachers at
+# gpu_memory_utilization=0.4 both can stay awake simultaneously, so
+# distillation.max_awake_teachers is left unset (null = unlimited).
+# Set TEACHER_SHARE_GPU_GROUP=False to fall back to disjoint per-teacher pools
+# (teacher pool = sum of both teachers' world sizes).
 
 set -xeuo pipefail
 
@@ -11,12 +22,27 @@ GEO3K_TEACHER_MODEL=${GEO3K_TEACHER_MODEL:-Qwen/Qwen3-VL-32B-Instruct}
 NNODES=${NNODES:-1}
 NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
 
-# Per-teacher replicas; total teacher GPUs = sum(num_replicas) * teacher_tp
+# Per-teacher replicas; total teacher GPUs depend on TEACHER_SHARE_GPU_GROUP (see header).
 TEACHER_NNODES=${TEACHER_NNODES:-1}
 TEACHER_NUM_REPLICAS_GSM8K=${TEACHER_NUM_REPLICAS_GSM8K:-1}
 TEACHER_NUM_REPLICAS_GEO3K=${TEACHER_NUM_REPLICAS_GEO3K:-1}
 teacher_tp=${TEACHER_TP:-2}
-TEACHER_WORLD_SIZE=$(( (TEACHER_NUM_REPLICAS_GSM8K + TEACHER_NUM_REPLICAS_GEO3K) * teacher_tp ))
+
+TEACHER_SHARE_GPU_GROUP=${TEACHER_SHARE_GPU_GROUP:-True}
+if [ "$TEACHER_SHARE_GPU_GROUP" = "True" ]; then
+    # Shared mode places both teachers on the same GPUs, so per-teacher world sizes
+    # must be equal; the teacher pool only needs to fit one teacher.
+    if [ "$TEACHER_NUM_REPLICAS_GSM8K" != "$TEACHER_NUM_REPLICAS_GEO3K" ]; then
+        echo "ERROR: TEACHER_SHARE_GPU_GROUP=True requires equal per-teacher world sizes, but " >&2
+        echo "TEACHER_NUM_REPLICAS_GSM8K ($TEACHER_NUM_REPLICAS_GSM8K) != TEACHER_NUM_REPLICAS_GEO3K ($TEACHER_NUM_REPLICAS_GEO3K)." >&2
+        echo "Set them equal, or set TEACHER_SHARE_GPU_GROUP=False to use disjoint teacher pools." >&2
+        exit 1
+    fi
+    TEACHER_WORLD_SIZE=$(( teacher_tp * TEACHER_NUM_REPLICAS_GSM8K ))
+else
+    # Disjoint pools: total teacher GPUs = sum(num_replicas) * teacher_tp
+    TEACHER_WORLD_SIZE=$(( (TEACHER_NUM_REPLICAS_GSM8K + TEACHER_NUM_REPLICAS_GEO3K) * teacher_tp ))
+fi
 
 distillation_loss_mode=${DISTILLATION_LOSS_MODE:-k1}
 use_policy_gradient=${USE_POLICY_GRADIENT:-True}
@@ -138,6 +164,10 @@ EXTRA=(
     distillation.distillation_loss.loss_max_clamp=10.0
     distillation.distillation_loss.log_prob_min_clamp=-10.0
 )
+
+if [ "$TEACHER_SHARE_GPU_GROUP" = "True" ]; then
+    EXTRA+=(distillation.share_gpu_group=True)
+fi
 
 ########################### launch ###########################
 python3 -m verl.trainer.main_ppo \

--- a/tests/experimental/teacher_loop/__init__.py
+++ b/tests/experimental/teacher_loop/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/experimental/teacher_loop/test_teacher_sleep_on_cpu.py
+++ b/tests/experimental/teacher_loop/test_teacher_sleep_on_cpu.py
@@ -1,0 +1,194 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for multi-teacher shared GPU group (share_gpu_group) support.
+
+Covers:
+- ``DistillationConfig`` shared-mode validation (equal per-teacher world_size,
+  world_size == pool size, free_cache_engine/enable_sleep_mode requirements,
+  max_awake_teachers >= 1), and that the non-shared sum check is unchanged.
+- ``TeacherSleepState``: acquire/release, LRU eviction, pinned teachers are never
+  evicted, acquire failure when all awake teachers are pinned, and sleep_all.
+"""
+
+import pytest
+
+from verl.experimental.teacher_loop.teacher_controller import TeacherSleepState
+from verl.workers.config.distillation import (
+    DistillationConfig,
+    DistillationLossConfig,
+    DistillationTeacherModelConfig,
+)
+from verl.workers.config.rollout import RolloutConfig
+
+
+def _teacher(key, num_replicas=1, tp=2, free_cache_engine=True, enable_sleep_mode=True):
+    return DistillationTeacherModelConfig(
+        key=key,
+        model_path="Qwen/Qwen3-0.6B",
+        num_replicas=num_replicas,
+        inference=RolloutConfig(
+            name="vllm",
+            tensor_model_parallel_size=tp,
+            free_cache_engine=free_cache_engine,
+            enable_sleep_mode=enable_sleep_mode,
+        ),
+    )
+
+
+def _two_teachers(**kwargs):
+    """Two named teachers plus the default ``teacher_model`` entry.
+
+    Mirrors the YAML layout: the default entry exists (resolution asserts on it) and is
+    popped once other teacher entries are present, leaving the two named teachers.
+    """
+    return {
+        "teacher_model": _teacher("default_placeholder"),
+        "teacher_a": _teacher("teacher_a", **kwargs),
+        "teacher_b": _teacher("teacher_b", **kwargs),
+    }
+
+
+def _distill_config(teacher_models, n_gpus_per_node, nnodes, share_gpu_group=True, max_awake_teachers=None):
+    return DistillationConfig(
+        enabled=True,
+        n_gpus_per_node=n_gpus_per_node,
+        nnodes=nnodes,
+        teacher_models=teacher_models,
+        distillation_loss=DistillationLossConfig(loss_mode="k1", use_policy_gradient=True),
+        share_gpu_group=share_gpu_group,
+        max_awake_teachers=max_awake_teachers,
+    )
+
+
+class TestSharedGpuGroupValidation:
+    def test_shared_ok(self):
+        # Two teachers, world_size 2 each; pool size 2. Valid in shared mode.
+        config = _distill_config(_two_teachers(), n_gpus_per_node=2, nnodes=1)
+        assert set(config.teacher_models) == {"teacher_a", "teacher_b"}
+
+    def test_shared_single_teacher_ok(self):
+        # Single teacher auto-fills num_replicas = pool / per_replica = 4 / 2 = 2,
+        # so its world_size equals the pool size.
+        config = _distill_config({"teacher_model": _teacher(None, num_replicas=0)}, n_gpus_per_node=4, nnodes=1)
+        assert config.teacher_models["default"].world_size == 4
+
+    def test_shared_unequal_world_size_raises(self):
+        teacher_models = {
+            "teacher_model": _teacher("default_placeholder"),
+            "teacher_a": _teacher("teacher_a", num_replicas=1),
+            "teacher_b": _teacher("teacher_b", num_replicas=2),
+        }
+        with pytest.raises(ValueError, match="world_size.*to be equal"):
+            _distill_config(teacher_models, n_gpus_per_node=4, nnodes=1)
+
+    def test_shared_pool_size_mismatch_raises(self):
+        # Each teacher world_size is 2 but the pool is 4.
+        with pytest.raises(ValueError, match="resource pool size"):
+            _distill_config(_two_teachers(), n_gpus_per_node=4, nnodes=1)
+
+    def test_shared_requires_free_cache_engine(self):
+        with pytest.raises(ValueError, match="free_cache_engine"):
+            _distill_config(_two_teachers(free_cache_engine=False), n_gpus_per_node=2, nnodes=1)
+
+    def test_shared_requires_enable_sleep_mode(self):
+        with pytest.raises(ValueError, match="enable_sleep_mode"):
+            _distill_config(_two_teachers(enable_sleep_mode=False), n_gpus_per_node=2, nnodes=1)
+
+    def test_shared_max_awake_teachers_must_be_positive(self):
+        with pytest.raises(ValueError, match="max_awake_teachers"):
+            _distill_config(_two_teachers(), n_gpus_per_node=2, nnodes=1, max_awake_teachers=0)
+
+    def test_shared_max_awake_teachers_ok(self):
+        config = _distill_config(_two_teachers(), n_gpus_per_node=2, nnodes=1, max_awake_teachers=1)
+        assert config.max_awake_teachers == 1
+
+    def test_non_shared_sum_check_unchanged(self):
+        # Non-shared: sum of world sizes (2 + 2 = 4) must equal the pool size.
+        config = _distill_config(_two_teachers(), n_gpus_per_node=4, nnodes=1, share_gpu_group=False)
+        assert set(config.teacher_models) == {"teacher_a", "teacher_b"}
+        with pytest.raises(ValueError, match="resource pool size"):
+            _distill_config(_two_teachers(), n_gpus_per_node=2, nnodes=1, share_gpu_group=False)
+
+
+class TestTeacherSleepState:
+    def test_max_awake_must_be_positive(self):
+        with pytest.raises(ValueError, match="max_awake"):
+            TeacherSleepState(["a"], max_awake=0)
+
+    def test_unknown_key_raises(self):
+        state = TeacherSleepState(["a"], max_awake=1)
+        with pytest.raises(KeyError, match="Unknown teacher key"):
+            state.try_acquire("zzz")
+
+    def test_first_acquire_needs_wake(self):
+        state = TeacherSleepState(["a", "b"], max_awake=2)
+        assert state.try_acquire("a") == (True, [], True)
+        assert state.awake == ["a"]
+
+    def test_acquire_awake_refreshes_lru_without_wake(self):
+        state = TeacherSleepState(["a", "b"], max_awake=2)
+        state.try_acquire("a")
+        state.try_acquire("b")
+        state.release("a")
+        state.release("b")
+        # Re-acquiring "a" (already awake) needs no wake and moves it to most-recent.
+        assert state.try_acquire("a") == (True, [], False)
+        assert state.awake == ["b", "a"]
+
+    def test_lru_eviction(self):
+        state = TeacherSleepState(["a", "b", "c"], max_awake=2)
+        state.try_acquire("a")
+        state.release("a")
+        state.try_acquire("b")
+        state.release("b")
+        # "a" is least-recently-used, so it is evicted to make room for "c".
+        assert state.try_acquire("c") == (True, ["a"], True)
+        assert state.awake == ["b", "c"]
+
+    def test_pinned_teacher_not_evicted(self):
+        state = TeacherSleepState(["a", "b", "c"], max_awake=2)
+        state.try_acquire("a")  # stays pinned
+        state.try_acquire("b")
+        state.release("b")
+        # "a" is LRU but pinned, so unpinned "b" is evicted instead.
+        assert state.try_acquire("c") == (True, ["b"], True)
+        assert state.awake == ["a", "c"]
+
+    def test_acquire_fails_when_all_awake_pinned(self):
+        state = TeacherSleepState(["a", "b"], max_awake=1)
+        state.try_acquire("a")  # pinned, occupies the only awake slot
+        assert state.try_acquire("b") == (False, [], False)
+        # Nothing changed: "a" is still awake and pinned.
+        assert state.awake == ["a"]
+        state.release("a")
+        assert state.try_acquire("b") == (True, ["a"], True)
+
+    def test_release_without_acquire_raises(self):
+        state = TeacherSleepState(["a"], max_awake=1)
+        with pytest.raises(ValueError, match="without a matching acquire"):
+            state.release("a")
+        state.try_acquire("a")
+        state.release("a")
+        with pytest.raises(ValueError, match="without a matching acquire"):
+            state.release("a")
+
+    def test_keys_to_sleep_all(self):
+        state = TeacherSleepState(["a", "b", "c"], max_awake=3)
+        state.try_acquire("a")
+        state.try_acquire("b")
+        assert state.keys_to_sleep_all() == ["a", "b"]
+        assert state.awake == []
+        assert state.keys_to_sleep_all() == []
+        # Teachers can be re-acquired (and woken) after sleep_all.
+        assert state.try_acquire("c") == (True, [], True)

--- a/verl/experimental/teacher_loop/teacher_controller.py
+++ b/verl/experimental/teacher_loop/teacher_controller.py
@@ -1,0 +1,226 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""On-demand teacher wake/sleep for multi-teacher shared GPU group placement.
+
+When ``distillation.share_gpu_group`` is enabled, all teachers' replicas are placed on
+the same GPU bundles, so keeping every teacher engine resident may not fit in GPU
+memory. This module provides:
+
+- ``TeacherSleepState``: pure-Python LRU/pin state machine deciding which teacher to
+  put to sleep when a new teacher must be woken. Unit-testable without Ray.
+- ``TeacherSleepController``: a Ray actor wrapping ``TeacherSleepState`` and issuing
+  the actual ``sleep``/``wake_up`` RPCs to teacher server actors. A plain sync actor,
+  so Ray serializes method calls, giving mutual exclusion across AgentLoopWorker
+  processes.
+- ``TeacherLLMServerClient``: an ``LLMServerClient`` subclass that acquires (wakes) its
+  teacher before each ``generate`` call and releases it afterwards.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any, Optional
+
+import ray
+from omegaconf import DictConfig
+from ray.actor import ActorHandle
+
+from verl.utils.rollout_trace import rollout_trace_op
+from verl.workers.rollout.llm_server import LLMServerClient
+from verl.workers.rollout.replica import TokenOutput
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+__all__ = ["TeacherSleepState", "TeacherSleepController", "TeacherLLMServerClient"]
+
+
+class TeacherSleepState:
+    """LRU/pin state machine for on-demand teacher wake/sleep.
+
+    All teachers start asleep. ``awake`` is an LRU list (least-recently-used first,
+    most-recent last); ``pins`` counts in-flight acquisitions per teacher. A pinned
+    teacher is never evicted.
+    """
+
+    def __init__(self, keys: list[str], max_awake: int):
+        if max_awake < 1:
+            raise ValueError(f"max_awake must be >= 1, but got {max_awake}.")
+        self._keys = set(keys)
+        self._max_awake = max_awake
+        self._awake: list[str] = []
+        self._pins: dict[str, int] = {key: 0 for key in keys}
+
+    @property
+    def awake(self) -> list[str]:
+        """Awake teachers, least-recently-used first."""
+        return list(self._awake)
+
+    def try_acquire(self, key: str) -> tuple[bool, list[str], bool]:
+        """Try to pin ``key`` for use, evicting LRU unpinned teachers if needed.
+
+        Returns:
+            (success, to_sleep, need_wake):
+                success: True if the caller may use the teacher now.
+                to_sleep: teachers evicted from the awake set (must be slept by the caller).
+                need_wake: True if ``key`` was asleep and must be woken by the caller.
+        """
+        if key not in self._keys:
+            raise KeyError(f"Unknown teacher key {key!r}; known keys: {sorted(self._keys)}.")
+
+        if key in self._awake:
+            # Refresh LRU position (most-recent last).
+            self._awake.remove(key)
+            self._awake.append(key)
+            self._pins[key] += 1
+            return True, [], False
+
+        to_sleep = []
+        while len(self._awake) >= self._max_awake:
+            victim = next((k for k in self._awake if self._pins[k] == 0), None)
+            if victim is None:
+                return False, [], False
+            self._awake.remove(victim)
+            to_sleep.append(victim)
+
+        self._pins[key] += 1
+        self._awake.append(key)
+        return True, to_sleep, True
+
+    def release(self, key: str) -> None:
+        """Release one pin on ``key`` previously taken by ``try_acquire``."""
+        if self._pins.get(key, 0) <= 0:
+            raise ValueError(
+                f"release({key!r}) called without a matching acquire "
+                f"(pins={self._pins.get(key, 0)}). Acquire/release must be paired."
+            )
+        self._pins[key] -= 1
+
+    def keys_to_sleep_all(self) -> list[str]:
+        """Return all awake teachers and mark them asleep."""
+        keys = list(self._awake)
+        self._awake.clear()
+        return keys
+
+
+@ray.remote
+class TeacherSleepController:
+    """Ray actor serializing teacher wake/sleep across all AgentLoopWorker processes.
+
+    A plain (sync) actor, so Ray serializes method calls: the state-machine update and
+    the wake/sleep RPCs inside ``acquire`` are mutually exclusive with any other call.
+    Wake/sleep RPCs complete before ``acquire`` returns True, so a subsequent
+    ``generate`` never hits a sleeping engine.
+    """
+
+    def __init__(self, server_handles: dict[str, list[ActorHandle]], max_awake: int):
+        self._server_handles = server_handles
+        self._state = TeacherSleepState(keys=list(server_handles), max_awake=max_awake)
+
+    def acquire(self, key: str) -> bool:
+        """Pin ``key``, sleeping LRU victims and waking ``key`` as needed.
+
+        Returns True once the teacher is awake and pinned; False if all awake teachers
+        are pinned and no victim can be evicted (caller should retry later).
+        """
+        success, to_sleep, need_wake = self._state.try_acquire(key)
+        if not success:
+            return False
+        for victim in to_sleep:
+            logger.info(f"[TeacherSleepController] sleeping teacher {victim!r} to make room for {key!r}")
+            ray.get([handle.sleep.remote() for handle in self._server_handles[victim]])
+        if need_wake:
+            logger.info(f"[TeacherSleepController] waking teacher {key!r}")
+            ray.get([handle.wake_up.remote() for handle in self._server_handles[key]])
+        return True
+
+    def release(self, key: str) -> None:
+        self._state.release(key)
+
+    def sleep_all(self) -> None:
+        """Sleep every currently-awake teacher."""
+        for key in self._state.keys_to_sleep_all():
+            ray.get([handle.sleep.remote() for handle in self._server_handles[key]])
+
+
+class TeacherLLMServerClient(LLMServerClient):
+    """LLMServerClient that wakes its teacher on demand in shared GPU group mode.
+
+    With ``controller_handle=None`` this behaves exactly like ``LLMServerClient``.
+    """
+
+    def __init__(
+        self,
+        config: DictConfig,
+        load_balancer_handle: ActorHandle = None,
+        teacher_key: Optional[str] = None,
+        controller_handle: Optional[ActorHandle] = None,
+        **kwargs,
+    ):
+        """Initialize the TeacherLLMServerClient.
+
+        Args:
+            config (DictConfig): whole config for main entrypoint.
+            load_balancer_handle (ray.actor.ActorHandle): shared global load balancer actor.
+            teacher_key (str): routing key of the teacher this client serves.
+            controller_handle (ray.actor.ActorHandle): TeacherSleepController actor.
+                Optional; when None, generate() skips wake/sleep entirely.
+        """
+        super().__init__(config=config, load_balancer_handle=load_balancer_handle, **kwargs)
+        self._teacher_key = teacher_key
+        self._controller_handle = controller_handle
+
+    @rollout_trace_op
+    async def generate(
+        self,
+        request_id,
+        *,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> TokenOutput:
+        if self._controller_handle is None:
+            return await super().generate(
+                request_id,
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                image_data=image_data,
+                video_data=video_data,
+                audio_data=audio_data,
+                mm_processor_kwargs=mm_processor_kwargs,
+                **kwargs,
+            )
+
+        # Wake the teacher (sleeping an LRU victim if the awake budget is full) before
+        # generating. acquire() returns False only when every awake teacher is pinned,
+        # in which case retry until one is released.
+        while not await self._controller_handle.acquire.remote(self._teacher_key):
+            await asyncio.sleep(1.0)
+        try:
+            return await super().generate(
+                request_id,
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                image_data=image_data,
+                video_data=video_data,
+                audio_data=audio_data,
+                mm_processor_kwargs=mm_processor_kwargs,
+                **kwargs,
+            )
+        finally:
+            await self._controller_handle.release.remote(self._teacher_key)

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -16,10 +16,13 @@ import asyncio
 import logging
 import os
 
+import ray
 from omegaconf import DictConfig, OmegaConf
 
-from verl.single_controller.ray.base import RayResourcePool, split_resource_pool
+from verl.experimental.teacher_loop.teacher_controller import TeacherLLMServerClient, TeacherSleepController
+from verl.single_controller.ray.base import RayResourcePool, SubRayResourcePool, split_resource_pool
 from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.device import get_device_name
 from verl.utils.ray_utils import auto_await
 from verl.workers.config import DistillationConfig, DistillationTeacherModelConfig
 from verl.workers.rollout.llm_server import LLMServerClient
@@ -185,10 +188,16 @@ class MultiTeacherModelManager:
         self.server_addresses: dict[str, list[str]] = {}
         self.server_handles: dict[str, list] = {}
         self.load_balancer_handle: dict[str, object] = {}
+        # TeacherSleepController actor; only set when share_gpu_group is enabled.
+        self._controller = None
 
         self._initialize_teacher_model_managers()
 
     def _initialize_teacher_model_managers(self):
+        if self.distillation_config.share_gpu_group:
+            self._initialize_shared_gpu_group()
+            return
+
         teacher_models = self.distillation_config.teacher_models
         split_sizes = [teacher.world_size for teacher in teacher_models.values()]
         split_pools = split_resource_pool(self.resource_pool, split_size=split_sizes)
@@ -199,17 +208,75 @@ class MultiTeacherModelManager:
                 teacher_model_config=teacher_model_config,
                 resource_pool=teacher_pool,
             )
-            self.teacher_model_managers[key] = manager
-            self.server_addresses[key] = manager.server_addresses
-            self.server_handles[key] = manager.server_handles
-            self.load_balancer_handle[key] = manager.load_balancer_handle
+            self._register_teacher_model_manager(key, manager)
+
+    def _initialize_shared_gpu_group(self):
+        """Place ALL teachers' replicas on the same GPU bundles and wake/sleep on demand.
+
+        Every teacher gets a SubRayResourcePool view over the parent's full placement
+        groups with the same start_bundle_index, so replicas within a teacher are
+        disjoint while across teachers they overlap. Each teacher is put to sleep right
+        after its engines boot — before the next teacher is constructed — so engine
+        boot/profiling does not OOM even when sum(gpu_memory_utilization) > 1, and to
+        establish the all-asleep initial state the TeacherSleepController assumes.
+        """
+        teacher_models = self.distillation_config.teacher_models
+        start_bundle_index = getattr(self.resource_pool, "start_bundle_index", 0)
+        placement_groups = self.resource_pool.get_placement_groups(device_name=get_device_name())
+
+        for idx, (key, teacher_model_config) in enumerate(teacher_models.items()):
+            teacher_pool = SubRayResourcePool(
+                placement_groups=placement_groups,
+                start_bundle_index=start_bundle_index,
+                subgroup_world_size=teacher_model_config.world_size,
+                process_on_nodes=self.resource_pool.store,
+                use_gpu=self.resource_pool.use_gpu,
+                name_prefix=f"{self.resource_pool.name_prefix}_shared_{idx}",
+                max_colocate_count=self.resource_pool.max_colocate_count,
+            )
+            manager = TeacherModelManager(
+                distillation_config=self.distillation_config,
+                teacher_model_config=teacher_model_config,
+                resource_pool=teacher_pool,
+            )
+            self._register_teacher_model_manager(key, manager)
+            _run_all([replica.sleep() for replica in manager.rollout_replicas])
+
+        server_handles = {
+            key: [server for replica in manager.rollout_replicas for server in replica.servers]
+            for key, manager in self.teacher_model_managers.items()
+        }
+        max_awake = self.distillation_config.max_awake_teachers or len(teacher_models)
+        self._controller = TeacherSleepController.remote(
+            server_handles=server_handles,
+            max_awake=max_awake,
+        )
+
+    def _register_teacher_model_manager(self, key: str, manager: TeacherModelManager):
+        self.teacher_model_managers[key] = manager
+        self.server_addresses[key] = manager.server_addresses
+        self.server_handles[key] = manager.server_handles
+        self.load_balancer_handle[key] = manager.load_balancer_handle
 
     def get_client(self) -> dict[str, LLMServerClient]:
         """Get the LLMServerClient for each teacher model."""
         teacher_clients = {}
         for key, manager in self.teacher_model_managers.items():
-            teacher_clients[key] = LLMServerClient(
-                config=self.config,
-                load_balancer_handle=manager.load_balancer_handle,
-            )
+            if self._controller is not None:
+                teacher_clients[key] = TeacherLLMServerClient(
+                    config=self.config,
+                    load_balancer_handle=manager.load_balancer_handle,
+                    teacher_key=key,
+                    controller_handle=self._controller,
+                )
+            else:
+                teacher_clients[key] = LLMServerClient(
+                    config=self.config,
+                    load_balancer_handle=manager.load_balancer_handle,
+                )
         return teacher_clients
+
+    def sleep_all(self):
+        """Sleep every awake teacher. No-op when share_gpu_group is disabled."""
+        if self._controller is not None:
+            ray.get(self._controller.sleep_all.remote())

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -16,10 +16,13 @@ import asyncio
 import logging
 import os
 
+import ray
 from omegaconf import DictConfig, OmegaConf
 
-from verl.single_controller.ray.base import RayResourcePool, split_resource_pool
+from verl.experimental.teacher_loop.teacher_controller import TeacherLLMServerClient, TeacherSleepController
+from verl.single_controller.ray.base import RayResourcePool, SubRayResourcePool, split_resource_pool
 from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.device import get_device_name
 from verl.utils.ray_utils import auto_await
 from verl.workers.config import DistillationConfig, DistillationTeacherModelConfig
 from verl.workers.rollout.llm_server import LLMServerClient
@@ -183,10 +186,16 @@ class MultiTeacherModelManager:
         self.server_addresses: dict[str, list[str]] = {}
         self.server_handles: dict[str, list] = {}
         self.load_balancer_handle: dict[str, object] = {}
+        # TeacherSleepController actor; only set when share_gpu_group is enabled.
+        self._controller = None
 
         self._initialize_teacher_model_managers()
 
     def _initialize_teacher_model_managers(self):
+        if self.distillation_config.share_gpu_group:
+            self._initialize_shared_gpu_group()
+            return
+
         teacher_models = self.distillation_config.teacher_models
         split_sizes = [teacher.world_size for teacher in teacher_models.values()]
         split_pools = split_resource_pool(self.resource_pool, split_size=split_sizes)
@@ -197,17 +206,75 @@ class MultiTeacherModelManager:
                 teacher_model_config=teacher_model_config,
                 resource_pool=teacher_pool,
             )
-            self.teacher_model_managers[key] = manager
-            self.server_addresses[key] = manager.server_addresses
-            self.server_handles[key] = manager.server_handles
-            self.load_balancer_handle[key] = manager.load_balancer_handle
+            self._register_teacher_model_manager(key, manager)
+
+    def _initialize_shared_gpu_group(self):
+        """Place ALL teachers' replicas on the same GPU bundles and wake/sleep on demand.
+
+        Every teacher gets a SubRayResourcePool view over the parent's full placement
+        groups with the same start_bundle_index, so replicas within a teacher are
+        disjoint while across teachers they overlap. Each teacher is put to sleep right
+        after its engines boot — before the next teacher is constructed — so engine
+        boot/profiling does not OOM even when sum(gpu_memory_utilization) > 1, and to
+        establish the all-asleep initial state the TeacherSleepController assumes.
+        """
+        teacher_models = self.distillation_config.teacher_models
+        start_bundle_index = getattr(self.resource_pool, "start_bundle_index", 0)
+        placement_groups = self.resource_pool.get_placement_groups(device_name=get_device_name())
+
+        for idx, (key, teacher_model_config) in enumerate(teacher_models.items()):
+            teacher_pool = SubRayResourcePool(
+                placement_groups=placement_groups,
+                start_bundle_index=start_bundle_index,
+                subgroup_world_size=teacher_model_config.world_size,
+                process_on_nodes=self.resource_pool.store,
+                use_gpu=self.resource_pool.use_gpu,
+                name_prefix=f"{self.resource_pool.name_prefix}_shared_{idx}",
+                max_colocate_count=self.resource_pool.max_colocate_count,
+            )
+            manager = TeacherModelManager(
+                distillation_config=self.distillation_config,
+                teacher_model_config=teacher_model_config,
+                resource_pool=teacher_pool,
+            )
+            self._register_teacher_model_manager(key, manager)
+            _run_all([replica.sleep() for replica in manager.rollout_replicas])
+
+        server_handles = {
+            key: [server for replica in manager.rollout_replicas for server in replica.servers]
+            for key, manager in self.teacher_model_managers.items()
+        }
+        max_awake = self.distillation_config.max_awake_teachers or len(teacher_models)
+        self._controller = TeacherSleepController.remote(
+            server_handles=server_handles,
+            max_awake=max_awake,
+        )
+
+    def _register_teacher_model_manager(self, key: str, manager: TeacherModelManager):
+        self.teacher_model_managers[key] = manager
+        self.server_addresses[key] = manager.server_addresses
+        self.server_handles[key] = manager.server_handles
+        self.load_balancer_handle[key] = manager.load_balancer_handle
 
     def get_client(self) -> dict[str, LLMServerClient]:
         """Get the LLMServerClient for each teacher model."""
         teacher_clients = {}
         for key, manager in self.teacher_model_managers.items():
-            teacher_clients[key] = LLMServerClient(
-                config=self.config,
-                load_balancer_handle=manager.load_balancer_handle,
-            )
+            if self._controller is not None:
+                teacher_clients[key] = TeacherLLMServerClient(
+                    config=self.config,
+                    load_balancer_handle=manager.load_balancer_handle,
+                    teacher_key=key,
+                    controller_handle=self._controller,
+                )
+            else:
+                teacher_clients[key] = LLMServerClient(
+                    config=self.config,
+                    load_balancer_handle=manager.load_balancer_handle,
+                )
         return teacher_clients
+
+    def sleep_all(self):
+        """Sleep every awake teacher. No-op when share_gpu_group is disabled."""
+        if self._controller is not None:
+            ray.get(self._controller.sleep_all.remote())

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -897,6 +897,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -928,6 +928,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -819,6 +819,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -823,6 +823,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -835,6 +835,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -892,6 +892,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -833,6 +833,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -857,6 +857,8 @@ distillation:
     clip_ratio_high: 0.2
   n_gpus_per_node: 8
   nnodes: 0
+  share_gpu_group: false
+  max_awake_teachers: null
   teacher_models:
     teacher_model:
       _target_: verl.workers.config.DistillationTeacherModelConfig

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -61,6 +61,19 @@ n_gpus_per_node: 8
 # Number of nodes in the distillation teacher resource pool
 nnodes: 0
 
+# Whether all teachers' replicas are placed on the SAME GPU bundles (multi-teacher
+# shared GPU group) instead of disjoint sub-pools. Requires every teacher's world_size
+# (num_replicas * per_replica_world_size) to be equal and to match the distillation
+# resource pool size (n_gpus_per_node * nnodes), and every teacher's
+# inference.free_cache_engine=True and inference.enable_sleep_mode=True. Teacher
+# engines start asleep (weights offloaded to CPU, KV cache freed) and are woken on demand.
+share_gpu_group: false
+
+# Maximum number of simultaneously-awake teachers when share_gpu_group is true.
+# null = unlimited (all teachers may stay awake). When the limit is hit, the
+# least-recently-used unpinned teacher is put to sleep (vLLM sleep level 1).
+max_awake_teachers: null
+
 # multi-teacher configs
 teacher_models:
 

--- a/verl/trainer/main_ppo_v0.py
+++ b/verl/trainer/main_ppo_v0.py
@@ -85,6 +85,7 @@ class BaseTaskRunner:
             config.reward.reward_model.n_gpus_per_node = config.trainer.n_gpus_per_node
 
         distillation_config = config.get("distillation")
+        max_colocate_count = 3
         if is_distillation_enabled(distillation_config):
             if distillation_config.n_gpus_per_node <= 0:
                 raise ValueError("config.distillation.n_gpus_per_node must be greater than 0")
@@ -94,9 +95,21 @@ class BaseTaskRunner:
             teacher_pool = [distillation_config.n_gpus_per_node] * distillation_config.nnodes
             resource_pool_spec["teacher_pool"] = teacher_pool
 
+            if distillation_config.get("share_gpu_group", False):
+                # All teachers' worker actors share the same placement-group bundles.
+                # Each bundle reserves max_colocate_count CPUs and actors request 1 CPU
+                # each (plus 1/max_colocate_count GPU), so the per-bundle actor count
+                # (= number of teachers) must not exceed max_colocate_count.
+                from verl.utils.config import omega_conf_to_dataclass
+
+                num_teachers = len(omega_conf_to_dataclass(distillation_config).teacher_models)
+                max_colocate_count = max(3, num_teachers)
+
         from verl.trainer.ppo.ray_trainer import ResourcePoolManager
 
-        resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
+        resource_pool_manager = ResourcePoolManager(
+            resource_pool_spec=resource_pool_spec, mapping=self.mapping, max_colocate_count=max_colocate_count
+        )
         return resource_pool_manager
 
     def add_reward_model_resource_pool(self, config):

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -778,6 +778,7 @@ class PPOTrainer(ABC):
             self.mapping[Role.RewardModel] = "global_pool"
 
         distillation_config = config.get("distillation")
+        max_colocate_count = 3
         if is_distillation_enabled(distillation_config):
             if distillation_config.n_gpus_per_node <= 0:
                 raise ValueError("config.distillation.n_gpus_per_node must be greater than 0")
@@ -788,7 +789,17 @@ class PPOTrainer(ABC):
             resource_pool_spec["teacher_pool"] = teacher_pool
             self.mapping[Role.TeacherModel] = "teacher_pool"
 
-        self.resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
+            if distillation_config.get("share_gpu_group", False):
+                # All teachers' worker actors share the same placement-group bundles.
+                # Each bundle reserves max_colocate_count CPUs and actors request 1 CPU
+                # each (plus 1/max_colocate_count GPU), so the per-bundle actor count
+                # (= number of teachers) must not exceed max_colocate_count.
+                num_teachers = len(omega_conf_to_dataclass(distillation_config).teacher_models)
+                max_colocate_count = max(3, num_teachers)
+
+        self.resource_pool_manager = ResourcePoolManager(
+            resource_pool_spec=resource_pool_spec, mapping=self.mapping, max_colocate_count=max_colocate_count
+        )
 
     def _load_checkpoint(self):
         self.global_steps = 0

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -235,6 +235,19 @@ class DistillationConfig(BaseConfig):
         the data proto, e.g., data_source.
     distillation_loss (DistillationLossConfig):
     Configuration for distillation loss settings.
+    share_gpu_group (bool):
+        Whether all teachers' replicas are placed on the SAME GPU bundles (multi-teacher
+        shared GPU group) instead of disjoint sub-pools. Requires every teacher's
+        `world_size` (= num_replicas * per_replica_world_size) to be equal and to match the
+        distillation resource pool size (`n_gpus_per_node * nnodes`), and every teacher's
+        `inference.free_cache_engine` and `inference.enable_sleep_mode` to be True. Teacher
+        engines start asleep (weights offloaded to CPU, KV cache freed) and are woken on
+        demand by the TeacherSleepController.
+    max_awake_teachers (int, optional):
+        Maximum number of simultaneously-awake teachers when `share_gpu_group` is True.
+        None means unlimited (all teachers may stay awake). When the limit is hit, the
+        least-recently-used unpinned teacher is put to sleep (vLLM sleep level 1) to make
+        room for the requested teacher.
 
     NOTE: The `teacher_model` entry is in the `teacher_models` dict by default.
     Since it is popped when other teacher entries are added, using `teacher_model` as
@@ -265,12 +278,18 @@ class DistillationConfig(BaseConfig):
     teacher_models: dict[str, DistillationTeacherModelConfig] = field(default_factory=dict)
     teacher_key: str = "data_source"
     distillation_loss: DistillationLossConfig = field(default_factory=DistillationLossConfig)
+    share_gpu_group: bool = False
+    max_awake_teachers: Optional[int] = None
 
     def __post_init__(self):
         if not self.enabled:
             return
 
         self.teacher_models = self._resolve_teacher_models()
+        if self.share_gpu_group:
+            self._validate_shared_gpu_group()
+            return
+
         teacher_world_size_sum = 0
         for teacher_model in self.teacher_models.values():
             teacher_model.validate_and_prepare_for_distillation(
@@ -284,6 +303,51 @@ class DistillationConfig(BaseConfig):
                 f"Sum of teacher (num_replicas * per_replica_world_size) ({teacher_world_size_sum}) must match "
                 f"the distillation resource pool size "
                 f"({self.n_gpus_per_node=} * {self.nnodes=} = {total_pool_size})."
+            )
+
+    def _validate_shared_gpu_group(self):
+        """Validate multi-teacher shared GPU group placement.
+
+        All teachers' replicas are placed on the same GPU bundles, so every teacher's
+        `world_size` must equal the distillation resource pool size, and every teacher
+        engine must support sleep/wake (`free_cache_engine` + `enable_sleep_mode`).
+        """
+        if self.max_awake_teachers is not None and self.max_awake_teachers < 1:
+            raise ValueError(
+                f"distillation.max_awake_teachers must be >= 1 when set, "
+                f"but got {self.max_awake_teachers}."
+            )
+
+        total_pool_size = self.n_gpus_per_node * self.nnodes
+        world_sizes = {}
+        for key, teacher_model in self.teacher_models.items():
+            teacher_model.validate_and_prepare_for_distillation(
+                use_topk=self.distillation_loss.loss_settings.use_topk,
+                topk=self.distillation_loss.topk,
+            )
+            world_sizes[key] = teacher_model.world_size
+            inference = teacher_model.inference
+            if not inference.free_cache_engine or not inference.enable_sleep_mode:
+                raise ValueError(
+                    f"share_gpu_group=True requires inference.free_cache_engine=True and "
+                    f"inference.enable_sleep_mode=True for every teacher (on-demand teacher "
+                    f"sleep/wake depends on both), but teacher {key!r} has "
+                    f"free_cache_engine={inference.free_cache_engine}, "
+                    f"enable_sleep_mode={inference.enable_sleep_mode}."
+                )
+
+        if len(set(world_sizes.values())) != 1:
+            raise ValueError(
+                f"share_gpu_group=True requires every teacher's world_size "
+                f"(num_replicas * per_replica_world_size) to be equal, but got {world_sizes}."
+            )
+        teacher_world_size = next(iter(world_sizes.values()))
+        if teacher_world_size != total_pool_size:
+            raise ValueError(
+                f"share_gpu_group=True requires each teacher's world_size ({teacher_world_size}) "
+                f"to equal the distillation resource pool size "
+                f"({self.n_gpus_per_node=} * {self.nnodes=} = {total_pool_size}), since all "
+                f"teachers are placed on the same GPU bundles."
             )
 
     def _resolve_teacher_models(self) -> dict[str, DistillationTeacherModelConfig]:

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -314,8 +314,7 @@ class DistillationConfig(BaseConfig):
         """
         if self.max_awake_teachers is not None and self.max_awake_teachers < 1:
             raise ValueError(
-                f"distillation.max_awake_teachers must be >= 1 when set, "
-                f"but got {self.max_awake_teachers}."
+                f"distillation.max_awake_teachers must be >= 1 when set, but got {self.max_awake_teachers}."
             )
 
         total_pool_size = self.n_gpus_per_node * self.nnodes


### PR DESCRIPTION
Add distillation.share_gpu_group: when enabled, all teachers' replicas are placed on the SAME GPU bundles (pool sized for one teacher instead of the sum), engines boot then immediately sleep (vLLM sleep level 1: weights offloaded to CPU, KV cache freed), and are woken on demand.

- DistillationConfig: share_gpu_group + max_awake_teachers fields with shared-mode validation (equal per-teacher world_size == pool size, free_cache_engine/enable_sleep_mode required)
- teacher_controller.py: TeacherSleepState (LRU/pin state machine), TeacherSleepController (sync Ray actor serializing acquire/release/ sleep_all across AgentLoopWorkers), TeacherLLMServerClient (wakes its teacher before generate, releases after; LRU eviction of unpinned teachers when max_awake_teachers is hit)
- MultiTeacherModelManager: shared SubRayResourcePool views, sleep each teacher right after boot (avoids OOM when sum(gpu_mem_util) > 1), sleep_all() hook; non-shared path unchanged
- trainer_base.py (v1) / main_ppo_v0.py: bump max_colocate_count to num_teachers when > 3 in shared mode (bundle CPU capacity)
- example run_qwen3_8b_mopd_fsdp.sh: TEACHER_SHARE_GPU_GROUP=True default, teacher pool 4 -> 2 GPUs for the 2-teacher setup
- 18 CPU unit tests for config validation and the sleep state machine

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
