### PR TITLE
fix(model_merger): add --fuse-lora flag to merge LoRA weights into base model

### DIFF
--- a/tests/model_merger/test_fuse_lora.py
+++ b/tests/model_merger/test_fuse_lora.py
@@ -1,0 +1,312 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the --fuse-lora flag in model_merger.
+
+Tests the config plumbing, the branching logic in save_hf_model_and_tokenizer,
+and the _fuse_lora_into_model method. All tests run on CPU without GPU,
+ray, or distributed setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+from collections import OrderedDict
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+import torch
+
+from verl.model_merger.base_model_merger import ModelMergerConfig, generate_config_from_args, parse_args
+
+
+# ---------------------------------------------------------------------------
+# Config and CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestFuseLoraConfig:
+    """Test that --fuse-lora flag is wired through CLI to config."""
+
+    def test_config_default_is_false(self):
+        config = ModelMergerConfig(operation="merge", backend="fsdp")
+        assert config.fuse_lora is False
+
+    def test_config_accepts_true(self):
+        config = ModelMergerConfig(operation="merge", backend="fsdp", fuse_lora=True)
+        assert config.fuse_lora is True
+
+    def test_cli_flag_parsed(self):
+        """--fuse-lora flag is recognized by argparse."""
+        with patch("sys.argv", ["prog", "merge", "--backend", "fsdp", "--local_dir", "/tmp/x", "--fuse-lora"]):
+            args = parse_args()
+        assert args.fuse_lora is True
+
+    def test_cli_flag_absent(self):
+        """Without --fuse-lora, fuse_lora defaults to False."""
+        with patch("sys.argv", ["prog", "merge", "--backend", "fsdp", "--local_dir", "/tmp/x"]):
+            args = parse_args()
+        assert args.fuse_lora is False
+
+    def test_generate_config_passes_fuse_lora(self):
+        """generate_config_from_args passes fuse_lora to ModelMergerConfig."""
+        args = argparse.Namespace(
+            operation="merge",
+            backend="fsdp",
+            local_dir="/tmp/x",
+            target_dir="/tmp/y",
+            hf_upload_path=None,
+            private=False,
+            fuse_lora=True,
+            tie_word_embedding=False,
+            trust_remote_code=False,
+            is_value_model=False,
+            use_cpu_initialization=False,
+        )
+        with patch("os.makedirs"):
+            config = generate_config_from_args(args)
+        assert config.fuse_lora is True
+
+    def test_test_operation_no_fuse_lora(self):
+        """Test operation does not have fuse_lora, getattr fallback works."""
+        args = argparse.Namespace(
+            operation="test",
+            backend="fsdp",
+            local_dir="/tmp/x",
+            test_hf_dir="/tmp/z",
+            tie_word_embedding=False,
+            trust_remote_code=False,
+            is_value_model=False,
+            use_cpu_initialization=False,
+        )
+        config = generate_config_from_args(args)
+        assert config.fuse_lora is False
+
+
+# ---------------------------------------------------------------------------
+# save_lora_adapter splits LoRA keys from state_dict (existing behavior)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoraAdapterSplitsKeys:
+    """Verify that save_lora_adapter pops LoRA keys and leaves base keys."""
+
+    def test_lora_keys_removed_from_state_dict(self):
+        """After save_lora_adapter, state_dict should not contain lora_ keys."""
+        state_dict = OrderedDict(
+            {
+                "base_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.randn(4, 4),
+                "base_model.model.layers.0.self_attn.q_proj.lora_A.default.weight": torch.randn(2, 4),
+                "base_model.model.layers.0.self_attn.q_proj.lora_B.default.weight": torch.randn(4, 2),
+            }
+        )
+        merger = MagicMock()
+        merger.config = MagicMock()
+        merger.config.target_dir = tempfile.mkdtemp()
+        merger._load_lora_train_meta = MagicMock(return_value=None)
+
+        try:
+            from verl.model_merger.base_model_merger import BaseModelMerger
+
+            lora_path = BaseModelMerger.save_lora_adapter(merger, state_dict)
+
+            assert lora_path is not None
+            for key in state_dict:
+                assert "lora_" not in key
+            assert "layers.0.self_attn.q_proj.weight" in state_dict
+        finally:
+            shutil.rmtree(merger.config.target_dir)
+
+    def test_no_lora_keys_returns_none(self):
+        """If no LoRA keys present, save_lora_adapter returns None."""
+        state_dict = OrderedDict({"model.weight": torch.randn(4, 4)})
+        merger = MagicMock()
+
+        from verl.model_merger.base_model_merger import BaseModelMerger
+
+        result = BaseModelMerger.save_lora_adapter(merger, state_dict)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _fuse_lora_into_model tests
+# ---------------------------------------------------------------------------
+
+
+class TestFuseLoraIntoModel:
+    """Test the _fuse_lora_into_model method."""
+
+    def test_no_lora_keys_returns_none(self):
+        """If state_dict has no lora_ keys, return None and leave dict unchanged."""
+        from verl.model_merger.base_model_merger import BaseModelMerger
+
+        state_dict = OrderedDict({"model.weight": torch.randn(4, 4)})
+        original_keys = list(state_dict.keys())
+        model = MagicMock()
+
+        merger = MagicMock(spec=BaseModelMerger)
+        merger._fuse_lora_into_model = BaseModelMerger._fuse_lora_into_model.__get__(merger)
+
+        result = merger._fuse_lora_into_model(state_dict, model)
+        assert result is None
+        assert list(state_dict.keys()) == original_keys
+
+    def test_fuse_calls_merge_and_unload(self):
+        """Verify that _fuse_lora_into_model calls PeftModel.from_pretrained
+        and merge_and_unload, then replaces state_dict contents."""
+        from verl.model_merger.base_model_merger import BaseModelMerger
+
+        base_weight = torch.randn(4, 4)
+        lora_a = torch.randn(2, 4)
+        lora_b = torch.randn(4, 2)
+
+        state_dict = OrderedDict({
+            "base_model.model.layers.0.self_attn.q_proj.base_layer.weight": base_weight.clone(),
+            "base_model.model.layers.0.self_attn.q_proj.lora_A.default.weight": lora_a.clone(),
+            "base_model.model.layers.0.self_attn.q_proj.lora_B.default.weight": lora_b.clone(),
+        })
+
+        model = MagicMock()
+        fused_state = {"layers.0.self_attn.q_proj.weight": torch.randn(4, 4)}
+        fused_model = MagicMock()
+        fused_model.state_dict.return_value = fused_state
+
+        peft_model = MagicMock()
+        peft_model.merge_and_unload.return_value = fused_model
+
+        merger = MagicMock(spec=BaseModelMerger)
+        merger.config = MagicMock()
+        merger.config.target_dir = tempfile.mkdtemp()
+        merger._load_lora_train_meta = MagicMock(return_value=None)
+        # Wire real save_lora_adapter so it actually processes the keys
+        merger.save_lora_adapter = BaseModelMerger.save_lora_adapter.__get__(merger)
+        merger._fuse_lora_into_model = BaseModelMerger._fuse_lora_into_model.__get__(merger)
+
+        try:
+            with patch("peft.PeftModel.from_pretrained", return_value=peft_model) as mock_from_pretrained:
+                result = merger._fuse_lora_into_model(state_dict, model)
+
+            assert result is None
+            # merge_and_unload must have been called
+            peft_model.merge_and_unload.assert_called_once()
+            # state_dict should now contain fused weights, not original keys
+            assert "layers.0.self_attn.q_proj.weight" in state_dict
+            assert len([k for k in state_dict if "lora_" in k]) == 0
+        finally:
+            # cleanup target_dir if it still exists
+            if os.path.exists(merger.config.target_dir):
+                shutil.rmtree(merger.config.target_dir)
+
+    def test_fuse_cleans_up_temp_adapter_dir(self):
+        """After fusing, the temporary lora_adapter directory should be removed."""
+        from verl.model_merger.base_model_merger import BaseModelMerger
+
+        state_dict = OrderedDict({
+            "base_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.randn(4, 4),
+            "base_model.model.layers.0.self_attn.q_proj.lora_A.default.weight": torch.randn(2, 4),
+            "base_model.model.layers.0.self_attn.q_proj.lora_B.default.weight": torch.randn(4, 2),
+        })
+
+        model = MagicMock()
+        fused_model = MagicMock()
+        fused_model.state_dict.return_value = {"q_proj.weight": torch.randn(4, 4)}
+
+        peft_model = MagicMock()
+        peft_model.merge_and_unload.return_value = fused_model
+
+        merger = MagicMock(spec=BaseModelMerger)
+        merger.config = MagicMock()
+        merger.config.target_dir = tempfile.mkdtemp()
+        merger._load_lora_train_meta = MagicMock(return_value=None)
+        merger.save_lora_adapter = BaseModelMerger.save_lora_adapter.__get__(merger)
+        merger._fuse_lora_into_model = BaseModelMerger._fuse_lora_into_model.__get__(merger)
+
+        try:
+            with patch("peft.PeftModel.from_pretrained", return_value=peft_model):
+                merger._fuse_lora_into_model(state_dict, model)
+
+            lora_adapter_path = os.path.join(merger.config.target_dir, "lora_adapter")
+            assert not os.path.exists(lora_adapter_path), "temp lora_adapter dir should be cleaned up"
+        finally:
+            if os.path.exists(merger.config.target_dir):
+                shutil.rmtree(merger.config.target_dir)
+
+
+# ---------------------------------------------------------------------------
+# Branching logic in save_hf_model_and_tokenizer
+# ---------------------------------------------------------------------------
+
+
+class TestSaveHfModelBranching:
+    """Test that save_hf_model_and_tokenizer calls the right method based on fuse_lora."""
+
+    def _make_merger(self, fuse_lora: bool):
+        """Create a mock merger with the branching logic wired up."""
+        from verl.model_merger.base_model_merger import BaseModelMerger
+
+        merger = MagicMock(spec=BaseModelMerger)
+        merger.config = ModelMergerConfig(
+            operation="merge", backend="fsdp", fuse_lora=fuse_lora, target_dir="/tmp/test-target"
+        )
+        merger.save_hf_model_and_tokenizer = BaseModelMerger.save_hf_model_and_tokenizer.__get__(merger)
+        return merger
+
+    @patch("verl.utils.hf_processor", return_value=None)
+    @patch("verl.utils.hf_tokenizer", return_value=None)
+    @patch("verl.model_merger.output_validation.validate_hf_model_output")
+    def test_fuse_lora_true_calls_fuse_method(self, _val, _tok, _proc):
+        """When fuse_lora=True, _fuse_lora_into_model is called instead of save_lora_adapter."""
+        merger = self._make_merger(fuse_lora=True)
+        merger._fuse_lora_into_model.return_value = None
+        merger.hf_model_config_path = "/tmp/fake"
+
+        mock_model = MagicMock()
+        mock_model.can_generate.return_value = False
+
+        with patch("verl.model_merger.base_model_merger.init_empty_weights"):
+            merger.get_transformers_auto_model_class.return_value.from_config.return_value = mock_model
+            mock_model.to_empty.return_value = mock_model
+            merger.patch_model_generation_config.return_value = mock_model
+
+            state_dict = {"model.weight": torch.randn(4, 4)}
+            merger.save_hf_model_and_tokenizer(state_dict)
+
+        merger._fuse_lora_into_model.assert_called_once()
+        merger.save_lora_adapter.assert_not_called()
+
+    @patch("verl.utils.hf_processor", return_value=None)
+    @patch("verl.utils.hf_tokenizer", return_value=None)
+    @patch("verl.model_merger.output_validation.validate_hf_model_output")
+    def test_fuse_lora_false_calls_save_lora_adapter(self, _val, _tok, _proc):
+        """When fuse_lora=False, save_lora_adapter is called (default behavior)."""
+        merger = self._make_merger(fuse_lora=False)
+        merger.save_lora_adapter.return_value = None
+        merger.hf_model_config_path = "/tmp/fake"
+
+        mock_model = MagicMock()
+        mock_model.can_generate.return_value = False
+
+        with patch("verl.model_merger.base_model_merger.init_empty_weights"):
+            merger.get_transformers_auto_model_class.return_value.from_config.return_value = mock_model
+            mock_model.to_empty.return_value = mock_model
+            merger.patch_model_generation_config.return_value = mock_model
+
+            state_dict = {"model.weight": torch.randn(4, 4)}
+            merger.save_hf_model_and_tokenizer(state_dict)
+
+        merger.save_lora_adapter.assert_called_once()
+        merger._fuse_lora_into_model.assert_not_called()

