### PR TITLE
fix: skip weight resume when sleep_level=1 in LoRA adapter mode (#7289)

### DIFF
--- a/tests/workers/test_engine_workers_lora_sync.py
+++ b/tests/workers/test_engine_workers_lora_sync.py
@@ -463,3 +463,94 @@ class TestEdgeCases:
 
         engine.get_per_tensor_param.assert_called_once_with(layered_summon=False, base_sync_done=True)
         assert rollout.update_weights.call_args.kwargs["base_sync_done"] is True
+
+
+# ---------------------------------------------------------------------------
+# Regression test for issue #7289: multi-iteration LoRA adapter cycle
+# ---------------------------------------------------------------------------
+
+
+class TestLoraAdapterMultiIterationCycle:
+    """Regression test for https://github.com/verl-project/verl/issues/7289.
+
+    The bug: on the second weight sync, resume(tags=["weights"]) is called
+    but release() only freed kv_cache (because sleep_level=1 was set during
+    the first sync). This causes a KeyError in SGLang because weights were
+    never released.
+
+    The fix: skip weight resume when sleep_level=1.
+    """
+
+    def test_second_iteration_does_not_resume_weights(self):
+        """Simulate two full sync cycles in adapter mode.
+
+        First cycle: sleep_level not set yet, so weights are resumed (OK).
+        Second cycle: sleep_level=1 from first cycle, weights NOT released
+        by release(), so resume must skip weights.
+        """
+        peft_cfg = MagicMock()
+        rollout, engine = _make_mocks(
+            peft_config=peft_cfg,
+            params_by_base_sync_done={False: "base_params", True: "adapter_params"},
+        )
+
+        # --- First iteration (base_sync_done=False) ---
+        asyncio.run(
+            _update_weights(
+                rollout=rollout,
+                actor_engine=engine,
+                peft_merge=False,
+                base_sync_done=False,
+                free_cache_engine=True,
+            )
+        )
+        # After first iteration, sleep_level must be 1
+        assert rollout.sleep_level == 1
+        # First iteration should resume weights (they were released at level 2)
+        first_resume_calls = rollout.resume.call_args_list
+        assert call(tags=["weights"]) in first_resume_calls
+
+        # --- Reset mock call history ---
+        rollout.reset_mock()
+
+        # --- Second iteration (base_sync_done=True, sleep_level already 1) ---
+        asyncio.run(
+            _update_weights(
+                rollout=rollout,
+                actor_engine=engine,
+                peft_merge=False,
+                base_sync_done=True,
+                free_cache_engine=True,
+            )
+        )
+        # Second iteration must NOT resume weights (they were never released)
+        second_resume_calls = rollout.resume.call_args_list
+        assert call(tags=["weights"]) not in second_resume_calls
+        # But kv_cache resume should still happen
+        assert call(tags=["kv_cache"]) in second_resume_calls
+
+    def test_three_iterations_stay_consistent(self):
+        """Three consecutive iterations: only the first one resumes weights."""
+        peft_cfg = MagicMock()
+        rollout, engine = _make_mocks(
+            peft_config=peft_cfg,
+            params_by_base_sync_done={False: "base_params", True: "adapter_params"},
+        )
+
+        for i in range(3):
+            rollout.reset_mock()
+            asyncio.run(
+                _update_weights(
+                    rollout=rollout,
+                    actor_engine=engine,
+                    peft_merge=False,
+                    base_sync_done=(i > 0),
+                    free_cache_engine=True,
+                )
+            )
+            resume_calls = rollout.resume.call_args_list
+            if i == 0:
+                assert call(tags=["weights"]) in resume_calls, f"Iteration {i}: should resume weights"
+            else:
+                assert call(tags=["weights"]) not in resume_calls, f"Iteration {i}: should NOT resume weights"
+            assert call(tags=["kv_cache"]) in resume_calls, f"Iteration {i}: should always resume kv_cache"

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -762,8 +762,12 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         log_gpu_memory_usage("Before resume weights", logger=logger)
 
         # 1. resume rollout memory (weights were released during sleep)
+        # When sleep_level=1 (LoRA adapter mode), release() only frees
+        # kv_cache and keeps base weights on GPU, so we must not try to
+        # resume weights that were never released.
         if self.config.rollout.free_cache_engine:
-            await self.rollout.resume(tags=["weights"])
+            if getattr(self.rollout, "sleep_level", 2) != 1:
+                await self.rollout.resume(tags=["weights"])
         log_gpu_memory_usage("After resume weights", logger=logger)
 
         # 2. determine if we need a base weight sync (adapter path only)


### PR DESCRIPTION
## What this fixes

When using LoRA as a hot-swappable adapter (`model.lora.merge=False`) with colocated SGLang rollout and `free_cache_engine=True`, the second weight sync crashes with:

```
KeyError: 'weights'
  ... sglang/srt/managers/scheduler_update_weights_mixin.py, in resume_memory_occupation
      self.offload_tags.remove(tag)
```

## Root cause

In `engine_workers.py`, `update_weights()` unconditionally calls `resume(tags=["weights"])` at line 766. But in LoRA adapter mode:

1. First sync: `sleep_level` defaults to `2`, so `release()` frees both `kv_cache` and `weights`. The resume works fine. Then `sleep_level` is set to `1` at line 776.
2. Second sync: `release()` sees `sleep_level=1` and only frees `kv_cache` (keeps base weights on GPU). But `resume(tags=["weights"])` still runs unconditionally. SGLang raises `KeyError` because `weights` was never added to `offload_tags`.

## Fix

One line change: check `sleep_level` before resuming weights. When `sleep_level=1`, skip the weight resume since those weights were never released.

```python
# Before (broken):
if self.config.rollout.free_cache_engine:
    await self.rollout.resume(tags=["weights"])

# After (fixed):
if self.config.rollout.free_cache_engine:
    if getattr(self.rollout, "sleep_level", 2) != 1:
        await self.rollout.resume(tags=["weights"])
```

`getattr(..., 2)` is used so the default behavior (resume weights) is preserved for non-SGLang rollout backends that may not have `sleep_level`.

## What is NOT changed

- The `release()` logic in `sglang_rollout.py` is already correct (branches on `sleep_level`).
- The `sleep()` logic in `async_sglang_server.py` is already correct (branches on `lora_as_adapter`).
- Non-LoRA, merge-mode, and `free_cache_engine=False` paths are not affected.

## Tests

Added 2 regression tests to `tests/workers/test_engine_workers_lora_sync.py`:
- `test_second_iteration_does_not_resume_weights`: simulates two full sync cycles, verifies the second one skips weight resume.
- `test_three_iterations_stay_consistent`: verifies behavior over three iterations (first resumes weights, subsequent ones skip).

All 18 tests pass (16 existing + 2 new).

Closes #7289