### PR TITLE
[megatron] feat: add Qwen3.5 THD (packed sequence) Megatron SFT example

### DIFF
--- a/examples/sft/gsm8k/run_qwen3_5_35b_a3b_megatron.sh
+++ b/examples/sft/gsm8k/run_qwen3_5_35b_a3b_megatron.sh
@@ -1,36 +1,46 @@
 #!/usr/bin/env bash
-# Qwen3.5-397B-A17B SFT with Megatron backend + mbridge
+# Qwen3.5-35B-A3B SFT with Megatron backend, packed sequences (THD format)
+#
+# This is the counterpart to run_qwen3_5_397b_a17b_megatron.sh, which runs the same
+# architecture family in bshd (padded) format. Qwen3.5 uses Gated Delta Net (GDN) linear
+# attention, and GDN did not support packed sequences until
+# https://github.com/NVIDIA/Megatron-LM/pull/2644 -- merged 2026-04-07 and first shipped
+# in a megatron-core release in 0.18.0. On 0.18.0+ THD works, so the padding no longer has
+# to be computed.
 #
 # Requirements:
-#   - 128+ GPUs (80GB each, e.g. 16x8 H100/H200)
-#   - Docker: verlai/verl:vllm015 (or equivalent)
+#   - 16+ GPUs (80GB each, e.g. 2x8 H100/H200/H20) for the parallelism below
+#   - megatron-core >= 0.18.0    <-- GDN packed-sequence support; earlier releases
+#                                    (0.16.x, 0.17.x) silently lack the THD branch in
+#                                    megatron/core/ssm/gated_delta_net.py
 #   - Additional packages on top of the base image:
 #       pip install --upgrade transformers
 #       pip install flash-linear-attention
-#       pip install -U git+https://github.com/ISEEKYAN/mbridge.git
-#   - Megatron-LM==0.16.0
 #
-# Qwen3.5 architecture notes:
-#   Qwen3.5 uses Gated Delta Net (GDN) linear attention. GDN did not support packed
-#   sequences (THD format) on the Megatron-LM 0.16.0 pinned above, so this script runs
-#   in bshd (padded) format:
-#     - engine.use_remove_padding=False  (forces bshd compute format)
-#     - data.use_dynamic_bsz=False       (required for bshd mode)
+# Data:
+#   python3 examples/data_preprocess/gsm8k_multiturn_sft.py --local_save_dir ~/dataset
 #
-#   https://github.com/NVIDIA/Megatron-LM/pull/2644 (the PR this note used to wait on)
-#   merged 2026-04-07 and first shipped in megatron-core 0.18.0, so THD is available
-#   there. This script is left on bshd because it is pinned to Megatron-LM 0.16.0 and its
-#   parallelism config was validated that way; see
-#   run_qwen3_5_35b_a3b_megatron.sh for a THD configuration on megatron-core >= 0.18.0.
+# THD (packed sequence) settings -- all three are needed:
+#   model.use_remove_padding=True    unpad on the model side
+#   engine.use_remove_padding=True   thd compute format in the Megatron engine
+#   data.use_dynamic_bsz=True        batch by token budget instead of sample count;
+#                                    this is what turns unpadding into a throughput win
+#   data.max_token_len_per_gpu       per-GPU token budget. The effective micro-batch
+#                                    budget is max_token_len_per_gpu * CP_SIZE, so it must
+#                                    be >= data.max_length / CP_SIZE for a longest-sample
+#                                    micro-batch to fit.
 #
-# MTP (Multi-Token Prediction) notes:
-#   - model.mtp.enable=True               enables MTP module
-#   - model.mtp.enable_train=True         enables MTP training loss
-#   - model.mtp.detach_encoder=True       detaches encoder gradients for MTP
-#   - model.mtp.mtp_loss_scaling_factor   weight of MTP auxiliary loss (e.g. 0.1)
+# attention_backend is deliberately not set: the default (Megatron-Bridge) path already
+# pins AttnBackend.flash. Do not switch this example to the deprecated
+# engine.vanilla_mbridge=True path without also setting
+#   +engine.override_transformer_config.attention_backend=flash
+# There, attention_backend falls back to megatron's `auto`, which prefers cuDNN fused
+# attention on Hopper+; cuDNN's SDPA backward has an uninitialized-workspace defect on
+# Hopper (fixed in cuDNN 9.18) that makes THD backward produce huge dK/dV and then NaN
+# gradients. See https://github.com/NVIDIA/TransformerEngine/issues/2186.
 #
