### PR TITLE
[ray] fix: remove conflicting PYTHONPATH forwarding

### DIFF
--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -118,11 +118,4 @@ def get_ppo_ray_runtime_env(config=None):
     # Always forward these at call-time, not import-time.
     for key in ("PYTHONHASHSEED", "VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT", "VERL_RL_INSIGHT_ENABLE"):
         runtime_env["env_vars"][key] = os.environ.get(key, "0")
-    # Forward PYTHONPATH to Ray workers so packages exposed only via PYTHONPATH (e.g. the
-    # Megatron-LM baked into the CI image at /workspace/Megatron-LM, which is not installed
-    # into site-packages) stay importable. Workers do not inherit the driver's PYTHONPATH when
-    # Ray is started out-of-band (e.g. `ray start --head`), so pass it through explicitly.
-    pythonpath = os.environ.get("PYTHONPATH")
-    if pythonpath:
-        runtime_env["env_vars"]["PYTHONPATH"] = pythonpath
     return runtime_env


### PR DESCRIPTION
### What does this PR do?

Removes automatic `PYTHONPATH` forwarding from `get_ppo_ray_runtime_env()`.

When a job submitted through `ray job submit --runtime-env` already defines `PYTHONPATH`, verl adds the same key again to `ray.init(runtime_env=...)`. Ray rejects the merge and training fails before initialization.

This reverts the forwarding introduced in #7101 and relies on the Ray Job runtime environment to propagate `PYTHONPATH`.

### Test

- Pre-commit checks passed for `verl/trainer/constants_ppo.py`.

### Checklist Before Starting

- [ ] Searched for similar open PRs.
- [x] PR title follows the required format.

### AI Assistance

AI assistance was used to investigate and draft this change. The submitter reviewed the final diff.