### PR TITLE
[fsdp] fix: preserve mRoPE token axis in no-padding conversion

### DIFF
--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import random
 
+import pytest
 import torch
 from tensordict import TensorDict
 
@@ -133,6 +134,32 @@ def test_padding_conversion_without_log_probs():
     assert data_converted["position_ids"].is_nested
     assert "old_log_probs" not in data_converted
     assert "ref_log_prob" not in data_converted
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_padding_conversion_preserves_mrope_token_axis_for_equal_lengths(batch_size):
+    """Pack singleton and equal-length mRoPE batches along the token dimension."""
+    num_rope_dimensions = 4
+    seq_len = 6
+
+    position_ids = torch.arange(batch_size * num_rope_dimensions * seq_len).reshape(
+        batch_size, num_rope_dimensions, seq_len
+    )
+    data = TensorDict(
+        {
+            "input_ids": torch.arange(batch_size * seq_len).reshape(batch_size, seq_len),
+            "attention_mask": torch.ones(batch_size, seq_len),
+            "response_mask": torch.ones(batch_size, 2),
+            "position_ids": position_ids,
+        }
+    )
+
+    packed_position_ids = left_right_2_no_padding(data)["position_ids"]
+
+    assert packed_position_ids._ragged_idx == 2
+    assert packed_position_ids.values().shape == (num_rope_dimensions, batch_size * seq_len)
+    torch.testing.assert_close(packed_position_ids.offsets(), torch.arange(batch_size + 1) * seq_len)
+    torch.testing.assert_close(packed_position_ids.values(), torch.cat(position_ids.unbind(0), dim=-1))
 
 
 def test_padding_roundtrip():

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -64,7 +64,7 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
         else:  # (4, seq_len)
             valid_ids = curr_pos_ids[:, curr_mask]
         position_ids_list.append(valid_ids)
-    position_ids_nested = torch.nested.as_nested_tensor(position_ids_list, layout=torch.jagged)
+    position_ids_nested = tu.nested_tensor_from_tensor_list(position_ids_list)
 
     data["input_ids"] = input_ids_nested
     data["position_ids"] = position_ids_nested


### PR DESCRIPTION
Use the existing explicit jagged-layout helper when packing multidimensional position IDs, and cover singleton and equal-length batches.

### What does this PR do?

`left_right_2_no_padding()` converts padded position IDs into a jagged `NestedTensor`. For multidimensional position IDs, each sample has shape `[rope_dim, seq_len]`, and the token dimension must remain the ragged dimension.

The previous implementation used `torch.nested.as_nested_tensor(...)`, which infers the ragged dimension from the input shapes. For a singleton batch or a batch whose samples have equal valid sequence lengths, this inference selects the RoPE dimension instead of the token dimension. The resulting tensor has incorrect ragged metadata, offsets, and, for multi-sample batches, values layout.

This PR replaces that ambiguous construction with the existing `nested_tensor_from_tensor_list()` helper, which explicitly preserves the last sample dimension as the token/ragged dimension. One-dimensional position IDs continue to use the helper's existing one-dimensional path.

This is a follow-up to #6127 and #6073. #6127 fixed the same equal-length jagged-layout ambiguity when selecting, chunking, concatenating, or otherwise rebuilding an existing `NestedTensor`, and introduced the helper used here. It did not update the initial padded-to-no-padding conversion in `left_right_2_no_padding()`. #6149 subsequently generalized that helper to support non-last ragged dimensions. This PR covers the remaining initial-construction call site and does not duplicate those changes.

Related work:

- #6073
- #6127
- #6149
- #4860 only restores `_ragged_idx` metadata after serialization; it cannot reconstruct values and offsets that were packed along the wrong dimension.

### Checklist Before Starting

- [x] Searched for similar PRs:
  - [`left_right_2_no_padding`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+left_right_2_no_padding)
  - [`position_ids_nested`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+position_ids_nested)
  - [`mRoPE position_ids ragged`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+mRoPE+position_ids+ragged)
  - No open PR was found that fixes this initial conversion call site.
- [x] Formatted the PR title as `[{modules}] {type}: {description}`.

### Test

The regression test exercises the production entry point and covers both ambiguous cases:

- `batch_size=1`;
- `batch_size=2` with equal valid sequence lengths.

Before the fix, both parameterized cases fail because `_ragged_idx` is `1` instead of `2`.

Targeted regression test:

```bash
python -m pytest -q \
  tests/utils/test_padding_on_cpu.py::test_padding_conversion_preserves_mrope_token_axis_for_equal_lengths
```

Result:

```text
2 passed
```

Related CPU test suites:

```bash
python -m pytest -q \
  tests/utils/test_padding_on_cpu.py \
  tests/test_protocol_v2_on_cpu.py
```

Result:

```text
48 passed in 9.46s
```

Repository checks:

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

Result: all hooks passed, including ruff, ruff-format, mypy, generated-config verification, test-structure validation, and Python compilation.

### API and Usage Example

No public API, configuration, or usage changes. Existing FSDP no-padding configurations automatically receive the corrected multidimensional position-ID layout.

### Design & Code Changes

- `verl/workers/utils/padding.py`
  - Use the existing explicit jagged-layout helper when packing filtered position IDs.
- `tests/utils/test_padding_on_cpu.py`
  - Add a parameterized regression test for singleton and equal-length mRoPE batches.
  - Verify the ragged axis, packed values shape, offsets, and values order.

The production change is one line and introduces no model-specific branch or new abstraction.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Documentation update is not required because this is an internal correctness fix with no public API or configuration change.
- [x] Added regression coverage to the existing CPU padding test suite; no CI workflow change is required because the test file is already collected by CPU CI.
- [ ] Once the PR is ready for CI, send a message in the [`ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in the [verl Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ), or use the [Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).
- [x] Recipe submodule update is not applicable.

### AI Assistance Disclosure

OpenAI Codex assisted with root-cause analysis, implementation, regression-test design, duplicate-work review, and drafting this PR description. The human submitter reviewed the final code changes and is responsible for the submission.
