### PR TITLE
[megatron] feat: bucket packed sequence lengths

### DIFF
--- a/tests/models/test_model_forward_fused.py
+++ b/tests/models/test_model_forward_fused.py
@@ -124,13 +124,22 @@ def test_engine_hook_context_and_current_thd_arguments(monkeypatch):
     assert hook_kwargs["output_processor"] is mff.fused_output_processor
     assert hook_kwargs["output_processor_context"].temperature == pytest.approx(0.7)
     assert preprocess_calls == [
-        {"pre_process": True, "use_fp8_padding": True, "min_local_rows": 64, "cp_layout": "dualpipev"},
+        {
+            "pre_process": True,
+            "use_fp8_padding": True,
+            "min_local_rows": 64,
+            "pad_to_length_bucket": None,
+            "cp_layout": "dualpipev",
+            "local_cp_size": None,
+        },
         {
             "pre_process": True,
             "need_roll": True,
             "use_fp8_padding": True,
             "min_local_rows": 64,
+            "pad_to_length_bucket": None,
             "cp_layout": "dualpipev",
+            "local_cp_size": None,
         },
     ]
 

--- a/tests/utils/test_dynamic_cp_scheduler.py
+++ b/tests/utils/test_dynamic_cp_scheduler.py
@@ -136,6 +136,7 @@ def test_engine_dcp_contracts():
     engine_config = SimpleNamespace(
         dynamic_context_parallel=True,
         use_remove_padding=True,
+        pad_to_length=False,
         virtual_pipeline_model_parallel_size=None,
         router_replay=SimpleNamespace(mode="R2"),
     )

--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -125,6 +125,15 @@ def test_preprocess_bshd_engine_preserves_1d_input_shape_on_cpu(monkeypatch):
     torch.testing.assert_close(position_ids, torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long))
 
 
+def test_preprocess_thd_engine_rounds_packed_length_to_bucket(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1)
+    input_ids = _nested_tensor([torch.arange(513)])
+
+    packed, _, _ = mcore_util.preprocess_thd_engine(input_ids, pad_to_length_bucket=512)
+
+    assert packed.shape == (1, 1024)
+
+
 def test_preprocess_bshd_engine_preserves_topk_dense_dim_on_cpu(monkeypatch):
     _check_topk_preprocess(monkeypatch, torch.device("cpu"))
 

--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -125,8 +125,8 @@ def test_preprocess_bshd_engine_preserves_1d_input_shape_on_cpu(monkeypatch):
     torch.testing.assert_close(position_ids, torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long))
 
 
-def test_preprocess_thd_engine_rounds_packed_length_to_bucket(monkeypatch):
-    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1)
+def test_preprocess_thd_engine_rounds_packed_length_to_bucket_without_cp(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1, cp_size=1)
     input_ids = _nested_tensor([torch.arange(513)])
 
     packed, _, _ = mcore_util.preprocess_thd_engine(input_ids, pad_to_length_bucket=512)

--- a/tests/workers/test_megatron_value_head_cp_layout_on_cpu.py
+++ b/tests/workers/test_megatron_value_head_cp_layout_on_cpu.py
@@ -27,7 +27,7 @@ def test_dsv4_value_head_forwards_contiguous_cp_layout():
         hf_config=SimpleNamespace(),
         tokenizer=SimpleNamespace(pad_token_id=0),
     )
