### PR TITLE
[ckpt] fix: align packed tensor offsets to dtype itemsize for mixed-dtype streams

### DIFF
--- a/tests/checkpoint_engine/test_packing_alignment_on_cpu.py
+++ b/tests/checkpoint_engine/test_packing_alignment_on_cpu.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Amazon.com Inc and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bucket-packing alignment for mixed-dtype weight streams (CPU-only).
+
+The checkpoint-engine wire packs tensors back-to-back into a uint8 bucket and
+the receive path reinterprets each single-chunk slice with
+``Tensor.view(dtype)``, which torch only allows when the slice starts at a
+multiple of the dtype's element size. A homogeneous stream keeps that
+invariant for free; a mixed-dtype stream does not (for example an odd-numel
+bf16 tensor followed by an fp32 tensor). ``align_bucket_offset`` restores the
+invariant at pack time.
+
+These tests pin the helper's math, drive a pack simulation that mirrors the
+senders' loop structure (align, overflow check, flush, place) through the
+real receive-side ``merge_weight_chunks`` across bucket sizes that force
+flushes and multi-chunk continuation, keep a control showing the pre-fix
+back-to-back layout is rejected at the view call, and assert at the source
+level that every engine's send loop calls the helper.
+"""
+
+import asyncio
+import pathlib
+import re
+
+import pytest
+import torch
+
+from verl.checkpoint_engine.base import TensorMeta, align_bucket_offset, merge_weight_chunks, split_weight_chunks
+
+
+@pytest.mark.parametrize(
+    ("offset", "dtype", "expected"),
+    [
+        (0, torch.float32, 0),  # bucket start is aligned for every dtype
+        (6, torch.float32, 8),  # the motivating case: odd-numel bf16 tail
+        (8, torch.float32, 8),  # already aligned: no-op
+        (1, torch.uint8, 1),  # itemsize 1 never pads
+        (2, torch.bfloat16, 2),
+        (3, torch.bfloat16, 4),
+        (9, torch.int64, 16),
+        (17, torch.complex128, 32),  # largest itemsize torch ships
+    ],
+)
+def test_align_bucket_offset_math(offset, dtype, expected):
+    assert align_bucket_offset(offset, dtype) == expected
+
+
+def _mixed_dtype_inventory() -> list[tuple[str, torch.Tensor]]:
+    """A stream shaped like the failure case: odd byte counts before wider dtypes."""
+    generator = torch.Generator().manual_seed(1234)
+    return [
+        ("norm.weight", torch.randn(3, generator=generator).to(torch.bfloat16)),  # 6 bytes: breaks fp32 alignment
+        ("router.weight", torch.randn(4, 4, generator=generator)),  # fp32
+        ("flags", torch.randint(0, 2, (5,), generator=generator, dtype=torch.uint8)),  # odd length
+        ("step", torch.randint(0, 100, (3,), generator=generator, dtype=torch.int64)),
+        ("proj.weight", torch.randn(7, 3, generator=generator).to(torch.bfloat16)),
+        ("big.weight", torch.randn(200, generator=generator)),  # 800 bytes: multi-chunk at small buckets
+        ("tail.weight", torch.randn(3, generator=generator).to(torch.bfloat16)),  # packs after the bucket cut
+    ]
+
+
+async def _pack(inventory, aligned: bool, bucket_size: int):
+    """Pack through the real ``split_weight_chunks``, mirroring the senders' loop.
+
+    The engines' send loops share one structure: (optionally) align the
+    offset, flush the bucket when the next chunk does not fit, place the
+    chunk, advance. This simulation reproduces that structure over sealed
+    CPU buckets; ``aligned=False`` reproduces the pre-fix back-to-back
+    layout. It does not drive the NCCL/zmq transport itself; the engines'
+    loops are additionally pinned by ``test_every_engine_send_loop_aligns``.
+    """
+    buckets: list[tuple[torch.Tensor, list[TensorMeta]]] = []
+    bucket = torch.zeros(bucket_size, dtype=torch.uint8)
+    metas: list[TensorMeta] = []
+    offset = 0
+
+    def _gen():
+        yield from inventory
+
+    async for tensor_meta, chunk in split_weight_chunks(_gen(), bucket_size):
+        chunk = chunk.contiguous()
+        if aligned:
+            offset = align_bucket_offset(offset, tensor_meta.dtype)
+        if offset + tensor_meta.chunk_size > bucket_size:
+            buckets.append((bucket, metas))
+            bucket = torch.zeros(bucket_size, dtype=torch.uint8)
+            metas = []
+            offset = 0
+        tensor_meta.offset = offset
+        bucket[offset : offset + tensor_meta.chunk_size] = chunk
+        metas.append(tensor_meta)
+        offset += tensor_meta.chunk_size
+    buckets.append((bucket, metas))
+    return buckets
+
+
+async def _receive(buckets, bucket_size: int):
+    """Drive the real receive-side merge over slices at the packed offsets."""
+
+    async def chunks():
+        for bucket, metas in buckets:
+            for meta in metas:
+                yield meta, bucket[meta.offset : meta.offset + meta.chunk_size]
+
+    received = []
+    async for name, weight in merge_weight_chunks(chunks(), bucket_size):
+        received.append((name, weight))
+    return received
+
+
+async def _round_trip(inventory, aligned: bool, bucket_size: int):
+    buckets = await _pack(inventory, aligned=aligned, bucket_size=bucket_size)
+    return buckets, await _receive(buckets, bucket_size)
+
+
+# 1 MiB: everything single-chunk, no flush. 512/300: flushes between tensors.
+# 257: odd bucket size with flushes. 256: exact fill by big.weight's chunks
+# plus multi-chunk continuation for every bucket size below 800 bytes.
+# 70/101: alignment padding itself forces a flush (offset aligned past what
+# the bucket can hold), pinning the align-before-overflow-check ordering:
+# with the align applied after the check instead, placement overruns the
+# bucket and the copy raises.
+@pytest.mark.parametrize("bucket_size", [70, 101, 256, 257, 300, 512, 1 << 20])
+def test_aligned_mixed_stream_round_trips_bit_exact(bucket_size):
+    inventory = _mixed_dtype_inventory()
+    buckets, received = asyncio.run(_round_trip(inventory, aligned=True, bucket_size=bucket_size))
+    for _, metas in buckets:
+        for meta in metas:
+            if meta.chunk_offset == 0:  # tensor start; continuation chunks are raw byte copies
+                assert meta.offset % meta.dtype.itemsize == 0
+    assert [name for name, _ in received] == [name for name, _ in inventory]
+    for (_, sent), (_, got) in zip(inventory, received, strict=True):
+        assert got.dtype == sent.dtype and got.shape == sent.shape
+        assert torch.equal(
+            got.contiguous().view(-1).view(torch.uint8),
+            sent.contiguous().view(-1).view(torch.uint8),
+        )
+
+
+def test_unaligned_mixed_stream_rejected_at_view():
+    """Control: the pre-fix back-to-back layout fails at the receive-side view.
+
+    Pins the bug mechanism (torch refuses a dtype view at a storage offset
+    that the element size does not divide) and proves the round-trip test
+    can fail.
+    """
+    inventory = _mixed_dtype_inventory()
+    with pytest.raises(RuntimeError, match="divisible"):
+        asyncio.run(_round_trip(inventory, aligned=False, bucket_size=1 << 20))
+
+
+# 64 bytes forces flushes between the 30-byte tensors; 1 MiB is the no-flush case.
+@pytest.mark.parametrize("bucket_size", [64, 1 << 20])
+def test_aligned_homogeneous_stream_layout_unchanged(bucket_size):
+    """On a single-dtype stream the fix is a byte-for-byte no-op: same bucket
+    count, same offsets bucket by bucket, same bucket bytes."""
+    generator = torch.Generator().manual_seed(99)
+    inventory = [(f"w{i}", torch.randn(5, 3, generator=generator).to(torch.bfloat16)) for i in range(4)]
+    aligned_buckets = asyncio.run(_pack(inventory, aligned=True, bucket_size=bucket_size))
+    packed_buckets = asyncio.run(_pack(inventory, aligned=False, bucket_size=bucket_size))
+    assert len(aligned_buckets) == len(packed_buckets)
+    for (a_bucket, a_metas), (p_bucket, p_metas) in zip(aligned_buckets, packed_buckets, strict=True):
+        assert [m.offset for m in a_metas] == [m.offset for m in p_metas]
+        assert torch.equal(a_bucket, p_bucket)
+
+
+def test_every_engine_send_loop_aligns():
+    """Source-level guard: every send loop that packs a running offset aligns it.
+
+    The affected loops (nccl, hccl, nixl today) require live transports, so
+    this pins their call sites the way tests/special_sanity pins API usage.
+    The file list is derived from the loop's signature line rather than
+    hardcoded, so an engine added later with the same packing structure is
+    checked automatically. Engines without the signature (mooncake casts to
+    the rollout dtype before packing; kimi takes offsets from the external
+    checkpoint-engine package) are out of scope by construction.
+    """
+    engine_dir = pathlib.Path(__file__).resolve().parents[2] / "verl" / "checkpoint_engine"
+    packing_engines = sorted(f.name for f in engine_dir.glob("*.py") if "tensor_meta.offset = offset" in f.read_text())
+    assert packing_engines, "no packing loops found; the signature line moved and this guard needs updating"
+    for engine in packing_engines:
+        source = (engine_dir / engine).read_text()
+        assert re.search(
+            r"^\s*offset = align_bucket_offset\(offset, tensor_meta\.dtype\)$", source, flags=re.MULTILINE
+        ), f"{engine}: packing loop no longer aligns offsets; mixed-dtype streams will crash the receiver"

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -538,6 +538,21 @@ class CheckpointEngineManager:
         return sync_metrics
 
 
+def align_bucket_offset(offset: int, dtype: torch.dtype) -> int:
+    """Round ``offset`` up to the next multiple of ``dtype``'s itemsize.
+
+    Bucket packing places tensors back-to-back in a uint8 buffer and records
+    each start in ``TensorMeta.offset``. The receive path reinterprets each
+    single-chunk slice with ``Tensor.view(dtype)``, which requires the slice's
+    storage offset to be a multiple of the element size. Aligning each
+    tensor's start keeps mixed-dtype streams viewable. On a homogeneous
+    stream, every tensor's byte length is a multiple of its own element size,
+    so this is a no-op and the wire layout is unchanged.
+    """
+    itemsize = dtype.itemsize
+    return (offset + itemsize - 1) // itemsize * itemsize
+
+
 async def split_weight_chunks(
     weights: Generator[tuple[str, torch.Tensor], None, None], bucket_size: int
 ) -> AsyncGenerator[tuple[TensorMeta, torch.Tensor], None]:

--- a/verl/checkpoint_engine/hccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/hccl_checkpoint_engine.py
@@ -27,6 +27,7 @@ from verl.checkpoint_engine.base import (
     CheckpointEngine,
     CheckpointEngineRegistry,
     TensorMeta,
+    align_bucket_offset,
     merge_weight_chunks,
     split_weight_chunks,
 )
@@ -262,6 +263,8 @@ class HCCLCheckpointEngine(CheckpointEngine):
         bucket_meta: dict[str, TensorMeta] = {}
         offset = 0
         async for tensor_meta, chunk in split_weight_chunks(weights, self.bucket_size):
+            # start each tensor at an offset its dtype can be viewed at (mixed-dtype streams)
+            offset = align_bucket_offset(offset, tensor_meta.dtype)
             # fill the tensor bucket
             if offset + tensor_meta.chunk_size > self.bucket_size:
                 torch.npu.synchronize()

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -31,6 +31,7 @@ from verl.checkpoint_engine.base import (
     CheckpointEngine,
     CheckpointEngineRegistry,
     TensorMeta,
+    align_bucket_offset,
     merge_weight_chunks,
     split_weight_chunks,
 )
@@ -253,6 +254,8 @@ class NCCLCheckpointEngine(CheckpointEngine):
         bucket_meta: dict[str, TensorMeta] = {}
         offset = 0
         async for tensor_meta, chunk in split_weight_chunks(weights, self.bucket_size):
+            # start each tensor at an offset its dtype can be viewed at (mixed-dtype streams)
+            offset = align_bucket_offset(offset, tensor_meta.dtype)
             # fill the tensor bucket
             if offset + tensor_meta.chunk_size > self.bucket_size:
                 torch.cuda.synchronize()

--- a/verl/checkpoint_engine/nixl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nixl_checkpoint_engine.py
@@ -35,6 +35,7 @@ from verl.checkpoint_engine.base import (
     CheckpointEngine,
     CheckpointEngineRegistry,
     TensorMeta,
+    align_bucket_offset,
     merge_weight_chunks,
     split_weight_chunks,
 )
@@ -395,6 +396,8 @@ class NIXLCheckpointEngine(CheckpointEngine):
         bucket_meta: dict[str, TensorMeta] = {}
         offset = 0
         async for tensor_meta, chunk in split_weight_chunks(weights, self.bucket_size):
+            # start each tensor at an offset its dtype can be viewed at (mixed-dtype streams)
+            offset = align_bucket_offset(offset, tensor_meta.dtype)
             # fill the tensor bucket
             if offset + tensor_meta.chunk_size > self.bucket_size:
                 torch.cuda.synchronize()


### PR DESCRIPTION
### What does this PR do?

Fixes a latent crash in the checkpoint-engine wire for mixed-dtype weight streams.

The `nccl`/`hccl`/`nixl` checkpoint engines pack tensors back-to-back into a uint8 bucket and record each start in `TensorMeta.offset`. On receive, each single-chunk tensor is materialized with `Tensor.view(dtype)` on a slice of the bucket, and torch requires that slice's storage offset to be a multiple of the dtype's element size. A homogeneous stream keeps that invariant for free (every tensor's byte length is a multiple of its own element size), which is why today's bf16-only exports never hit it. A mixed-dtype stream breaks it: an odd-numel bf16 tensor (6 bytes) followed by an fp32 tensor puts the fp32 start at `offset % 4 == 2`, and the receiver raises at the view. The fix lives in the engines rather than a backend because the wire should not crash on any legal stream, whichever of FSDP, Megatron or veomni produces it.

The fix is sender-side only: a shared `align_bucket_offset` helper rounds each tensor's bucket offset up to its dtype's itemsize at pack time. The receiver already slices strictly by the recorded offsets, so no receive-path change is needed, and homogeneous streams produce a byte-identical wire layout to before (the alignment is a no-op there). On mixed streams the cost is bounded padding, at most itemsize minus one bytes ahead of a tensor whose start would otherwise misalign; pad gaps are never read.

This is worth fixing now rather than when it fires:

- The open #7165 restores Hugging Face's fp32-keep contract (under the default bf16 policy, the `_keep_in_fp32_modules_strict` declarations); once it lands, models with strict fp32-keep modules export mixed bf16+fp32 streams down the default FSDP2 path.
- Quantized weight refit produces mixed streams by construction: the in-tree QAT export (`verl/utils/qat/quantizer.py`, wired into `get_per_tensor_param` behind the QAT config) already yields packed narrow weights alongside their scales and bf16 passthrough tensors, and the very large models discussed in [discussion 7273](https://github.com/verl-project/verl/discussions/7273) push the same `(weight, scale)` shape through whichever engine carries them.

#7263, our open checkpoint-engine PR, notes this residual case in its text; its 16-byte rounding fixes the bucket-cut variant in the engine it adds, and this PR fixes the per-tensor packing case shared by the existing engines.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+itemsize
  - https://github.com/verl-project/verl/issues?q=misaligned+OR+misalignment
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+%22storage+offset%22
  - Closest prior art: #6919 fixed the sibling crash class (non-contiguous inputs to the uint8 view) in the colocated vLLM bucketed path; #7107 (open) changes bucket length metadata in `verl/checkpoint_engine/nccl_checkpoint_engine.py` and rebases cleanly against this in either order (verified by applying its diff onto this branch).
- [x] Format the PR title as `[{modules}] {type}: {description}`
  - `[ckpt] fix: align packed tensor offsets to dtype itemsize for mixed-dtype streams`

### Reproduction

On a machine with two GPUs at main, drive the stock engine with a stream that puts an odd-numel bf16 tensor immediately ahead of an fp32 tensor; the crash needs the running byte offset in front of a tensor to not be a multiple of its element size, so what matters is the total byte length of everything packed before it. The receiver crashes at the view:

```python
# repro_mixed_dtype.py: drive NCCLCheckpointEngine with a mixed-dtype inventory.
# Runs on one node with 2 GPUs. Exit 0 = transfer completed and every received
# tensor compared bit-equal; nonzero = the receiver raised (prints the error).
import asyncio
import sys

import ray
import torch


@ray.remote(num_gpus=1)
class Sender:
    def __init__(self, bucket_mb: int):
        from verl.checkpoint_engine.nccl_checkpoint_engine import NCCLCheckpointEngine

        self.engine = NCCLCheckpointEngine(bucket_size=bucket_mb << 20, is_master=True)
        self.meta = self.engine.prepare()

    def metadata(self):
        return {"zmq_ip": self.meta.zmq_ip, "zmq_port": self.meta.zmq_port}

    def init_group(self, world_size: int):
        self.engine.init_process_group(rank=0, world_size=world_size, master_metadata=self.meta)

    def send(self):
        def inventory():
            g = torch.Generator().manual_seed(7)
            # odd-numel bf16 (6 bytes) ahead of fp32: the misalignment trigger
            yield "norm.weight", torch.randn(3, generator=g).to(torch.bfloat16).cuda()
            yield "router.weight", torch.randn(64, 64, generator=g).cuda()  # fp32
            yield "proj.weight", torch.randn(4096, 512, generator=g).to(torch.bfloat16).cuda()
            yield "step", torch.arange(3, dtype=torch.int64).cuda()

        asyncio.run(self.engine.send_weights(inventory()))
        return True


@ray.remote(num_gpus=1)
class Receiver:
    def __init__(self, bucket_mb: int):
        from verl.checkpoint_engine.nccl_checkpoint_engine import NCCLCheckpointEngine

        self.engine = NCCLCheckpointEngine(bucket_size=bucket_mb << 20, is_master=False)
        self.engine.prepare()

    def init_group(self, world_size: int, master_metadata: dict):
        from verl.checkpoint_engine.nccl_checkpoint_engine import MasterMetadata

        self.engine.init_process_group(
            rank=1, world_size=world_size, master_metadata=MasterMetadata(**master_metadata)
        )

    def receive_and_check(self):
        async def run():
            received = {}
            async for name, tensor in self.engine.receive_weights():
                received[name] = tensor.clone()
            return received

        received = asyncio.run(run())
        g = torch.Generator().manual_seed(7)
        expected = {
            "norm.weight": torch.randn(3, generator=g).to(torch.bfloat16),
            "router.weight": torch.randn(64, 64, generator=g),
            "proj.weight": torch.randn(4096, 512, generator=g).to(torch.bfloat16),
            "step": torch.arange(3, dtype=torch.int64),
        }
        for name, exp in expected.items():
            got = received[name].cpu()
            assert got.dtype == exp.dtype and got.shape == exp.shape, name
            assert torch.equal(got.view(torch.uint8).view(-1), exp.view(torch.uint8).view(-1)), name
        return sorted(received)


def main():
    ray.init(num_gpus=2)
    try:
        sender = Sender.remote(bucket_mb=128)
        receiver = Receiver.remote(bucket_mb=128)
        meta = ray.get(sender.metadata.remote())
        ray.get([sender.init_group.remote(2), receiver.init_group.remote(2, meta)])
        send_ref = sender.send.remote()
        names = ray.get(receiver.receive_and_check.remote())
        ray.get(send_ref)
        print(f"OK: transfer completed, {len(names)} tensors bit-equal: {names}")
        return 0
    finally:
        ray.shutdown()


if __name__ == "__main__":
    sys.exit(main())
```

```
ray.exceptions.RayTaskError(RuntimeError): ray::Receiver.receive_and_check()
  File ".../repro_mixed_dtype.py", line 57, in run
    async for name, tensor in self.engine.receive_weights():
  File ".../verl/checkpoint_engine/nccl_checkpoint_engine.py", line 318, in receive_weights
    async for name, weight in merge_weight_chunks(self._receive_weight_chunks(), self.bucket_size):
  File ".../verl/checkpoint_engine/base.py", line 604, in merge_weight_chunks
    name, weight = tensor_meta.name, chunk.view(tensor_meta.dtype).view(tensor_meta.shape)
RuntimeError: self.storage_offset() must be divisible by 4 to view Byte as Float (different element sizes), but got 6
```

With this PR applied, the same run completes: `OK: transfer completed, 4 tensors bit-equal: ['norm.weight', 'proj.weight', 'router.weight', 'step']`.

### Test

CPU lane (no GPU; runs in `cpu_unit_tests`):

```bash
pytest tests/checkpoint_engine/test_packing_alignment_on_cpu.py -q
```

- `align_bucket_offset` math across dtypes (uint8 through complex128, no-op when aligned, no-op at bucket start).
- A mixed-dtype inventory driven through the real `split_weight_chunks` and receive-side `merge_weight_chunks`, with a pack simulation mirroring the senders' loop, round-trips bit-exactly across bucket sizes that force flushes, exact bucket fills, multi-chunk continuation, and flushes triggered by the alignment padding itself (70/101/256/257/300/512 bytes and 1 MiB), with every tensor-start offset checked against its itemsize.
- Control: the same inventory packed back-to-back (the pre-fix layout) is rejected at the view call with the divisibility error, proving the round-trip test can fail.
- A homogeneous bf16 stream produces identical bucket counts, offsets and bucket bytes with and without the fix, at flush-forcing and single-bucket sizes (wire layout unchanged for all current users).
- A source-level guard asserts every engine's packing loop calls the helper, since the engines' send loops need live transports and cannot run in this lane.

Results: `19 passed in 14.67s` (CPU, inside the training image used for the runs below).

GPU regression check (stock engine unaffected on the homogeneous path):

```bash
pytest tests/checkpoint_engine/test_correctness_on_gpu.py -q
```

Results: `test_nccl_checkpoint_engine` ran in both `rebuild_group` parametrizations on one 8-GPU B200 node (2 trainer + 6 rollout workers, 3 update rounds each, weight comparison on) with the model path overridden to a locally staged Qwen2.5-0.5B-Instruct; both passed. The file's nixl and NPU cases are upstream-skipped and did not run.

End-to-end A/B (same recipe, same injected mixed-dtype stream, only this fix differs):

| arm | tree | result |
|---|---|---|
| A (stock) | main @ 474c2f4 + inject shim | crashed at the first weight sync with `RuntimeError: self.storage_offset() must be divisible by 4 to view Byte as Float (different element sizes), but got 6` at `merge_weight_chunks` (`base.py:604`); the job's single automatic restart also failed and the job finished FAILED |
| B (fixed) | main @ 474c2f4 + inject shim + this PR | completed all 5 steps; weight syncs 3.3-4.3 s; job finished SUCCEEDED |

The injection shim is an env-gated test hook (identical commit in both arms) that prepends one odd-numel bf16 tensor and one fp32 tensor to the export stream, emulating the stream shape #7165 and quantized refit will produce. Each arm ran the same GRPO one-step-off recipe on two 8-GPU B200 nodes (one trainer node, one rollout node), Qwen3.5-27B bf16, rollout TP=4, 2048 MB buckets, 5 training steps, identical seeds.

Validation scope: nccl engine end-to-end + backend-independent CPU tests of the shared pack/merge path; the hccl and nixl senders carry the same alignment call (hccl is exercised by the NPU CI lane). The mooncake engine casts to the rollout dtype before packing and the kimi engine takes its offsets from the external checkpoint-engine package, so neither packs mixed-dtype buckets this way.

### Additional Info

- The colocated vLLM update path (`verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py`) has the same back-to-back packing and we are happy to bring the same fix there as a follow-up.
- Sequencing with #7263: that PR (in review) adds a fourth engine with its own packing loop and publicly flagged this issue in its text; once both are in-tree it adopts the same alignment call in its loop as a follow-through.
- AI disclosure: this fix was developed with AI assistance (Claude, via internal agent tooling). All changes were human-reviewed and the branch was reviewed internally before submission; the commit carries a `Co-authored-by: Claude` trailer per AGENTS.md.

### API and Usage Example

No API, CLI or config change; behavior is identical for homogeneous-dtype streams.

### Design & Code Changes

- `verl/checkpoint_engine/base.py`: new `align_bucket_offset(offset, dtype)` helper next to the packing utilities.
- `verl/checkpoint_engine/nccl_checkpoint_engine.py`, `hccl_checkpoint_engine.py`, `nixl_checkpoint_engine.py`: one alignment call at the top of each send loop, before the bucket-overflow check.
- `tests/checkpoint_engine/test_packing_alignment_on_cpu.py`: new CPU-lane tests described above.
