### PR TITLE
[misc] fix: reduce_metrics crash on empty lists and tighten max/min k…

### DIFF
--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -70,6 +70,37 @@ class TestReduceMetrics(unittest.TestCase):
 
         self.assertEqual(result["single"], 5.0)
 
+    def test_reduce_metrics_empty_max_min(self):
+        """Empty lists under /max and /min keys reduce to NaN, not a ValueError."""
+        metrics = {
+            "critic/values/max": [],
+            "response_length/min": [],
+            "plain": [],
+        }
+        result = reduce_metrics(metrics)
+        for key in metrics:
+            self.assertTrue(np.isnan(result[key]), f"{key} should be NaN")
+
+    def test_reduce_metrics_final_segment_matching(self):
+        """Reduction follows the final path segment, not a substring.
+
+        Keys ending in /max or /min are max/min-reduced; a mid-key 'max'/'min'
+        (e.g. global_seqlen/minmax_diff) is mean-reduced.
+        """
+        metrics = {
+            "critic/values/max": [1.0, 3.0, 2.0],
+            "response_length/min": [4.0, 1.0, 2.0],
+            "global_seqlen/minmax_diff": [10.0, 20.0, 30.0],
+            "perf/max_memory_allocated_gb": [5.0, 7.0, 9.0],
+            "loss": [1.0, 2.0, 3.0],
+        }
+        result = reduce_metrics(metrics)
+        self.assertEqual(result["critic/values/max"], 3.0)
+        self.assertEqual(result["response_length/min"], 1.0)
+        self.assertEqual(result["global_seqlen/minmax_diff"], 20.0)
+        self.assertEqual(result["perf/max_memory_allocated_gb"], 7.0)
+        self.assertEqual(result["loss"], 2.0)
+
 
 class TestMetric(unittest.TestCase):
     """Tests for the Metric class."""
@@ -95,6 +126,13 @@ class TestMetric(unittest.TestCase):
         """Test Metric initialization with invalid aggregation type."""
         with self.assertRaises(ValueError):
             Metric(aggregation="invalid")
+
+    def test_aggregate_empty_min_max(self):
+        """Empty MIN/MAX aggregation returns NaN instead of raising (np.min/np.max on [])."""
+        for agg in ("min", "max"):
+            metric = Metric(aggregation=agg)
+            result = metric.aggregate()
+            self.assertTrue(np.isnan(result), f"empty {agg} should be NaN, got {result}")
 
     def test_append_float(self):
         """Test appending float values."""

--- a/verl/utils/metric/utils.py
+++ b/verl/utils/metric/utils.py
@@ -25,10 +25,17 @@ import torch
 def reduce_metrics(metrics: dict[str, Union["Metric", list[Any]]]) -> dict[str, Any]:
     """
     Reduces a dictionary of metric lists by computing the mean, max, or min of each list.
-    The reduce operation is determined by the key name:
-    - If the key contains "max", np.max is used
-    - If the key contains "min", np.min is used
-    - Otherwise, np.mean is used
+    The reduction is chosen from the **final path segment** of the key:
+
+    - a key whose final segment is ``"max"`` (e.g. ``"critic/values/max"``) -> ``np.max``
+    - a key whose final segment is ``"min"`` (e.g. ``"response_length/min"``) -> ``np.min``
+    - otherwise -> ``np.mean``
+
+    Matching only the final segment avoids mis-reducing keys in which ``"max"``/``"min"``
+    appears mid-key (e.g. ``"global_seqlen/minmax_diff"``, ``"perf/max_memory_allocated_gb"``);
+    such names describe a per-value property, not the cross-batch reduction. For explicit
+    control, wrap values in a :class:`Metric` with the desired :class:`AggregationType`.
+    Empty lists reduce to ``NaN`` (``np.max``/``np.min`` would otherwise raise on empty input).
 
     Args:
         metrics: A dictionary mapping metric names to lists of metric values.
@@ -40,21 +47,27 @@ def reduce_metrics(metrics: dict[str, Union["Metric", list[Any]]]) -> dict[str, 
         >>> metrics = {
         ...     "loss": [1.0, 2.0, 3.0],
         ...     "accuracy": [0.8, 0.9, 0.7],
-        ...     "max_reward": [5.0, 8.0, 6.0],
-        ...     "min_error": [0.1, 0.05, 0.2]
+        ...     "reward/max": [5.0, 8.0, 6.0],
+        ...     "error/min": [0.1, 0.05, 0.2],
         ... }
         >>> reduce_metrics(metrics)
-        {"loss": 2.0, "accuracy": 0.8, "max_reward": 8.0, "min_error": 0.05}
+        {"loss": 2.0, "accuracy": 0.8, "reward/max": 8.0, "error/min": 0.05}
     """
     for key, val in metrics.items():
         if isinstance(val, Metric):
             metrics[key] = val.aggregate()