-    engine.engine_config = SimpleNamespace(use_remove_padding=True)
+    engine.engine_config = SimpleNamespace(use_remove_padding=True, pad_to_length=False)
     engine.prepare_model_inputs = lambda batch: {
         "input_ids": batch["input_ids"],
         "multi_modal_inputs": None,

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -274,6 +274,7 @@ def gptmodel_forward_model_engine(
     mtp_enable_train: bool = False,
     local_cp_size: Optional[int] = None,
     forced_max_seqlen: Optional[int] = None,
+    pad_to_length_bucket: Optional[int] = None,
     cp_layout: str = "zigzag",
     router_padding_mask: torch.Tensor | None = None,
     mtp_loss_normalization_factor: float | None = None,
@@ -304,6 +305,7 @@ def gptmodel_forward_model_engine(
             pre_process=pre_process or (post_process and mtp_enable_train),
             use_fp8_padding=use_fp8_padding,
             local_cp_size=local_cp_size,
+            pad_to_length_bucket=pad_to_length_bucket,
             cp_layout=cp_layout,
         )
         if mtp_loss_normalization_factor is not None:
@@ -330,6 +332,7 @@ def gptmodel_forward_model_engine(
                     need_roll=True,
                     use_fp8_padding=use_fp8_padding,
                     local_cp_size=local_cp_size,
+                    pad_to_length_bucket=pad_to_length_bucket,
                     cp_layout=cp_layout,
                 )[0]
 
@@ -365,6 +368,7 @@ def gptmodel_forward_model_engine(
                     need_roll=(k == "label"),
                     use_fp8_padding=use_fp8_padding,
                     local_cp_size=local_cp_size,
+                    pad_to_length_bucket=pad_to_length_bucket,
                     cp_layout=cp_layout,
                 )[0]
                 for k, v in logits_processor_args.items()

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -268,6 +268,7 @@ def fused_forward_model_engine(vision_model: bool = False):
         cp_layout: str = "zigzag",
         local_cp_size: int | None = None,
         router_padding_mask: Tensor | None = None,
+        pad_to_length_bucket: int | None = None,
     ):
         pre_process = unwrap_model(model).pre_process
         post_process = unwrap_model(model).post_process
@@ -284,6 +285,7 @@ def fused_forward_model_engine(vision_model: bool = False):
             pre_process=pre_process,
             use_fp8_padding=use_fp8_padding,
             min_local_rows=min_local_rows,
+            pad_to_length_bucket=pad_to_length_bucket,
             cp_layout=cp_layout,
             local_cp_size=local_cp_size,
         )
@@ -316,6 +318,7 @@ def fused_forward_model_engine(vision_model: bool = False):
             need_roll=True,
             use_fp8_padding=use_fp8_padding,
             min_local_rows=min_local_rows,
