### PR TITLE
[vllm] feat: release KV cache during async mode weight updates

### DIFF
--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import platform
+from datetime import datetime
 import signal
 import threading
 from collections.abc import Mapping
@@ -383,6 +384,87 @@ class vLLMColocateWorkerExtension:
         trainer_rank = int(trainer_rank_base) + local_rank if trainer_rank_base is not None else local_rank
         return f"ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{replica_rank}-rank-{trainer_rank}.sock"
 
+
+    def release_kv_cache(self) -> None:
+        """Unmap only vLLM-Ascend KV-cache allocations."""
+        from vllm.platforms import current_platform
+        if current_platform.device_type != "npu":
+            logger.warning("KV-cache-only release is currently implemented only for vLLM-Ascend")
+            return
+        from vllm_ascend.device_allocator.camem import CaMemAllocator, unmap_and_release
+        allocator = CaMemAllocator.get_instance()
+        released_ptrs = getattr(self, "_verl_released_kv_cache_ptrs", set())
+        if released_ptrs:
+            logger.warning("KV cache is already released; skipping duplicate release")
+            return
+        torch.npu.synchronize()
+        free_before, total = torch.npu.mem_get_info()
+        rank = getattr(self, "rank", getattr(self, "local_rank", "unknown"))
+        device = torch.npu.current_device()
+        gib = 1024**3
+        print(
+            f"[KVCacheMemory][time={datetime.now().astimezone().isoformat(timespec='milliseconds')}]"
+            f"[release][before][rank={rank}][device={device}] "
+            f"free={free_before / gib:.2f} GiB used={(total - free_before) / gib:.2f} GiB "
+            f"total={total / gib:.2f} GiB",
+            flush=True,
+        )
+        for ptr, data in allocator.pointer_to_data.items():
+            if data.tag == "kv_cache":
+                unmap_and_release(data.handle)
+                released_ptrs.add(ptr)
+        self._verl_released_kv_cache_ptrs = released_ptrs
+        torch.npu.empty_cache()
+        torch.npu.synchronize()
+        free_after, _ = torch.npu.mem_get_info()
+        print(
+            f"[KVCacheMemory][time={datetime.now().astimezone().isoformat(timespec='milliseconds')}]"
+            f"[release][after][rank={rank}][device={device}] "
+            f"free={free_after / gib:.2f} GiB used={(total - free_after) / gib:.2f} GiB "
+            f"total={total / gib:.2f} GiB freed={(free_after - free_before) / gib:.2f} GiB "
+            f"allocations={len(released_ptrs)}",
+            flush=True,
+        )
+        logger.info("Released %d KV-cache allocations without touching weights", len(released_ptrs))
+
+
+    def resume_kv_cache(self) -> None:
+        """Remap KV-cache allocations released by release_kv_cache()."""
+        from vllm.platforms import current_platform
+        if current_platform.device_type != "npu":
+            logger.warning("KV-cache-only resume is currently implemented only for vLLM-Ascend")
+            return
+        from vllm_ascend.device_allocator.camem import CaMemAllocator, create_and_map
+        allocator = CaMemAllocator.get_instance()
+        released_ptrs = getattr(self, "_verl_released_kv_cache_ptrs", set())
+        torch.npu.synchronize()
+        free_before, total = torch.npu.mem_get_info()
+        rank = getattr(self, "rank", getattr(self, "local_rank", "unknown"))
+        device = torch.npu.current_device()
+        gib = 1024**3
+        print(
+            f"[KVCacheMemory][time={datetime.now().astimezone().isoformat(timespec='milliseconds')}]"
+            f"[resume][before][rank={rank}][device={device}] "
+            f"free={free_before / gib:.2f} GiB used={(total - free_before) / gib:.2f} GiB "
+            f"total={total / gib:.2f} GiB allocations={len(released_ptrs)}",
+            flush=True,
+        )
+        for ptr in released_ptrs:
+            data = allocator.pointer_to_data.get(ptr)
+            if data is None:
+                raise RuntimeError(f"KV-cache allocation {ptr:#x} disappeared while released")
+            create_and_map(data.handle)
+        torch.npu.synchronize()
+        free_after, _ = torch.npu.mem_get_info()
+        print(
+            f"[KVCacheMemory][time={datetime.now().astimezone().isoformat(timespec='milliseconds')}]"
+            f"[resume][after][rank={rank}][device={device}] "
+            f"free={free_after / gib:.2f} GiB used={(total - free_after) / gib:.2f} GiB "
+            f"total={total / gib:.2f} GiB restored={(free_before - free_after) / gib:.2f} GiB",
+            flush=True,
+        )
+        logger.info("Restored %d KV-cache allocations without touching weights", len(released_ptrs))
+        released_ptrs.clear()
 
 class SuppressSignalInThread:
     def __enter__(self):

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -812,15 +812,36 @@ class vLLMHttpServer:
 
     async def release_kv_cache(self):
         """Release only kv_cache GPU memory, keeping model weights intact.
-        # TODO: support true release of kv_cache
         """
         if self.node_rank != 0 or not self.config.free_cache_engine:
             return
-
+        debug_prefix = (
+            f"[vLLMHttpServer][replica={self.replica_rank}][node={self.node_rank}]"
+            f"[mode={self.rollout_mode}]"
+        )
+        print(f"{debug_prefix} release_kv_cache: releasing KV-cache allocations only", flush=True)
+        await self.engine.collective_rpc("release_kv_cache")
+        print(f"{debug_prefix} release_kv_cache: completed; weights remain on device", flush=True)
+    
     async def resume_kv_cache(self):
         """Restore kv_cache GPU memory after a weight sync. Counterpart to release_kv_cache()."""
-        if self.node_rank != 0:
+        if self.node_rank != 0 or not self.config.free_cache_engine:
             return
+        debug_prefix = (
+            f"[elease_kv_cache_replic={self.replica_rank}][node={self.node_rank}]"
+            f"[mode={self.rollout_mode}]"
+        )
+        print(f"{debug_prefix} resume_kv_cache: restoring KV-cache allocations only", flush=True)
+        await self.engine.collective_rpc("resume_kv_cache")
+        print(f"{debug_prefix} resume_kv_cache: KV cache restored; resetting prefix cache", flush=True)
+        await self.engine.reset_prefix_cache(**_RESET_PREFIX_CACHE_KWARGS)
+        if _VLLM_VERSION >= version.parse("0.9.0"):
+            print(f"{debug_prefix} resume_kv_cache: resetting multimodal cache", flush=True)
+            await self.engine.reset_mm_cache()
+        if _VLLM_VERSION >= version.parse("0.16.0"):
+            print(f"{debug_prefix} resume_kv_cache: resetting encoder cache", flush=True)
+            await self.engine.reset_encoder_cache()
+        print(f"{debug_prefix} resume_kv_cache: completed", flush=True)
 
     async def start_profile(self, **kwargs):
         if self.node_rank != 0:


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

Still WIP.

Extra memory is allocated for update_weights_bucket_megabytes in the update weights stage. The async mode omits vllm.sleep. Under constrained memory, maintaining sync-mode KV cache utilization leads to OOM, while lowering utilization impairs rollout inference throughput.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
