### PR TITLE
[single_controller, trainer] fix: finalize nsys capture range in continuous profiling

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -465,7 +465,15 @@ class RayWorkerGroup(WorkerGroup):
         self.worker_nsight_options = kwargs.get("worker_nsight_options", None)
         self.customized_worker_env = kwargs.get("worker_env", {})
         if self.worker_nsight_options is not None and self.worker_nsight_options["capture-range-end"] is None:
-            self.worker_nsight_options["capture-range-end"] = f"repeat-shutdown:{6 * len(self.profile_steps)}"
+            # Continuous profiling (discrete=False) opens a single cudaProfilerApi
+            # capture range per profiled step, while discrete profiling opens one
+            # per annotated role. Match repeat-shutdown to the number of ranges
+            # that are actually produced; otherwise nsys keeps waiting for ranges
+            # that never arrive and only finalizes the .nsys-rep at process exit.
+            ranges_per_step = 6 if kwargs.get("profiler_discrete", True) else 1
+            self.worker_nsight_options["capture-range-end"] = (
+                f"repeat-shutdown:{ranges_per_step * len(self.profile_steps)}"
+            )
 
         if worker_names is not None and (not self.fused_worker_used):
             assert self._is_init_with_detached_workers

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -865,6 +865,9 @@ class RayPPOTrainer:
                 wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
                     OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
                 )
+                wg_kwargs["profiler_discrete"] = bool(
+                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "discrete")
+                )
         wg_kwargs["device_name"] = self.device_name
 
         for resource_pool, class_dict in self.resource_pool_to_cls.items():


### PR DESCRIPTION
### What does this PR do?

Finalize the nsys `.nsys-rep` when profiling in continuous (non-discrete) mode.

`RayWorkerGroup` defaults `capture-range-end` to `repeat-shutdown:{6 * len(profile_steps)}`, which assumes discrete profiling emits six `cudaProfilerApi` ranges per profiled step. With `discrete=False` (the default), `NsightSystemsProfiler.start/stop` opens a single capture range for the whole step, so only `len(profile_steps)` ranges are ever produced. nsys keeps waiting for ranges that never arrive, never reaches `repeat-shutdown`, and only flushes the report when the worker process exits. Collection that runs per profiled step (or any time before teardown) then finds no finalized report.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+capture-range-end (none address the continuous-mode finalization)

### Test

Repro with continuous nsys profiling:

- `global_profiler.tool=nsys`, `global_profiler.steps=[<step>]`, `global_profiler.global_tool_config.nsys.discrete=false`, and `worker_nsight_options["capture-range-end"]=null`.
- Before: the profiled step runs but the `.nsys-rep` is not finalized during the run; it only appears after the worker process exits, so reading it right after the profiled step yields nothing usable.
- After: `capture-range-end` resolves to `repeat-shutdown:{len(steps)}`; nsys finalizes the `.nsys-rep` right after the profiled step(s) and the report is readable without waiting for teardown.

Discrete mode (`discrete=true`) is unaffected and still uses `repeat-shutdown:{6 * len(steps)}`.

### API and Usage Example

No public API change. `profiler_discrete` is an internal kwarg passed from `RayPPOTrainer.init_workers` to `RayWorkerGroup`; the default preserves prior behavior for any caller that does not set it.

### Design & Code Changes

- `verl/trainer/ppo/ray_trainer.py`: pass `profiler_discrete` (from `global_profiler.global_tool_config.nsys.discrete`) into the worker group kwargs.
- `verl/single_controller/ray/base.py`: scale `repeat-shutdown` by the ranges actually produced per step (1 continuous, 6 discrete) instead of hardcoding 6.
