### PR TITLE
[npu] fix: preserve PyTorch environment when installing vLLM

### DIFF
--- a/scripts/install_vllm_mcore_npu.sh
+++ b/scripts/install_vllm_mcore_npu.sh
@@ -9,13 +9,20 @@ pip install torchvision==0.25.0
 pip install torchaudio==2.10.0
 pip install triton-ascend==3.2.1 --extra-index-url https://triton-ascend.osinfra.cn/pypi/simple/ --trusted-host triton-ascend.osinfra.cn
 pip install "transformers==5.10.4" 
-pip install setuptools-scm
+# vLLM v0.23.0's [build-system].requires pins torch==2.11.0. Default PEP 517
+# build isolation would provision a build overlay by downloading torch 2.11
+# and nvidia_* CUDA wheels, leaving pip check warnings and a dangling
+# torch_npu 2.10.0 dependent. VLLM_TARGET_DEVICE=empty does not influence
+# build isolation. Below we install the build backend deps up front and pass
+# --no-build-isolation to the vLLM install, matching the pattern already
+# used for the vLLM-Ascend install a few lines below.
+pip install setuptools-scm setuptools-rust wheel
 
 
 echo "2. install vllm & vllm-ascend"
 git clone --depth 1 --branch v0.23.0 https://github.com/vllm-project/vllm.git
 cd vllm
-VLLM_TARGET_DEVICE=empty pip install -v -e .
+VLLM_TARGET_DEVICE=empty pip install -v --no-build-isolation -e .
 cd ..
 git clone -b releases/v0.23.0 https://github.com/vllm-project/vllm-ascend.git
 cd vllm-ascend


### PR DESCRIPTION
## Summary

- Add `--no-build-isolation` to the vLLM editable install in `scripts/install_vllm_mcore_npu.sh`.
- Pre-install `setuptools-rust` and `wheel` alongside the existing `setuptools-scm`.
- Make the vLLM source install consistent with the following vLLM-Ascend install, which already uses `--no-build-isolation`.

## Motivation

The NPU install script prepares a PyTorch/torch_npu-compatible environment before installing vLLM.

vLLM v0.23.0 specifies `torch == 2.11.0` in its `[build-system].requires`. With the current editable install:

```
VLLM_TARGET_DEVICE=empty pip install -v -e .
```

pip creates an isolated build environment and resolves that build requirement independently of the existing Ascend PyTorch stack.

For the NPU installation path, the existing PyTorch environment should instead be reused when building the `VLLM_TARGET_DEVICE=empty` variant.

## Fix

```diff
-pip install setuptools-scm
+pip install setuptools-scm setuptools-rust wheel

-VLLM_TARGET_DEVICE=empty pip install -v -e .
+VLLM_TARGET_DEVICE=empty pip install -v --no-build-isolation -e .
```

`setuptools-rust` and `wheel` are installed explicitly because they are required by vLLM's build backend when build isolation is disabled.

## Test Plan

Validated on Ascend 910B2 with:
- CANN 8.5.1
- torch 2.10.0+cpu
- torch_npu 2.10.0
- vLLM v0.23.0, cloned using the same `git clone --depth 1 --branch v0.23.0` path as the script

Before the vLLM install:
```
torch      2.10.0+cpu
torch_npu  2.10.0
```

After the modified install:
```
torch      2.10.0+cpu
torch_npu  2.10.0
vllm       0.23.0+empty
```

Additional checks:
- `python -c "import vllm"` succeeds.
- The full pip log contains no downloads of torch 2.11, `nvidia_*` wheels, or CUDA wheels.
- Changes are limited to the vLLM installation step; the vLLM-Ascend, MindSpeed, and Megatron installation blocks are unchanged.

The later vLLM-Ascend build was not validated end-to-end because the test host uses CANN 8.5.1; that environment limitation is outside the scope of this change.