### PR TITLE
[megatron] fix: bugfix qwen 3 qwen 3.5 router replay

### DIFF
--- a/tests/utils/megatron/test_router_replay_model_walk_on_cpu.py
+++ b/tests/utils/megatron/test_router_replay_model_walk_on_cpu.py
@@ -122,3 +122,15 @@ def test_action_is_toggled_on_the_forwarded_models_own_routers(orphans_then_mode
 
     assert all(router.router_replay_action == RouterReplayAction.REPLAY_BACKWARD for router in _routers(model))
     assert all(orphan.router_replay_action is None for orphan in orphans)
+
+
+def test_mtp_routers_are_not_addressed(orphans_then_model):
+    """MTP layers restart layer numbering at 1, so they would alias decoder layer 1."""
+    _, decoder = orphans_then_model
+    model = torch.nn.Module()
+    model.decoder, model.mtp = decoder, torch.nn.ModuleList([FakeTopKRouter(1)])
+
+    router_replay_utils.set_model_router_replay_action(model, RouterReplayAction.REPLAY_BACKWARD)
+
+    assert [ln for ln, _ in router_replay_utils.iter_model_routers(model)] == list(range(1, NUM_LAYERS + 1))
+    assert model.mtp[0].router_replay.router_replay_action is None

--- a/tests/utils/megatron/test_router_replay_model_walk_on_cpu.py
+++ b/tests/utils/megatron/test_router_replay_model_walk_on_cpu.py
@@ -1,0 +1,124 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Router replay addressed through the forwarded model rather than the global router list.
+
+Every ``RouterReplay`` appends itself to the process-global ``RouterReplay.router_instances``, so
+when a build registers routers that are not part of the final model — an mbridge prebuild does this
+for Qwen3-VL — that list is longer than the model's local layer count and a positional slice of it
+addresses the wrong objects. Replay targets then land on orphans while the real routers keep an
+unset ``target_topk_idx``, and the action toggle never reaches the routers that actually forward.
+
+Megatron-Core is not importable in the lightweight CPU CI image, so the ``megatron.core`` surfaces
+``router_replay_utils`` needs at import are stubbed with ``MagicMock`` via ``sys.modules``
+(``setdefault``, so a real install wins), along with ``verl.models.mcore.util`` — importing it for
+real pulls in the whole Megatron model-provider registry. The sequence-parallel scatter and the
+pack/unpack are monkeypatched to identity so the tests exercise the addressing, not the tensor
+plumbing (that is covered by the GPU and e2e suites).
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+for _mod in (
+    "megatron",
+    "megatron.core",
+    "megatron.core.pipeline_parallel",
+    "megatron.core.pipeline_parallel.schedules",
+    "megatron.core.pipeline_parallel.utils",
+    "megatron.core.tensor_parallel",
+    "megatron.core.transformer",
+    "megatron.core.transformer.moe",
+    "megatron.core.transformer.moe.moe_utils",
+    "megatron.core.transformer.moe.router",
+    "megatron.core.transformer.moe.token_dispatcher",
+    "megatron.core.transformer.transformer_config",
+    "megatron.core.transformer.transformer_layer",
+    "verl.models.mcore.util",
+):
+    sys.modules.setdefault(_mod, MagicMock())
+
+
+from verl.utils.megatron import router_replay_utils  # noqa: E402
+from verl.utils.megatron.router_replay_patch import RouterReplay, RouterReplayAction  # noqa: E402
+
+NUM_LAYERS = 4
+NUM_TOKENS = 3
+TOPK = 2
+
+
+class FakeTopKRouter(torch.nn.Module):
+    """Stands in for Megatron's ``TopKRouter``: owns a ``router_replay`` and the 1-based
+    ``layer_number`` its transformer layer assigns it."""
+
+    def __init__(self, layer_number):
+        super().__init__()
+        self.layer_number = layer_number
+        self.router_replay = RouterReplay()
+
+
+def _build_model():
+    return torch.nn.ModuleList([FakeTopKRouter(layer_number) for layer_number in range(1, NUM_LAYERS + 1)])
+
+
+def _routers(model):
+    return [module.router_replay for module in model]
+
+
+@pytest.fixture
+def orphans_then_model(monkeypatch):
+    """Register routers that never make it into the model, then build the model — the registration
+    order an mbridge prebuild produces."""
+    monkeypatch.setattr(router_replay_utils, "TopKRouter", FakeTopKRouter)
+    RouterReplay.router_instances.clear()
+    orphans = [RouterReplay() for _ in range(NUM_LAYERS)]
+    model = _build_model()
+    yield orphans, model
+    RouterReplay.router_instances.clear()
+
+
+@pytest.fixture
+def tf_config(monkeypatch):
+    monkeypatch.setattr(router_replay_utils, "device_name", "cpu")
+    monkeypatch.setattr(router_replay_utils, "preprocess_packed_seqs", lambda x, mask, **kwargs: (x, None))
+    monkeypatch.setattr(router_replay_utils, "scatter_to_sequence_parallel_region", lambda x: x)
+    return SimpleNamespace(fp8=None, num_layers=NUM_LAYERS, moe_layer_freq=1)
+
+
+def test_targets_are_written_to_the_forwarded_models_own_routers(orphans_then_model, tf_config):
+    orphans, model = orphans_then_model
+
+    # [1, tokens, layers, topk], with every row of layer i filled with i.
+    layers_topk_idx = torch.zeros(1, NUM_TOKENS, NUM_LAYERS, TOPK, dtype=torch.int64)
+    for layer in range(NUM_LAYERS):
+        layers_topk_idx[:, :, layer, :] = layer
+
+    router_replay_utils.set_router_replay_data(layers_topk_idx, None, tf_config, vp_rank=0, model=model)
+
+    for layer, router in enumerate(_routers(model)):
+        assert torch.equal(router.target_topk_idx, torch.full((NUM_TOKENS, TOPK), layer, dtype=torch.int64))
+    assert all(orphan.target_topk_idx is None for orphan in orphans)
+
+
+def test_action_is_toggled_on_the_forwarded_models_own_routers(orphans_then_model):
+    orphans, model = orphans_then_model
+
+    router_replay_utils.set_model_router_replay_action(model, RouterReplayAction.REPLAY_BACKWARD)
+
+    assert all(router.router_replay_action == RouterReplayAction.REPLAY_BACKWARD for router in _routers(model))
+    assert all(orphan.router_replay_action is None for orphan in orphans)

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -31,6 +31,7 @@ except ImportError:
 from megatron.core import parallel_state as mpu
 from megatron.core.pipeline_parallel.schedules import get_schedule_table
 from megatron.core.tensor_parallel import gather_from_sequence_parallel_region, scatter_to_sequence_parallel_region
+from megatron.core.transformer.moe.router import TopKRouter
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import get_transformer_layer_offset
 
@@ -371,6 +372,7 @@ def set_router_replay_data(
     vp_rank=None,
     replay_mask=None,
     local_cp_size=None,
+    model=None,
 ):
     """
     Scatter the packed router top-k indices back to sequence-parallel ranks and update each local
@@ -388,6 +390,8 @@ def set_router_replay_data(
             Megatron parallel state will be used.
         replay_mask (Optional[torch.Tensor]): Optional per-token mask. Masked tokens use replayed routes;
             unmasked tokens keep native Megatron routes.
+        model: The forwarded model (or list of VPP chunks). When given, targets are written to its own
+            routers instead of a positional slice of the global RouterReplay.router_instances list.
 
     Returns:
         None: The function updates internal RouterReplay instances in-place.
@@ -443,14 +447,25 @@ def set_router_replay_data(
         layers_topk_idx_reshape = layers_topk_idx_rmpad_split.permute(0, 2, 1, 3).squeeze(
             dim=0
         )  # layer_num, dynamic_bs_all, topk
-        local_rank_info = get_current_rank_layer_info(tf_config, vp_rank)
-        offset, end = local_rank_info["start"], local_rank_info["end"]
-        router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
-
         # When dim-0 covers all layers (e.g. R3, or R2 with all-MoE models),
         # index by absolute layer_idx; otherwise (R2 with mixed dense/MoE),
         # dim-0 only contains MoE layers, index by MoE-layer ordinal.
         index_by_layer = len(layers_topk_idx_reshape) == tf_config.num_layers
+
+        if model is not None:
+            for layer_number, router in iter_model_routers(model):
+                layer_idx = layer_number - 1
+                idx = layer_idx if index_by_layer else sum(1 for i in range(layer_idx) if is_moe_layer(tf_config, i))
+                if 0 <= idx < layers_topk_idx_reshape.shape[0]:
+                    router.set_target_indices(
+                        layers_topk_idx_reshape[idx].to(torch.int64),
+                        replay_mask=replay_mask_rmpad_split,
+                    )
+            return
+
+        local_rank_info = get_current_rank_layer_info(tf_config, vp_rank)
+        offset, end = local_rank_info["start"], local_rank_info["end"]
+        router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
 
         # For R2: count MoE layers before `offset` as the starting position.
         moe_idx = sum(1 for i in range(offset) if is_moe_layer(tf_config, i))
@@ -467,6 +482,33 @@ def set_router_replay_data(
             )
             router_offset += 1
             moe_idx += 1
+
+
+def iter_model_routers(model):
+    """Yield ``(layer_number, RouterReplay)`` for every replay-enabled router owned by ``model``.
+
+    ``model`` is a single module or the list of virtual-pipeline chunks. The process-global
+    ``RouterReplay.router_instances`` list can hold more routers than this model has local layers —
+    a model that rebuilds its decoder registers a set it then discards — so a positional slice of it
+    can address the wrong objects. Walking the forwarded model reaches each layer's own router.
+    """
+    for chunk in model if isinstance(model, list | tuple) else [model]:
+        for module in chunk.modules():
+            router = getattr(module, "router_replay", None)
+            if isinstance(module, TopKRouter) and router is not None and module.layer_number is not None:
+                yield module.layer_number, router
+
+
+def set_model_router_replay_action(model, router_replay_action):
+    """Set the router replay action on the forwarded model's own routers.
+
+    Mirrors the module walk in ``set_router_replay_data``. Toggling through the positional slice can
+    miss the real routers, leaving them stuck in REPLAY_FORWARD so the backward recompute reads a
+    stale cross-micro-batch ``target_topk_idx`` instead of popping its own entry from
+    ``replay_backward_list``.
+    """
+    for _, router in iter_model_routers(model):
+        router.set_router_replay_action(router_replay_action)
 
 
 def reorder_and_merge_vpp_layers(

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -493,7 +493,10 @@ def iter_model_routers(model):
     can address the wrong objects. Walking the forwarded model reaches each layer's own router.
     """
     for chunk in model if isinstance(model, list | tuple) else [model]:
-        for module in chunk.modules():
+        # Scope to the decoder: MTP layers restart layer numbering at 1, so they alias decoder
+        # layers, and the replay tensor carries no MTP rows. ``mtp`` is a sibling of ``decoder``
+        # on both GPTModel and HybridModel, the only two classes that build one.
+        for module in getattr(chunk, "decoder", chunk).modules():
             router = getattr(module, "router_replay", None)
             if isinstance(module, TopKRouter) and router is not None and module.layer_number is not None:
                 yield module.layer_number, router

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -53,6 +53,7 @@ from verl.utils.megatron.router_replay_utils import (
     merge_router_topk_indices,
     pp_gather,
     reorder_and_merge_vpp_layers,
+    set_model_router_replay_action,
     set_router_replay_data,
 )
 from verl.utils.megatron.tensor_parallel import (
@@ -1260,6 +1261,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
             router_instance_list = RouterReplayHelper.get_micro_batch_router_list(self.tf_config, vp_rank)
             for router in router_instance_list:
                 router.set_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+            set_model_router_replay_action(unwrapped_model, RouterReplayAction.REPLAY_FORWARD)
 
         if RouterReplayHelper.is_replay_forward_action(self.tf_config, vp_rank):
             layers_topk_idx = model_inputs["routed_experts"]
@@ -1274,6 +1276,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 vp_rank,
                 replay_mask=replay_mask,
                 local_cp_size=local_cp_size,
+                model=unwrapped_model,
             )
 
         if pad_mode == DatasetPadMode.NO_PADDING:
@@ -1372,6 +1375,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
             router_instance_list = RouterReplayHelper.get_micro_batch_router_list(self.tf_config, vp_rank)
             for router in router_instance_list:
                 router.set_router_replay_action(RouterReplayAction.REPLAY_BACKWARD)
+            set_model_router_replay_action(unwrapped_model, RouterReplayAction.REPLAY_BACKWARD)
 
         return output, partial(postprocess_micro_batch_func, data=batch, local_cp_size=local_cp_size)
 


### PR DESCRIPTION
### What does this PR do?

Fixes a router replay bug for Qwen 3 VL / Qwen 3.5. 

`Qwen3VLGPTModel.__init__` in megatron bridge builds its decoder twice: `super().__init__()` runs `GPTModel.__init__` ([here](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/d17190fa4d2d023b9b2531c8d449ddb21c13b908/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py#L63-L83)), which creates `self.decoder = TransformerBlock(...)` and with it every local `MoELayer`/`TopKRouter`; the subclass then discards that block and rebuilds it (`# rebuild the transformer block`, `self.decoder = Qwen3VLTransformerBlock(...)`) ([here](https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/d17190fa4d2d023b9b2531c8d449ddb21c13b908/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/text_model.py#L99-L107)). The discarded routers have already appended themselves to the global list and are never removed, leaving 2N entries for N live layers, orphans first.

Since the slice starts at offset 0, it returns exactly those orphans, causing a _silent_ break of the router replay. Targets and the `RouterReplayAction` toggle go to a decoder that no longer forwards; the live routers keep `target_topk_idx = None`, `get_replay_topk` falls through to `default_compute_topk`, and router replay silently does nothing: no error, no warning. The backward recompute never enters `REPLAY_BACKWARD` and reads stale per-microbatch state.

Observed on two runs (pins: megatron-core `d1410e15e`, megatron-bridge `d17190fa`) via the existing `routing replay layers: N` log:

| model | decoder layers | PP | local layers | `len(router_instances)` |
|---|---|---|---|---|
| Qwen3.5-35B-A3B | 40 (`moe_layer_freq=1`) | 1 | 40 | **80** |
| Qwen3.5-122B-A10B | 48 | 2 | 24 | **48** |

Double what they should be.

Fix: address each layer's own router by walking the forwarded model — `isinstance(mod, TopKRouter)` with a non-`None` `mod.router_replay`, indexed by that module's own 1-based `layer_number`. The discarded decoder is unreachable from the model, so the walk only ever reaches live routers, and the result is invariant to how many other routers exist in the process. The positional path is kept for callers that pass no model. An old PR #4567 reported the same symptom on Qwen3-VL but did not fix or merge.

Note it fires now on each microbatch, but it is various microseconds. If you prefer, we can add some memoization; let me know. 

### Checklist Before Starting

- [x] Search for similar PRs: <https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+router+replay> — nearest is #4567 (stale), same symptom, not fixed/merged
- [x] PR title follows `[{modules}] {type}: {description}`.

### Test

Small proof-of-concept test that adds 'fake' orphans.

```
$ pytest -q tests/utils/megatron/test_router_replay_model_walk_on_cpu.py
2 passed
```

Reverting only the addressing (walking `RouterReplay.router_instances` instead of the model) fails:

```
E  TypeError: equal(): argument 'input' must be Tensor, not NoneType   # live routers left unset
E  assert False  # ...orphan.router_replay_action is None              # action went to the orphans
2 failed
```

### API and Usage Example

No config or CLI change. Two additive, backward-compatible signatures in `verl/utils/megatron/router_replay_utils.py`:

```python
# new optional `model`; omitting it keeps the previous positional behaviour
set_router_replay_data(layers_topk_idx, attention_mask, tf_config, vp_rank=None, replay_mask=None, model=None)

# new helper, mirrors the module walk used by set_router_replay_data
set_model_router_replay_action(model, router_replay_action)
```

`model` accepts a single module or the list of virtual-pipeline chunks.

### Design & Code Changes

- `verl/utils/megatron/router_replay_utils.py`
  - `iter_model_routers(model)` — yields `(layer_number, RouterReplay)` for replay-enabled `TopKRouter`s in the forwarded model; handles a single module or a VPP chunk list.
  - `set_router_replay_data(..., model=None)` — with a model, writes each layer's targets to its own router, keeping the existing `index_by_layer` / MoE-ordinal row selection so R2 with interleaved dense layers is unaffected; positional path retained for `model=None`.
  - `set_model_router_replay_action(model, action)`.
- `verl/workers/engine/megatron/transformer_impl.py` — three lines in `forward_step`: pass `model=unwrapped_model` to `set_router_replay_data`, and call `set_model_router_replay_action(unwrapped_model, ...)` after each of the two existing action-toggle loops.

`+50/−4` functional changes across the two files (excludes the test).

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [x] Add / Update the documentation — no user-facing behaviour or config change.
- [x] Add unit or end-to-end test(s) 
- [ ] Send a message in the `ci-request` channel.
