### PR TITLE
[fsdp, lora] fix: support disabling adapters after FSDP wrapping

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1010,7 +1010,25 @@ class FSDPEngine(BaseEngine):
             log_gpu_memory_usage("After offload_fsdp_model_to_cpu", logger=logger)
 
     def disable_adapter(self) -> ContextManager:
-        return self.module.disable_adapter()
+        # torch.distributed fully_shard changes the root module class and does
+        # not preserve PEFT's dynamically forwarded disable_adapter method.
+        # The original PEFT model remains available as the wrapped module.
+        if hasattr(self.module, "disable_adapter"):
+            return self.module.disable_adapter()
+        wrapped_module = getattr(self.module, "_fsdp_wrapped_module", None)
+        if wrapped_module is not None and hasattr(wrapped_module, "disable_adapter"):
+            return wrapped_module.disable_adapter()
+        if hasattr(self.module, "disable_adapters") and hasattr(self.module, "enable_adapters"):
+            @contextmanager
+            def adapter_disabled():
+                self.module.disable_adapters()
+                try:
+                    yield
+                finally:
+                    self.module.enable_adapters()
+
+            return adapter_disabled()
+        raise AttributeError("FSDP-wrapped PEFT model does not expose disable_adapter")
 
 
 class EngineEvalModeCtx(BaseEngineCtx):


### PR DESCRIPTION
### What does this PR do?

Fix adapter disabling for PEFT/LoRA models after FSDP wrapping.

Depending on the FSDP wrapper, `disable_adapter()` may be exposed by the root module, the wrapped PEFT module, or only through the plural `disable_adapters()` / `enable_adapters()` APIs. This change supports these cases while preserving the existing context-manager behavior.

No related issue was found after searching existing PRs:
https://github.com/verl-project/verl/pulls?q=is%3Apr+disable_adapter+FSDP

### Test

- `python3 -m py_compile verl/workers/engine/fsdp/transformer_impl.py`
- `pytest -q tests/utils/test_fsdp2_peft_wrapping.py`
  - 5 passed
- Added manual regression coverage for:
  - FSDP-wrapped PEFT adapter context
  - adapter restoration after context exit

### API and Usage Example

No public API or configuration changes.

Existing usage remains unchanged:

```python
with engine.disable_adapter():
    ...