### PR TITLE
[vllm] fix: resolve .base_layer on the vLLM receiver for non-merged LoRA sync

### DIFF
--- a/tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py
+++ b/tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py
@@ -47,9 +47,7 @@ class TestReinforcePPMultiTurn:
         expanded_mask = torch.tensor([[1.0, 1.0, 0.0, 0.0, 1.0, 1.0]])
         expanded_rewards = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
 
-        _, compact_returns = compute_reinforce_plus_plus_outcome_advantage(
-            compact_rewards, compact_mask, config=config
-        )
+        _, compact_returns = compute_reinforce_plus_plus_outcome_advantage(compact_rewards, compact_mask, config=config)
         _, expanded_returns = compute_reinforce_plus_plus_outcome_advantage(
             expanded_rewards, expanded_mask, config=config
         )
@@ -111,14 +109,18 @@ class TestReinforcePPMultiTurn:
     def test_batch_dimension(self):
         """Verify correct behavior across a batch of sequences."""
         config = _config(gamma=1.0)
-        mask = torch.tensor([
-            [1.0, 0.0, 1.0, 1.0],  # observation at position 1
-            [1.0, 1.0, 1.0, 0.0],  # padding at position 3
-        ])
-        rewards = torch.tensor([
-            [0.0, 0.0, 0.0, 1.0],
-            [0.0, 0.0, 1.0, 0.0],
-        ])
+        mask = torch.tensor(
+            [
+                [1.0, 0.0, 1.0, 1.0],  # observation at position 1
+                [1.0, 1.0, 1.0, 0.0],  # padding at position 3
+            ]
+        )
+        rewards = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ]
+        )
 
         _, returns = compute_reinforce_plus_plus_outcome_advantage(rewards, mask, config=config)
 

--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -147,7 +147,9 @@ def _receiver_fn(zmq_handle, use_shm, result_queue):
         use_shm=use_shm,
     )
     received = []
-    receiver.receive_weights(on_bucket_received=lambda w: received.extend([(name, t.clone()) for name, t in w]))
+    receiver.receive_weights(
+        on_bucket_received=lambda w, is_last: received.extend([(name, t.clone()) for name, t in w])
+    )
     # Only send lightweight metadata + checksum back through the queue
     summaries = [(name, t.dtype, tuple(t.shape), t.float().sum().item()) for name, t in received]
     result_queue.put(summaries)

--- a/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
+++ b/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
@@ -57,16 +57,15 @@ def _load_vllm_rollout_utils():
     fake_vllm = types.ModuleType("vllm")
     fake_vllm.outputs = fake_outputs
 
-    # Simulate a newer vLLM where ``BaseLayerWithLoRA`` defines ``load_weights``
-    # (delegating to ``AutoWeightsLoader(self.base_layer)`` and thus expecting
-    # inner names without ``.base_layer.``). The resolver probes this at import
-    # time via ``"load_weights" in BaseLayerWithLoRA.__dict__``, so the stub
-    # chain must be importable as ``vllm.lora.layers.base``.
+    # Stub ``vllm.lora.layers.base.BaseLayerWithLoRA`` WITHOUT ``load_weights`` --
+    # the module-level probe (``"load_weights" in BaseLayerWithLoRA.__dict__``)
+    # then falls to False, matching released vLLM. Tests that exercise the
+    # newer-vLLM path monkeypatch ``_HAS_LORA_LOAD_WEIGHTS`` so both branches
+    # are covered.
     fake_lora_base = types.ModuleType("vllm.lora.layers.base")
 
     class _FakeBaseLayerWithLoRA:
-        def load_weights(self, weights):
-            return iter(())
+        pass
 
     fake_lora_base.BaseLayerWithLoRA = _FakeBaseLayerWithLoRA
     fake_lora_layers = types.ModuleType("vllm.lora.layers")
@@ -239,10 +238,11 @@ def test_vision_merger_base_layer_is_stripped():
 # ---------------------------------------------------------------------------
 
 
-def test_lora_wrapped_base_layer_gets_stripped():
+def test_lora_wrapped_base_layer_gets_stripped(monkeypatch):
     """A LoRA-wrapped leaf with .base_layer is stripped: vLLM's
     BaseLayerWithLoRA.load_weights delegates to AutoWeightsLoader(base_layer)
     which expects the inner name (no base_layer. prefix)."""