-# Tested parallelism config (128 GPUs / 16 nodes):
-#   TP=2 PP=4 EP=32 CP=1
+# Tested parallelism config (16 GPUs / 2 nodes):
+#   TP=2 PP=2 CP=2 EP=8
 
 set -xeuo pipefail
 
@@ -40,7 +50,7 @@ set -xeuo pipefail
 NUM_GPUS=${NUM_GPUS:-8}
 MASTER_ADDR=${MASTER_ADDR:-localhost}
 MASTER_PORT=${MASTER_PORT:-29500}
-NNODES=${NNODES:-16}
+NNODES=${NNODES:-2}
 NODE_RANK=${NODE_RANK:-0}
 
 # ============================================================
@@ -52,24 +62,25 @@ TRAIN_FILES=${TRAIN_FILES:-${DATASET_DIR}/train.parquet}
 # ============================================================
 # Model
 # ============================================================
-MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3.5-397B-A17B}
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3.5-35B-A3B}
 
 # ============================================================
 # Parallelism
 # ============================================================
 TP_SIZE=${TP_SIZE:-2}
-PP_SIZE=${PP_SIZE:-4}
+PP_SIZE=${PP_SIZE:-2}
 VPP_SIZE=${VPP_SIZE:-null}
-CP_SIZE=${CP_SIZE:-1}
-EP_SIZE=${EP_SIZE:-32}
+CP_SIZE=${CP_SIZE:-2}
+EP_SIZE=${EP_SIZE:-8}
 ETP_SIZE=${ETP_SIZE:-1}
 
 # ============================================================
 # Training
 # ============================================================
-TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-128}
-MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-2}
+TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-64}
 MAX_LENGTH=${MAX_LENGTH:-2048}
+# Token budget per GPU per micro-batch. Effective budget is this * CP_SIZE.
+MAX_TOKEN_LEN_PER_GPU=${MAX_TOKEN_LEN_PER_GPU:-2048}
 LR=${LR:-2e-5}
 MIN_LR=${MIN_LR:-2e-6}
 DTYPE=${DTYPE:-bfloat16}
@@ -78,24 +89,16 @@ BACKEND=megatron
 RESUME_MODE=${RESUME_MODE:-disable}
 
 project_name=verl_sft_qwen3_5
-exp_name=qwen3_5-${BACKEND}-tp${TP_SIZE}-pp${PP_SIZE}-cp${CP_SIZE}-ep${EP_SIZE}
+exp_name=qwen3_5-35b-a3b-${BACKEND}-thd-tp${TP_SIZE}-pp${PP_SIZE}-cp${CP_SIZE}-ep${EP_SIZE}
 ckpts_home=${ckpts_home:-~/verl/checkpoints/${project_name}/${exp_name}}
 mkdir -p "${ckpts_home}"
 
 # ============================================================
-# MTP hyper-parameters
-# ============================================================
-MTP_ENABLE=${MTP_ENABLE:-True}
-MTP_ENABLE_TRAIN=${MTP_ENABLE_TRAIN:-True}
-MTP_DETACH_ENCODER=${MTP_DETACH_ENCODER:-True}
-MTP_LOSS_SCALING_FACTOR=${MTP_LOSS_SCALING_FACTOR:-0.1}
-
-# ============================================================
 # Engine config
 # ============================================================
-# Key Qwen3.5 settings:
-#   engine.use_remove_padding=False   - bshd format (THD needs megatron-core >= 0.18.0)
-#   engine.vanilla_mbridge=True       - use mbridge (not megatron-bridge)
+# Key Qwen3.5 THD settings:
+#   engine.use_remove_padding=True   - thd compute format (needs megatron-core >= 0.18.0)
+#   attention_backend unset          - default bridge path already pins flash (see header)
 ENGINE_CONFIG="\
     engine=${BACKEND} \
     optim=${BACKEND} \
@@ -107,21 +110,14 @@ ENGINE_CONFIG="\
     optim.clip_grad=1.0 \
     optim.lr_warmup_init=0 \
     optim.lr_decay_style=cosine \
-    +optim.override_optimizer_config.optimizer_offload_fraction=1 \
-    +optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True \
-    +optim.override_optimizer_config.use_precision_aware_optimizer=True \
-    +optim.override_optimizer_config.optimizer_cpu_offload=True \
     engine.tensor_model_parallel_size=${TP_SIZE} \
     engine.pipeline_model_parallel_size=${PP_SIZE} \
     engine.virtual_pipeline_model_parallel_size=${VPP_SIZE} \
     engine.context_parallel_size=${CP_SIZE} \
     engine.expert_model_parallel_size=${EP_SIZE} \
     engine.expert_tensor_parallel_size=${ETP_SIZE} \
