### PR TITLE
fix: add trainer.max_ckpt_to_keep to PPO config (#7295)

### DIFF
--- a/tests/trainer/test_max_ckpt_to_keep_config.py
+++ b/tests/trainer/test_max_ckpt_to_keep_config.py
@@ -1,0 +1,90 @@
+"""Tests for trainer.max_ckpt_to_keep Hydra config support (#7295).
+
+Verifies that the PPO trainer YAML accepts max_ckpt_to_keep and that
+the trainer fallback logic resolves it correctly when the per-role
+fields (max_actor_ckpt_to_keep, max_critic_ckpt_to_keep) are unset.
+"""
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def _resolve_ckpt_limits(trainer_cfg: DictConfig):
+    """Mirrors the resolution logic in ray_trainer / v1 trainer_base."""
+    remove_previous = trainer_cfg.get("remove_previous_ckpt_in_save", False)
+    max_ckpt_to_keep = trainer_cfg.get("max_ckpt_to_keep", None)
+    max_actor = (
+        (trainer_cfg.get("max_actor_ckpt_to_keep", None) or max_ckpt_to_keep)
+        if not remove_previous
+        else 1
+    )
+    max_critic = (
+        (trainer_cfg.get("max_critic_ckpt_to_keep", None) or max_ckpt_to_keep)
+        if not remove_previous
+        else 1
+    )
+    return max_actor, max_critic
+
+
+def test_max_ckpt_to_keep_applies_to_both():
+    """When only max_ckpt_to_keep is set, both actor and critic inherit it."""
+    cfg = OmegaConf.create({
+        "max_ckpt_to_keep": 3,
+        "max_actor_ckpt_to_keep": None,
+        "max_critic_ckpt_to_keep": None,
+    })
+    actor, critic = _resolve_ckpt_limits(cfg)
+    assert actor == 3
+    assert critic == 3
+
+
+def test_per_role_overrides_global():
+    """Per-role fields take priority over the global max_ckpt_to_keep."""
+    cfg = OmegaConf.create({
+        "max_ckpt_to_keep": 5,
+        "max_actor_ckpt_to_keep": 2,
+        "max_critic_ckpt_to_keep": 10,
+    })
+    actor, critic = _resolve_ckpt_limits(cfg)
+    assert actor == 2
+    assert critic == 10
+
+
+def test_all_null_means_unlimited():
+    """When nothing is set, both resolve to None (unlimited)."""
+    cfg = OmegaConf.create({
+        "max_ckpt_to_keep": None,
+        "max_actor_ckpt_to_keep": None,
+        "max_critic_ckpt_to_keep": None,
+    })
+    actor, critic = _resolve_ckpt_limits(cfg)
+    assert actor is None
+    assert critic is None
+
+
+def test_remove_previous_overrides_everything():
+    """Deprecated remove_previous_ckpt_in_save forces both to 1."""
+    cfg = OmegaConf.create({
+        "remove_previous_ckpt_in_save": True,
+        "max_ckpt_to_keep": 5,
+        "max_actor_ckpt_to_keep": 10,
+        "max_critic_ckpt_to_keep": 10,
+    })
+    actor, critic = _resolve_ckpt_limits(cfg)
+    assert actor == 1
+    assert critic == 1
+
+
+def test_ppo_yaml_has_max_ckpt_to_keep():
+    """The PPO trainer YAML must define max_ckpt_to_keep so Hydra struct mode allows it."""
+    cfg = OmegaConf.load("verl/trainer/config/ppo_trainer.yaml")
+    OmegaConf.set_struct(cfg, True)
+
+    trainer = cfg.trainer
+    assert "max_ckpt_to_keep" in trainer
+
+    # Setting the value under struct mode must not raise.
+    # Use open_dict to allow writes on a struct config.
+    from omegaconf import open_dict
+    with open_dict(cfg):
+        cfg.trainer.max_ckpt_to_keep = 2
+    assert cfg.trainer.max_ckpt_to_keep == 2

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -943,11 +943,16 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
                 "[FullyAsyncTrainer] Warning: remove_previous_ckpt_in_save is deprecated,"
                 + " set max_actor_ckpt_to_keep=1 and max_critic_ckpt_to_keep=1 instead"
             )
