### PR TITLE
[megatron] fix: make MTP work with recompute_granularity=full on megatron-core 0.18.x

### DIFF
--- a/tests/models/test_mtp_checkpointed_forward_shim_on_cpu.py
+++ b/tests/models/test_mtp_checkpointed_forward_shim_on_cpu.py
@@ -1,0 +1,114 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for the MTP ``_checkpointed_forward`` compatibility shim.
+
+Covers the three megatron-core signature generations that ``mtp_patch`` has to cope with:
+
+* ``0.14``-``0.17``: ``_checkpointed_forward(forward_func, *args, **kwargs)``
+  -> verl's slime-derived recompute patch applies, no shim.
+* ``0.18.x``: ``_checkpointed_forward(hidden_states, decoder_input, ..., no padding_mask)``
+  while ``MultiTokenPredictionLayer.forward`` passes ``padding_mask=...``
+  -> hard ``TypeError`` without the shim (NVIDIA/Megatron-LM#4933).
+* megatron-core ``main``: signature already declares ``padding_mask`` -> no shim.
+
+These run on CPU. The shim only inspects and rebinds ``layer._checkpointed_forward``, so
+stand-in objects with the right signatures are enough -- no model, no GPU, no distributed init.
+``mtp_patch`` itself imports megatron.core at module scope, hence the ``importorskip``.
+"""
+
+import pytest
+
+# ``mtp_patch`` imports megatron.core at module scope; skip rather than fail where it is absent.
+pytest.importorskip("megatron.core", reason="mtp_patch requires megatron-core at import time")
+
+from verl.models.mcore.mtp_patch import _patch_padding_mask_kwarg  # noqa: E402
+
+
+class _LayerOldApi:
+    """megatron-core 0.14-0.17: first parameter is a callable."""
+
+    def _checkpointed_forward(self, forward_func, *args, **kwargs):
+        return ("old", forward_func, args, kwargs)
+
+
+class _Layer018:
+    """megatron-core 0.18.x: tensors passed directly, ``padding_mask`` **not** declared."""
+
+    def _checkpointed_forward(self, hidden_states, decoder_input, attention_mask=None, context=None):
+        return ("0.18", hidden_states, decoder_input, attention_mask, context)
+
+
+class _LayerMain:
+    """megatron-core main: ``padding_mask`` is declared, so nothing to shim."""
+
+    def _checkpointed_forward(self, hidden_states, decoder_input, attention_mask=None, padding_mask=None, context=None):
+        return ("main", hidden_states, decoder_input, attention_mask, padding_mask, context)
+
+
+def _bound_params(layer):
+    from inspect import signature
+
+    return list(signature(layer._checkpointed_forward).parameters)
+
+
+def test_shim_not_installed_when_padding_mask_already_supported():
+    layer = _LayerMain()
+    before = layer._checkpointed_forward
+    assert _patch_padding_mask_kwarg(layer, _bound_params(layer)) is False
+    assert layer._checkpointed_forward is before, "must not rebind when megatron already accepts it"
+    # and the real kwarg still reaches the method
+    assert layer._checkpointed_forward(1, 2, padding_mask="pm")[4] == "pm"
+
+
+def test_shim_installed_on_0_18_and_accepts_padding_mask_none():
+    """Without the shim this raises TypeError -- that is the bug users hit."""
+    layer = _Layer018()
+    with pytest.raises(TypeError, match="padding_mask"):
+        layer._checkpointed_forward(1, 2, padding_mask=None)
+
+    assert _patch_padding_mask_kwarg(layer, _bound_params(layer)) is True
+    out = layer._checkpointed_forward(1, 2, attention_mask="am", padding_mask=None)
+    assert out == ("0.18", 1, 2, "am", None), "original args must still be forwarded unchanged"
+
+
+def test_shim_raises_instead_of_silently_dropping_a_real_mask():
+    """A non-None mask means padded positions must be excluded; dropping it would be silent
+    corruption (padding treated as real tokens), so fail loudly instead."""
+    layer = _Layer018()
+    _patch_padding_mask_kwarg(layer, _bound_params(layer))
+    with pytest.raises(NotImplementedError, match="padding_mask"):
+        layer._checkpointed_forward(1, 2, padding_mask=object())
+
+
+def test_old_api_is_left_for_the_slime_recompute_patch():
+    """params[0] == 'forward_func' is handled by the existing patch, not by this shim."""
+    layer = _LayerOldApi()
+    params = _bound_params(layer)
+    assert params[0] == "forward_func"
+    # the caller only reaches the shim when params[0] != "forward_func", but assert the shim
+    # itself is a no-op here too, so an ordering change upstream cannot double-patch.
+    assert _patch_padding_mask_kwarg(layer, params) is True  # signature lacks padding_mask
+    # ...and forwarding still works through the shim
+    sentinel = object()
+    assert layer._checkpointed_forward(sentinel)[1] is sentinel
+
+
+def test_shim_is_idempotent_per_layer():
+    layer = _Layer018()
+    assert _patch_padding_mask_kwarg(layer, _bound_params(layer)) is True
+    after_first = layer._checkpointed_forward
+    # second call sees the shim's own signature, which does declare padding_mask
+    assert _patch_padding_mask_kwarg(layer, _bound_params(layer)) is False
+    assert layer._checkpointed_forward is after_first

--- a/tests/models/test_mtp_checkpointed_forward_shim_on_cpu.py
+++ b/tests/models/test_mtp_checkpointed_forward_shim_on_cpu.py
@@ -65,9 +65,12 @@ def _bound_params(layer):
 
 def test_shim_not_installed_when_padding_mask_already_supported():
     layer = _LayerMain()
-    before = layer._checkpointed_forward
     assert _patch_padding_mask_kwarg(layer, _bound_params(layer)) is False
-    assert layer._checkpointed_forward is before, "must not rebind when megatron already accepts it"
+    # The shim rebinds by assigning an *instance* attribute, so "was not rebound" means no such
+    # attribute exists. Comparing the accessed method with `is` would not work here: attribute
+    # access on an un-rebound method builds a fresh bound-method object every time, so the
+    # identity check fails even when nothing was patched.
+    assert "_checkpointed_forward" not in vars(layer), "must not rebind when megatron already accepts it"
     # and the real kwarg still reaches the method
     assert layer._checkpointed_forward(1, 2, padding_mask="pm")[4] == "pm"
 

--- a/verl/models/mcore/mtp_patch.py
+++ b/verl/models/mcore/mtp_patch.py
@@ -268,6 +268,51 @@ def patch_mtp_layer_get_embeddings(model: torch.nn.Module):
         return False
 
 
+def _patch_padding_mask_kwarg(layer, params: list) -> bool:
+    """Make MTP + ``recompute_granularity='full'`` usable on megatron-core 0.18.x.
+
+    megatron-core 0.18.x is internally inconsistent: ``MultiTokenPredictionLayer.forward``
+    calls ``self._checkpointed_forward(..., padding_mask=padding_mask)`` while
+    ``_checkpointed_forward`` itself does not declare ``padding_mask``, so **any** MTP run with
+    ``recompute_granularity == 'full'`` raises::
+
+        TypeError: MultiTokenPredictionLayer._checkpointed_forward() got an unexpected
+                   keyword argument 'padding_mask'
+
+    Introduced by two landings that do not compose (NVIDIA/Megatron-LM#2645 added the call-site
+    kwarg, #4593 refactored the method without it) and tracked upstream as
+    NVIDIA/Megatron-LM#4933. Fixed on megatron-core ``main``, but ``core_v0.18.2`` -- tagged
+    two months after that issue was filed and still the newest release -- ships the bug, so
+    every released megatron-core is affected. A backport is proposed as
+    NVIDIA/Megatron-LM#6367; once a release carries it, this shim becomes dead code and the
+    signature check below will skip it automatically.
+
+    ``padding_mask`` is dropped rather than forwarded: the method has no parameter to forward it
+    to on these versions, and verl never constructs one, so it is always ``None`` in practice.
+    A non-``None`` value would mean padded positions must be excluded, and silently ignoring it
+    would treat padding as real tokens -- so raise instead of guessing.
+
+    Returns True if a shim was installed on this layer.
+    """
+    if "padding_mask" in params:
+        return False  # megatron-core main and later: nothing to do
+
+    orig = layer._checkpointed_forward
+
+    def _checkpointed_forward_accepting_padding_mask(*args, padding_mask=None, **kwargs):
+        if padding_mask is not None:
+            raise NotImplementedError(
+                "megatron-core's MultiTokenPredictionLayer._checkpointed_forward does not accept "
+                "padding_mask on this version (see NVIDIA/Megatron-LM#4933), and dropping a "
+                "non-None mask would treat padded positions as real tokens. Upgrade "
+                "megatron-core, or disable full activation recomputation for MTP."
+            )
+        return orig(*args, **kwargs)
+
+    layer._checkpointed_forward = _checkpointed_forward_accepting_padding_mask
+    return True
+
+
 def patch_mtp_layer_checkpointed_forward(model: torch.nn.Module):
     """Patch the _checkpointed_forward method of MultiTokenPredictionLayer"""
     from megatron.core.models.gpt.gpt_model import GPTModel
@@ -292,6 +337,8 @@ def patch_mtp_layer_checkpointed_forward(model: torch.nn.Module):
 
     if target_layers:
         patched_count = 0
+        skipped_signature = 0
+        needs_padding_mask_shim = 0
         for layer in target_layers:
             if hasattr(layer, "_checkpointed_forward_backup"):
                 continue
@@ -300,12 +347,34 @@ def patch_mtp_layer_checkpointed_forward(model: torch.nn.Module):
             except (TypeError, ValueError):
                 params = ["forward_func"]
             if not params or params[0] != "forward_func":
+                # megatron-core >= 0.18 changed the signature from
+                # ``_checkpointed_forward(forward_func, *args, **kwargs)`` to
+                # ``_checkpointed_forward(hidden_states, decoder_input, ...)`` and moved the
+                # "keep non-tensor args out of the checkpoint" handling into its own
+                # ``custom_forward`` closure, so the patch below is neither applicable nor
+                # needed there. Skipping is correct -- but do it visibly: silently doing
+                # nothing here makes it impossible to tell whether the patch took effect.
+                skipped_signature += 1
+                if _patch_padding_mask_kwarg(layer, params):
+                    needs_padding_mask_shim += 1
                 continue
             layer._checkpointed_forward_backup = layer._checkpointed_forward
             layer._checkpointed_forward = _patched_checkpointed_forward.__get__(layer, layer.__class__)
             patched_count += 1
         if patched_count:
             print(f"Found and patched checkpointed forward for {patched_count} MTP layer(s)")
+        if skipped_signature:
+            print(
+                f"Skipped checkpointed-forward patch for {skipped_signature} MTP layer(s): "
+                "megatron-core >= 0.18 handles non-tensor checkpoint args natively "
+                "(MultiTokenPredictionLayer._checkpointed_forward no longer takes forward_func)."
+            )
+        if needs_padding_mask_shim:
+            print(
+                f"Applied padding_mask compatibility shim to {needs_padding_mask_shim} MTP layer(s) "
+                "(megatron-core 0.18.x passes padding_mask into _checkpointed_forward but the "
+                "method does not accept it; see NVIDIA/Megatron-LM#4933)."
+            )
         return patched_count > 0
     else:
         print("No MTP layers found to patch checkpointed forward")


### PR DESCRIPTION
## What does this PR do?

Makes Multi-Token Prediction usable together with `recompute_granularity='full'` on every
released megatron-core, and makes the existing signature-based branch in
`patch_mtp_layer_checkpointed_forward` visible instead of silent.

### The bug

megatron-core 0.18.x is internally inconsistent: `MultiTokenPredictionLayer.forward` calls

```python
self._checkpointed_forward(..., padding_mask=padding_mask, ...)
```

while `_checkpointed_forward` itself does not declare `padding_mask`. Any MTP run with
`recompute_granularity == 'full'` dies at the first forward:

```
TypeError: MultiTokenPredictionLayer._checkpointed_forward() got an unexpected
           keyword argument 'padding_mask'
```

Upstream cause: two landings that do not compose — NVIDIA/Megatron-LM#2645 added the call-site
kwarg, #4593 refactored the method without it. Tracked as NVIDIA/Megatron-LM#4933, still open.

It is fixed on megatron-core `main`, but `core_v0.18.2` was tagged 2026-07-20 — two months after
that issue was filed — and is still the newest release, so **every released megatron-core hits
this**. I have proposed a backport as NVIDIA/Megatron-LM#6367; until a release carries it, verl
users cannot combine MTP with full activation recomputation without patching megatron themselves.

### Why the existing patch does not cover it

`patch_mtp_layer_checkpointed_forward` skips any layer whose `_checkpointed_forward` does not
start with `forward_func`. That gate matches megatron-core 0.14–0.17 only; 0.18+ renamed the
first parameter to `hidden_states`, so on every 0.18+ install the patch silently does nothing —
when `target_layers` is non-empty but `patched_count == 0`, neither log line is printed, so there
is no way to tell whether it applied.

Skipping is in fact **correct** on 0.18+: megatron now keeps non-tensor args out of the
checkpoint natively, via its own `custom_forward` closure. But it should say so rather than be
inferred from missing output.

## Changes

* `_patch_padding_mask_kwarg()` — when the layer's `_checkpointed_forward` lacks `padding_mask`,
  rebind it to accept and drop the kwarg. `padding_mask` is dropped rather than forwarded because
  there is no parameter to forward it to on these versions, and verl never constructs one, so it
  is always `None` in practice. A non-`None` value raises `NotImplementedError` rather than being
  silently ignored — ignoring it would treat padded positions as real tokens. Idempotent per
  layer (after installation the shim's own signature declares `padding_mask`, so a second call is
  a no-op).
* `patch_mtp_layer_checkpointed_forward()` — log the skip-by-signature and shim counts.

Style follows the existing precedent a few lines above in the same file, which already probes
`signature(self.mtp.forward)` for `padding_mask` before passing it.

Once a megatron-core release carries #6367, the signature check makes this shim skip itself
automatically, and it can be deleted.

## Not a duplicate

Searched verl issues and PRs for `patch_mtp_layer_checkpointed_forward`,
`mtp_patch checkpointed_forward`, `forward_func signature mtp` — no hits. The `forward_func` gate
is still present on `main` (`verl/models/mcore/mtp_patch.py`), so nothing has superseded this.

## Test

`tests/models/test_mtp_checkpointed_forward_shim_on_cpu.py` — 5 CPU cases, no GPU, no distributed
init, covering all three megatron-core signature generations:

```
pytest tests/models/test_mtp_checkpointed_forward_shim_on_cpu.py -q
```

* megatron-core `main` signature (declares `padding_mask`) → shim not installed, kwarg still
  reaches the method
* 0.18.x signature → reproduces the bare `TypeError` first, then asserts the shim accepts
  `padding_mask=None` and forwards the remaining args unchanged
* non-`None` mask → `NotImplementedError` instead of silent corruption
* 0.14–0.17 `forward_func` signature → left to the existing recompute patch
* shim is idempotent

All 5 pass locally.

Also exercised end to end on 4x8 H20 with Qwen3.6-35B-A3B (MoE, 40 layers, 256 experts),
TP2/PP2/CP4/EP8, 64K context, `mtp_num_layers=1`, `recompute_granularity='full'`, megatron-core
0.18.2 + torch 2.11: without the shim training aborts at the first forward with the `TypeError`
above; with it, MTP trains and `mtp_losses/*` is reported normally (30 steps, loss 0.447 → 0.318).

AI assistance (Claude) was used for the investigation and to draft the patch and tests; the diff
was reviewed line by line before submitting.
