### PR TITLE
[doc] fix: note the megatron commit MTP needs for recompute_granularity=full

### DIFF
--- a/docs/advance/mtp.md
+++ b/docs/advance/mtp.md
@@ -2,7 +2,7 @@
 
 **Author**: `https://github.com/meituan-search`
 
-Last updated: 02/15/2026
+Last updated: 08/11/2026
 
 ## 1. Scope of Support
 
@@ -18,7 +18,7 @@ Currently, RL training can be performed on mimo-7B-RL, Qwen-next, and Deepseek s
 
     - Megatron-Bridge: Apply the patches and review suggestions from PR if you want to try out mimo-7B-RL: [#2387](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/2387) (will be merged into the main branch in the future);
 
-    - megatron: Use the latest dev version (commit: [23e092f41ec8bc659020e401ddac9576c1cfed7e](https://github.com/NVIDIA/Megatron-LM/tree/23e092f41ec8bc659020e401ddac9576c1cfed7e)), which supports MTP + CP training methods.
+    - megatron: Use the latest dev version (commit: [23e092f41ec8bc659020e401ddac9576c1cfed7e](https://github.com/NVIDIA/Megatron-LM/tree/23e092f41ec8bc659020e401ddac9576c1cfed7e)), which supports MTP + CP training methods. If you additionally enable `recompute_granularity=full`, use a dev commit that includes [#3457](https://github.com/NVIDIA/Megatron-LM/pull/3457) (`ffd66a3e6`, 2026-06-03) — the commit pinned above predates it by about six months. #3457 threads `padding_mask` through `MultiTokenPredictionLayer._checkpointed_forward`; without it, `MultiTokenPredictionLayer.forward` passes a keyword the method does not declare and training raises a `TypeError` on the first step. Released `megatron-core` 0.18.0 and 0.18.2 do not carry the fix either (tracked as [#4933](https://github.com/NVIDIA/Megatron-LM/issues/4933)).
     
     - sglang: Use the specified branch: [https://github.com/ArronHZG/sglang/tree/fix_mtp_update_weights_from_tensor](https://github.com/ArronHZG/sglang/tree/fix_mtp_update_weights_from_tensor), [PR](https://github.com/sgl-project/sglang/pull/17870) , which fix the MTP update weights from tensor OOM issue.
 


### PR DESCRIPTION
### What does this PR do?

Follow-up to #7326, where the review outcome was that verl should document the required Megatron fix rather than carry a compatibility shim. This does that.

`docs/advance/mtp.md` pins megatron dev at [`23e092f41`](https://github.com/NVIDIA/Megatron-LM/tree/23e092f41ec8bc659020e401ddac9576c1cfed7e) (2025-12-09) for MTP + CP. That commit predates [`ffd66a3e6`](https://github.com/NVIDIA/Megatron-LM/pull/3457) ("Roll input IDs for MTP labels", NVIDIA/Megatron-LM#3457, 2026-06-03) by about six months, and #3457 is what threads `padding_mask` through `MultiTokenPredictionLayer._checkpointed_forward`.

Without it, `MultiTokenPredictionLayer.forward` passes `padding_mask=` to a `_checkpointed_forward` that does not declare the parameter, so **MTP with `recompute_granularity=full` raises a `TypeError` on the first step** — i.e. following this doc as written still crashes for that combination. Released `megatron-core` 0.18.0 and 0.18.2 do not carry the fix either, tracked upstream as NVIDIA/Megatron-LM#4933.

### Checklist Before Starting

- [x] Search for similar PRs. Queries run: [`mtp.md megatron dev commit`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+mtp.md+megatron+dev+commit), [`mtp recompute_granularity`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+mtp+recompute_granularity), [`3457 megatron`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+3457+megatron) — no open PR touches this.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Documentation only, so the thing to verify is that the factual claim is right. I checked the signature of `MultiTokenPredictionLayer._checkpointed_forward` at each ref by parsing the file with `ast` rather than grepping — grep is misleading here because the call site a few lines below the signature also contains the string `padding_mask`, which is how I first got this wrong:

| ref | date | `padding_mask` in signature |
|---|---|---|
| `4c6360260` | 2026-05-22 | no |
| **`ffd66a3e6`** (#3457) | **2026-06-03** | **yes** — first commit that has it |
| `23e092f41` (currently pinned in this doc) | 2025-12-09 | no |
| `core_v0.18.0` | 2026-06-22 | no |
| `core_v0.18.2` (newest release) | 2026-07-20 | no |
| `dev` @`43124b60c` | 2026-08-08 | yes |
| `main` @`6518b75ec` | 2026-08-09 | yes |

The bisect was done over the file's commit history via `gh api "repos/NVIDIA/Megatron-LM/commits?path=megatron/core/transformer/multi_token_prediction.py&sha=main"`, then fetching the blob at each candidate.

Repo checks run: `python3 tests/special_sanity/check_docs_time_info.py` (✅), `PR_TITLE=... python3 tests/special_sanity/check_pr_title.py` (✅). Both added links return HTTP 200.

### API and Usage Example

No API change.

### Design & Code Changes

One bullet in `docs/advance/mtp.md` §1 "Scope of Support" gains the additional constraint for `recompute_granularity=full`, plus the `Last updated` date.

**I deliberately did not move the pin itself.** I have not validated MTP + CP on a newer dev commit, and I would rather add the constraint than silently replace a pin someone else verified. If you have a newer dev commit you trust for MTP + CP, bumping it would make this bullet simpler and I'm happy to do that instead.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] Apply pre-commit checks — `pre-commit` was not installable in my environment; I ran the repo's own sanity checks directly (above). Note that `pre-commit (3.12)` is currently failing on `main` for an unrelated file (`tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py`, a `ruff-format` diff from #7300), so a red pre-commit here would not be from this change.
- [x] Add / Update the documentation — this PR *is* the documentation change.
- [ ] Add unit or end-to-end test(s) — not applicable to a docs-only change.

---

**AI assistance disclosure:** prepared with AI assistance (Claude). I reviewed every changed line and verified each factual claim above myself.