+            pad_to_length_bucket=pad_to_length_bucket,
             cp_layout=cp_layout,
             local_cp_size=local_cp_size,
         )

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -339,6 +339,7 @@ def preprocess_thd_engine(
     use_fp8_padding: bool = False,
     local_cp_size: int | None = None,
     min_local_rows: int | None = None,
+    pad_to_length_bucket: int | None = None,
     cp_layout: ContextParallelLayout = "zigzag",
 ) -> tuple[torch.Tensor, PackedSeqParams, torch.Tensor | None]:
     """Pack nested THD sequences and shard their rows across CP ranks.
@@ -398,6 +399,16 @@ def preprocess_thd_engine(
             pad_size_last = min_total_rows - cu_seqlens_padded[-1]
             cu_seqlens_padded[-1] += pad_size_last
             seqlens_in_batch_padded[-1] += pad_size_last
+
+    if pad_to_length_bucket is not None:
+        if pad_to_length_bucket <= 0:
+            raise ValueError("pad_to_length_bucket must be a positive integer")
+        total_alignment = math.lcm(pad_to_length_bucket, cp_size)
+        if use_fp8_padding:
+            total_alignment = math.lcm(total_alignment, total_align)
+        pad_size_last = (-cu_seqlens_padded[-1]) % total_alignment
+        cu_seqlens_padded[-1] += pad_size_last
+        seqlens_in_batch_padded[-1] += pad_size_last
 
     # ----------------------------------------------------------------------------
     # Move the index information needed in the subsequent loop to the CPU at once,

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -78,6 +78,8 @@ actor_rollout_ref:
       vanilla_mbridge: false
       use_remove_padding: true
       pad_bshd_to_minibatch_max: true
+      pad_to_length: false
+      pad_to_length_bucket: 512
       use_megatron_fsdp: false
       forward_only: false
       dtype: bfloat16
@@ -280,6 +282,8 @@ actor_rollout_ref:
       vanilla_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.vanilla_mbridge,False}
       use_remove_padding: ${oc.select:actor_rollout_ref.actor.megatron.use_remove_padding,True}
       pad_bshd_to_minibatch_max: true
+      pad_to_length: ${oc.select:actor_rollout_ref.actor.megatron.pad_to_length,False}
+      pad_to_length_bucket: ${oc.select:actor_rollout_ref.actor.megatron.pad_to_length_bucket,512}
       use_megatron_fsdp: false
       forward_only: true
       dtype: bfloat16
@@ -616,6 +620,8 @@ critic:
     vanilla_mbridge: false
     use_remove_padding: true
     pad_bshd_to_minibatch_max: true
+    pad_to_length: false
+    pad_to_length_bucket: 512
     use_megatron_fsdp: false
     forward_only: false
     dtype: bfloat16

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -109,6 +109,10 @@ use_remove_padding: True
 # effect when use_remove_padding=False (BSHD); no-op on the THD path.
 pad_bshd_to_minibatch_max: True
 
+# Match the FSDP packed-padding controls. Set the bucket to 512 to reduce THD shape variability.
+pad_to_length: false
+pad_to_length_bucket: 512
+
 # Whether to use Megatron-FSDP (Zero-3 sharding)
 use_megatron_fsdp: False
 

--- a/verl/trainer/config/ref/megatron_ref.yaml
+++ b/verl/trainer/config/ref/megatron_ref.yaml
@@ -24,6 +24,8 @@ megatron:
   use_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.use_mbridge,False}
   vanilla_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.vanilla_mbridge,False}
   use_remove_padding: ${oc.select:actor_rollout_ref.actor.megatron.use_remove_padding,True}
+  pad_to_length: ${oc.select:actor_rollout_ref.actor.megatron.pad_to_length,False}
+  pad_to_length_bucket: ${oc.select:actor_rollout_ref.actor.megatron.pad_to_length_bucket,512}
   tensor_model_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.tensor_model_parallel_size,1}
   pipeline_model_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.pipeline_model_parallel_size,1}
   virtual_pipeline_model_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.virtual_pipeline_model_parallel_size,null}

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -177,6 +177,8 @@ class McoreEngineConfig(EngineConfig):
         use_mbridge (bool): Whether to use MBridge for communication.
         vanilla_mbridge (bool): Whether to use the deprecated legacy mbridge backend instead of Megatron-Bridge.
         use_megatron_fsdp (bool): Whether to use Megatron-FSDP (Zero-3 sharding).
+        pad_to_length (bool): Whether to round every packed micro-batch up to a bucket-aligned length.
+        pad_to_length_bucket (int): Padding granularity on the global packed sequence.
         dtype (str): Mixed precision training param dtype, default "bfloat16"
     """
 
@@ -196,6 +198,8 @@ class McoreEngineConfig(EngineConfig):
     sequence_parallel: bool = True
     use_distributed_optimizer: bool = True
     pad_bshd_to_minibatch_max: bool = True
