### PR TITLE
[trainer] fix: migrate legacy reward config on the main PPO entrypoint

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -19,6 +19,7 @@ import hydra
 import ray
 from omegaconf import DictConfig, OmegaConf
 
+from verl.experimental.reward_loop import migrate_legacy_reward_impl
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
 from verl.trainer.ppo.utils import need_critic, need_reference_policy
 from verl.utils.config import validate_config
@@ -173,6 +174,12 @@ def main(config):
     """
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
     auto_set_device(config)
+
+    # Map the deprecated top-level reward keys (custom_reward_function, reward_model,
+    # sandbox_fusion) that ppo_trainer.yaml still ships via `legacy_reward_impl` onto
+    # `config.reward.*`, which is the only location the reward loop reads. Without this
+    # a legacy config is silently ignored.
+    config = migrate_legacy_reward_impl(config)
 
     # validate config
     validate_config(


### PR DESCRIPTION
### What does this PR do?

Restore the `migrate_legacy_reward_impl(config)` call on the main PPO entrypoint so the deprecated top-level reward keys are mapped onto `config.reward.*` before validation and use.

`verl/trainer/config/ppo_trainer.yaml` still composes `legacy_reward_impl` ("legacy reward impl config, for backward compatibility"), which ships the top-level `custom_reward_function`, `reward_model` and `sandbox_fusion` groups (all defaulting to `null`). The reward loop only ever reads the migrated location:

- `verl/trainer/ppo/reward.py::get_custom_reward_fn` reads `config.reward.custom_reward_function`
- `verl/trainer/ppo/reward.py::load_reward_manager` reads `config.reward.reward_manager` / `config.reward.sandbox_fusion`

`migrate_legacy_reward_impl` (`verl/experimental/reward_loop/reward_loop.py`) is the only thing that copies the legacy top-level keys onto `config.reward.*`. `verl/trainer/main_ppo.py::main` no longer calls it, so a run that sets the still-shipped legacy keys has them silently ignored and falls back to the default reward manager. The sibling entrypoint `verl/experimental/fully_async_policy/fully_async_main.py` still calls the migration, so the two entrypoints disagree.

### Checklist Before Starting

- [x] Searched for similar PRs (none open touch the `main_ppo.py` migration call).

### Test

Repro (before this PR):

- Set only the legacy top-level keys, e.g. `custom_reward_function.path=/path/to/reward.py custom_reward_function.name=compute_score`, and leave `reward.custom_reward_function.path` unset.
- Before: the legacy value is not migrated onto `config.reward.custom_reward_function`, so `get_custom_reward_fn` returns `None` and the run silently uses the default reward manager instead of the user's function.
- After: `migrate_legacy_reward_impl` copies the legacy keys onto `config.reward.*` before validation, so the user's custom reward function is used, matching `fully_async_main.py`.

Passing `reward.custom_reward_function.*` directly is unaffected (migration only fills the new keys when the legacy ones are non-null).

### API and Usage Example

No public API change. This only restores backward compatibility for the legacy top-level reward config on the main entrypoint.

### Design & Code Changes

- `verl/trainer/main_ppo.py`: import `migrate_legacy_reward_impl` and call it in `main()` right after `auto_set_device`, before `validate_config`, mirroring `fully_async_main.py`.
