### PR TITLE
[misc] fix: warn on engine backend import failure instead of silent skip

### DIFF
--- a/verl/workers/engine/__init__.py
+++ b/verl/workers/engine/__init__.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
+
 from .base import BaseEngine, EngineRegistry
 from .fsdp import FSDPEngine, FSDPEngineWithLMHead
 
@@ -25,7 +27,8 @@ try:
     from .torchtitan import TorchTitanEngine, TorchTitanEngineWithLMHead
 
     __all__ += ["TorchTitanEngine", "TorchTitanEngineWithLMHead"]
-except ImportError:
+except ImportError as e:
+    warnings.warn(f"torchtitan engine is not available: {e!r}", stacklevel=1)
     TorchTitanEngine = None
     TorchTitanEngineWithLMHead = None
 
@@ -33,7 +36,8 @@ try:
     from .veomni import VeOmniEngine, VeOmniEngineWithLMHead
 
     __all__ += ["VeOmniEngine", "VeOmniEngineWithLMHead"]
-except ImportError:
+except ImportError as e:
+    warnings.warn(f"veomni engine is not available: {e!r}", stacklevel=1)
     VeOmniEngine = None
     VeOmniEngineWithLMHead = None
 
@@ -41,7 +45,8 @@ try:
     from .automodel import AutomodelEngine, AutomodelEngineWithLMHead
 
     __all__ += ["AutomodelEngine", "AutomodelEngineWithLMHead"]
-except ImportError:
+except ImportError as e:
+    warnings.warn(f"automodel engine is not available: {e!r}", stacklevel=1)
     AutomodelEngine = None
     AutomodelEngineWithLMHead = None
 
@@ -50,7 +55,8 @@ try:
     from .mindspeed import MindspeedEngineWithLMHead, MindspeedEngineWithValueHead, MindSpeedMegatronEngineWithLMHead
 
     __all__ += ["MindspeedEngineWithLMHead", "MindspeedEngineWithValueHead", "MindSpeedMegatronEngineWithLMHead"]
-except ImportError:
+except ImportError as e:
+    warnings.warn(f"mindspeed engine is not available: {e!r}", stacklevel=1)
     MindspeedEngineWithLMHead = None
     MindspeedEngineWithValueHead = None
     MindSpeedMegatronEngineWithLMHead = None
@@ -59,6 +65,7 @@ try:
     from .megatron import MegatronEngine, MegatronEngineWithLMHead, MegatronEngineWithValueHead
 
     __all__ += ["MegatronEngine", "MegatronEngineWithLMHead", "MegatronEngineWithValueHead"]
-except ImportError:
+except ImportError as e:
+    warnings.warn(f"megatron engine is not available: {e!r}", stacklevel=1)
     MegatronEngine = None
     MegatronEngineWithLMHead = None


### PR DESCRIPTION
### What does this PR do?

Optional engine backends (torchtitan/veomni/automodel/mindspeed/megatron) were swallowed by bare `except ImportError`, so a broken dependency (e.g. flash-attn built against a mismatched CUDA runtime) only surfaced later as a misleading `"Unknown backend: megatron"` assertion. Emit a warning with the actual ImportError to make the root cause visible in logs.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