+    pad_to_length: bool = False
+    pad_to_length_bucket: int = 512
     use_dist_checkpointing: bool = False
     dist_checkpointing_path: Optional[str] = None
     dist_checkpointing_prefix: str = ""

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -113,6 +113,8 @@ def _check_dcp_unsupported_features(engine_config, model_config, tf_config=None,
         return
     if not engine_config.use_remove_padding:
         raise ValueError("dynamic_context_parallel requires use_remove_padding=True")
+    if engine_config.pad_to_length:
+        raise NotImplementedError("dynamic_context_parallel does not support pad_to_length")
     if model_config.model_type == "value_model":
         raise NotImplementedError("Dynamic CP currently supports language models only")
     if hasattr(model_config.hf_config, "vision_config"):
@@ -1211,6 +1213,16 @@ class MegatronEngineWithLMHead(MegatronEngine):
         calculate_sum_pi_squared = tu.get_non_tensor_data(batch, key="calculate_sum_pi_squared", default=False)
         distillation_use_topk = tu.get_non_tensor_data(batch, key="distillation_use_topk", default=False)
         distillation_only = tu.get_non_tensor_data(batch, key="distillation_only", default=False)
+        pad_to_length_bucket = (
+            self.engine_config.pad_to_length_bucket
+            if self.engine_config.pad_to_length and self.engine_config.use_remove_padding
+            else None
+        )
+
+        if pad_to_length_bucket is not None and distillation_use_topk:
+            raise RuntimeError("pad_to_length is not supported with top-K distillation")
+        if pad_to_length_bucket is not None and self.enable_routing_replay:
+            raise RuntimeError("pad_to_length is not supported with router replay")
 
         if calculate_sum_pi_squared and use_fused_kernels:
             raise NotImplementedError(
@@ -1284,6 +1296,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 cp_layout=cp_layout,
                 local_cp_size=local_cp_size,
                 router_padding_mask=router_padding_mask,
+                pad_to_length_bucket=pad_to_length_bucket,
             )
         else:
             if not isinstance(temperature, torch.Tensor):
@@ -1343,6 +1356,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 router_padding_mask=router_padding_mask,
                 mtp_loss_normalization_factor=mtp_loss_normalization_factor,
                 forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
+                pad_to_length_bucket=pad_to_length_bucket,
                 cp_layout=cp_layout,
             )
 
@@ -1464,6 +1478,11 @@ class MegatronEngineWithValueHead(MegatronEngineWithLMHead):
             pad_token_id=self.model_config.tokenizer.pad_token_id,
             data_format="thd" if self.engine_config.use_remove_padding else "bshd",
             forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
+            pad_to_length_bucket=(
+                self.engine_config.pad_to_length_bucket
+                if self.engine_config.pad_to_length and self.engine_config.use_remove_padding
+                else None
+            ),
             cp_layout=cp_layout,
         )
 


### PR DESCRIPTION
### What does this PR do?

Adds FSDP-compatible `pad_to_length` controls to the Megatron engine and optionally rounds each packed THD micro-batch to a 512-token bucket. This reduces packed-shape variability and associated JIT/compilation overhead while leaving existing behavior unchanged by default (`pad_to_length: false`).

This does not duplicate an existing PR: the upstream searches for [Megatron packed-sequence padding](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+megatron+packed+sequence+padding) and [`pad_to_length_bucket`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+pad_to_length_bucket) found no PR implementing this configuration.

AI assistance was used to implement, test, and prepare this change. The human submitter must review every changed line and understand the change before proposing it upstream.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [Megatron packed-sequence padding](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+megatron+packed+sequence+padding), [`pad_to_length_bucket`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+pad_to_length_bucket)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `python -m pytest tests/utils/test_megatron_bshd_preprocess.py -q` — 15 passed, 1 skipped in 16.01s.
- `pre-commit run --all-files --show-diff-on-failure --color=always` — all 12 hooks passed.
- `python scripts/print_cfg.py --cfg job model_engine=megatron` — actor and critic resolve `pad_to_length_bucket: 512`.

### API and Usage Example

```yaml
actor_rollout_ref:
  actor:
    megatron:
      pad_to_length: true
      pad_to_length_bucket: 512
```

### Design & Code Changes

- Add Megatron engine configuration matching the FSDP names, disabled by default with a 512-token bucket.
- Round the global packed THD length to an alignment compatible with the configured bucket, context parallelism, and FP8 padding.
- Propagate the bucket through standard, fused, reference, and value-model Megatron paths.
- Reject unsupported combinations with dynamic context parallelism, top-K distillation, or router replay.
- Add one focused CPU unit test covering 513 tokens rounding to 1024.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed for this narrowly scoped, self-documented engine configuration.
- [x] Add unit test coverage for packed-length bucket rounding.
- [ ] Once ready for upstream CI, request CI in the verl community channel.
- [ ] Recipe submodule update. Not applicable; this PR does not modify `recipe`.