### PR TITLE
[megatron] fix: forward mhc_multistream to MTP and skip activation reclaim for MTP checkpoints

### DIFF
--- a/verl/models/mcore/mtp_patch.py
+++ b/verl/models/mcore/mtp_patch.py
@@ -22,11 +22,7 @@ from typing import Callable
 import torch
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.models.gpt.gpt_model import GPTModel
-from megatron.core.transformer.multi_token_prediction import (
-    MTPLossAutoScaler,
-    MTPLossLoggingHelper,
-    roll_tensor,
-)
+from megatron.core.transformer.multi_token_prediction import MTPLossAutoScaler, MTPLossLoggingHelper, roll_tensor
 
 try:
     from megatron.core.transformer.multi_token_prediction import process_mtp_loss as _process_mtp_loss
@@ -93,6 +89,7 @@ def _megatron_gptmodel_postprocess(
     output_processor=None,
     output_processor_context=None,
     is_spec_decode=None,
+    mhc_multistream=None,
 ):
     """Postprocesses decoder hidden states to generate logits or compute loss.
 
@@ -111,6 +108,8 @@ def _megatron_gptmodel_postprocess(
             self.mtp._forward_has_padding_mask = "padding_mask" in signature(self.mtp.forward).parameters
         if self.mtp._forward_has_padding_mask:
             mtp_kwargs["padding_mask"] = padding_mask
+        if mhc_multistream is not None:
+            mtp_kwargs["mhc_multistream"] = mhc_multistream
         hidden_states = self.mtp(
             input_ids=input_ids,
             position_ids=position_ids,

--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -642,14 +642,29 @@ def apply_patch_megatron_recomputation_backward():
             for inp in detached_inputs
         )
         cur_stream = torch.cuda.current_stream()
-        # Release original input and grad tensors
-        for t in detached_inputs:
-            if isinstance(t, torch.Tensor) and t.requires_grad:
-                t.record_stream(cur_stream)
-                t.untyped_storage().resize_(0)
-                if t.grad is not None:
-                    t.grad.record_stream(cur_stream)
-                    t.grad.untyped_storage().resize_(0)
+        # Release saved input/grad tensors (MoE residual-memory leak fix, commit 04df110c).
+        # Skip MTP layer checkpoints: their saved ``hidden_states`` aliases the decoder
+        # output (a ``torch.chunk`` view), and MTP backward runs before the decoder
+        # backward, so ``resize_(0)`` would truncate storage the decoder still needs
+        # -> async CUDA illegal-memory-access.
+        is_mtp_checkpoint = False
+        run_fn = getattr(ctx, "run_function", None)
+        for cell in getattr(run_fn, "__closure__", None) or ():
+            try:
+                obj = cell.cell_contents
+            except ValueError:
+                continue
+            if obj.__class__.__name__ == "MultiTokenPredictionLayer":
+                is_mtp_checkpoint = True
+                break
+        if not is_mtp_checkpoint:
+            for t in detached_inputs:
+                if isinstance(t, torch.Tensor) and t.requires_grad:
+                    t.record_stream(cur_stream)
+                    t.untyped_storage().resize_(0)
+                    if t.grad is not None:
+                        t.grad.record_stream(cur_stream)
+                        t.grad.untyped_storage().resize_(0)
         # ctx.saved_tensors = None
         return (None, None) + grads
 

--- a/verl/utils/vllm/vllm_quant_utils.py
+++ b/verl/utils/vllm/vllm_quant_utils.py
@@ -30,6 +30,7 @@ dispatch below stays unconditional.
 
 import importlib.metadata
 import logging
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -37,10 +38,14 @@ import torch
 from packaging import version
 
 try:
-    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
     from vllm.model_executor.layers.linear import LinearBase
 except ImportError as e:
     raise ImportError("FP8 quantization not available") from e
+
+try:
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+except ImportError:
+    FusedMoE = None
 
 from verl.utils.kernel.fp8_kernel import scaled_fp8_blockwise
 from verl.utils.vllm.vllm_fp4_utils import (
@@ -91,10 +96,12 @@ def is_fp8_model(vllm_config):
 # ``nn.Module`` class. ``FusedMoE`` is now a factory *function* that builds a
 # ``MoERunner``, and the fused expert weight tensors (``w13_weight`` /
 # ``w2_weight``) moved onto a ``RoutedExperts`` submodule owned by the runner
-# (i.e. ``experts`` -> ``experts.routed_experts``). Resolve the concrete module
-# classes once so ``isinstance`` checks keep working across vLLM versions --
-# calling ``isinstance(x, FusedMoE)`` when ``FusedMoE`` is a function raises
-# ``TypeError: isinstance() arg 2 must be a type``.
+# (i.e. ``experts`` -> ``experts.routed_experts``). vLLM 0.26.1 removed the
+# ``FusedMoE`` name entirely. Resolve the concrete module classes once so
+# ``isinstance`` checks keep working across vLLM versions -- calling
+# ``isinstance(x, FusedMoE)`` when ``FusedMoE`` is a function raises
+# ``TypeError: isinstance() arg 2 must be a type``, and ``FusedMoE`` may be
+# ``None`` when the name no longer exists.
 if isinstance(FusedMoE, type):
     # vLLM < 0.24: ``FusedMoE`` is itself the expert-weight-holding module.
     _MOE_STOP_CLASSES = (FusedMoE,)
@@ -380,9 +387,17 @@ def load_quanted_weights(weights, model_runner, is_drafter=False):
         if hasattr(param, "subclass_type"):
             param.orig_type = param.__class__
             param.__class__ = param.subclass_type
-    # Finally load the weights into vllm
+    # Finally load the weights into vllm.
+    # MTP completeness check assumes a single full-checkpoint load; in RL refit
+    # weights arrive bucketed, so disable it (like vLLM's own NCCL/IPC engines).
+    # ``nullcontext`` covers older vLLM without the guard.
     try:
-        loaded_params = model.load_weights(weights_quantized)
+        from vllm.model_executor.model_loader.mtp_validation import disable_mtp_completeness_check
+    except ImportError:
+        disable_mtp_completeness_check = nullcontext
+    try:
+        with disable_mtp_completeness_check():
+            loaded_params = model.load_weights(weights_quantized)
     finally:
         # Undo the type change above to the original type
         for name, param in model.named_parameters():


### PR DESCRIPTION
### What does this PR do?

Fixes two crashes that block mHC (manifold hyper-connections) + MTP training on Megatron-core (DeepSeek-V4, `use_fused_mhc=False` + `mtp.enable=True`). Both stem from verl's MTP postprocess / recomputation patches not accounting for the mHC multi-stream tensor.

**Background:** With mHC + MTP, the decoder returns a tuple `(contracted_hidden, mhc_multistream)` where `mhc_multistream` is the pre-contraction `[s, b, n*h]` multi-stream tensor. `GPTModel._postprocess` forwards `mhc_multistream` into `self.mtp(...)`, and the MTP module branches on it (`if mhc_multistream is not None`) to use the multi-stream tensor as its depth input. `mhc_multistream` is a plain alias of the decoder output (`transformer_block.py`: `mhc_multistream = hidden_states`), and the MTP depth input is a `torch.chunk` **view** of it — i.e. shared storage, not a copy.

**Bug 1 — reshape crash (forward):** verl's patched `_megatron_gptmodel_postprocess` (`mtp_patch.py`) accepted `mhc_multistream` as a parameter but never forwarded it into `self.mtp(...)`, so it arrived as `None` inside MTP. MTP then took the contracted `[s, b, h]` path while the mHC branch of `_concat_embeddings` expected `[s, b, n*h]`, failing at:
```
RuntimeError: shape '[23986, 1, 4, 4096]' is invalid for input of size 98246656
```
Fix: forward `mhc_multistream` into the `self.mtp(...)` call, matching the upstream `GPTModel._postprocess`.

**Bug 2 — async CUDA illegal-memory-access (backward):** verl's recomputation backward patch (`apply_patch_megatron_recomputation_backward`, commit 04df110c, a MoE residual-memory leak fix) reclaims saved activation memory by calling `t.untyped_storage().resize_(0)` on every checkpoint input after computing grads. With mHC + MTP this is a **use-after-free**: the MTP checkpoint's saved `hidden_states` is a `torch.chunk` view of the decoder's `mhc_multistream` (shared storage via `make_viewless_tensor` → `_kernel_make_viewless_tensor` doing `out.data = inp.data`), and the MTP checkpoint backward runs **before** the decoder's `learned_output_contract` backward (reverse topological order). `resize_(0)` therefore truncates storage the pending decoder backward still reads → async CUDA illegal-memory-access, surfacing at the next sync point (`set_state` inside `_fork_rng.__exit__`).

Fix: detect MTP-layer checkpoints by inspecting the `MultiTokenPredictionLayer` instance captured in `ctx.run_function.__closure__` (its `__qualname__` is `..._checkpointed_forward.<locals>.custom_forward`, which carries no class name), and skip the `resize_(0)` reclaim for those. Non-MTP checkpoints keep the reclaim, preserving the original MoE leak fix.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