+        max_ckpt_to_keep = self.config.trainer.get("max_ckpt_to_keep", None)
         max_actor_ckpt_to_keep = (
-            self.config.trainer.get("max_actor_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+            (self.config.trainer.get("max_actor_ckpt_to_keep", None) or max_ckpt_to_keep)
+            if not remove_previous_ckpt_in_save
+            else 1
         )
         max_critic_ckpt_to_keep = (
-            self.config.trainer.get("max_critic_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+            (self.config.trainer.get("max_critic_ckpt_to_keep", None) or max_ckpt_to_keep)
+            if not remove_previous_ckpt_in_save
+            else 1
         )
 
         self.actor_rollout_wg.save_checkpoint(

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -997,6 +997,7 @@ trainer:
   default_hdfs_dir: null
   del_local_ckpt_after_load: false
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+  max_ckpt_to_keep: null
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
   ray_wait_register_center_timeout: 300

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -895,6 +895,7 @@ trainer:
   default_hdfs_dir: null
   del_local_ckpt_after_load: false
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+  max_ckpt_to_keep: null
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
   ray_wait_register_center_timeout: 300

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -919,6 +919,7 @@ trainer:
   default_hdfs_dir: null
   del_local_ckpt_after_load: false
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+  max_ckpt_to_keep: null
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
   ray_wait_register_center_timeout: 300

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -926,6 +926,7 @@ trainer:
   default_hdfs_dir: null
   del_local_ckpt_after_load: false
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+  max_ckpt_to_keep: null
   max_actor_ckpt_to_keep: null
   max_critic_ckpt_to_keep: null
   ray_wait_register_center_timeout: 300

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -206,6 +206,10 @@ trainer:
   # Default local directory for saving checkpoints
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
 
+  # Maximum number of checkpoints to keep (applies to both actor and critic when
+  # max_actor_ckpt_to_keep / max_critic_ckpt_to_keep are not set)
+  max_ckpt_to_keep: null
+
   # Maximum number of actor checkpoints to keep
   max_actor_ckpt_to_keep: null
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1003,11 +1003,16 @@ class RayPPOTrainer:
                 "Warning: remove_previous_ckpt_in_save is deprecated,"
                 + " set max_actor_ckpt_to_keep=1 and max_critic_ckpt_to_keep=1 instead"
             )
+        max_ckpt_to_keep = self.config.trainer.get("max_ckpt_to_keep", None)
         max_actor_ckpt_to_keep = (
-            self.config.trainer.get("max_actor_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+            (self.config.trainer.get("max_actor_ckpt_to_keep", None) or max_ckpt_to_keep)
+            if not remove_previous_ckpt_in_save
+            else 1
         )
         max_critic_ckpt_to_keep = (
-            self.config.trainer.get("max_critic_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+            (self.config.trainer.get("max_critic_ckpt_to_keep", None) or max_ckpt_to_keep)
+            if not remove_previous_ckpt_in_save
+            else 1
         )
 
         self.actor_rollout_wg.save_checkpoint(

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -898,11 +898,16 @@ class PPOTrainer(ABC):
                 "remove_previous_ckpt_in_save is deprecated, "
                 "set max_actor_ckpt_to_keep=1 and max_critic_ckpt_to_keep=1 instead"
             )
+        max_ckpt_to_keep = self.config.trainer.get("max_ckpt_to_keep", None)
         max_actor_ckpt_to_keep = (
-            self.config.trainer.get("max_actor_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+            (self.config.trainer.get("max_actor_ckpt_to_keep", None) or max_ckpt_to_keep)
+            if not remove_previous_ckpt_in_save
+            else 1
         )
         max_critic_ckpt_to_keep = (
-            self.config.trainer.get("max_critic_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+            (self.config.trainer.get("max_critic_ckpt_to_keep", None) or max_ckpt_to_keep)
+            if not remove_previous_ckpt_in_save
+            else 1
         )
 
         # save actor


### PR DESCRIPTION
## Summary

Fixes #7295 — `trainer.max_ckpt_to_keep` cannot be set on PPO training runs because the key does not exist in the PPO YAML config, causing a Hydra struct-mode error.

Supersedes #7301 (closed due to unsigned CLA, now signed).

## Root Cause

The PPO trainer YAML (`ppo_trainer.yaml`) defines `max_actor_ckpt_to_keep` and `max_critic_ckpt_to_keep` but **not** `max_ckpt_to_keep`. The SFT YAML already has `max_ckpt_to_keep`.

When Hydra struct mode is enabled (`OmegaConf.set_struct(config, True)` — called in `ray_trainer.py:444`, `v1/trainer_base.py:724`, `fully_async_trainer.py:360`), any attempt to override a key that doesn't exist in the YAML is rejected:

```
Could not override 'trainer.max_ckpt_to_keep'.
To append to your config use +trainer.max_ckpt_to_keep=2
Key 'max_ckpt_to_keep' is not in struct
    full_key: trainer.max_ckpt_to_keep
    object_type=dict
```

This is confusing because:
- The SFT trainer supports `max_ckpt_to_keep`
- Shell scripts in the repo use `trainer.max_ckpt_to_keep` (e.g., `run_nemotron_nano_v3_megatron.sh`)
- Users expect a single knob to limit all checkpoints

## Fix

### YAML config — add the key

Added `max_ckpt_to_keep: null` to:
- `verl/trainer/config/ppo_trainer.yaml`
- `verl/trainer/config/_generated_ppo_trainer.yaml`
- `verl/trainer/config/_generated_ppo_megatron_trainer.yaml`
- `verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml`
- `verl/trainer/config/_generated_ppo_veomni_trainer.yaml`

### Trainer code — add fallback logic

Updated checkpoint-limit resolution in 3 trainer files to use `max_ckpt_to_keep` as a fallback when the per-role fields are null:

```python
# Before:
max_actor_ckpt_to_keep = self.config.trainer.get("max_actor_ckpt_to_keep", None)

# After:
max_ckpt_to_keep = self.config.trainer.get("max_ckpt_to_keep", None)
max_actor_ckpt_to_keep = (
    (self.config.trainer.get("max_actor_ckpt_to_keep", None) or max_ckpt_to_keep)
    if not remove_previous_ckpt_in_save
    else 1
)
```

**Priority order**: `max_actor_ckpt_to_keep` > `max_ckpt_to_keep` > unlimited (None)

Note: OmegaConf's `.get()` returns `None` when a key exists with value `null` (ignoring the default), so `or max_ckpt_to_keep` is used instead of relying on the default parameter.

### Files Changed

- `verl/trainer/config/ppo_trainer.yaml` — added field + comment
- `verl/trainer/config/_generated_ppo_*.yaml` (4 files) — added field
- `verl/trainer/ppo/ray_trainer.py` — fallback logic
- `verl/trainer/ppo/v1/trainer_base.py` — fallback logic
- `verl/experimental/fully_async_policy/fully_async_trainer.py` — fallback logic

## Tests

5 tests in `tests/trainer/test_max_ckpt_to_keep_config.py`:

| Test | What it verifies |
|------|-----------------|
| `test_max_ckpt_to_keep_applies_to_both` | Global value applies to both actor and critic when per-role fields are null |
| `test_per_role_overrides_global` | `max_actor_ckpt_to_keep=2` takes priority over `max_ckpt_to_keep=5` |
| `test_all_null_means_unlimited` | All null = no checkpoint rotation (backwards compatible) |
| `test_remove_previous_overrides_everything` | Deprecated `remove_previous_ckpt_in_save` still forces both to 1 |
| `test_ppo_yaml_has_max_ckpt_to_keep` | PPO YAML passes Hydra struct-mode validation (the exact error from the issue) |

```
tests/trainer/test_max_ckpt_to_keep_config.py: 5 passed
```