-    engine.use_mbridge=True \
-    engine.vanilla_mbridge=True \
     engine.dtype=${DTYPE} \
-    engine.use_remove_padding=False \
-    engine.override_transformer_config.attention_backend=auto \
+    engine.use_remove_padding=True \
     +engine.override_transformer_config.recompute_method=uniform \
     +engine.override_transformer_config.recompute_granularity=full \
     +engine.override_transformer_config.recompute_num_layers=1"
@@ -138,26 +134,21 @@ torchrun \
     -m verl.trainer.sft_trainer \
     data.train_files="${TRAIN_FILES}" \
     data.train_batch_size=${TRAIN_BATCH_SIZE} \
-    data.micro_batch_size_per_gpu=${MICRO_BATCH_SIZE} \
     data.max_length=${MAX_LENGTH} \
     data.pad_mode=no_padding \
     data.truncation=error \
-    data.use_dynamic_bsz=False \
-    data.max_token_len_per_gpu=${MAX_LENGTH} \
+    data.use_dynamic_bsz=True \
+    data.max_token_len_per_gpu=${MAX_TOKEN_LEN_PER_GPU} \
     data.messages_key=messages \
     model.path=${MODEL_PATH} \
-    model.use_remove_padding=False \
+    model.use_remove_padding=True \
     model.trust_remote_code=True \
-    model.mtp.enable=${MTP_ENABLE} \
-    model.mtp.enable_train=${MTP_ENABLE_TRAIN} \
-    model.mtp.detach_encoder=${MTP_DETACH_ENCODER} \
-    model.mtp.mtp_loss_scaling_factor=${MTP_LOSS_SCALING_FACTOR} \
     ${ENGINE_CONFIG} \
     trainer.test_freq=-1 \
     trainer.save_freq=500 \
-    trainer.logger='["console","wandb"]' \
+    trainer.logger='["console"]' \
     trainer.project_name="${project_name}" \
     trainer.experiment_name="${exp_name}" \
     trainer.total_epochs=1 \
     trainer.default_local_dir="${ckpts_home}" \
-    trainer.resume_mode=${RESUME_MODE} 
+    trainer.resume_mode=${RESUME_MODE}


### PR DESCRIPTION
### What does this PR do?

`examples/sft/gsm8k/` has no Megatron 3D-parallel SFT example that uses packed sequences (THD). Every megatron example there runs bshd, and the only one that sets the flag explicitly — `run_qwen3_5_397b_a17b_megatron.sh` — sets `use_remove_padding=False` with this note:

> Qwen3.5 uses Gated Delta Net (GDN) linear attention which currently does NOT support packed sequences (THD format) in Megatron-LM. [...] Once https://github.com/NVIDIA/Megatron-LM/pull/2644 is merged, THD format will be supported.