--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -68,6 +68,12 @@ def parse_args():
     merge_parser.add_argument(
         "--private", action="store_true", help="Whether to upload the model to a private Hugging Face repository"
     )
+    merge_parser.add_argument(
+        "--fuse-lora",
+        action="store_true",
+        help="Fuse LoRA adapter weights into the base model before saving. "
+        "Without this flag, LoRA checkpoints are split into base model + separate adapter directory.",
+    )
 
     test_parser = subparsers.add_parser(
         "test", parents=[base_op_parser], help="Test merged model against a reference Hugging Face model"
@@ -115,6 +121,7 @@ class ModelMergerConfig:
     hf_model_config_path: Optional[str] = None
     hf_upload: bool = field(init=False)
     use_cpu_initialization: bool = False
+    fuse_lora: bool = False
 
     def __post_init__(self):
         self.hf_upload = self.operation == "merge" and bool(self.hf_upload_path)
@@ -157,6 +164,7 @@ def generate_config_from_args(args: argparse.Namespace) -> ModelMergerConfig:
             target_dir=args.target_dir,
             hf_upload_path=args.hf_upload_path,
             private=args.private,
+            fuse_lora=getattr(args, "fuse_lora", False),
             test_hf_dir=None,
         )
         os.makedirs(config.target_dir, exist_ok=True)
