### PR TITLE
[trainer, ray] feat: support worker-scoped environment variables

### DIFF
--- a/tests/trainer/ppo/test_worker_env_on_cpu.py
+++ b/tests/trainer/ppo/test_worker_env_on_cpu.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.trainer.ppo.utils import get_trainer_worker_env
+
+
+def test_get_trainer_worker_env_resolves_values():
+    config = OmegaConf.create(
+        {
+            "segment_size_mb": 128,
+            "trainer": {
+                "worker_env": {
+                    "PYTORCH_CUDA_ALLOC_CONF": "large_segment_size_mb:${segment_size_mb}",
+                }
+            },
+        }
+    )
+
+    assert get_trainer_worker_env(config) == {
+        "PYTORCH_CUDA_ALLOC_CONF": "large_segment_size_mb:128",
+    }
+
+
+def test_get_trainer_worker_env_defaults_to_empty():
+    assert get_trainer_worker_env(OmegaConf.create({"trainer": {}})) == {}
+
+
+def test_get_trainer_worker_env_requires_string_values():
+    config = OmegaConf.create({"trainer": {"worker_env": {"INVALID_ENV": 128}}})
+
+    with pytest.raises(TypeError, match="must map strings to strings"):
+        get_trainer_worker_env(config)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -973,6 +973,7 @@ transfer_queue:
       local_buffer_size: 1073741824
       device_name: ''
 trainer:
+  worker_env: {}
   balance_batch: true
   total_epochs: 30
   total_training_steps: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -871,6 +871,7 @@ transfer_queue:
       local_buffer_size: 1073741824
       device_name: ''
 trainer:
+  worker_env: {}
   balance_batch: true
   total_epochs: 30
   total_training_steps: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -895,6 +895,7 @@ transfer_queue:
       local_buffer_size: 1073741824
       device_name: ''
 trainer:
+  worker_env: {}
   balance_batch: true
   total_epochs: 30
   total_training_steps: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -902,6 +902,7 @@ transfer_queue:
       local_buffer_size: 1073741824
       device_name: ''
 trainer:
+  worker_env: {}
   balance_batch: true
   total_epochs: 30
   total_training_steps: null

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -133,6 +133,9 @@ algorithm:
 # config for the trainer
 trainer:
 