+    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel(
         {
             "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
@@ -254,10 +254,11 @@ def test_lora_wrapped_base_layer_gets_stripped():
     assert _resolve(worker, model, name) == ("language_model.model.layers.0.self_attn.q_proj.weight")
 
 
-def test_missing_base_layer_not_added_on_newer_vllm():
+def test_missing_base_layer_not_added_on_newer_vllm(monkeypatch):
     """On newer vLLM, incoming without .base_layer is NOT suffixed --
     BaseLayerWithLoRA.load_weights delegates to AutoWeightsLoader(base_layer)
     expecting inner names."""
+    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel(
         {
             "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
@@ -266,6 +267,36 @@ def test_missing_base_layer_not_added_on_newer_vllm():
     worker = _make_worker(model)
 
     name = "language_model.model.layers.0.self_attn.q_proj.weight"
+    assert _resolve(worker, model, name) == name
+
+
+def test_missing_base_layer_is_added_on_released_vllm():
+    """On released vLLM (no BaseLayerWithLoRA.load_weights), an incoming leaf
+    without ``.base_layer`` is suffixed so the model's load_weights recurses
+    into the ``base_layer`` child and matches the real param."""
+    model = _FakeModel(
+        {
+            "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    name = "language_model.model.layers.0.self_attn.q_proj.weight"
+    assert _resolve(worker, model, name) == ("language_model.model.layers.0.self_attn.q_proj.base_layer.weight")
+
+
+def test_suffixed_leaf_is_kept_on_released_vllm():
+    """On released vLLM, an incoming ``.base_layer.`` leaf is kept as-is
+    (the loader recurses and matches the suffixed param -- the strip is gated
+    off when the model has ``.base_layer`` params and the version is old)."""
+    model = _FakeModel(
+        {
+            "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    name = "language_model.model.layers.0.self_attn.q_proj.base_layer.weight"
     assert _resolve(worker, model, name) == name
 
 
@@ -340,9 +371,10 @@ def test_unpacked_proj_exists_via_packed_owner():
     assert _resolve(worker, model, incoming) == incoming
 
 
-def test_stacked_gdn_in_proj_not_double_mapped():
+def test_stacked_gdn_in_proj_not_double_mapped(monkeypatch):
     """GDN ``in_proj_qkv`` is NOT suffixed with ``.base_layer`` on newer vLLM --
     the name stays unmapped so vLLM's mapper stacks it cleanly."""
+    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
     mapper = _FakeMapper({".in_proj_qkv.": ".in_proj_qkvz."})
     model = _FakeModel(
         {"language_model.model.layers.0.linear_attn.in_proj_qkvz.base_layer.weight": torch.empty(0)},
@@ -360,10 +392,11 @@ def test_stacked_gdn_in_proj_not_double_mapped():
     )
 
 
-def test_shared_expert_packed_owner_no_base_layer_on_newer_vllm():
+def test_shared_expert_packed_owner_no_base_layer_on_newer_vllm(monkeypatch):
     """On newer vLLM, shared expert gate_proj.weight is NOT suffixed with
     .base_layer -- vLLM's mapper stacks gate_proj -> gate_up_proj and
     BaseLayerWithLoRA.load_weights handles the inner name."""
+    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
     mapper = _FakeMapper({".shared_expert.gate_proj.": ".shared_expert.gate_up_proj."})
     model = _FakeModel(
         {"language_model.model.layers.0.mlp.shared_expert.gate_up_proj.base_layer.weight": torch.empty(0)},
@@ -412,8 +445,9 @@ def test_already_matching_name_is_noop():
     )
 
 
-def test_truly_unknown_name_strips_base_layer():
+def test_truly_unknown_name_strips_base_layer(monkeypatch):
     """Even unknown names have ``.base_layer.`` stripped on newer vLLM."""
+    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel({"a.base_layer.weight": torch.empty(0)})
     worker = _make_worker(model)
 
@@ -436,7 +470,12 @@ def test_drafter_drops_base_layer_wholesale():
 # ---------------------------------------------------------------------------
 
 
-def test_update_weights_resolves_names_before_load():
+def test_update_weights_resolves_names_before_load(monkeypatch):
+    # LoRA base-sync phase (peft_config set, base_sync_done=False): the vLLM model
+    # is LoRA-wrapped (has ``.base_layer``), so the resolver reconciles incoming
+    # names against it. (``peft_config=None`` is the non-LoRA / merge path where the
+    # model is never wrapped and the resolver is skipped -- it can't reach here.)
+    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel(
         {
             "merger.linear_fc1.weight": torch.empty(0),

--- a/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
+++ b/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
@@ -450,7 +450,7 @@ def test_update_weights_resolves_names_before_load():
         ("language_model.model.layers.0.self_attn.q_proj.base_layer.weight", torch.empty(0)),
     ]
 
-    worker._update_weights(weights, peft_config=None, base_sync_done=False)
+    worker._update_weights(weights, peft_config={"r": 1}, base_sync_done=False)
 
     assert model.loaded == [
         "merger.linear_fc1.weight",

--- a/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
+++ b/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
@@ -107,12 +107,31 @@ def _load_vllm_rollout_utils():
     fake_platform = types.ModuleType("verl.plugin.platform")
     fake_platform.get_platform = lambda: None
 
+    # Minimal stubs for the heavyweight vllm.lora.* imports pulled in by
+    # ``verl/utils/vllm/utils.py`` (which also defines ``resolve_weight_name``).
+    # Only the symbols touched at import time need to exist.
+    fake_lora_request = types.ModuleType("vllm.lora.request")
+    fake_lora_request.LoRARequest = type("LoRARequest", (), {})
+    fake_lora_utils = types.ModuleType("vllm.lora.utils")
+    fake_lora_utils.get_adapter_absolute_path = lambda p: p
+    fake_lora_worker_manager = types.ModuleType("vllm.lora.worker_manager")
+    fake_lora_worker_manager.LRUCacheWorkerLoRAManager = type("LRUCacheWorkerLoRAManager", (), {})
+    fake_lora_model = types.ModuleType("vllm.lora.lora_model")
+    fake_lora_model.LoRAModel = type("LoRAModel", (), {})
+    fake_lora_models = types.ModuleType("vllm.lora.models")
+    fake_lora_models.LoRAModel = type("LoRAModel", (), {})
+
     fakes = {
         "vllm": fake_vllm,
         "vllm.outputs": fake_outputs,
         "vllm.lora": fake_lora,
         "vllm.lora.layers": fake_lora_layers,
         "vllm.lora.layers.base": fake_lora_base,
+        "vllm.lora.request": fake_lora_request,
+        "vllm.lora.utils": fake_lora_utils,
+        "vllm.lora.worker_manager": fake_lora_worker_manager,
+        "vllm.lora.lora_model": fake_lora_model,
+        "vllm.lora.models": fake_lora_models,
         "verl.third_party.vllm": fake_vllm_third_party,
         "verl.utils.vllm": fake_vllm_utils,
         "verl.utils.vllm.patch": fake_vllm_patch,
@@ -124,10 +143,23 @@ def _load_vllm_rollout_utils():
     saved = {name: sys.modules.get(name) for name in fakes}
     try:
         sys.modules.update(fakes)
+        # Load the real ``verl/utils/vllm/utils.py`` under the stubbed deps so
+        # ``vllm_rollout/utils.py``'s ``from verl.utils.vllm import resolve_weight_name``
+        # resolves to the genuine function (with its module-level ``_HAS_LORA_LOAD_WEIGHTS``
+        # probe falling to False since the stub ``BaseLayerWithLoRA`` has no load_weights).
+        utils_path = _REPO_ROOT / "verl/utils/vllm/utils.py"
+        utils_spec = importlib.util.spec_from_file_location("verl.utils.vllm.utils_real", utils_path)
+        utils_module = importlib.util.module_from_spec(utils_spec)
+        assert utils_spec is not None and utils_spec.loader is not None
+        utils_spec.loader.exec_module(utils_module)
+        fake_vllm_utils.resolve_weight_name = utils_module.resolve_weight_name
+        fake_vllm_utils._HAS_LORA_LOAD_WEIGHTS = utils_module._HAS_LORA_LOAD_WEIGHTS
+
         spec = importlib.util.spec_from_file_location(module_name, module_path)
         module = importlib.util.module_from_spec(spec)
         assert spec is not None and spec.loader is not None
         spec.loader.exec_module(module)
+        module._vllm_utils_real = utils_module
     finally:
         for name, prev in saved.items():
             if prev is None:
@@ -140,6 +172,11 @@ def _load_vllm_rollout_utils():
 _weight_update_utils = _load_weight_update_utils()
 _vllm_rollout_utils = _load_vllm_rollout_utils()
 vLLMColocateWorkerExtension = _vllm_rollout_utils.vLLMColocateWorkerExtension
+# The real ``verl/utils/vllm/utils.py`` module hosting ``resolve_weight_name``
+# (loaded under stubbed deps); monkeypatch its ``_HAS_LORA_LOAD_WEIGHTS`` to flip
+# the vLLM-version branch under test.
+_vllm_utils_real = _vllm_rollout_utils._vllm_utils_real
+resolve_weight_name = _vllm_utils_real.resolve_weight_name
 
 
 class _FakeMapper:
@@ -200,9 +237,10 @@ def _make_worker(model):
 
 
 def _resolve(worker, model, name):
+    del worker  # resolve_weight_name is a pure function (no worker state)
     names = {n for n, _ in model.named_parameters(remove_duplicate=False)}
     names.update(n for n, _ in model.named_buffers())
-    return worker._resolve_weight_name(model, name, names)
+    return resolve_weight_name(model, name, names)
 
 
 def _mapped(worker, model, name):
@@ -242,7 +280,7 @@ def test_lora_wrapped_base_layer_gets_stripped(monkeypatch):
     """A LoRA-wrapped leaf with .base_layer is stripped: vLLM's
     BaseLayerWithLoRA.load_weights delegates to AutoWeightsLoader(base_layer)
     which expects the inner name (no base_layer. prefix)."""
-    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
+    monkeypatch.setattr(_vllm_utils_real, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel(
         {
             "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
@@ -258,7 +296,7 @@ def test_missing_base_layer_not_added_on_newer_vllm(monkeypatch):
     """On newer vLLM, incoming without .base_layer is NOT suffixed --
     BaseLayerWithLoRA.load_weights delegates to AutoWeightsLoader(base_layer)
     expecting inner names."""
-    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
+    monkeypatch.setattr(_vllm_utils_real, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel(
         {
             "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
@@ -374,7 +412,7 @@ def test_unpacked_proj_exists_via_packed_owner():
 def test_stacked_gdn_in_proj_not_double_mapped(monkeypatch):
     """GDN ``in_proj_qkv`` is NOT suffixed with ``.base_layer`` on newer vLLM --
     the name stays unmapped so vLLM's mapper stacks it cleanly."""
-    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
+    monkeypatch.setattr(_vllm_utils_real, "_HAS_LORA_LOAD_WEIGHTS", True)
     mapper = _FakeMapper({".in_proj_qkv.": ".in_proj_qkvz."})
     model = _FakeModel(
         {"language_model.model.layers.0.linear_attn.in_proj_qkvz.base_layer.weight": torch.empty(0)},
@@ -396,7 +434,7 @@ def test_shared_expert_packed_owner_no_base_layer_on_newer_vllm(monkeypatch):
     """On newer vLLM, shared expert gate_proj.weight is NOT suffixed with
     .base_layer -- vLLM's mapper stacks gate_proj -> gate_up_proj and
     BaseLayerWithLoRA.load_weights handles the inner name."""
-    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
+    monkeypatch.setattr(_vllm_utils_real, "_HAS_LORA_LOAD_WEIGHTS", True)
     mapper = _FakeMapper({".shared_expert.gate_proj.": ".shared_expert.gate_up_proj."})
     model = _FakeModel(
         {"language_model.model.layers.0.mlp.shared_expert.gate_up_proj.base_layer.weight": torch.empty(0)},
@@ -447,7 +485,7 @@ def test_already_matching_name_is_noop():
 
 def test_truly_unknown_name_strips_base_layer(monkeypatch):
     """Even unknown names have ``.base_layer.`` stripped on newer vLLM."""
-    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
+    monkeypatch.setattr(_vllm_utils_real, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel({"a.base_layer.weight": torch.empty(0)})
     worker = _make_worker(model)
 
@@ -475,7 +513,7 @@ def test_update_weights_resolves_names_before_load(monkeypatch):
     # is LoRA-wrapped (has ``.base_layer``), so the resolver reconciles incoming
     # names against it. (``peft_config=None`` is the non-LoRA / merge path where the
     # model is never wrapped and the resolver is skipped -- it can't reach here.)
-    monkeypatch.setattr(_vllm_rollout_utils, "_HAS_LORA_LOAD_WEIGHTS", True)
+    monkeypatch.setattr(_vllm_utils_real, "_HAS_LORA_LOAD_WEIGHTS", True)
     model = _FakeModel(
         {
             "merger.linear_fc1.weight": torch.empty(0),

--- a/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
+++ b/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
@@ -1,0 +1,558 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for the receiver-side weight-name normalization in
+``vLLMColocateWorkerExtension``.
+
+Covers the regression that motivated reverting PR #5599: with LoRA enabled, vLLM
+wraps *every* linear layer (exposing base weights under ``.base_layer``), while
+Megatron only LoRA-wraps the user's target_modules and exports plain names for
+the rest (e.g. the Qwen3.5-VL vision merger ``merger.linear_fc1``). The receiver
+reconciles each name against the live vLLM namespace rather than a hard-coded
+list. Imports *only* from ``verl.workers.rollout.vllm_rollout.utils`` (deps
+stubbed) to prove the receiver is decoupled from ``megatron_peft_utils``.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_weight_update_utils():
+    module_path = _REPO_ROOT / "verl/workers/rollout/vllm_rollout/weight_update_utils.py"
+    spec = importlib.util.spec_from_file_location("weight_update_utils", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_vllm_rollout_utils():
+    """Load ``vllm_rollout/utils.py`` with heavyweight deps stubbed (no GPU/vLLM needed)."""
+    module_name = "verl.workers.rollout.vllm_rollout.utils"
+    module_path = _REPO_ROOT / "verl/workers/rollout/vllm_rollout/utils.py"
+
+    fake_outputs = types.ModuleType("vllm.outputs")
+
+    class _FakeRequestOutput:
+        pass
+
+    fake_outputs.RequestOutput = _FakeRequestOutput
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.outputs = fake_outputs
+
+    fake_vllm_third_party = types.ModuleType("verl.third_party.vllm")
+    fake_vllm_third_party.VLLM_SLEEP_LEVEL = 1
+    fake_vllm_third_party.get_version = lambda pkg: "0.8.0"
+
+    fake_vllm_utils = types.ModuleType("verl.utils.vllm")
+
+    class _FakeTensorLoRARequest:
+        def __init__(self, *args, **kwargs):
+            self.lora_name = kwargs.get("lora_name")
+            self.lora_int_id = kwargs.get("lora_int_id")
+            self.lora_path = kwargs.get("lora_path")
+            self.peft_config = kwargs.get("peft_config")
+            self.lora_tensors = kwargs.get("lora_tensors")
+
+    class _FakeVLLMHijack:
+        @staticmethod
+        def hijack():
+            return None
+
+    fake_vllm_utils.TensorLoRARequest = _FakeTensorLoRARequest
+    fake_vllm_utils.VLLMHijack = _FakeVLLMHijack
+
+    fake_vllm_patch = types.ModuleType("verl.utils.vllm.patch")
+    fake_vllm_patch.patch_vllm_moe_model_weight_loader = lambda model: None
+
+    fake_vllm_quant = types.ModuleType("verl.utils.vllm.vllm_quant_utils")
+    fake_vllm_quant.apply_vllm_quant_patches = lambda: None
+    fake_vllm_quant.is_fp8_model = lambda config: False
+    fake_vllm_quant.load_quanted_weights = lambda *a, **k: []
+
+    fake_platform = types.ModuleType("verl.plugin.platform")
+    fake_platform.get_platform = lambda: None
+
+    fakes = {
+        "vllm": fake_vllm,
+        "vllm.outputs": fake_outputs,
+        "verl.third_party.vllm": fake_vllm_third_party,
+        "verl.utils.vllm": fake_vllm_utils,
+        "verl.utils.vllm.patch": fake_vllm_patch,
+        "verl.utils.vllm.vllm_quant_utils": fake_vllm_quant,
+        "verl.plugin.platform": fake_platform,
+        "verl.workers.rollout.vllm_rollout.weight_update_utils": _weight_update_utils,
+    }
+
+    saved = {name: sys.modules.get(name) for name in fakes}
+    try:
+        sys.modules.update(fakes)
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec is not None and spec.loader is not None
+        spec.loader.exec_module(module)
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+    return module
+
+
+_weight_update_utils = _load_weight_update_utils()
+_vllm_rollout_utils = _load_vllm_rollout_utils()
+vLLMColocateWorkerExtension = _vllm_rollout_utils.vLLMColocateWorkerExtension
+
+
+class _FakeMapper:
+    """Minimal stand-in for vLLM ``WeightsMapper``.
+
+    Mimics substring-based ``orig_to_new_substr`` / ``orig_to_new_stacked``
+    mapping: each key is a substring that is replaced (once) in the name. This
+    matches how the real mapper rewrites names like ``in_proj_qkv`` ->
+    ``in_proj_qkvz`` regardless of the trailing ``.weight`` / ``.base_layer``.
+    """
+
+    def __init__(self, mapping: dict[str, str]):
+        self.mapping = mapping
+
+    def apply_list(self, names: list[str]) -> list[str]:
+        out = []
+        for name in names:
+            mapped = name
+            for substr, new in self.mapping.items():
+                if substr in mapped:
+                    mapped = mapped.replace(substr, new, 1)
+            out.append(mapped)
+        return out
+
+
+class _FakeModel:
+    """A fake vLLM model exposing only the introspection surface the resolver uses."""
+
+    def __init__(self, params: dict[str, torch.Tensor], *, mapper=None, packed=None):
+        # name -> tensor (for named_parameters / named_buffers)
+        self._params = dict(params)
+        self.hf_to_vllm_mapper = mapper
+        self.packed_modules_mapping = packed
+
+    def named_parameters(self, remove_duplicate: bool = False):
+        del remove_duplicate
+        yield from self._params.items()
+
+    def named_buffers(self):
+        return iter(())
+
+    def load_weights(self, weights):
+        # Record resolved names for assertions.
+        self.loaded = [name for name, _ in weights]
+
+
+class _FakeVllmConfig:
+    def __init__(self, speculative_config=None, quant_config=None):
+        self.speculative_config = speculative_config
+        self.quant_config = quant_config
+        self.model_config = types.SimpleNamespace()
+
+
+def _make_worker(model):
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = types.SimpleNamespace(model=model, vllm_config=_FakeVllmConfig(), drafter=None)
+    return worker
+
+
+def _resolve(worker, model, name):
+    names = {n for n, _ in model.named_parameters(remove_duplicate=False)}
+    names.update(n for n, _ in model.named_buffers())
+    return worker._resolve_weight_name(model, name, names)
+
+
+def _mapped(worker, model, name):
+    mapper = getattr(model, "hf_to_vllm_mapper", None)
+    if mapper is None:
+        return name
+    out = mapper.apply_list([name])
+    return out[0] if out else name
+
+
+# ---------------------------------------------------------------------------
+# The exact nohup.out failure: vision merger leaf param with .base_layer must
+# resolve to the unwrapped name.
+# ---------------------------------------------------------------------------
+
+
+def test_vision_merger_base_layer_is_stripped():
+    """Qwen3.5-VL ``merger.linear_fc1.base_layer.weight`` -> ``merger.linear_fc1.weight``."""
+    model = _FakeModel(
+        {
+            "merger.linear_fc1.weight": torch.empty(0),
+            "merger.linear_fc1.bias": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    assert _resolve(worker, model, "merger.linear_fc1.base_layer.weight") == "merger.linear_fc1.weight"
+    assert _resolve(worker, model, "merger.linear_fc1.base_layer.bias") == "merger.linear_fc1.bias"
+
+
+# ---------------------------------------------------------------------------
+# LoRA-wrapped language params KEEP .base_layer (the suffix is real there).
+# ---------------------------------------------------------------------------
+
+
+def test_lora_wrapped_base_layer_is_preserved():
+    """A language proj that exists with .base_layer is returned unchanged."""
+    model = _FakeModel(
+        {
+            "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    name = "language_model.model.layers.0.self_attn.q_proj.base_layer.weight"
+    assert _resolve(worker, model, name) == name
+
+
+def test_missing_base_layer_is_added_for_leaf():
+    """If the incoming name lacks .base_layer but the wrapped form exists, add it."""
+    model = _FakeModel(
+        {
+            "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    assert (
+        _resolve(worker, model, "language_model.model.layers.0.self_attn.q_proj.weight")
+        == "language_model.model.layers.0.self_attn.q_proj.base_layer.weight"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-leaf fused-MoE expert alias: strip Bridge-inserted .base_layer.
+# ---------------------------------------------------------------------------
+
+
+def test_expert_alias_base_layer_gets_stripped():
+    """``experts.base_layer.gate_up_proj`` (non-leaf) -> ``experts.gate_up_proj`` when that exists."""
+    model = _FakeModel(
+        {
+            "language_model.model.layers.0.mlp.experts.gate_up_proj": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    name = "language_model.model.layers.0.mlp.experts.base_layer.gate_up_proj"
+    assert _resolve(worker, model, name) == "language_model.model.layers.0.mlp.experts.gate_up_proj"
+
+
+def test_packed_routed_expert_alias_routed_through_base_layer():
+    """Qwen3.5 routed experts: Bridge exports packed ``experts.gate_up_proj``
+    (non-leaf). vLLM's LoRA-wrapped MoE (``FusedMoE3DWithLoRA``) has no
+    ``load_weights``, so AutoWeightsLoader can't dispatch it -- route it under
+    ``experts.base_layer.gate_up_proj`` so the loader recurses into ``base_layer``
+    (MoERunner.load_weights -> routed_experts.load_weights). The ``lora_base_layer_prefix``
+    clear (see patch_vllm_moe_model_weight_loader) then makes the mapping resolve."""
+    model = _FakeModel(
+        {
+            "language_model.model.layers.0.mlp.experts.base_layer.routed_experts.w13_weight": torch.empty(0),
+            "language_model.model.layers.0.mlp.experts.base_layer.routed_experts.w2_weight": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    incoming = "language_model.model.layers.0.mlp.experts.gate_up_proj"
+    assert _resolve(worker, model, incoming) == ("language_model.model.layers.0.mlp.experts.base_layer.gate_up_proj")
+    assert _resolve(worker, model, "language_model.model.layers.0.mlp.experts.down_proj") == (
+        "language_model.model.layers.0.mlp.experts.base_layer.down_proj"
+    )
+
+
+def test_packed_routed_expert_alias_not_routed_without_lora():
+    """Without a LoRA experts.base_layer, packed aliases stay unchanged
+    (AutoWeightsLoader dispatches directly to the MoERunner)."""
+    model = _FakeModel({"language_model.model.layers.0.mlp.experts.gate_up_proj": torch.empty(0)})
+    worker = _make_worker(model)
+
+    incoming = "language_model.model.layers.0.mlp.experts.gate_up_proj"
+    assert _resolve(worker, model, incoming) == incoming
+
+
+# ---------------------------------------------------------------------------
+# Packed/stacked names: the resolver toggles ``.base_layer`` on the UNMAPPED
+# name (deciding the toggle via the mapper AND ``packed_modules_mapping``), but
+# returns the unmapped form so vLLM's own ``load_weights`` does the stacking
+# (returning the mapped name would double-map, e.g. ``in_proj_qkvz`` ->
+# ``in_proj_qkvzz`` with a wrong shard_id).
+# ---------------------------------------------------------------------------
+
+
+def test_unpacked_proj_exists_via_packed_owner():
+    """An unpacked alias whose packed owner exists is returned unchanged."""
+    model = _FakeModel(
+        {"language_model.model.layers.0.self_attn.qkv_proj.weight": torch.empty(0)},
+        packed={"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+    )
+    worker = _make_worker(model)
+
+    incoming = "language_model.model.layers.0.self_attn.q_proj.weight"
+    assert _resolve(worker, model, incoming) == incoming
+
+
+def test_stacked_gdn_in_proj_not_double_mapped():
+    """GDN ``in_proj_qkv`` toggles ``.base_layer`` but is NOT mapped to
+    ``in_proj_qkvz`` here — the mapper is consulted only to *decide* the toggle,
+    and the returned name stays unmapped so vLLM maps it cleanly (returning the
+    mapped name would double-map ``in_proj_qkvz`` -> ``in_proj_qkvzz``)."""
+    mapper = _FakeMapper({".in_proj_qkv.": ".in_proj_qkvz."})
+    model = _FakeModel(
+        {"language_model.model.layers.0.linear_attn.in_proj_qkvz.base_layer.weight": torch.empty(0)},
+        mapper=mapper,
+    )
+    worker = _make_worker(model)
+
+    incoming = "language_model.model.layers.0.linear_attn.in_proj_qkv.weight"
+    resolved = _resolve(worker, model, incoming)
+    # Toggle on the unmapped name; no qkvz stacking here.
+    assert resolved == "language_model.model.layers.0.linear_attn.in_proj_qkv.base_layer.weight"
+    # vLLM's mapper then maps it cleanly (single z):
+    assert _mapped(_make_worker(model), model, resolved) == (
+        "language_model.model.layers.0.linear_attn.in_proj_qkvz.base_layer.weight"
+    )
+
+
+def test_shared_expert_packed_owner_toggles_base_layer():
+    """Qwen3.5 shared expert: Bridge exports separate ``gate_proj.weight`` /
+    ``up_proj.weight``; the live LoRA-wrapped model has the packed
+    ``gate_up_proj.base_layer.weight``. The resolver toggles ``.base_layer`` on
+    the UNMAPPED ``gate_proj`` name (decided via packed_modules_mapping +
+    mapper); vLLM's mapper then stacks ``gate_proj.base_layer`` ->
+    ``gate_up_proj.base_layer``. This is the regression that crashed with
+    ``There is no module ... named 'shared_expert.gate_up_proj.weight'``."""
+    mapper = _FakeMapper({".shared_expert.gate_proj.": ".shared_expert.gate_up_proj."})
+    model = _FakeModel(
+        {"language_model.model.layers.0.mlp.shared_expert.gate_up_proj.base_layer.weight": torch.empty(0)},
+        mapper=mapper,
+        packed={"gate_up_proj": ["gate_proj", "up_proj"]},
+    )
+    worker = _make_worker(model)
+
+    incoming = "language_model.model.layers.0.mlp.shared_expert.gate_proj.weight"
+    resolved = _resolve(worker, model, incoming)
+    # Toggle on the unmapped name; vLLM stacks it to gate_up_proj.base_layer.
+    assert resolved == "language_model.model.layers.0.mlp.shared_expert.gate_proj.base_layer.weight"
+    assert _mapped(_make_worker(model), model, resolved) == (
+        "language_model.model.layers.0.mlp.shared_expert.gate_up_proj.base_layer.weight"
+    )
+
+
+def test_mapper_alias_left_to_vllm_mapper():
+    """A logical alias absent on the model is returned unchanged (not pre-mapped)."""
+    model = _FakeModel(
+        {"language_model.model.layers.0.mlp.experts.base_layer.w13_weight": torch.empty(0)},
+        mapper=_FakeMapper(
+            {
+                "language_model.model.layers.0.mlp.experts.gate_up_proj": (
+                    "language_model.model.layers.0.mlp.experts.base_layer.w13_weight"
+                )
+            }
+        ),
+    )
+    worker = _make_worker(model)
+
+    incoming = "language_model.model.layers.0.mlp.experts.gate_up_proj"
+    assert _resolve(worker, model, incoming) == incoming
+
+
+# ---------------------------------------------------------------------------
+# Already-correct names are a no-op (the common case for non-VLM LoRA).
+# ---------------------------------------------------------------------------
+
+
+def test_already_matching_name_is_noop():
+    model = _FakeModel({"language_model.model.layers.0.self_attn.q_proj.weight": torch.empty(0)})
+    worker = _make_worker(model)
+
+    assert _resolve(worker, model, "language_model.model.layers.0.self_attn.q_proj.weight") == (
+        "language_model.model.layers.0.self_attn.q_proj.weight"
+    )
+
+
+def test_truly_unknown_name_falls_back_unchanged():
+    """When nothing matches (on a LoRA-wrapped model), return the original so
+    vLLM raises a clear error."""
+    model = _FakeModel({"a.base_layer.weight": torch.empty(0)})
+    worker = _make_worker(model)
+
+    assert _resolve(worker, model, "does.not.exist.base_layer.weight") == "does.not.exist.base_layer.weight"
+
+
+def test_drafter_drops_base_layer_wholesale():
+    """A model with no ``.base_layer`` params (e.g. the MTP drafter) has the
+    suffix stripped wholesale from every name, regardless of whether the
+    stripped form ultimately exists."""
+    model = _FakeModel({"a.weight": torch.empty(0)})
+    worker = _make_worker(model)
+
+    assert _resolve(worker, model, "does.not.exist.base_layer.weight") == "does.not.exist.weight"
+    assert _resolve(worker, model, "fc.base_layer.weight") == "fc.weight"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through _update_weights: load_weights receives resolved names.
+# ---------------------------------------------------------------------------
+
+
+def test_update_weights_resolves_names_before_load():
+    model = _FakeModel(
+        {
+            "merger.linear_fc1.weight": torch.empty(0),
+            "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    weights = [
+        ("merger.linear_fc1.base_layer.weight", torch.empty(0)),
+        ("language_model.model.layers.0.self_attn.q_proj.base_layer.weight", torch.empty(0)),
+    ]
+
+    worker._update_weights(weights, peft_config=None, base_sync_done=False)
+
+    assert model.loaded == [
+        "merger.linear_fc1.weight",
+        "language_model.model.layers.0.self_attn.q_proj.base_layer.weight",
+    ]
+
+
+def test_lora_adapter_path_skips_normalization():
+    """LoRA adapter tensors (peft_config + base_sync_done) keep .base_layer — vLLM expects it."""
+    model = _FakeModel({"language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0)})
+
+    added = []
+
+    def _add_lora(request):
+        added.append(set(request.lora_tensors))
+
+    worker = _make_worker(model)
+    worker.add_lora = _add_lora
+
+    # These are LoRA tensors (lora_A/lora_B), not base weights; the .base_layer here
+    # is irrelevant to normalization and must be passed through verbatim.
+    weights = [("language_model.model.layers.0.self_attn.q_proj.lora_A.weight", torch.ones(1))]
+    worker._update_weights(weights, peft_config={"r": 1}, base_sync_done=True)
+
+    assert added == [{"language_model.model.layers.0.self_attn.q_proj.lora_A.weight"}]
+
+
+# ---------------------------------------------------------------------------
+# Multi-bucket LoRA accumulation: add_lora is called exactly once, with the
+# complete adapter, after is_last — never per-bucket.
+# ---------------------------------------------------------------------------
+
+
+class _FakeBucketReceiver:
+    """Drives the on_bucket_received callback with a scripted bucket sequence."""
+
+    def __init__(self, buckets):
+        # buckets: list of (weights_list, is_last)
+        self._buckets = buckets
+
+    def receive_weights(self, on_bucket_received):
+        for weights, is_last in self._buckets:
+            on_bucket_received(weights, is_last)
+
+
+def test_update_weights_from_ipc_accumulates_lora_across_buckets(monkeypatch):
+    """A LoRA adapter split across two buckets yields one add_lora with all tensors."""
+    import verl.workers.rollout.vllm_rollout.bucketed_weight_transfer as bwt
+
+    monkeypatch.setattr(
+        bwt,
+        "BucketedWeightReceiver",
+        lambda *a, **k: _FakeBucketReceiver(
+            [
+                ([("lora.A.weight", torch.ones(1))], False),
+                ([("lora.B.weight", torch.zeros(1))], True),
+            ]
+        ),
+    )
+
+    model = _FakeModel({"q.base_layer.weight": torch.empty(0)})
+
+    added = []
+
+    def _add_lora(request):
+        added.append(dict(request.lora_tensors))
+
+    worker = _make_worker(model)
+    worker.add_lora = _add_lora
+    worker.remove_lora = lambda lora_id: None
+    worker.device = torch.device("cpu")
+    worker.local_rank = 0
+    worker._is_qat_model = False
+    worker._is_modelopt_qat = False
+    worker._get_zmq_handle = lambda: "ipc:///tmp/test-bucketed-lora.sock"
+
+    worker.update_weights_from_ipc(peft_config={"r": 1}, base_sync_done=True)
+
+    # Exactly one add_lora, holding both buckets' tensors (accumulated, not
+    # overwritten) with the first bucket's tensor preserved (cloned, not a view
+    # into a reused buffer).
+    assert len(added) == 1
+    assert set(added[0]) == {"lora.A.weight", "lora.B.weight"}
+    torch.testing.assert_close(added[0]["lora.A.weight"], torch.ones(1))
+
+
+def test_update_weights_from_ipc_standard_loads_per_bucket(monkeypatch):
+    """Standard (non-LoRA) base sync loads every bucket immediately (no accumulation)."""
+    import verl.workers.rollout.vllm_rollout.bucketed_weight_transfer as bwt
+
+    monkeypatch.setattr(
+        bwt,
+        "BucketedWeightReceiver",
+        lambda *a, **k: _FakeBucketReceiver(
+            [
+                ([("q.weight", torch.ones(1))], False),
+                ([("k.weight", torch.zeros(1))], True),
+            ]
+        ),
+    )
+
+    model = _FakeModel({"q.weight": torch.empty(0), "k.weight": torch.empty(0)})
+    loaded = []
+    model.load_weights = lambda weights: loaded.extend(name for name, _ in weights)
+
+    worker = _make_worker(model)
+    worker.device = torch.device("cpu")
+    worker.local_rank = 0
+    worker._is_qat_model = False
+    worker._is_modelopt_qat = False
+    worker._get_zmq_handle = lambda: "ipc:///tmp/test-bucketed-std.sock"
+
+    # Bypass the post-load process_weights_after_loading (needs real vLLM).
+    fake_loader_utils = types.ModuleType("vllm.model_executor.model_loader.utils")
+    fake_loader_utils.process_weights_after_loading = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.model_loader.utils", fake_loader_utils)
+
+    worker.update_weights_from_ipc(peft_config=None, base_sync_done=False)
+
+    assert loaded == ["q.weight", "k.weight"]

--- a/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
+++ b/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
@@ -57,6 +57,24 @@ def _load_vllm_rollout_utils():
     fake_vllm = types.ModuleType("vllm")
     fake_vllm.outputs = fake_outputs
 
+    # Simulate a newer vLLM where ``BaseLayerWithLoRA`` defines ``load_weights``
+    # (delegating to ``AutoWeightsLoader(self.base_layer)`` and thus expecting
+    # inner names without ``.base_layer.``). The resolver probes this at import
+    # time via ``"load_weights" in BaseLayerWithLoRA.__dict__``, so the stub
+    # chain must be importable as ``vllm.lora.layers.base``.
+    fake_lora_base = types.ModuleType("vllm.lora.layers.base")
+
+    class _FakeBaseLayerWithLoRA:
+        def load_weights(self, weights):
+            return iter(())
+
+    fake_lora_base.BaseLayerWithLoRA = _FakeBaseLayerWithLoRA
+    fake_lora_layers = types.ModuleType("vllm.lora.layers")
+    fake_lora_layers.base = fake_lora_base
+    fake_lora = types.ModuleType("vllm.lora")
+    fake_lora.layers = fake_lora_layers
+    fake_vllm.lora = fake_lora
+
     fake_vllm_third_party = types.ModuleType("verl.third_party.vllm")
     fake_vllm_third_party.VLLM_SLEEP_LEVEL = 1
     fake_vllm_third_party.get_version = lambda pkg: "0.8.0"
@@ -93,6 +111,9 @@ def _load_vllm_rollout_utils():
     fakes = {
         "vllm": fake_vllm,
         "vllm.outputs": fake_outputs,
+        "vllm.lora": fake_lora,
+        "vllm.lora.layers": fake_lora_layers,
+        "vllm.lora.layers.base": fake_lora_base,
         "verl.third_party.vllm": fake_vllm_third_party,
         "verl.utils.vllm": fake_vllm_utils,
         "verl.utils.vllm.patch": fake_vllm_patch,
@@ -218,8 +239,10 @@ def test_vision_merger_base_layer_is_stripped():
 # ---------------------------------------------------------------------------
 
 
-def test_lora_wrapped_base_layer_is_preserved():
-    """A language proj that exists with .base_layer is returned unchanged."""
+def test_lora_wrapped_base_layer_gets_stripped():
+    """A LoRA-wrapped leaf with .base_layer is stripped: vLLM's
+    BaseLayerWithLoRA.load_weights delegates to AutoWeightsLoader(base_layer)
+    which expects the inner name (no base_layer. prefix)."""
     model = _FakeModel(
         {
             "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
@@ -228,11 +251,13 @@ def test_lora_wrapped_base_layer_is_preserved():
     worker = _make_worker(model)
 
     name = "language_model.model.layers.0.self_attn.q_proj.base_layer.weight"
-    assert _resolve(worker, model, name) == name
+    assert _resolve(worker, model, name) == ("language_model.model.layers.0.self_attn.q_proj.weight")
 
 
-def test_missing_base_layer_is_added_for_leaf():
-    """If the incoming name lacks .base_layer but the wrapped form exists, add it."""
+def test_missing_base_layer_not_added_on_newer_vllm():
+    """On newer vLLM, incoming without .base_layer is NOT suffixed --
+    BaseLayerWithLoRA.load_weights delegates to AutoWeightsLoader(base_layer)
+    expecting inner names."""
     model = _FakeModel(
         {
             "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
@@ -240,10 +265,8 @@ def test_missing_base_layer_is_added_for_leaf():
     )
     worker = _make_worker(model)
 
-    assert (
-        _resolve(worker, model, "language_model.model.layers.0.self_attn.q_proj.weight")
-        == "language_model.model.layers.0.self_attn.q_proj.base_layer.weight"
-    )
+    name = "language_model.model.layers.0.self_attn.q_proj.weight"
+    assert _resolve(worker, model, name) == name
 
 
 # ---------------------------------------------------------------------------
@@ -318,10 +341,8 @@ def test_unpacked_proj_exists_via_packed_owner():
 
 
 def test_stacked_gdn_in_proj_not_double_mapped():
-    """GDN ``in_proj_qkv`` toggles ``.base_layer`` but is NOT mapped to
-    ``in_proj_qkvz`` here — the mapper is consulted only to *decide* the toggle,
-    and the returned name stays unmapped so vLLM maps it cleanly (returning the
-    mapped name would double-map ``in_proj_qkvz`` -> ``in_proj_qkvzz``)."""
+    """GDN ``in_proj_qkv`` is NOT suffixed with ``.base_layer`` on newer vLLM --
+    the name stays unmapped so vLLM's mapper stacks it cleanly."""
     mapper = _FakeMapper({".in_proj_qkv.": ".in_proj_qkvz."})
     model = _FakeModel(
         {"language_model.model.layers.0.linear_attn.in_proj_qkvz.base_layer.weight": torch.empty(0)},
@@ -331,22 +352,18 @@ def test_stacked_gdn_in_proj_not_double_mapped():
 
     incoming = "language_model.model.layers.0.linear_attn.in_proj_qkv.weight"
     resolved = _resolve(worker, model, incoming)
-    # Toggle on the unmapped name; no qkvz stacking here.
-    assert resolved == "language_model.model.layers.0.linear_attn.in_proj_qkv.base_layer.weight"
+    # No .base_layer added on newer vLLM.
+    assert resolved == incoming
     # vLLM's mapper then maps it cleanly (single z):
     assert _mapped(_make_worker(model), model, resolved) == (
-        "language_model.model.layers.0.linear_attn.in_proj_qkvz.base_layer.weight"
+        "language_model.model.layers.0.linear_attn.in_proj_qkvz.weight"
     )
 
 
-def test_shared_expert_packed_owner_toggles_base_layer():
-    """Qwen3.5 shared expert: Bridge exports separate ``gate_proj.weight`` /
-    ``up_proj.weight``; the live LoRA-wrapped model has the packed
-    ``gate_up_proj.base_layer.weight``. The resolver toggles ``.base_layer`` on
-    the UNMAPPED ``gate_proj`` name (decided via packed_modules_mapping +
-    mapper); vLLM's mapper then stacks ``gate_proj.base_layer`` ->
-    ``gate_up_proj.base_layer``. This is the regression that crashed with
-    ``There is no module ... named 'shared_expert.gate_up_proj.weight'``."""
+def test_shared_expert_packed_owner_no_base_layer_on_newer_vllm():
+    """On newer vLLM, shared expert gate_proj.weight is NOT suffixed with
+    .base_layer -- vLLM's mapper stacks gate_proj -> gate_up_proj and
+    BaseLayerWithLoRA.load_weights handles the inner name."""
     mapper = _FakeMapper({".shared_expert.gate_proj.": ".shared_expert.gate_up_proj."})
     model = _FakeModel(
         {"language_model.model.layers.0.mlp.shared_expert.gate_up_proj.base_layer.weight": torch.empty(0)},
@@ -357,10 +374,9 @@ def test_shared_expert_packed_owner_toggles_base_layer():
 
     incoming = "language_model.model.layers.0.mlp.shared_expert.gate_proj.weight"
     resolved = _resolve(worker, model, incoming)
-    # Toggle on the unmapped name; vLLM stacks it to gate_up_proj.base_layer.
-    assert resolved == "language_model.model.layers.0.mlp.shared_expert.gate_proj.base_layer.weight"
+    assert resolved == incoming
     assert _mapped(_make_worker(model), model, resolved) == (
-        "language_model.model.layers.0.mlp.shared_expert.gate_up_proj.base_layer.weight"
+        "language_model.model.layers.0.mlp.shared_expert.gate_up_proj.weight"
     )
 
 
@@ -396,13 +412,12 @@ def test_already_matching_name_is_noop():
     )
 
 
-def test_truly_unknown_name_falls_back_unchanged():
-    """When nothing matches (on a LoRA-wrapped model), return the original so
-    vLLM raises a clear error."""
+def test_truly_unknown_name_strips_base_layer():
+    """Even unknown names have ``.base_layer.`` stripped on newer vLLM."""
     model = _FakeModel({"a.base_layer.weight": torch.empty(0)})
     worker = _make_worker(model)
 
-    assert _resolve(worker, model, "does.not.exist.base_layer.weight") == "does.not.exist.base_layer.weight"
+    assert _resolve(worker, model, "does.not.exist.base_layer.weight") == "does.not.exist.weight"
 
 
 def test_drafter_drops_base_layer_wholesale():
@@ -439,7 +454,7 @@ def test_update_weights_resolves_names_before_load():
 
     assert model.loaded == [
         "merger.linear_fc1.weight",
-        "language_model.model.layers.0.self_attn.q_proj.base_layer.weight",
+        "language_model.model.layers.0.self_attn.q_proj.weight",
     ]
 
 

--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -71,6 +71,7 @@ def _load_vllm_rollout_utils():
 
     fake_vllm_utils.TensorLoRARequest = _FakeTensorLoRARequest
     fake_vllm_utils.VLLMHijack = _FakeVLLMHijack
+    fake_vllm_utils.resolve_weight_name = lambda model, name, names: name
 
     fake_vllm_patch = types.ModuleType("verl.utils.vllm.patch")
     fake_vllm_patch.patch_vllm_moe_model_weight_loader = lambda model: None

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1751,10 +1751,15 @@ class PPOTrainer(ABC):
                 partition_id=batch.partition_id,
                 select_fields=["extra_fields"],
             )
-            extra_fields = spec_data["extra_fields"].tolist()
-            spec_drafts = [extra_field["spec_num_draft_tokens"] for extra_field in extra_fields]
-            spec_accepts = [extra_field["spec_num_accepted_tokens"] for extra_field in extra_fields]
-            spec_verifies = [extra_field["spec_num_verify_steps"] for extra_field in extra_fields]
+            extra_fields = spec_data.pop("extra_fields").tolist()
+            # The rollout omits the spec_* stats when the backend does not report
+            # per-request spec-decode stats; leave all three as None in that case.
+            if extra_fields and all(
+                isinstance(extra_field, dict) and "spec_num_draft_tokens" in extra_field for extra_field in extra_fields
+            ):
+                spec_drafts = [extra_field["spec_num_draft_tokens"] for extra_field in extra_fields]
+                spec_accepts = [extra_field["spec_num_accepted_tokens"] for extra_field in extra_fields]
+                spec_verifies = [extra_field["spec_num_verify_steps"] for extra_field in extra_fields]
 
         data = data.to_padded_tensor()
         data["token_level_scores"] = data["rm_scores"]

--- a/verl/utils/megatron_peft_utils.py
+++ b/verl/utils/megatron_peft_utils.py
@@ -13,60 +13,6 @@
 # limitations under the License.
 """Utilities for PEFT (Parameter-Efficient Fine-Tuning) of Megatron in VERL."""
 
-from typing import Iterator
-
-import torch
-
-# Map megatron lora target modules to HF-style module names for vLLM
-MEGATRON_TO_HF_MODULES = {
-    "linear_qkv": ["q_proj", "k_proj", "v_proj"],
-    "linear_proj": ["o_proj"],
-    "linear_fc1": ["gate_proj", "up_proj"],
-    "linear_fc2": ["down_proj"],
-    "router": ["gate"],
-    # Canonical LoRA mappings
-    "linear_q": ["q_proj"],
-    "linear_k": ["k_proj"],
-    "linear_v": ["v_proj"],
-    "linear_fc1_up": ["up_proj"],
-    "linear_fc1_gate": ["gate_proj"],
-    # MLA mappings
-    "linear_kv_down_proj": ["kv_a_proj_with_mqa"],
-    "linear_kv_up_proj": ["kv_b_proj"],
-    "linear_q_down_proj": ["q_a_proj"],
-    "linear_q_up_proj": ["q_b_proj"],
-    "linear_q_proj": ["q_proj"],
-    # DSA indexer mappings
-    "linear_wq_b": ["wq_b"],
-    "linear_wk": ["wk"],
-    "linear_weights_proj": ["weights_proj"],
-}
-
-# Modules with stacked parameters that need .base_layer suffix in vLLM
-STACKED_PARAMS = [
-    ".q_proj.weight",
-    ".q_proj.bias",
-    ".k_proj.weight",
-    ".k_proj.bias",
-    ".v_proj.weight",
-    ".v_proj.bias",
-    ".o_proj.weight",
-    ".o_proj.bias",
-    ".gate_proj.weight",
-    ".up_proj.weight",
-    ".down_proj.weight",
-    ".mlp.gate.weight",
-    ".mlp.gate.bias",
-    ".mlp.gate.e_score_correction_bias",
-    ".kv_a_proj_with_mqa.weight",
-    ".kv_b_proj.weight",
-    ".q_a_proj.weight",
-    ".q_b_proj.weight",
-    ".wq_b.weight",
-    ".wk.weight",
-    ".weights_proj.weight",
-]
-
 
 def count_adapter_parameters(model):
     """Count the number of trainable adapter parameters.
@@ -109,25 +55,6 @@ def print_adapter_info(model):
     print(f"{'=' * 60}\n")
 
 
-def convert_megatron_to_hf_target_modules(megatron_modules: list[str]) -> list[str]:
-    """Convert megatron lora target modules to HF-style module names.
-
-    Args:
-        megatron_modules: List of megatron-style module names.
-
-    Returns:
-        List of HF-style module names with duplicates removed.
-    """
-    hf_target_modules = []
-    for module in megatron_modules:
-        if module in MEGATRON_TO_HF_MODULES:
-            hf_target_modules.extend(MEGATRON_TO_HF_MODULES[module])
-        else:
-            hf_target_modules.append(module)
-    # Remove duplicates while preserving order
-    return list(dict.fromkeys(hf_target_modules))
-
-
 def build_peft_config_for_vllm(lora_config: dict) -> dict:
     """Build a peft_config dict compatible with vLLM's PEFTHelper from megatron lora config.
 
@@ -139,53 +66,20 @@ def build_peft_config_for_vllm(lora_config: dict) -> dict:
     """
     from peft import TaskType
 
-    target_modules = lora_config.get("target_modules", ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"])
-    exclude_modules = lora_config.get("exclude_modules", [])
-    hf_target_modules = convert_megatron_to_hf_target_modules(target_modules)
-    hf_exclude_modules = convert_megatron_to_hf_target_modules(exclude_modules)
-
     return {
         "task_type": TaskType.CAUSAL_LM,
         "r": lora_config.get("rank", 0),
         "lora_alpha": lora_config.get("alpha", 32),
-        "target_modules": hf_target_modules,
-        "exclude_modules": hf_exclude_modules,
+        # vLLM doesn't really use target_modules to determine which modules
+        # to apply LoRA to, so we set "all-linear" as a placeholder.
+        "target_modules": "all-linear",
         "bias": "none",
         "lora_dropout": lora_config.get("dropout", 0.0),
     }
 
 
-# vLLM needs to target all-linear no matter about specific LoRA config
-def add_base_layer_suffix(
-    params: Iterator[tuple[str, torch.Tensor]],
-    model_type: str,
-) -> Iterator[tuple[str, torch.Tensor]]:
-    """Yield param pairs with a base-layer suffix added to the param name.
-
-    Args:
-        params: Iterator of (param_name, tensor)
-        model_type: The type of the model (e.g., "llama").
-    """
-    stacked_params = STACKED_PARAMS
-    # TODO: other models may have more special treatment, or integrate this into Megatron-Bridge
-    if model_type == "llama":
-        stacked_params = [".embed_tokens.weight", *STACKED_PARAMS]
-    for name, param in params:
-        ending_suffix = ""
-        for suffix in stacked_params:
-            if name.endswith(suffix):
-                ending_suffix = suffix
-                break
-        if ending_suffix:
-            suffix = ending_suffix.rsplit(".", 1)[-1]
-            name = f"{name[: -len(suffix)]}base_layer.{suffix}"
-        yield name, param
-
-
 __all__ = [
     "count_adapter_parameters",
     "print_adapter_info",
-    "convert_megatron_to_hf_target_modules",
     "build_peft_config_for_vllm",
-    "add_base_layer_suffix",
 ]

--- a/verl/utils/vllm/__init__.py
+++ b/verl/utils/vllm/__init__.py
@@ -14,7 +14,7 @@
 
 
 from .npu_vllm_patch import apply_npu_vllm_patches
-from .utils import TensorLoRARequest, VLLMHijack, is_version_ge
+from .utils import TensorLoRARequest, VLLMHijack, is_version_ge, resolve_weight_name
 
 # The contents of vllm/patch.py should not be imported here, because the contents of
 # patch.py should be imported after the vllm LLM instance is created. Therefore,
@@ -29,4 +29,5 @@ __all__ = [
     "TensorLoRARequest",
     "VLLMHijack",
     "is_version_ge",
+    "resolve_weight_name",
 ]

--- a/verl/utils/vllm/patch.py
+++ b/verl/utils/vllm/patch.py
@@ -133,7 +133,18 @@ def patch_vllm_moe_model_weight_loader(model):
             continue
 
         experts = getattr(mlp, "experts", None)
-        if not experts or not hasattr(experts, "weight_loader"):
+        if not experts:
+            continue
+
+        # verl syncs plain HF names, not PEFT checkpoint names, so the LoRA MoE
+        # ``lora_base_layer_prefix`` (folded into a dotted param_name that
+        # getattr can't resolve) must be cleared. Runs before the
+        # ``weight_loader`` guard so LoRA-wrapped MoE (no weight_loader) is covered.
+        routed_experts = getattr(getattr(experts, "base_layer", None), "routed_experts", None)
+        if routed_experts is not None and getattr(routed_experts, "lora_base_layer_prefix", ""):
+            routed_experts.lora_base_layer_prefix = ""
+
+        if not hasattr(experts, "weight_loader"):
             continue
 
         # Patch the weight loaders

--- a/verl/utils/vllm/utils.py
+++ b/verl/utils/vllm/utils.py
@@ -126,3 +126,121 @@ class VLLMHijack:
 def is_version_ge(pkg: str = "vllm", minver: str = "0.7.3"):
     """check if the package version is greater than or equal to the minimum version"""
     return vs.parse(get_version(pkg)) >= vs.parse(minver)
+
+
+# Whether the installed vLLM ships ``BaseLayerWithLoRA.load_weights`` (landed in
+# #39935 / ``b50fdebce0``). On newer vLLM the LoRA layer's ``load_weights``
+# delegates to ``AutoWeightsLoader(base_layer)`` and expects inner names without
+# ``.base_layer.``; on released vLLM (False) the model's ``load_weights``
+# recurses into the ``base_layer`` child and matches the suffixed name.
+_HAS_LORA_LOAD_WEIGHTS = False
+
+try:
+    from vllm.lora.layers.base import BaseLayerWithLoRA
+
+    _HAS_LORA_LOAD_WEIGHTS = "load_weights" in BaseLayerWithLoRA.__dict__
+except ImportError:
+    pass
+
+
+def resolve_weight_name(model, name: str, model_weight_names: set[str]) -> str:
+    """Reconcile an incoming weight-sync name with the live vLLM namespace.
+
+    Toggles one ``.base_layer`` segment (strip it for non-LoRA-wrapped modules
+    on all vLLM versions and for LoRA-wrapped modules on newer vLLM; add it for
+    LoRA-wrapped leaves on released vLLM) and routes packed routed-expert
+    aliases under the LoRA ``base_layer`` so ``AutoWeightsLoader`` reaches
+    ``MoERunner.load_weights``.
+
+    The mapper / ``packed_modules_mapping`` are consulted only to *decide* the
+    toggle; the return is always the unmapped name (vLLM's ``load_weights`` does
+    the stacking -- returning a mapped name would double-map, e.g.
+    ``in_proj_qkvz`` -> ``in_proj_qkvzz``, corrupting shard_id).
+    """
+    mapper = getattr(model, "hf_to_vllm_mapper", None)
+    packed = getattr(model, "packed_modules_mapping", None) or {}
+    leaf = name.rsplit(".", 1)[-1]
+    is_leaf = leaf in {"weight", "bias"} or leaf.endswith(("_weight", "_bias"))
+
+    def _exists(candidate: str) -> bool:
+        if candidate in model_weight_names:
+            return True
+        if mapper is not None:
+            mapped = mapper.apply_list([candidate])
+            mapped = mapped[0] if mapped else candidate
+            if mapped != candidate and mapped in model_weight_names:
+                return True
+        # Packed-owner lookup (q/k/v -> qkv) via packed_modules_mapping.
+        # Hoisted out of the mapper guard so models with
+        # packed_modules_mapping but no hf_to_vllm_mapper (e.g. Llama) also
+        # reach it.
+        if packed and "." in candidate:
+            parts = candidate.split(".")
+            mi = -3 if len(parts) >= 3 and parts[-2] == "base_layer" else -2
+            if -mi <= len(parts):
+                # packed is {owner: [unpacked,...]}; invert to {unpacked: owner}.
+                rev = {u: p for p, us in packed.items() for u in us}
+                owner = rev.get(parts[mi])
+                for pn in (owner,) if owner else ():
+                    pp = parts.copy()
+                    pp[mi] = pn
+                    joined = ".".join(pp)
+                    if joined in model_weight_names:
+                        return True
+                    if mapper is not None:
+                        mp = mapper.apply_list([joined])
+                        mp = mp[0] if mp else joined
+                        if mp != candidate and mp in model_weight_names:
+                            return True
+        return False
+
+    # Strip ``.base_layer.``:
+    # - On models with NO ``.base_layer.`` params at all (auxiliary models like
+    #   the MTP drafter, or non-LoRA-wrapped modules such as the Qwen3.5-VL vision
+    #   merger): strip unconditionally -- there is no ``base_layer`` child to
+    #   recurse into on any vLLM version, so the inner name is the only one that
+    #   could match.
+    # - On LoRA-wrapped models (which DO have ``.base_layer.`` params): strip only
+    #   on newer vLLM, where ``BaseLayerWithLoRA.load_weights`` delegates to
+    #   ``AutoWeightsLoader(base_layer)`` expecting inner names. On released vLLM
+    #   keep the suffix (the loader recurses into ``base_layer`` and matches it)
+    #   and fall through to the leaf-add path below.
+    if ".base_layer." in name:
+        model_has_base_layer = any(".base_layer." in n for n in model_weight_names)
+        if not model_has_base_layer or _HAS_LORA_LOAD_WEIGHTS:
+            return name.replace(".base_layer.", ".", 1)
+
+    if _exists(name):
+        return name
+
+    # Packed routed-expert alias: route under the LoRA base_layer so
+    # AutoWeightsLoader reaches MoERunner.load_weights (FusedMoE3DWithLoRA has no
+    # load_weights itself). Only for non-leaf, non-routed names.
+    marker = ".mlp.experts."
+    idx = name.find(marker)
+    if idx != -1:
+        tail = name[idx + len(marker) :]
+        if (
+            tail
+            and ".base_layer." not in tail
+            and not is_leaf
+            and any("mlp.experts.base_layer." in n for n, _ in model.named_parameters(remove_duplicate=False))
+        ):
+            return name.replace(marker, marker + "base_layer.", 1)
+
+    if ".mlp.experts.base_layer." in name and not is_leaf:
+        stripped = name.replace(".base_layer.", ".", 1)
+        if _exists(stripped):
+            return stripped
+
+    # Leaf weight/bias: on vLLM versions without BaseLayerWithLoRA.load_weights,
+    # add ``.base_layer.`` so AutoWeightsLoader recurses into the base_layer
+    # child; on newer vLLM, the strip above already handled it.
+    if is_leaf:
+        if not _HAS_LORA_LOAD_WEIGHTS and ".base_layer." not in name:
+            prefix, lf = name.rsplit(".", 1)
+            alt = f"{prefix}.base_layer.{lf}"
+            if alt != name and _exists(alt):
+                return alt
+
+    return name

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -50,7 +50,7 @@ from verl.utils.megatron.tensor_parallel import (
     vocab_parallel_log_probs_from_logits,
     vocab_parallel_sum_pi_squared,
 )
-from verl.utils.megatron_peft_utils import add_base_layer_suffix, build_peft_config_for_vllm
+from verl.utils.megatron_peft_utils import build_peft_config_for_vllm
 from verl.utils.megatron_utils import (
     check_mtp_config,
     get_megatron_module_device,
@@ -847,10 +847,6 @@ class MegatronEngine(BaseEngine):
                 if non_merge_lora_sync
                 else self.bridge.export_hf_weights(self.module)
             )
-            if non_merge_lora_sync:
-                per_tensor_param = add_base_layer_suffix(
-                    per_tensor_param, model_type=self.model_config.hf_config.model_type
-                )
 
         # QAT: process weights through QATWeightExporter for quantized weight sync to vLLM
         if self._qat_enabled:

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -266,7 +266,11 @@ class BucketedWeightReceiver:
         Receive weights from sender and process each bucket via callback.
 
         Args:
-            on_bucket_received: Callback function(weights: list[(name, tensor)]) called per bucket.
+            on_bucket_received: Callback function(weights: list[(name, tensor)],
+            is_last: bool) called per bucket. ``is_last`` marks the final bucket
+            of a weight-sync round so consumers that need the complete tensor set
+            (e.g. vLLM ``add_lora``, which takes one adapter dict per call) can
+            defer their finalization until the whole adapter has arrived.
         """
         try:
             self._init_socket()
@@ -287,11 +291,12 @@ class BucketedWeightReceiver:
                     if self.use_shm:
                         tensor = tensor.to(self.device)
                     weights.append((name, tensor))
-                on_bucket_received(weights)
+                is_last = metadata["is_last"]
+                on_bucket_received(weights, is_last)
                 get_torch_device().synchronize()
                 self.socket.send(b"")
                 del weights, tensor
-                if metadata["is_last"]:
+                if is_last:
                     break
         finally:
             self._cleanup()

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -26,7 +26,7 @@ import torch
 from vllm.outputs import RequestOutput
 
 from verl.utils.device import get_device_name, is_npu_available
-from verl.utils.vllm import TensorLoRARequest, VLLMHijack
+from verl.utils.vllm import TensorLoRARequest, VLLMHijack, resolve_weight_name
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches, is_fp8_model, load_quanted_weights
 from verl.workers.rollout.vllm_rollout.weight_update_utils import apply_buffer_updates, split_buffer_updates
@@ -40,15 +40,6 @@ VLLM_LORA_NAME = "123"
 VLLM_LORA_PATH = "simon_lora_path"
 
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
-
-_HAS_LORA_LOAD_WEIGHTS = False
-
-try:
-    from vllm.lora.layers.base import BaseLayerWithLoRA
-
-    _HAS_LORA_LOAD_WEIGHTS = "load_weights" in BaseLayerWithLoRA.__dict__
-except ImportError:
-    pass
 
 
 def _resolve_vllm_weight_sync_local_rank(worker_local_rank: int, parallel_config: Any) -> int:
@@ -197,105 +188,6 @@ class vLLMColocateWorkerExtension:
         instance._is_qat_model = _is_qat_model
         instance._is_modelopt_qat = _is_modelopt_qat
         return instance
-
-    # ------------------------------------------------------------------
-    # Receiver-side ``.base_layer`` reconciliation. With LoRA enabled, vLLM
-    # wraps *every* linear layer (not just the user's target_modules), exposing
-    # base weights under ``.base_layer``; Megatron only LoRA-wraps the user's
-    # target_modules, so Bridge exports plain names for the rest.
-    # The receiver reconciles each name against the live vLLM namespace --
-    # toggling one ``.base_layer`` segment (probe the model, not a hard-coded list).
-    # ------------------------------------------------------------------
-
-    def _resolve_weight_name(self, model, name: str, model_weight_names: set[str]) -> str:
-        """Reconcile an incoming sync name with the live vLLM namespace:
-
-        - toggle one ``.base_layer`` segment (add it for vLLM-wrapped leaves the
-          Megatron side didn't suffix, drop it for unwrapped ones);
-        - route packed routed-expert aliases (``experts.gate_up_proj``) under the
-          LoRA ``base_layer`` so AutoWeightsLoader reaches MoERunner.load_weights.
-
-        The mapper/``packed_modules_mapping`` are consulted only to *decide* the
-        toggle; the return is always the unmapped name (vLLM's load_weights does
-        the stacking -- returning a mapped name would double-map, e.g.
-        ``in_proj_qkvz`` -> ``in_proj_qkvzz``, corrupting shard_id).
-        """
-        mapper = getattr(model, "hf_to_vllm_mapper", None)
-        packed = getattr(model, "packed_modules_mapping", None) or {}
-        leaf = name.rsplit(".", 1)[-1]
-        is_leaf = leaf in {"weight", "bias"} or leaf.endswith(("_weight", "_bias"))
-
-        def _exists(candidate: str) -> bool:
-            if candidate in model_weight_names:
-                return True
-            if mapper is not None:
-                mapped = mapper.apply_list([candidate])
-                mapped = mapped[0] if mapped else candidate
-                if mapped != candidate and mapped in model_weight_names:
-                    return True
-            # Packed-owner lookup (q/k/v -> qkv) via packed_modules_mapping.
-            # Hoisted out of the mapper guard so models with
-            # packed_modules_mapping but no hf_to_vllm_mapper (e.g. Llama) also
-            # reach it.
-            if packed and "." in candidate:
-                parts = candidate.split(".")
-                mi = -3 if len(parts) >= 3 and parts[-2] == "base_layer" else -2
-                if -mi <= len(parts):
-                    # packed is {owner: [unpacked,...]}; invert to {unpacked: owner}.
-                    rev = {u: p for p, us in packed.items() for u in us}
-                    owner = rev.get(parts[mi])
-                    for pn in (owner,) if owner else ():
-                        pp = parts.copy()
-                        pp[mi] = pn
-                        joined = ".".join(pp)
-                        if joined in model_weight_names:
-                            return True
-                        if mapper is not None:
-                            mp = mapper.apply_list([joined])
-                            mp = mp[0] if mp else joined
-                            if mp != candidate and mp in model_weight_names:
-                                return True
-            return False
-
-        if ".base_layer." in name:
-            model_has_base_layer = any(".base_layer." in n for n in model_weight_names)
-            if not model_has_base_layer or _HAS_LORA_LOAD_WEIGHTS:
-                return name.replace(".base_layer.", ".", 1)
-
-        if _exists(name):
-            return name
-
-        # Packed routed-expert alias: route under the LoRA base_layer so
-        # AutoWeightsLoader reaches MoERunner.load_weights (FusedMoE3DWithLoRA
-        # has no load_weights itself). Only for non-leaf, non-routed names.
-        marker = ".mlp.experts."
-        idx = name.find(marker)
-        if idx != -1:
-            tail = name[idx + len(marker) :]
-            if (
-                tail
-                and ".base_layer." not in tail
-                and not is_leaf
-                and any("mlp.experts.base_layer." in n for n, _ in model.named_parameters(remove_duplicate=False))
-            ):
-                return name.replace(marker, marker + "base_layer.", 1)
-
-        if ".mlp.experts.base_layer." in name and not is_leaf:
-            stripped = name.replace(".base_layer.", ".", 1)
-            if _exists(stripped):
-                return stripped
-
-        # Leaf weight/bias: on vLLM versions without BaseLayerWithLoRA.load_weights),
-        # add ``.base_layer.`` so AutoWeightsLoader recurses into the base_layer
-        # child; on newer vLLM, the strip above already handled it.
-        if is_leaf:
-            if not _HAS_LORA_LOAD_WEIGHTS and ".base_layer." not in name:
-                prefix, lf = name.rsplit(".", 1)
-                alt = f"{prefix}.base_layer.{lf}"
-                if alt != name and _exists(alt):
-                    return alt
-
-        return name
 
     def _get_drafter_model(self):
         """Return the drafter's model object, or None if unavailable."""
@@ -498,9 +390,7 @@ class vLLMColocateWorkerExtension:
                         else:
                             names = {n for n, _ in model.named_parameters(remove_duplicate=False)}
                             names.update(n for n, _ in model.named_buffers())
-                            model.load_weights(
-                                (self._resolve_weight_name(model, n, names), t) for n, t in param_updates
-                            )
+                            model.load_weights((resolve_weight_name(model, n, names), t) for n, t in param_updates)
                 loaded_buffers = self._apply_buffer_updates_all_models(buffer_updates, named_buffers)
                 logger.info(
                     f"Loading standard weights (non-FP8, async), "

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -41,6 +41,15 @@ VLLM_LORA_PATH = "simon_lora_path"
 
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
 
+_HAS_LORA_LOAD_WEIGHTS = False
+
+try:
+    from vllm.lora.layers.base import BaseLayerWithLoRA
+
+    _HAS_LORA_LOAD_WEIGHTS = "load_weights" in BaseLayerWithLoRA.__dict__
+except ImportError:
+    pass
+
 
 def _resolve_vllm_weight_sync_local_rank(worker_local_rank: int, parallel_config: Any) -> int:
     worker_local_rank = int(worker_local_rank)
@@ -211,10 +220,9 @@ class vLLMColocateWorkerExtension:
         the stacking -- returning a mapped name would double-map, e.g.
         ``in_proj_qkvz`` -> ``in_proj_qkvzz``, corrupting shard_id).
         """
-        # Auxiliary models (e.g. the MTP drafter) are never LoRA-wrapped, so they
-        # have no ``.base_layer`` params at all; drop the suffix wholesale (their
-        # name prefix differs from the main model, so per-name probing won't hit).
-        if ".base_layer." in name and not any(".base_layer." in n for n in model_weight_names):
+        # Strip ``.base_layer.``: vLLM's BaseLayerWithLoRA.load_weights delegates
+        # to AutoWeightsLoader(base_layer) expecting inner names (no base_layer.).
+        if ".base_layer." in name:
             return name.replace(".base_layer.", ".")
 
         mapper = getattr(model, "hf_to_vllm_mapper", None)
@@ -268,15 +276,15 @@ class vLLMColocateWorkerExtension:
             if _exists(stripped):
                 return stripped
 
-        # Leaf weight/bias: toggle one ``.base_layer`` segment.
+        # Leaf weight/bias: on vLLM versions without BaseLayerWithLoRA.load_weights),
+        # add ``.base_layer.`` so AutoWeightsLoader recurses into the base_layer
+        # child; on newer vLLM, the strip above already handled it.
         if is_leaf:
-            if ".base_layer." in name:
-                alt = name.replace(".base_layer.", ".", 1)
-            else:
+            if not _HAS_LORA_LOAD_WEIGHTS and ".base_layer." not in name:
                 prefix, lf = name.rsplit(".", 1)
                 alt = f"{prefix}.base_layer.{lf}"
-            if alt != name and _exists(alt):
-                return alt
+                if alt != name and _exists(alt):
+                    return alt
 
         return name
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -189,6 +189,97 @@ class vLLMColocateWorkerExtension:
         instance._is_modelopt_qat = _is_modelopt_qat
         return instance
 
+    # ------------------------------------------------------------------
+    # Receiver-side ``.base_layer`` reconciliation. With LoRA enabled, vLLM
+    # wraps *every* linear layer (not just the user's target_modules), exposing
+    # base weights under ``.base_layer``; Megatron only LoRA-wraps the user's
+    # target_modules, so Bridge exports plain names for the rest.
+    # The receiver reconciles each name against the live vLLM namespace --
+    # toggling one ``.base_layer`` segment (probe the model, not a hard-coded list).
+    # ------------------------------------------------------------------
+
+    def _resolve_weight_name(self, model, name: str, model_weight_names: set[str]) -> str:
+        """Reconcile an incoming sync name with the live vLLM namespace:
+
+        - toggle one ``.base_layer`` segment (add it for vLLM-wrapped leaves the
+          Megatron side didn't suffix, drop it for unwrapped ones);
+        - route packed routed-expert aliases (``experts.gate_up_proj``) under the
+          LoRA ``base_layer`` so AutoWeightsLoader reaches MoERunner.load_weights.
+
+        The mapper/``packed_modules_mapping`` are consulted only to *decide* the
+        toggle; the return is always the unmapped name (vLLM's load_weights does
+        the stacking -- returning a mapped name would double-map, e.g.
+        ``in_proj_qkvz`` -> ``in_proj_qkvzz``, corrupting shard_id).
+        """
+        # Auxiliary models (e.g. the MTP drafter) are never LoRA-wrapped, so they
+        # have no ``.base_layer`` params at all; drop the suffix wholesale (their
+        # name prefix differs from the main model, so per-name probing won't hit).
+        if ".base_layer." in name and not any(".base_layer." in n for n in model_weight_names):
+            return name.replace(".base_layer.", ".")
+
+        mapper = getattr(model, "hf_to_vllm_mapper", None)
+        packed = getattr(model, "packed_modules_mapping", None) or {}
+        leaf = name.rsplit(".", 1)[-1]
+        is_leaf = leaf in {"weight", "bias"} or leaf.endswith(("_weight", "_bias"))
+
+        def _exists(candidate: str) -> bool:
+            if candidate in model_weight_names:
+                return True
+            if mapper is not None:
+                mapped = mapper.apply_list([candidate])
+                mapped = mapped[0] if mapped else candidate
+                if mapped != candidate and mapped in model_weight_names:
+                    return True
+                # Packed-owner lookup (q/k/v -> qkv) via packed_modules_mapping.
+                if packed and "." in candidate:
+                    parts = candidate.split(".")
+                    mi = -3 if len(parts) >= 3 and parts[-2] == "base_layer" else -2
+                    if -mi <= len(parts):
+                        rev = {u: p for p, us in packed.items() for u in us}
+                        for pn in rev.get(parts[mi], ()):
+                            pp = parts.copy()
+                            pp[mi] = pn
+                            mp = mapper.apply_list([".".join(pp)])
+                            mp = mp[0] if mp else ".".join(pp)
+                            if mp != candidate and mp in model_weight_names:
+                                return True
+            return False
+
+        if _exists(name):
+            return name
+
+        # Packed routed-expert alias: route under the LoRA base_layer so
+        # AutoWeightsLoader reaches MoERunner.load_weights (FusedMoE3DWithLoRA
+        # has no load_weights itself). Only for non-leaf, non-routed names.
+        marker = ".mlp.experts."
+        idx = name.find(marker)
+        if idx != -1:
+            tail = name[idx + len(marker) :]
+            if (
+                tail
+                and ".base_layer." not in tail
+                and not is_leaf
+                and any("mlp.experts.base_layer." in n for n, _ in model.named_parameters(remove_duplicate=False))
+            ):
+                return name.replace(marker, marker + "base_layer.", 1)
+
+        if ".mlp.experts.base_layer." in name and not is_leaf:
+            stripped = name.replace(".base_layer.", ".", 1)
+            if _exists(stripped):
+                return stripped
+
+        # Leaf weight/bias: toggle one ``.base_layer`` segment.
+        if is_leaf:
+            if ".base_layer." in name:
+                alt = name.replace(".base_layer.", ".", 1)
+            else:
+                prefix, lf = name.rsplit(".", 1)
+                alt = f"{prefix}.base_layer.{lf}"
+            if alt != name and _exists(alt):
+                return alt
+
+        return name
+
     def _get_drafter_model(self):
         """Return the drafter's model object, or None if unavailable."""
         drafter = getattr(self.model_runner, "drafter", None)
@@ -263,8 +354,7 @@ class vLLMColocateWorkerExtension:
             prepare_modelopt_for_weight_reload(self.model_runner.model, device=self.device)
             logger.info("ModelOpt: prepare_modelopt_for_weight_reload completed")
         elif peft_config and base_sync_done:
-            # In async mode, make sure the old lora is removed before adding the new one
-            # TODO: this is buggy if lora span multiple buckets.
+            # Remove the old LoRA before the new one arrives (applied after is_last below).
             self.remove_lora(VLLM_LORA_INT_ID)
             logger.info("LoRA adapter sync: remove old lora and prepare new lora")
         elif is_fp8_model(self.model_runner.vllm_config):
@@ -284,13 +374,31 @@ class vLLMColocateWorkerExtension:
             device=self.device,
             use_shm=use_shm,
         )
-        receiver.receive_weights(
-            on_bucket_received=lambda weights: self._update_weights(
+        # LoRA adapters need a single complete tensor dict per ``add_lora``, but
+        # the bucketed transport may split one across buckets. Accumulate and
+        # apply only after ``is_last``; standard base weights load per bucket.
+        lora_weights: dict[str, torch.Tensor] | None = {} if (peft_config and base_sync_done) else None
+
+        def on_bucket_received(weights: list[tuple[str, torch.Tensor]], is_last: bool) -> None:
+            if lora_weights is not None:
+                # Clone: add_lora keeps these past the callback (reused IPC buffer, #6454).
+                lora_weights.update((name, tensor.clone()) for name, tensor in weights)
+                if not is_last:
+                    return
+                self._update_weights(
+                    list(lora_weights.items()),
+                    peft_config=peft_config,
+                    base_sync_done=base_sync_done,
+                )
+                lora_weights.clear()
+                return
+            self._update_weights(
                 weights,
                 peft_config=peft_config,
                 base_sync_done=base_sync_done,
             )
-        )
+
+        receiver.receive_weights(on_bucket_received=on_bucket_received)
 
         # =========================== step 3: process weights after loading ===========================
         if self._is_qat_model:
@@ -368,7 +476,9 @@ class vLLMColocateWorkerExtension:
             else:
                 if param_updates:
                     for model in self._iter_all_models():
-                        model.load_weights(param_updates)
+                        names = {n for n, _ in model.named_parameters(remove_duplicate=False)}
+                        names.update(n for n, _ in model.named_buffers())
+                        model.load_weights((self._resolve_weight_name(model, n, names), t) for n, t in param_updates)
                 loaded_buffers = self._apply_buffer_updates_all_models(buffer_updates, named_buffers)
                 logger.info(
                     f"Loading standard weights (non-FP8, async), "

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -484,9 +484,14 @@ class vLLMColocateWorkerExtension:
             else:
                 if param_updates:
                     for model in self._iter_all_models():
-                        names = {n for n, _ in model.named_parameters(remove_duplicate=False)}
-                        names.update(n for n, _ in model.named_buffers())
-                        model.load_weights((self._resolve_weight_name(model, n, names), t) for n, t in param_updates)
+                        if peft_config is None:
+                            model.load_weights(param_updates)
+                        else:
+                            names = {n for n, _ in model.named_parameters(remove_duplicate=False)}
+                            names.update(n for n, _ in model.named_buffers())
+                            model.load_weights(
+                                (self._resolve_weight_name(model, n, names), t) for n, t in param_updates
+                            )
                 loaded_buffers = self._apply_buffer_updates_all_models(buffer_updates, named_buffers)
                 logger.info(
                     f"Loading standard weights (non-FP8, async), "

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -220,11 +220,6 @@ class vLLMColocateWorkerExtension:
         the stacking -- returning a mapped name would double-map, e.g.
         ``in_proj_qkvz`` -> ``in_proj_qkvzz``, corrupting shard_id).
         """
-        # Strip ``.base_layer.``: vLLM's BaseLayerWithLoRA.load_weights delegates
-        # to AutoWeightsLoader(base_layer) expecting inner names (no base_layer.).
-        if ".base_layer." in name:
-            return name.replace(".base_layer.", ".")
-
         mapper = getattr(model, "hf_to_vllm_mapper", None)
         packed = getattr(model, "packed_modules_mapping", None) or {}
         leaf = name.rsplit(".", 1)[-1]
@@ -238,20 +233,34 @@ class vLLMColocateWorkerExtension:
                 mapped = mapped[0] if mapped else candidate
                 if mapped != candidate and mapped in model_weight_names:
                     return True
-                # Packed-owner lookup (q/k/v -> qkv) via packed_modules_mapping.
-                if packed and "." in candidate:
-                    parts = candidate.split(".")
-                    mi = -3 if len(parts) >= 3 and parts[-2] == "base_layer" else -2
-                    if -mi <= len(parts):
-                        rev = {u: p for p, us in packed.items() for u in us}
-                        for pn in rev.get(parts[mi], ()):
-                            pp = parts.copy()
-                            pp[mi] = pn
-                            mp = mapper.apply_list([".".join(pp)])
-                            mp = mp[0] if mp else ".".join(pp)
+            # Packed-owner lookup (q/k/v -> qkv) via packed_modules_mapping.
+            # Hoisted out of the mapper guard so models with
+            # packed_modules_mapping but no hf_to_vllm_mapper (e.g. Llama) also
+            # reach it.
+            if packed and "." in candidate:
+                parts = candidate.split(".")
+                mi = -3 if len(parts) >= 3 and parts[-2] == "base_layer" else -2
+                if -mi <= len(parts):
+                    # packed is {owner: [unpacked,...]}; invert to {unpacked: owner}.
+                    rev = {u: p for p, us in packed.items() for u in us}
+                    owner = rev.get(parts[mi])
+                    for pn in (owner,) if owner else ():
+                        pp = parts.copy()
+                        pp[mi] = pn
+                        joined = ".".join(pp)
+                        if joined in model_weight_names:
+                            return True
+                        if mapper is not None:
+                            mp = mapper.apply_list([joined])
+                            mp = mp[0] if mp else joined
                             if mp != candidate and mp in model_weight_names:
                                 return True
             return False
+
+        if ".base_layer." in name:
+            model_has_base_layer = any(".base_layer." in n for n in model_weight_names)
+            if not model_has_base_layer or _HAS_LORA_LOAD_WEIGHTS:
+                return name.replace(".base_layer.", ".", 1)
 
         if _exists(name):
             return name


### PR DESCRIPTION
### What does this PR do?

Reland of #5599 

With LoRA enabled, vLLM wraps *every* linear layer (exposing base weights under `.base_layer`), while Megatron only LoRA-wraps the user's `target_modules` and exports plain HF names for the rest. The old sender-side `add_base_layer_suffix` relied on hard-coded module lists (`MEGATRON_TO_HF_MODULES` / `STACKED_PARAMS`) that cannot track which names actually need the suffix, breaking e.g. the Qwen3.5-VL vision merger (`merger.linear_fc1`), packed shared-expert projections (`shared_expert.gate_up_proj`, crashing with `There is no module ... named 'shared_expert.gate_up_proj.weight'`), GDN `in_proj_qkv`, and LoRA-wrapped fused-MoE experts. The receiver now reconciles each incoming name against the live vLLM model namespace instead — toggling one `.base_layer` segment per name, consulting `hf_to_vllm_mapper` and `packed_modules_mapping` only to decide the toggle so vLLM's own `load_weights` still performs the stacking.

This PR also fixes two adjacent bugs hit in the same runs:

- LoRA adapters spanning multiple transfer buckets: the receiver now accumulates tensors and calls `add_lora` exactly once after the final bucket (resolving the previous `TODO: this is buggy if lora span multiple buckets`), cloning tensors because the IPC buffer is reused (#6454).
- Trainer spec-decode metrics: guard against rollout backends that do not report per-request `spec_num_*` stats, which previously raised `KeyError`.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