That note was accurate when it was written (#5381, 2026-03-13) but is **no longer true**:

- Megatron-LM#2644 *"feat(moe): Support packed sequence for gated delta net (GDN)"* merged **2026-04-07**.
- The THD branch in `megatron/core/ssm/gated_delta_net.py` first ships in a megatron-core release in **0.18.0**. Verified by content inspection across release tags — `git show <tag>:megatron/core/ssm/gated_delta_net.py | grep "qkv_format == 'thd'"` finds nothing in `core_v0.16.0` / `0.16.1` / `0.17.0` / `0.17.1`, and finds it in `core_v0.18.0` / `0.18.2`. (`git merge-base --is-ancestor` is not usable here: NVIDIA's public mirror does not carry the internal merge commit as an ancestor of the release tags, so it reports a false negative.)
- megatron-core 0.18.2 also parametrizes its own GDN test over `sequence_packing` (`tests/unit_tests/ssm/test_gated_delta_net.py`).

So THD works for this architecture family on megatron-core >= 0.18.0, and the padding no longer has to be computed.

### Checklist Before Starting

- [x] Search for similar PRs. Queries run: [`GDN THD sequence packing`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+GDN+THD+sequence+packing), [`use_remove_padding megatron sft`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+use_remove_padding+megatron+sft), [`attention_backend flash fused NaN`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+attention_backend+flash+fused+NaN). No open PR covers GDN+THD or a Megatron THD SFT example. The nearest related one is #5346 (`[fsdp] fix: make GDN work correctly when using ulysses and varlen sequence`), which is the FSDP path and does not overlap.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Ran the new example end-to-end on **2 nodes / 16 GPUs (H20-141G)**, `megatron-core 0.18.2`, `torch 2.11.0+cu128`, Qwen3.5-35B-A3B, gsm8k:

```bash
python3 examples/data_preprocess/gsm8k_multiturn_sft.py --local_save_dir ~/dataset
NNODES=2 NUM_GPUS=8 MODEL_PATH=<Qwen3.5-35B-A3B> \
  bash examples/sft/gsm8k/run_qwen3_5_35b_a3b_megatron.sh
```

Result — **completed the full epoch, 116/116 steps**:

| step | 1 | 13 | 25 | 37 | 49 | 61 | 73 | 85 | 97 | 109 | 116 |
|---|---|---|---|---|---|---|---|---|---|---|---|
| `train/loss` | 0.7730 | 0.3938 | 0.3717 | 0.3110 | 0.3379 | 0.2985 | 0.3214 | 0.3267 | 0.2901 | 0.2984 | 0.3116 |

- 3.76 s/it steady state (9.22 s/it for the first few steps, including warmup)
- `max_memory_allocated 42.93 GB`, `max_memory_reserved 51.85 GB`
- **Zero NaN / errors** — `found NaN`, `loss:nan`, `Traceback`, `RuntimeError`, `AssertionError` all have zero occurrences in the logs
- THD was confirmed genuinely active (not silently falling back to bshd): `model.use_remove_padding=True`, `engine.use_remove_padding=True` and `data.use_dynamic_bsz=True` all present in the launched `torchrun` arguments, with **no** `attention_backend` override — which is also what the header claims (the default Megatron-Bridge path already pins `AttnBackend.flash`).

One deviation to disclose: the cluster used for this run has no external network access, so instead of downloading gsm8k, the run converted an already-present RL-format gsm8k parquet into the SFT `messages` schema. This is field-for-field equivalent to `gsm8k_multiturn_sft.py`, because `gsm8k.py` and `gsm8k_multiturn_sft.py` build the user turn from the *same* literal instruction string, so `prompt[0].content` equals the SFT user content and `extra_info.answer` equals `answer_raw` (7473 rows, no rows dropped).

### API and Usage Example

No API change. New example script only:

```bash
# THD (packed sequences) on megatron-core >= 0.18.0
NNODES=2 NUM_GPUS=8 bash examples/sft/gsm8k/run_qwen3_5_35b_a3b_megatron.sh

# knobs (defaults shown)
TP_SIZE=2 PP_SIZE=2 CP_SIZE=2 EP_SIZE=8 \
MAX_LENGTH=2048 MAX_TOKEN_LEN_PER_GPU=2048 \
  bash examples/sft/gsm8k/run_qwen3_5_35b_a3b_megatron.sh
```

### Design & Code Changes

1. **Add `examples/sft/gsm8k/run_qwen3_5_35b_a3b_megatron.sh`** — Qwen3.5-35B-A3B on gsm8k, TP2/PP2/CP2/EP8, with the three settings THD needs (`model.use_remove_padding`, `engine.use_remove_padding`, `data.use_dynamic_bsz`) and a note on how `data.max_token_len_per_gpu` interacts with `CP_SIZE` (the effective micro-batch budget is `max_token_len_per_gpu * CP_SIZE`).

   `attention_backend` is deliberately left unset, because the default (Megatron-Bridge) path already pins `AttnBackend.flash`. The header records why the deprecated `engine.vanilla_mbridge=True` path needs it set explicitly: there `attention_backend` falls back to megatron's `auto`, which prefers cuDNN fused attention on Hopper+, and cuDNN's SDPA backward has an uninitialized-workspace defect on Hopper (fixed in cuDNN 9.18) that makes THD backward produce huge dK/dV and then NaN gradients — see NVIDIA/TransformerEngine#2186.

2. **Update the stale THD note in `run_qwen3_5_397b_a17b_megatron.sh`** to point at the new example. Comment-only; **its behaviour is deliberately unchanged**, since it is pinned to Megatron-LM 0.16.0 and its parallelism config was validated that way, and I cannot test a 128-GPU 397B configuration.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] Apply pre-commit checks — `pre-commit` was not installable in my environment, so I ran the repo's own sanity checks directly instead: `python3 tests/special_sanity/check_example_naming.py --root examples` (✅ 101/101), `python3 tests/special_sanity/check_pr_title.py` with this title (✅), and `bash -n` on both scripts. Please let me know if you want a pre-commit run before merge.
- [ ] Add / Update the documentation — not applicable; this is an example script with an explanatory header.
- [ ] Add unit or end-to-end test(s) to the CI workflow — not feasible: this needs 16 GPUs, a 35B MoE checkpoint and megatron-core >= 0.18.0. Validated by the experiment above instead.

---

**AI assistance disclosure:** this change was prepared with AI assistance (Claude). I reviewed every changed line, ran the verification run described above myself, and can defend the change end-to-end.