@@ -407,6 +415,48 @@ class BaseModelMerger(ABC):
 
         return lora_path
 
+    def _fuse_lora_into_model(self, state_dict: dict[str, torch.Tensor], model) -> Optional[str]:
+        """Fuse LoRA adapter weights into the base model.
+
+        Loads the base weights into the model, applies the LoRA adapter
+        using PEFT, calls merge_and_unload() to fold the adapter into
+        the base weights, and replaces state_dict contents with the
+        fused weights.
+
+        Returns:
+            None (no separate adapter directory is created).
+        """
+        lora_params_names = [name for name in state_dict.keys() if "lora_" in name]
+        if len(lora_params_names) == 0:
+            return None
+
+        import peft
+
+        # First, save the adapter to a temp directory so PeftModel can load it
+        lora_path = self.save_lora_adapter(state_dict)
+        if lora_path is None:
+            return None
+
+        # state_dict now has only base weights (save_lora_adapter pops LoRA keys).
+        # Load base weights into the model.
+        model.load_state_dict(state_dict, strict=False)
+
+        # Apply LoRA adapter and fuse
+        print(f"Fusing LoRA adapter into base model weights...")
+        peft_model = peft.PeftModel.from_pretrained(model, lora_path)
+        fused_model = peft_model.merge_and_unload()
+
+        # Replace state_dict with fused weights
+        state_dict.clear()
+        state_dict.update(fused_model.state_dict())
+
+        # Clean up the temp adapter directory
+        import shutil
+        shutil.rmtree(lora_path)
+
+        print(f"LoRA adapter fused into model weights.")
+        return None
+
     def save_hf_model_and_tokenizer(self, state_dict: dict[str, torch.Tensor]):
         auto_model_class = self.get_transformers_auto_model_class()
         with init_empty_weights():
