### PR TITLE
fix: repair 3D position_ids ragged index selection

### DIFF
--- a/tests/test_protocol_v2_on_cpu.py
+++ b/tests/test_protocol_v2_on_cpu.py
@@ -149,6 +149,31 @@ def test_index_select_tensor_dict_preserves_3d_nested_tensor_layout_with_equal_s
     tu.assert_tensordict_eq(selected, tu.get_tensordict({"position_ids": expected}))
 
 
+def test_index_select_tensor_dict_repairs_broken_3d_position_ids_ragged_idx():
+    position_ids = tu.nested_tensor_from_tensor_list(
+        [
+            torch.arange(2).expand(4, 2),
+            torch.arange(5).expand(4, 5),
+            (torch.arange(5) + 10).expand(4, 5),
+            torch.arange(3).expand(4, 3),
+        ]
+    )
+    position_ids._ragged_idx = 1
+    data = tu.get_tensordict({"position_ids": position_ids})
+
+    selected = tu.index_select_tensor_dict(data, torch.tensor([1, 2]))
+    expected = tu.nested_tensor_from_tensor_list(
+        [
+            torch.arange(5).expand(4, 5),
+            (torch.arange(5) + 10).expand(4, 5),
+        ],
+        ragged_idx=2,
+    )
+
+    assert selected["position_ids"]._ragged_idx == 2
+    tu.assert_tensordict_eq(selected, tu.get_tensordict({"position_ids": expected}))
+
+
 def test_tensordict_with_images():
     # each sample contains a sequence with multiple images of different sizes
     vocab_size = 128

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -492,7 +492,30 @@ def index_select_tensor_dict(batch: TensorDict, indices: torch.Tensor | list[int
             if isinstance(tensor, torch.Tensor) and not tensor.is_nested:
                 data_dict[key] = tensor[indices]
             elif isinstance(tensor, torch.Tensor) and tensor.is_nested:
-                tensor_lst = tensor.unbind()  # for performance
+                is_3d_position_ids = key == "position_ids" and tensor.dim() == 3
+                if is_3d_position_ids:
+                    tensor._ragged_idx = 2
+
+                try:
+                    tensor_lst = tensor.unbind()  # for performance
+                except RuntimeError as unbind_error:
+                    if not is_3d_position_ids:
+                        raise
+
+                    try:
+                        padded = tensor.to_padded_tensor(0)
+                        lengths = tensor.offsets().diff().tolist()
+                        selected_tensors = [
+                            padded[idx, :, : lengths[idx]]
+                            for idx in indices.tolist()
+                        ]
+                        data_dict[key] = nested_tensor_from_tensor_list(
+                            selected_tensors, ragged_idx=2
+                        )
+                    except Exception as fallback_error:
+                        raise unbind_error from fallback_error
+                    continue
+
                 selected_tensors = [tensor_lst[idx] for idx in indices]
                 data_dict[key] = nested_tensor_from_tensor_list(
                     selected_tensors, ragged_idx=getattr(tensor, "_ragged_idx", tensor.dim() - 1)


### PR DESCRIPTION
### What does this PR do?

Fixes `index_select_tensor_dict` for 3D jagged `position_ids`.

After TensorDict consolidation and serialization/deserialization, the internal `_ragged_idx` of 3D `position_ids` may incorrectly become `1` instead of `2`. Calling `unbind()` then raises a runtime error or produces invalid indexing behavior.

This change restores the expected ragged dimension for 3D `position_ids` and adds a defensive fallback based on padded values and sequence lengths.

Related PR: https://github.com/verl-project/verl/pull/4860

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+position_ids+ragged
- [x] PR title follows the required format.

### Test

Executed on the server:

```bash
python3 -m py_compile \
  verl/utils/tensordict_utils.py \
  tests/test_protocol_v2_on_cpu.py

pytest -q tests/test_protocol_v2_on_cpu.py