### PR TITLE
fix(megatron): fall back to non-pinned CPU copy when pin_memory() fails on resume

### DIFF
--- a/tests/utils/test_try_pin_memory.py
+++ b/tests/utils/test_try_pin_memory.py
@@ -1,0 +1,97 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for _try_pin_memory fallback in megatron_utils.
+
+Tests that pin_memory() is attempted first and that a graceful
+fallback to non-pinned CPU tensors occurs when pinning fails.
+All tests run on CPU without GPU, distributed setup, or Megatron.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from verl.utils.megatron_utils import _try_pin_memory
+
+
+class TestTryPinMemory:
+    """Test the _try_pin_memory helper."""
+
+    def test_returns_tensor_on_success(self):
+        """When pin_memory succeeds, the returned tensor should be pinned."""
+        t = torch.randn(4, 4)
+        result = _try_pin_memory(t)
+        # On machines without CUDA, pin_memory() may itself raise or
+        # return the same tensor.  We just verify it does not crash and
+        # returns a tensor with the same data.
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == t.shape
+        assert result.dtype == t.dtype
+        assert torch.equal(result, t)
+
+    def test_falls_back_on_failure(self):
+        """When pin_memory raises, _try_pin_memory returns the original tensor."""
+        t = torch.randn(8, 8)
+        with patch.object(torch.Tensor, "pin_memory", side_effect=RuntimeError("CUDA error: invalid argument")):
+            result = _try_pin_memory(t)
+        # Should be the exact same object (not a copy)
+        assert result is t
+
+    def test_falls_back_preserves_data(self):
+        """Fallback tensor has identical contents to the input."""
+        t = torch.arange(16, dtype=torch.bfloat16).reshape(4, 4)
+        with patch.object(torch.Tensor, "pin_memory", side_effect=RuntimeError("cudaErrorInvalidValue")):
+            result = _try_pin_memory(t)
+        assert torch.equal(result, t)
+        assert result.dtype == torch.bfloat16
+
+    def test_logs_warning_on_fallback(self):
+        """A warning should be logged when falling back."""
+        t = torch.randn(2, 2)
+        with patch.object(torch.Tensor, "pin_memory", side_effect=RuntimeError("out of pinned memory")):
+            with patch("verl.utils.megatron_utils.logger") as mock_logger:
+                _try_pin_memory(t)
+                mock_logger.warning.assert_called_once()
+                warning_msg = mock_logger.warning.call_args[0][0]
+                assert "pin_memory" in warning_msg
+
+    def test_does_not_log_on_success(self):
+        """No warning should be logged when pin_memory succeeds."""
+        t = torch.randn(2, 2)
+        # Patch pin_memory to succeed normally (return a new tensor)
+        with patch.object(torch.Tensor, "pin_memory", return_value=torch.randn(2, 2)):
+            with patch("verl.utils.megatron_utils.logger") as mock_logger:
+                _try_pin_memory(t)
+                mock_logger.warning.assert_not_called()
+
+    def test_handles_empty_tensor(self):
+        """Works correctly with zero-element tensors."""
+        t = torch.empty(0, dtype=torch.float32)
+        result = _try_pin_memory(t)
+        assert isinstance(result, torch.Tensor)
+        assert result.numel() == 0
+
+    def test_handles_large_tensor_failure(self):
+        """Simulates the real scenario: large tensor pin fails on resume."""
+        # Create a tensor similar in spirit to the 1.4 GiB bf16 buffer in the issue
+        t = torch.randn(1024, 1024, dtype=torch.bfloat16)
+        with patch.object(torch.Tensor, "pin_memory", side_effect=RuntimeError("CUDA error: invalid argument (cudaErrorInvalidValue)")):
+            result = _try_pin_memory(t)
+        assert result is t
+        assert result.shape == (1024, 1024)
+        assert result.dtype == torch.bfloat16

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -51,6 +51,24 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+def _try_pin_memory(tensor: torch.Tensor) -> torch.Tensor:
+    """Try to pin a CPU tensor; fall back to the unpinned tensor on failure.
+
+    pin_memory() is a performance optimization for faster H2D copies.
+    On resume with CPU-offloaded optimizer state, the pinned-memory pool
+    may already be exhausted, causing pin_memory() to raise.  Falling
+    back to a pageable tensor is functionally correct -- only the next
+    H2D copy for that buffer will be slightly slower.
+    """
+    try:
+        return tensor.pin_memory()
+    except Exception:
+        logger.warning(
+            "pin_memory() failed (likely pinned-memory pool exhausted "
+            "by CPU-offloaded optimizer on resume); using non-pinned CPU copy."
+        )
+        return tensor
+
 def get_model_config(model):
     return get_attr_wrapped_model(model, "config", allow_none=False)
 
@@ -670,11 +688,12 @@ def offload_megatron_model_to_cpu(models):
                         # rather than silently worked around.
                         existing = getattr(buffer.param_data, "cpu_data", None)
                         if existing is None:
-                            buffer.param_data.cpu_data = torch.empty(
-                                buffer.param_data.size(),
-                                dtype=buffer.param_data.dtype,
-                                device="cpu",
-                                pin_memory=True,
+                            buffer.param_data.cpu_data = _try_pin_memory(
+                                torch.empty(
+                                    buffer.param_data.size(),
+                                    dtype=buffer.param_data.dtype,
+                                    device="cpu",
+                                )
                             )
                             buffer.param_data_size = buffer.param_data.storage().size()
                         else:
@@ -1941,9 +1960,9 @@ def copy_megatron_model_to_cpu(models):
 
                     # Copy parameter data to CPU
                     if buffer.param_data.storage().size() > 0:
-                        buffer_state["param_data"] = buffer.param_data.data.cpu().clone().pin_memory()
+                        buffer_state["param_data"] = _try_pin_memory(buffer.param_data.data.cpu().clone())
                     else:
-                        buffer_state["param_data"] = buffer.param_data.cpu_data.clone().pin_memory()
+                        buffer_state["param_data"] = _try_pin_memory(buffer.param_data.cpu_data.clone())
 
                     buffer_list.append(buffer_state)
                 buffer_states.append(buffer_list)
@@ -1953,7 +1972,7 @@ def copy_megatron_model_to_cpu(models):
             # Handle non-DDP models (ref module)
             model_state = {}
             for name, param in model_chunk.named_parameters():
-                param_state = {"data": param.data.cpu().clone().pin_memory()}
+                param_state = {"data": _try_pin_memory(param.data.cpu().clone())}
                 model_state[name] = param_state
 
             cpu_state[f"model_chunk_{model_idx}"] = {"model_state": model_state, "is_ddp": False}


### PR DESCRIPTION
## Problem

When resuming Megatron training with CPU-offloaded optimizer enabled, the process crashes in `offload_megatron_model_to_cpu` with:

```
torch.AcceleratorError: CUDA error: invalid argument (cudaErrorInvalidValue)
```

at the `pin_memory()` call. Training from scratch works fine; only resume triggers the crash.

Reported in #6690.

## Root cause

On resume, the call order in `load_checkpoint` is:

1. `load_megatron_model_to_gpu(self.module)` — loads model weights to GPU
2. `self.checkpoint_mananager.load_checkpoint(...)` — loads optimizer state. With `optimizer_cpu_offload=True`, the entire fp32 optimizer state is materialized into **pinned host memory**
3. `offload_megatron_model_to_cpu(self.module)` — tries to allocate **more** pinned memory for the model parameter buffers

By step 3, the pinned memory pool is already full from step 2. The `pin_memory()` call (or `torch.empty(..., pin_memory=True)`) fails with `cudaErrorInvalidValue`.

During normal (non-resume) training, the offload runs before the optimizer state is fully materialized in pinned memory, so there is always enough room. This is why the bug is resume-specific.

## Fix

A small helper function `_try_pin_memory()` wraps `pin_memory()` in a try/except and falls back to a regular (non-pinned) CPU tensor when pinning fails:

```python
def _try_pin_memory(tensor: torch.Tensor) -> torch.Tensor:
    try:
        return tensor.pin_memory()
    except Exception:
        logger.warning(
            "pin_memory() failed (likely pinned-memory pool exhausted "
            "by CPU-offloaded optimizer on resume); using non-pinned CPU copy."
        )
        return tensor
```

This is applied to all four `pin_memory()` call sites in `megatron_utils.py`:

| Location | Before | After |
|---|---|---|
| `offload_megatron_model_to_cpu` (buffer alloc) | `torch.empty(..., pin_memory=True)` | `_try_pin_memory(torch.empty(...))` |
| `copy_megatron_model_to_cpu` (DDP on-GPU) | `.cpu().clone().pin_memory()` | `_try_pin_memory(.cpu().clone())` |
| `copy_megatron_model_to_cpu` (DDP offloaded) | `.cpu_data.clone().pin_memory()` | `_try_pin_memory(.cpu_data.clone())` |
| `copy_megatron_model_to_cpu` (non-DDP) | `.cpu().clone().pin_memory()` | `_try_pin_memory(.cpu().clone())` |

### Why this is safe

- `pin_memory()` is only a performance optimization for faster H2D (host-to-device) copies.
- `load_megatron_model_to_gpu` copies from `cpu_data` using `.copy_(..., non_blocking=True)` regardless of whether the source tensor is pinned or not. Non-pinned just means that specific H2D copy is slightly slower.
- The helper still **attempts** pinning every time. It only falls back when pinning actually fails, which in practice only happens on resume with CPU-offloaded optimizer.
- A warning is logged so users are aware of the fallback.

### What this does NOT change

- No changes to the optimizer offload path
- No changes to the checkpoint save/load logic
- No changes to `load_megatron_model_to_gpu`
- Default behavior is unchanged when pinned memory is available

## Files changed

- `verl/utils/megatron_utils.py` — `_try_pin_memory()` helper + 4 call site updates (27 lines added, 8 removed)
- `tests/utils/test_try_pin_memory.py` — 7 tests covering success path, fallback on failure, data preservation, warning logging, edge cases

## Tests

| Test | What it verifies |
|---|---|
| `test_returns_tensor_on_success` | pin_memory succeeds: returns tensor with same shape/dtype/data |
| `test_falls_back_on_failure` | RuntimeError from pin_memory: returns the original tensor object |
| `test_falls_back_preserves_data` | Fallback tensor has identical contents and dtype (bf16) |
| `test_logs_warning_on_fallback` | Warning is logged with "pin_memory" in the message |
| `test_does_not_log_on_success` | No warning logged on success |
| `test_handles_empty_tensor` | Works with zero-element tensors |
| `test_handles_large_tensor_failure` | Simulates the real scenario (large bf16 tensor, CUDA error) |