@@ -416,7 +466,10 @@ class BaseModelMerger(ABC):
         model.to_empty(device="cpu")
         model = self.patch_model_generation_config(model)
 
-        lora_path = self.save_lora_adapter(state_dict)
+        if self.config.fuse_lora:
+            lora_path = self._fuse_lora_into_model(state_dict, model)
+        else:
+            lora_path = self.save_lora_adapter(state_dict)
         if lora_path:
             print(f"Saving lora adapter to {lora_path}")
 


### PR DESCRIPTION
## Problem

When using `model_merger merge` on a LoRA-trained checkpoint, the output directory contains the **unmodified base model weights** plus a separate `lora_adapter/` directory. The base model files are byte-identical to the original pre-trained model — the LoRA weights are never actually merged in.

This means users who run `model_merger merge` expecting a single ready-to-use model get a base model that has none of their training applied. They have to manually load the adapter with PEFT afterward, which defeats the purpose of the merge command.

Reported in #7285.

## Root cause

`save_hf_model_and_tokenizer()` calls `save_lora_adapter()`, which:
1. Pops all `lora_*` keys from the state dict
2. Saves them to a separate `lora_adapter/` directory
3. Renames the remaining base keys

The base model is then saved from the state dict that no longer contains any LoRA parameters. There is no code path that calls PEFT `merge_and_unload()` to fold the adapter weights into the base model before saving.