+  # Environment variables applied only to training workers
+  worker_env: {}
+
   # Whether to balance batch sizes across distributed workers
   balance_batch: True
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -54,6 +54,7 @@ from verl.trainer.ppo.utils import (
     WorkerType,
     create_rl_dataset,
     create_rl_sampler,
+    get_trainer_worker_env,
     need_critic,
     need_reference_policy,
     need_reward_model,
@@ -854,6 +855,7 @@ class RayPPOTrainer:
         wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
         if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
             wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
+        wg_kwargs["worker_env"] = get_trainer_worker_env(self.config)
         if OmegaConf.select(self.config.global_profiler, "steps") is not None:
             wg_kwargs["profile_steps"] = OmegaConf.select(self.config.global_profiler, "steps")
             # Only require nsight worker options when tool is nsys

--- a/verl/trainer/ppo/utils.py
+++ b/verl/trainer/ppo/utils.py
@@ -15,13 +15,27 @@
 import warnings
 from enum import Enum
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from verl.single_controller.base import Worker
 from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.ppo.core_algos import AdvantageEstimator
 
 WorkerType = type[Worker]
+
+
+def get_trainer_worker_env(config: DictConfig) -> dict[str, str]:
+    """Return resolved environment variables scoped to training workers."""
+    worker_env = OmegaConf.select(config, "trainer.worker_env", default=None)
+    if worker_env is None:
+        return {}
+
+    resolved_env = OmegaConf.to_container(worker_env, resolve=True)
+    if not isinstance(resolved_env, dict) or not all(
+        isinstance(key, str) and isinstance(value, str) for key, value in resolved_env.items()
+    ):
+        raise TypeError("trainer.worker_env must map strings to strings")
+    return resolved_env
 
 
 class Role(Enum):

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -67,6 +67,7 @@ from verl.trainer.ppo.utils import (
     Role,
     create_rl_dataset,
     create_rl_sampler,
+    get_trainer_worker_env,
     need_critic,
     need_reference_policy,
     need_teacher_policy,
@@ -285,6 +286,7 @@ class PPOTrainer(ABC):
                     OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
                 )
         wg_kwargs["device_name"] = self.config.trainer.device
+        wg_kwargs["worker_env"] = get_trainer_worker_env(self.config)
         logger.info(f"worker group kwargs: {wg_kwargs}")
 
         for resource_pool, class_dict in self.resource_pool_to_cls.items():


### PR DESCRIPTION
### What does this PR do?

This PR adds `trainer.worker_env`, allowing environment variables to be applied specifically to Ray worker groups managed by the PPO trainer.

Both the legacy and V1 PPO trainers resolve and forward this mapping to `RayWorkerGroup(worker_env=...)`. No environment variables are enabled by default, and no example configuration is changed.

Duplicate-work search:

- https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+large_segment_size_mb
- https://github.com/verl-project/verl/issues?q=is%3Aissue+state%3Aopen+large_segment_size_mb

No open PR or issue implementing the same trainer-scoped environment interface was found.

### Motivation

We evaluated PyTorch CUDA CachingAllocator `large_segment_size_mb` in a Megatron workload with model, optimizer, and gradient offloading enabled.

Environment:

- 8 x NVIDIA B200
- PyTorch 2.11.0+cu130
- vLLM 0.22.1
- Qwen3-30B-A3B
- Megatron backend
- asynchronous vLLM rollout

| `large_segment_size_mb` | Mean `empty_cache` time at the `update_actor` offload exit | Mean peak segment count | Peak reserved memory |
|---|---:|---:|---:|
| 20 | 5.113 s | 824.0 | 89.066 GB |
| 128 | 0.916 s | 142.3 | 89.437 GB |
| 256 | 0.692 s | 98.5 | 89.408 GB |

Changing 20 to 128 reduced the measured allocator cleanup overhead by 82.1%, while released memory and peak reserved memory remained statistically equivalent. These numbers measure the `empty_cache` portion of the actor offload path, not an 82% end-to-end training speedup.

The setting can currently be supplied through the Ray job-wide runtime environment:

```bash
python3 -m verl.trainer.main_ppo \
  model_engine=megatron \
  +ray_kwargs.ray_init.runtime_env.env_vars.PYTORCH_CUDA_ALLOC_CONF="large_segment_size_mb:128" \
  ...
```

However, the job-wide environment also reaches vLLM workers. During `load_model()`, vLLM 0.22.1 temporarily applies:

```python
self._scoped_allocator_max_split(max_split_size_mb=20)
```

PyTorch requires `max_split_size_mb >= large_segment_size_mb`, so worker initialization fails with:

```text
ValueError: CachingAllocator option max_split_size_mb too small, must be >= 128
```

A trainer-scoped mapping lets users tune model workers without changing the environment of independently launched vLLM server actors.

### API and Usage Example

verl configurations are normally supplied through Hydra overrides:

```bash
python3 -m verl.trainer.main_ppo \
  model_engine=megatron \
  +trainer.worker_env.PYTORCH_CUDA_ALLOC_CONF="large_segment_size_mb:128" \
  ...
```

`trainer.worker_env` accepts arbitrary string-to-string environment mappings. OmegaConf interpolations are resolved before actor creation, and non-string keys or values are rejected because Ray runtime environment variables must be strings.

### Scope

The mapping is applied to all model worker groups created by the PPO trainer, including actor/rollout/reference fused workers, separately deployed reference-policy workers in the legacy trainer, and critic workers when enabled.

Environment variables are process-scoped, so logical roles colocated in one Ray worker process share the same environment.

It is not applied to independently created vLLM server actors, reward-loop servers, teacher-model servers, or TaskRunner/controller actors.

### Design & Code Changes

- Add an empty `trainer.worker_env` mapping to the PPO trainer configuration.
- Resolve OmegaConf interpolations and validate string keys and values.
- Forward the mapping in both legacy and V1 PPO trainers.
- Add CPU tests for empty defaults, interpolation resolution, and invalid values.
- Regenerate the flattened trainer reference configurations.

### Test

Project server environment: Python 3.12.9, PyTorch 2.11.0+cu130, Ray 2.51.1.

```text
python -m pytest -q \
  tests/trainer/ppo/test_worker_env_on_cpu.py \
  tests/single_controller/test_ray_local_envs_on_cpu.py

5 passed
```

Additional checks:

- changed-files pre-commit: all hooks passed
- `ruff check`: passed
- `ruff format --check`: passed
- `scripts/generate_trainer_config.sh`: passed
- Hydra native override parsing: passed
- Python compilation for the changed trainer modules: passed
- `git diff --check`: passed

### Checklist Before Starting

- [x] Searched for similar open PRs and issues.
- [x] PR title follows the required format.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Applied the relevant pre-commit checks.
- [x] Added CPU tests.
- [x] Regenerated trainer reference configurations.
- [x] The public field is documented inline in the canonical PPO config; no example defaults are changed.

### AI Assistance Disclosure

AI assistance was used to inspect the existing environment propagation paths, draft the implementation and tests, run validation under human direction, and prepare this PR description.

The submitter reviewed the changed lines, understands the implementation and its worker-group scope, and can defend the change end to end.