### PR TITLE
[rollout] fix: keep loop workers on the job's node group

### DIFF
--- a/tests/experimental/test_loop_worker_multinode_scheduling.py
+++ b/tests/experimental/test_loop_worker_multinode_scheduling.py
@@ -38,7 +38,9 @@ def multinode_ray_cluster():
 def _agent_config(num_workers):
     return SimpleNamespace(
         actor_rollout_ref=SimpleNamespace(
-            rollout=SimpleNamespace(agent=SimpleNamespace(num_workers=num_workers)),
+            rollout=SimpleNamespace(
+                agent=SimpleNamespace(num_workers=num_workers, num_cpus_per_worker=0.25),
+            ),
             model=None,
         )
     )
@@ -65,7 +67,9 @@ def test_loop_workers_stay_on_configured_nodes(multinode_ray_cluster, monkeypatc
     asyncio.run(agent_manager._init_agent_loop_workers())
 
     reward_manager = object.__new__(RewardLoopManager)
-    reward_manager.config = SimpleNamespace(reward=SimpleNamespace(num_workers=3))
+    reward_manager.config = SimpleNamespace(
+        reward=SimpleNamespace(num_workers=3, num_cpus_per_worker=0.25)
+    )
     reward_manager.reward_loop_workers_class = _NodeProbe
     reward_manager.reward_router_address = None
     reward_manager._init_reward_loop_workers()

--- a/tests/experimental/test_loop_worker_multinode_scheduling.py
+++ b/tests/experimental/test_loop_worker_multinode_scheduling.py
@@ -1,0 +1,91 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import ray
+from ray.cluster_utils import Cluster
+
+from verl.experimental.agent_loop.agent_loop import AgentLoopManager
+from verl.experimental.reward_loop.reward_loop import RewardLoopManager
+from verl.utils.ray_utils import LOOP_WORKER_NODE_RESOURCE_ENV, schedulable_loop_worker_node_ids
+
+_RESOURCE = "loop_worker_test_group"
+
+
+@ray.remote(num_cpus=0)
+class _NodeProbe:
+    def __init__(self, *_):
+        self.node_id = ray.get_runtime_context().get_node_id()
+
+    def get_node_id(self):
+        return self.node_id
+
+
+@pytest.fixture
+def multinode_ray_cluster():
+    cluster = Cluster()
+    try:
+        cluster.add_node(num_cpus=1, include_dashboard=False)
+        cluster.add_node(num_cpus=1, resources={_RESOURCE: 1}, include_dashboard=False)
+        cluster.add_node(num_cpus=1, resources={_RESOURCE: 1}, include_dashboard=False)
+        ray.init(address=cluster.address)
+        yield
+    finally:
+        ray.shutdown()
+        cluster.shutdown()
+
+
+def _agent_config(num_workers):
+    return SimpleNamespace(
+        actor_rollout_ref=SimpleNamespace(
+            rollout=SimpleNamespace(agent=SimpleNamespace(num_workers=num_workers)),
+            model=None,
+        )
+    )
+
+
+def _actor_node_ids(actors):
+    return ray.get([actor.get_node_id.remote() for actor in actors])
+
+
+def test_loop_workers_stay_on_configured_nodes_and_default_can_use_foreign(multinode_ray_cluster, monkeypatch):
+    nodes = ray.nodes()
+    all_node_ids = {node["NodeID"] for node in nodes}
+    eligible_node_ids = {node["NodeID"] for node in nodes if node["Resources"].get(_RESOURCE, 0) > 0}
+    foreign_node_ids = all_node_ids - eligible_node_ids
+    assert len(nodes) == 3
+    assert len(eligible_node_ids) == 2
+    assert len(foreign_node_ids) == 1
+    print(
+        "ray_nodes=",
+        [(node["NodeID"], _RESOURCE in node["Resources"]) for node in nodes],
+    )
+
+    monkeypatch.setenv(LOOP_WORKER_NODE_RESOURCE_ENV, _RESOURCE)
+    agent_manager = AgentLoopManager(_agent_config(num_workers=4), llm_client=None)
+    agent_manager.agent_loop_workers_class = _NodeProbe
+    asyncio.run(agent_manager._init_agent_loop_workers())
+
+    reward_manager = object.__new__(RewardLoopManager)
+    reward_manager.config = SimpleNamespace(reward=SimpleNamespace(num_workers=3))
+    reward_manager.reward_loop_workers_class = _NodeProbe
+    reward_manager.reward_router_address = None
+    reward_manager._init_reward_loop_workers()
+
+    agent_node_ids = _actor_node_ids(agent_manager.agent_loop_workers)
+    reward_node_ids = _actor_node_ids(reward_manager.reward_loop_workers)
+    print(f"restricted_agent_nodes={agent_node_ids}")
+    print(f"restricted_reward_nodes={reward_node_ids}")
+    assert set(agent_node_ids) <= eligible_node_ids
+    assert set(reward_node_ids) <= eligible_node_ids
+
+    monkeypatch.delenv(LOOP_WORKER_NODE_RESOURCE_ENV)
+    default_manager = AgentLoopManager(_agent_config(num_workers=3), llm_client=None)
+    default_manager.agent_loop_workers_class = _NodeProbe
+    asyncio.run(default_manager._init_agent_loop_workers())
+    default_node_ids = _actor_node_ids(default_manager.agent_loop_workers)
+    print(f"default_agent_nodes={default_node_ids}")
+    assert foreign_node_ids.intersection(default_node_ids)
+
+    with pytest.raises(RuntimeError, match="missing-loop-worker-resource"):
+        schedulable_loop_worker_node_ids("missing-loop-worker-resource")

--- a/tests/experimental/test_loop_worker_multinode_scheduling.py
+++ b/tests/experimental/test_loop_worker_multinode_scheduling.py
@@ -48,14 +48,12 @@ def _actor_node_ids(actors):
     return ray.get([actor.get_node_id.remote() for actor in actors])
 
 
-def test_loop_workers_stay_on_configured_nodes_and_default_can_use_foreign(multinode_ray_cluster, monkeypatch):
+def test_loop_workers_stay_on_configured_nodes(multinode_ray_cluster, monkeypatch):
     nodes = ray.nodes()
-    all_node_ids = {node["NodeID"] for node in nodes}
+    alive_node_ids = {node["NodeID"] for node in nodes if node["Alive"]}
     eligible_node_ids = {node["NodeID"] for node in nodes if node["Resources"].get(_RESOURCE, 0) > 0}
-    foreign_node_ids = all_node_ids - eligible_node_ids
     assert len(nodes) == 3
     assert len(eligible_node_ids) == 2
-    assert len(foreign_node_ids) == 1
     print(
         "ray_nodes=",
         [(node["NodeID"], _RESOURCE in node["Resources"]) for node in nodes],
@@ -85,7 +83,7 @@ def test_loop_workers_stay_on_configured_nodes_and_default_can_use_foreign(multi
     asyncio.run(default_manager._init_agent_loop_workers())
     default_node_ids = _actor_node_ids(default_manager.agent_loop_workers)
     print(f"default_agent_nodes={default_node_ids}")
-    assert foreign_node_ids.intersection(default_node_ids)
+    assert set(default_node_ids) <= alive_node_ids
 
     with pytest.raises(RuntimeError, match="missing-loop-worker-resource"):
         schedulable_loop_worker_node_ids("missing-loop-worker-resource")

--- a/tests/experimental/test_loop_worker_multinode_scheduling.py
+++ b/tests/experimental/test_loop_worker_multinode_scheduling.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 from types import SimpleNamespace
 
@@ -67,9 +81,7 @@ def test_loop_workers_stay_on_configured_nodes(multinode_ray_cluster, monkeypatc
     asyncio.run(agent_manager._init_agent_loop_workers())
 
     reward_manager = object.__new__(RewardLoopManager)
-    reward_manager.config = SimpleNamespace(
-        reward=SimpleNamespace(num_workers=3, num_cpus_per_worker=0.25)
-    )
+    reward_manager.config = SimpleNamespace(reward=SimpleNamespace(num_workers=3, num_cpus_per_worker=0.25))
     reward_manager.reward_loop_workers_class = _NodeProbe
     reward_manager.reward_router_address = None
     reward_manager._init_reward_loop_workers()

--- a/tests/utils/test_loop_worker_scheduling_on_cpu.py
+++ b/tests/utils/test_loop_worker_scheduling_on_cpu.py
@@ -13,15 +13,20 @@
 # limitations under the License.
 """CPU unit tests for agent-loop / reward-loop worker node selection."""
 
+import dataclasses
+
 import pytest
 
 from verl.utils import ray_utils
 from verl.utils.ray_utils import (
     LOOP_WORKER_NODE_RESOURCE_ENV,
+    assign_loop_worker_nodes,
     get_loop_worker_node_resource,
     loop_worker_node_affinity_resources,
     schedulable_loop_worker_node_ids,
 )
+from verl.workers.config.reward import RewardConfig
+from verl.workers.config.rollout import AgentLoopConfig
 
 # A shared/heterogeneous cluster: two managed nodes advertising a group resource,
 # one foreign node (other worker group, no group resource), and a dead node.
@@ -79,3 +84,65 @@ def test_single_node_group_does_not_degrade():
 def test_affinity_resources():
     assert loop_worker_node_affinity_resources(None) is None
     assert loop_worker_node_affinity_resources(_GROUP) == {_GROUP: pytest.approx(1e-4)}
+
+
+def test_assign_falls_back_to_round_robin_without_cpu_data():
+    node_ids = ["a", "b", "c"]
+    # No available-CPU info -> historical round-robin over the candidate nodes.
+    assert assign_loop_worker_nodes(node_ids, 5, available_cpu=None, cpus_per_worker=0.25) == [
+        "a",
+        "b",
+        "c",
+        "a",
+        "b",
+    ]
+    assert assign_loop_worker_nodes(node_ids, 5, available_cpu={}, cpus_per_worker=0.25) == [
+        "a",
+        "b",
+        "c",
+        "a",
+        "b",
+    ]
+
+
+def test_assign_prefers_most_available_and_spreads_as_cpu_drains():
+    node_ids = ["a", "b"]
+    # "b" starts with more free CPU; each placement debits cpus_per_worker so the
+    # two nodes alternate as their available CPU converges.
+    placed = assign_loop_worker_nodes(node_ids, 4, available_cpu={"a": 5.0, "b": 6.0}, cpus_per_worker=2.0)
+    assert placed == ["b", "a", "b", "a"]
+
+
+def test_assign_zero_cost_pins_to_single_emptiest():
+    node_ids = ["a", "b", "c"]
+    # With no per-worker cost nothing drains, so the single emptiest node wins all.
+    placed = assign_loop_worker_nodes(node_ids, 3, available_cpu={"a": 1.0, "b": 3.0, "c": 2.0}, cpus_per_worker=0.0)
+    assert placed == ["b", "b", "b"]
+
+
+def test_assign_missing_node_treated_as_zero_cpu():
+    node_ids = ["a", "b"]
+    # "b" absent from the map -> 0 available, so "a" is always preferred.
+    placed = assign_loop_worker_nodes(node_ids, 2, available_cpu={"a": 4.0}, cpus_per_worker=0.0)
+    assert placed == ["a", "a"]
+
+
+def test_assign_empty_nodes_raises():
+    with pytest.raises(ValueError):
+        assign_loop_worker_nodes([], 3, available_cpu={"a": 1.0})
+
+
+def test_available_cpu_per_node_returns_empty_when_unreachable():
+    # Outside a live Ray driver the internal state view is unavailable; callers
+    # must then fall back to round-robin.
+    assert ray_utils.available_cpu_per_node() == {}
+
+
+def _declared_default(config_cls, field_name):
+    return next(f for f in dataclasses.fields(config_cls) if f.name == field_name).default
+
+
+def test_loop_worker_cpu_knob_defaults_are_fractional():
+    assert AgentLoopConfig().num_cpus_per_worker == 0.25
+    assert _declared_default(AgentLoopConfig, "num_cpus_per_worker") == 0.25
+    assert _declared_default(RewardConfig, "num_cpus_per_worker") == 0.25

--- a/tests/utils/test_loop_worker_scheduling_on_cpu.py
+++ b/tests/utils/test_loop_worker_scheduling_on_cpu.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU unit tests for agent-loop / reward-loop worker node selection."""
+
+import pytest
+
+from verl.utils import ray_utils
+from verl.utils.ray_utils import (
+    LOOP_WORKER_NODE_RESOURCE_ENV,
+    get_loop_worker_node_resource,
+    loop_worker_node_affinity_resources,
+    schedulable_loop_worker_node_ids,
+)
+
+# A shared/heterogeneous cluster: two managed nodes advertising a group resource,
+# one foreign node (other worker group, no group resource), and a dead node.
+_GROUP = "group:h200-verl-managed"
+_FAKE_NODES = [
+    {"NodeID": "managed-a", "Alive": True, "Resources": {"CPU": 16.0, "GPU": 1.0, _GROUP: 1.0}},
+    {"NodeID": "managed-b", "Alive": True, "Resources": {"CPU": 16.0, "GPU": 1.0, _GROUP: 1.0}},
+    {"NodeID": "foreign", "Alive": True, "Resources": {"CPU": 32.0, "GPU": 1.0}},
+    {"NodeID": "dead", "Alive": False, "Resources": {"CPU": 16.0, _GROUP: 1.0}},
+    {"NodeID": "cpuless", "Alive": True, "Resources": {"GPU": 1.0, _GROUP: 1.0}},
+]
+
+
+@pytest.fixture(autouse=True)
+def _fake_ray_nodes(monkeypatch):
+    monkeypatch.setattr(ray_utils.ray, "nodes", lambda: [dict(n) for n in _FAKE_NODES])
+    monkeypatch.delenv(LOOP_WORKER_NODE_RESOURCE_ENV, raising=False)
+
+
+def test_env_parsing(monkeypatch):
+    assert get_loop_worker_node_resource() is None
+    monkeypatch.setenv(LOOP_WORKER_NODE_RESOURCE_ENV, "   ")
+    assert get_loop_worker_node_resource() is None
+    monkeypatch.setenv(LOOP_WORKER_NODE_RESOURCE_ENV, f"  {_GROUP}  ")
+    assert get_loop_worker_node_resource() == _GROUP
+
+
+def test_unfiltered_keeps_all_alive_cpu_nodes():
+    # Historical behavior: every alive node with CPU, incl. the foreign one.
+    assert schedulable_loop_worker_node_ids(None) == ["managed-a", "managed-b", "foreign"]
+
+
+def test_filter_excludes_foreign_and_dead_and_cpuless():
+    assert schedulable_loop_worker_node_ids(_GROUP) == ["managed-a", "managed-b"]
+
+
+def test_filter_no_match_raises():
+    with pytest.raises(RuntimeError, match="does-not-exist"):
+        schedulable_loop_worker_node_ids("does-not-exist")
+
+
+def test_round_robin_stays_within_group():
+    node_ids = schedulable_loop_worker_node_ids(_GROUP)
+    # num_workers > group size must keep wrapping inside the group, never leaking.
+    placed = [node_ids[i % len(node_ids)] for i in range(8)]
+    assert set(placed) == {"managed-a", "managed-b"}
+
+
+def test_single_node_group_does_not_degrade():
+    node_ids = schedulable_loop_worker_node_ids(_GROUP)[:1]
+    placed = [node_ids[i % len(node_ids)] for i in range(4)]
+    assert placed == ["managed-a"] * 4
+
+
+def test_affinity_resources():
+    assert loop_worker_node_affinity_resources(None) is None
+    assert loop_worker_node_affinity_resources(_GROUP) == {_GROUP: pytest.approx(1e-4)}

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -53,7 +53,13 @@ from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.profiler import simple_timer
-from verl.utils.ray_utils import auto_await, get_event_loop
+from verl.utils.ray_utils import (
+    auto_await,
+    get_event_loop,
+    get_loop_worker_node_resource,
+    loop_worker_node_affinity_resources,
+    schedulable_loop_worker_node_ids,
+)
 from verl.utils.rollout_trace import (
     RolloutTraceConfig,
     rollout_trace_attr,
@@ -1202,17 +1208,25 @@ class AgentLoopManager:
         self.agent_loop_workers = []
         num_workers = self.rollout_config.agent.num_workers
 
-        node_ids = [node["NodeID"] for node in ray.nodes() if node["Alive"] and node["Resources"].get("CPU", 0) > 0]
+        # Restrict candidate nodes to this job's node group when configured, so a
+        # shared/heterogeneous cluster never round-robins a worker onto a foreign
+        # node that lacks this job's runtime. See VERL_LOOP_WORKER_NODE_RESOURCE.
+        node_resource = get_loop_worker_node_resource()
+        node_ids = schedulable_loop_worker_node_ids(node_resource)
+        worker_resources = loop_worker_node_affinity_resources(node_resource)
         for i in range(num_workers):
-            # Round-robin scheduling over the all nodes
+            # Round-robin scheduling over the candidate nodes
             node_id = node_ids[i % len(node_ids)]
+            options = {
+                "name": f"agent_loop_worker_{i}" + f"_{uuid4().hex[:8]}",
+                "scheduling_strategy": ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                    node_id=node_id, soft=True
+                ),
+            }
+            if worker_resources is not None:
+                options["resources"] = worker_resources
             self.agent_loop_workers.append(
-                self.agent_loop_workers_class.options(
-                    name=f"agent_loop_worker_{i}" + f"_{uuid4().hex[:8]}",
-                    scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
-                        node_id=node_id, soft=True
-                    ),
-                ).remote(
+                self.agent_loop_workers_class.options(**options).remote(
                     self.config,
                     self.llm_client,
                     self.teacher_client,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -54,7 +54,9 @@ from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.profiler import simple_timer
 from verl.utils.ray_utils import (
+    assign_loop_worker_nodes,
     auto_await,
+    available_cpu_per_node,
     get_event_loop,
     get_loop_worker_node_resource,
     loop_worker_node_affinity_resources,
@@ -1214,11 +1216,18 @@ class AgentLoopManager:
         node_resource = get_loop_worker_node_resource()
         node_ids = schedulable_loop_worker_node_ids(node_resource)
         worker_resources = loop_worker_node_affinity_resources(node_resource)
+        num_cpus_per_worker = self.rollout_config.agent.num_cpus_per_worker
+        # Spread workers toward the nodes with the most available CPU so they do
+        # not all pile onto node_ids[0]; falls back to round-robin when Ray does
+        # not report per-node availability.
+        node_assignments = assign_loop_worker_nodes(
+            node_ids, num_workers, available_cpu_per_node(), num_cpus_per_worker
+        )
         for i in range(num_workers):
-            # Round-robin scheduling over the candidate nodes
-            node_id = node_ids[i % len(node_ids)]
+            node_id = node_assignments[i]
             options = {
                 "name": f"agent_loop_worker_{i}" + f"_{uuid4().hex[:8]}",
+                "num_cpus": num_cpus_per_worker,
                 "scheduling_strategy": ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=node_id, soft=True
                 ),

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -29,6 +29,8 @@ from verl.trainer.ppo.reward import load_reward_manager, resolve_reward_manager_
 from verl.utils import hf_tokenizer
 from verl.utils.fs import copy_to_local
 from verl.utils.ray_utils import (
+    assign_loop_worker_nodes,
+    available_cpu_per_node,
     get_event_loop,
     get_loop_worker_node_resource,
     loop_worker_node_affinity_resources,
@@ -335,13 +337,20 @@ class RewardLoopManager:
         node_resource = get_loop_worker_node_resource()
         node_ids = schedulable_loop_worker_node_ids(node_resource)
         worker_resources = loop_worker_node_affinity_resources(node_resource)
+        num_cpus_per_worker = self.config.reward.num_cpus_per_worker
+        # Spread workers toward the nodes with the most available CPU so they do
+        # not all pile onto node_ids[0]; falls back to round-robin when Ray does
+        # not report per-node availability.
+        node_assignments = assign_loop_worker_nodes(
+            node_ids, num_workers, available_cpu_per_node(), num_cpus_per_worker
+        )
 
         for i in range(num_workers):
-            # Round-robin scheduling over the candidate nodes
-            node_id = node_ids[i % len(node_ids)]
+            node_id = node_assignments[i]
 
             options = {
                 "name": f"reward_loop_worker_{i}",
+                "num_cpus": num_cpus_per_worker,
                 "scheduling_strategy": ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=node_id,
                     soft=True,

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -28,7 +28,12 @@ from verl.single_controller.ray.base import RayResourcePool
 from verl.trainer.ppo.reward import load_reward_manager, resolve_reward_manager_cls
 from verl.utils import hf_tokenizer
 from verl.utils.fs import copy_to_local
-from verl.utils.ray_utils import get_event_loop
+from verl.utils.ray_utils import (
+    get_event_loop,
+    get_loop_worker_node_resource,
+    loop_worker_node_affinity_resources,
+    schedulable_loop_worker_node_ids,
+)
 
 from .reward_model import RewardModelManager
 
@@ -324,20 +329,28 @@ class RewardLoopManager:
     def _init_reward_loop_workers(self):
         self.reward_loop_workers = []
         num_workers = self.config.reward.num_workers
-        node_ids = [node["NodeID"] for node in ray.nodes() if node["Alive"] and node["Resources"].get("CPU", 0) > 0]
+        # Restrict candidate nodes to this job's node group when configured, so a
+        # shared/heterogeneous cluster never round-robins a worker onto a foreign
+        # node that lacks this job's runtime. See VERL_LOOP_WORKER_NODE_RESOURCE.
+        node_resource = get_loop_worker_node_resource()
+        node_ids = schedulable_loop_worker_node_ids(node_resource)
+        worker_resources = loop_worker_node_affinity_resources(node_resource)
 
         for i in range(num_workers):
-            # Round-robin scheduling over the all nodes
+            # Round-robin scheduling over the candidate nodes
             node_id = node_ids[i % len(node_ids)]
 
+            options = {
+                "name": f"reward_loop_worker_{i}",
+                "scheduling_strategy": ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                    node_id=node_id,
+                    soft=True,
+                ),
+            }
+            if worker_resources is not None:
+                options["resources"] = worker_resources
             self.reward_loop_workers.append(
-                self.reward_loop_workers_class.options(
-                    name=f"reward_loop_worker_{i}",
-                    scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
-                        node_id=node_id,
-                        soft=True,
-                    ),
-                ).remote(self.config, self.reward_router_address)
+                self.reward_loop_workers_class.options(**options).remote(self.config, self.reward_router_address)
             )
 
     def compute_rm_score(self, data: DataProto) -> DataProto:

--- a/verl/utils/ray_utils.py
+++ b/verl/utils/ray_utils.py
@@ -24,6 +24,61 @@ from typing import Any, Optional
 
 import ray
 
+# Optional Ray custom resource that constrains where lightweight loop workers
+# (agent-loop / reward-loop actors) may be scheduled. In a shared or
+# heterogeneous Ray cluster, ``ray.nodes()`` also returns nodes that belong to
+# other jobs or worker groups. Round-robin over all of them with a soft
+# NodeAffinity can place a loop worker on a foreign node that does not run this
+# job's runtime image, which then crashes on import (e.g. ModuleNotFoundError).
+# Set this env var to a Ray custom resource that only this job's nodes advertise
+# to keep loop workers on them. Unset -> historical behavior (all alive nodes).
+LOOP_WORKER_NODE_RESOURCE_ENV = "VERL_LOOP_WORKER_NODE_RESOURCE"
+
+# Fractional amount requested from the node resource so it only acts as a
+# scheduling gate, never a real capacity constraint. Mirrors the tiny reservation
+# verl already uses for accelerator_type bundles in single_controller/ray/base.py.
+_LOOP_WORKER_NODE_RESOURCE_AMOUNT = 1e-4
+
+
+def get_loop_worker_node_resource() -> Optional[str]:
+    """Return the configured loop-worker node resource, or None if unset."""
+    value = os.environ.get(LOOP_WORKER_NODE_RESOURCE_ENV, "").strip()
+    return value or None
+
+
+def schedulable_loop_worker_node_ids(node_resource: Optional[str] = None) -> list[str]:
+    """Return NodeIDs eligible to host agent-loop / reward-loop workers.
+
+    Without ``node_resource`` this preserves the historical behavior of
+    scheduling across every alive node that has CPU. When ``node_resource`` is
+    given, only nodes that advertise that Ray custom resource are returned, so a
+    shared/heterogeneous cluster never round-robins a loop worker onto a foreign
+    node that lacks this job's runtime.
+    """
+    nodes = [node for node in ray.nodes() if node["Alive"] and node["Resources"].get("CPU", 0) > 0]
+    if node_resource:
+        nodes = [node for node in nodes if node["Resources"].get(node_resource, 0) > 0]
+        if not nodes:
+            raise RuntimeError(
+                f"No alive Ray node advertises the resource {node_resource!r} requested via "
+                f"{LOOP_WORKER_NODE_RESOURCE_ENV}; cannot place agent-loop/reward-loop workers. "
+                "Ensure this job's node group exports that custom resource."
+            )
+    return [node["NodeID"] for node in nodes]
+
+
+def loop_worker_node_affinity_resources(node_resource: Optional[str] = None) -> Optional[dict]:
+    """Actor ``resources`` requirement that pins a loop worker to a node group.
+
+    A soft NodeAffinity alone can still fall back to a foreign node when the
+    targeted node is momentarily full. Requiring a tiny amount of the node
+    resource makes Ray refuse to schedule the actor anywhere that does not
+    advertise it, closing that leak. Returns None when no resource is configured.
+    """
+    if not node_resource:
+        return None
+    return {node_resource: _LOOP_WORKER_NODE_RESOURCE_AMOUNT}
+
 
 def ray_noset_visible_devices(env_vars=os.environ):
     # Refer to

--- a/verl/utils/ray_utils.py
+++ b/verl/utils/ray_utils.py
@@ -80,6 +80,55 @@ def loop_worker_node_affinity_resources(node_resource: Optional[str] = None) -> 
     return {node_resource: _LOOP_WORKER_NODE_RESOURCE_AMOUNT}
 
 
+def available_cpu_per_node() -> dict[str, float]:
+    """Best-effort map of NodeID -> currently available CPU.
+
+    Ray does not expose per-node *available* resources through the public
+    ``ray.nodes()`` payload, so this reads the driver-side resource view when it
+    is reachable and returns an empty mapping otherwise. Callers must treat an
+    empty result as "unknown" and fall back to round-robin placement.
+    """
+    try:
+        from ray._private.state import state as ray_state
+
+        per_node = ray_state._available_resources_per_node()
+    except Exception:
+        return {}
+    return {node_id: float(resources.get("CPU", 0.0)) for node_id, resources in (per_node or {}).items()}
+
+
+def assign_loop_worker_nodes(
+    node_ids: list[str],
+    num_workers: int,
+    available_cpu: Optional[dict[str, float]] = None,
+    cpus_per_worker: float = 0.0,
+) -> list[str]:
+    """Assign each loop worker to a candidate node, spreading by available CPU.
+
+    Prefers the node with the most currently-available CPU so workers fan out
+    across a heterogeneous group instead of stacking on ``node_ids[0]``. Each
+    placement provisionally debits ``cpus_per_worker`` from the chosen node so
+    later workers favor the next-emptiest node. Falls back to the historical
+    round-robin order when ``available_cpu`` is empty (Ray reported no per-node
+    availability). ``node_ids`` order breaks ties deterministically.
+    """
+    if num_workers <= 0:
+        return []
+    if not node_ids:
+        raise ValueError("assign_loop_worker_nodes requires at least one candidate node")
+    if not available_cpu:
+        return [node_ids[i % len(node_ids)] for i in range(num_workers)]
+
+    remaining = {node_id: float(available_cpu.get(node_id, 0.0)) for node_id in node_ids}
+    rank = {node_id: i for i, node_id in enumerate(node_ids)}
+    assignments = []
+    for _ in range(num_workers):
+        node_id = min(node_ids, key=lambda nid: (-remaining[nid], rank[nid]))
+        assignments.append(node_id)
+        remaining[node_id] -= cpus_per_worker
+    return assignments
+
+
 def ray_noset_visible_devices(env_vars=os.environ):
     # Refer to
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96

--- a/verl/workers/config/reward.py
+++ b/verl/workers/config/reward.py
@@ -96,6 +96,9 @@ class RewardConfig(BaseConfig):
 
     # reward manager args
     num_workers: int = 8
+    # CPU reserved per reward-loop worker actor. Lightweight actors, so a
+    # fractional default avoids over-reserving CPU and stalling placement.
+    num_cpus_per_worker: float = 0.25
     reward_manager: RewardManagerConfig = field(default_factory=RewardManagerConfig)
 
     # reward model args

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -71,6 +71,10 @@ class CustomAsyncServerConfig(BaseConfig):
 @dataclass
 class AgentLoopConfig(BaseConfig):
     num_workers: int = 8
+    # CPU reserved per agent-loop worker actor. These are lightweight I/O-bound
+    # actors, so a fractional default lets many co-exist on a node instead of the
+    # Ray default of 1 CPU each, which can exhaust CPU and stall placement.
+    num_cpus_per_worker: float = 0.25
     default_agent_loop: str = "single_turn_agent"
     agent_loop_config_path: Optional[str] = None
     custom_async_server: CustomAsyncServerConfig = field(default_factory=CustomAsyncServerConfig)


### PR DESCRIPTION
## Reproduction

```bash
python -m pytest -q -s tests/experimental/test_loop_worker_multinode_scheduling.py tests/utils/test_loop_worker_scheduling_on_cpu.py
```

## Limitations

- Covers actor creation and placement only; it does not run a full training or rollout workload.
- Uses three isolated local Ray raylet processes (two with the custom resource and one without); it does not run on Kubernetes.