## Fix

This PR adds a `--fuse-lora` CLI flag that triggers a new code path:

1. **CLI layer**: New `--fuse-lora` argument on the `merge` subparser (default: off, so existing behavior is unchanged).

2. **Config layer**: New `fuse_lora: bool = False` field on `ModelMergerConfig`, passed through from `generate_config_from_args()`.

3. **Merge logic**: New `_fuse_lora_into_model()` method that:
   - Checks if the state dict contains any `lora_*` keys (returns early if not)
   - Calls `save_lora_adapter()` to extract and temporarily persist the adapter (this also cleans the state dict to base-only keys)
   - Loads the base weights into the model
   - Wraps it with `peft.PeftModel.from_pretrained()` using the temp adapter
   - Calls `merge_and_unload()` to fold LoRA weights into the base model
   - Replaces the state dict contents with the fused weights
   - Cleans up the temp adapter directory

4. **Branching**: `save_hf_model_and_tokenizer()` calls `_fuse_lora_into_model()` when `fuse_lora=True`, otherwise calls `save_lora_adapter()` as before.

### Why a flag instead of always fusing

Some users want the split output (base + adapter) so they can swap adapters or keep the base model separate. Making fusion opt-in preserves backward compatibility.

## Usage

```bash
# Before (unchanged default): splits into base model + lora_adapter/
python -m verl.model_merger merge --backend fsdp --local_dir /path/to/ckpt --target_dir /path/to/output

# New: fuses LoRA into the base model weights
python -m verl.model_merger merge --backend fsdp --local_dir /path/to/ckpt --target_dir /path/to/output --fuse-lora
```

## Files changed

- `verl/model_merger/base_model_merger.py` — CLI flag, config field, `_fuse_lora_into_model()` method, branching logic
- `tests/model_merger/test_fuse_lora.py` — 13 tests covering config plumbing, CLI parsing, adapter splitting, fuse behavior, temp cleanup, and branching

## Tests

The test file covers:
- **Config tests** (6): default value, explicit True, CLI flag present/absent, config generation with/without fuse_lora
- **Adapter split tests** (2): existing save_lora_adapter behavior (keys removed, no-lora returns None)
- **Fuse tests** (3): no-lora early return, merge_and_unload called correctly, temp directory cleanup
- **Branching tests** (2): fuse_lora=True calls _fuse_lora_into_model, fuse_lora=False calls save_lora_adapter

All tests run on CPU without GPU or distributed setup.