-        elif "max" in key:
-            metrics[key] = np.max(val)
-        elif "min" in key:
-            metrics[key] = np.min(val)
+        elif len(val) == 0:
+            # np.max([])/np.min([]) raise ValueError, so normalise to NaN here.
+            metrics[key] = float("nan")
         else:
-            metrics[key] = np.mean(val)
+            # avoid matching on mid-key "max"/"min" segments
+            leaf = key.rsplit("/", 1)[-1]
+            if leaf == "max":
+                metrics[key] = np.max(val)
+            elif leaf == "min":
+                metrics[key] = np.min(val)
+            else:
+                metrics[key] = np.mean(val)
     return metrics
 
 
@@ -131,9 +144,10 @@ class Metric:
             case AggregationType.SUM:
                 return np.sum(values)
             case AggregationType.MIN:
-                return np.min(values)
+                # np.min([])/np.max([]) raise; mirror reduce_metrics and return NaN.
+                return np.min(values) if len(values) else float("nan")
             case AggregationType.MAX:
-                return np.max(values)
+                return np.max(values) if len(values) else float("nan")
 
     @classmethod
     def aggregate_dp(cls, metric_lists: list["Metric"]) -> float:


### PR DESCRIPTION
### What does this PR do?

Fix `reduce_metrics` so metric reduction is selected from the final path segment (`/max` or `/min`) instead of any `"max"`/`"min"` substring in the key, and so empty metric lists reduce to `NaN` instead of crashing under max/min reductions. This prevents keys such as `global_seqlen/minmax_diff` from being accidentally max/min-reduced and prevents `np.max([])` / `np.min([])` from raising during metric aggregation. The same empty MIN/MAX guard is applied to `Metric._aggregate`, and CPU regression tests cover the new behavior.

AI assistance was used to identify this change. I have personally reviewed to confirm the accuracy.

### Checklist Before Starting

- [x] Search for similar PRs. Query links: https://github.com/verl-project/verl/pulls?q=is%3Apr+reduce_metrics+empty and https://github.com/verl-project/verl/pulls?q=is%3Apr+reduce_metrics+max+min
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[misc] fix: reduce_metrics crash on empty lists and tighten max/min key matching`

### Test

```bash
python3 -m pytest tests/trainer/ppo/test_metric_utils_on_cpu.py -v
```

Result: `39 passed in 9.62s`.

### API and Usage Example

No public API or user-facing config changes. The raw-list fallback in `reduce_metrics` now treats only a final key segment of `max` or `min` as an implicit max/min aggregation.

### Design & Code Changes

- `reduce_metrics` now returns `NaN` for empty raw metric lists before selecting a reduction, avoiding `np.max([])` / `np.min([])` crashes.
- `reduce_metrics` now selects implicit max/min aggregation from `key.rsplit("/", 1)[-1]`, so `critic/values/max` and `response_length/min` keep max/min behavior while mid-key names such as `global_seqlen/minmax_diff` mean-reduce.
- `Metric._aggregate` now returns `NaN` for empty MIN/MAX aggregations instead of raising.
- Added CPU tests for empty `/max` and `/min` raw-list reductions, final-segment matching, and empty `Metric` MIN/MAX aggregation.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed: this is an internal metric-reduction bug fix with no user-facing docs change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Added tests to the existing CPU metric utility test file: `tests/trainer/ppo/test_metric_utils_on_cpu.py`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable: this PR does not touch `recipe`.
