### PR TITLE
[rollout] fix: Enable rollout-side profiling

### DIFF
--- a/tests/trainer/ppo/v1/test_trainer_profiler_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_trainer_profiler_on_cpu.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only unit tests for profiling orchestration in the V1 PPO trainer."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+from verl.trainer.ppo.v1.trainer_colocate_async import PPOTrainerColocateAsync
+from verl.trainer.ppo.v1.trainer_separate_async import PPOTrainerSeparateAsync
+from verl.trainer.ppo.v1.trainer_sync import PPOTrainerSync
+
+
+class _StubTrainer(PPOTrainer):
+    def on_step_end(self):
+        pass
+
+    def on_sample_end(self):
+        pass
+
+
+def _make_trainer(
+    trainer_cls: type[PPOTrainer],
+    steps: list[int] | None,
+    *,
+    continuous: bool = False,
+    global_step: int = 1,
+    use_reference_policy: bool = False,
+    use_critic: bool = False,
+) -> PPOTrainer:
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.config = SimpleNamespace(
+        global_profiler=SimpleNamespace(
+            steps=steps,
+            profile_continuous_steps=continuous,
+        )
+    )
+    trainer.global_steps = global_step
+    trainer.actor_rollout_wg = MagicMock()
+    trainer.ref_policy_wg = MagicMock()
+    trainer.critic_wg = MagicMock()
+    trainer.llm_server_manager = MagicMock()
+    trainer.standalone_server_manager = MagicMock()
+    trainer.use_reference_policy = use_reference_policy
+    trainer.use_critic = use_critic
+    return trainer
+
+
+def _profile_boundaries(trainer: PPOTrainer, max_step: int = 9) -> tuple[list[int], list[int]]:
+    """Returns which steps the trainer would start and stop profiling on."""
+    starts = []
+    stops = []
+    for step in range(max_step + 1):
+        trainer.global_steps = step
+        if trainer._should_start_profiling():
+            starts.append(step)
+        if trainer._should_stop_profiling():
+            stops.append(step)
+    return starts, stops
+
+
+def test_continuous_profiling_uses_span_boundaries():
+    steps = [1, 2, 4, 6, 7, 8]
+    trainer = _make_trainer(_StubTrainer, steps, continuous=True)
+
+    starts, stops = _profile_boundaries(trainer)
+
+    assert starts == [1, 4, 6]
+    assert stops == [2, 4, 8]
+
+
+def test_discrete_profiling_uses_each_requested_step():
+    steps = [1, 2, 4, 6, 7, 8]
+    trainer = _make_trainer(_StubTrainer, steps, continuous=False)
+
+    starts, stops = _profile_boundaries(trainer)
+
+    assert starts == list(steps)
+    assert stops == list(steps)
+
+
+def test_profiling_disabled_without_requested_steps():
+    trainer = _make_trainer(_StubTrainer, steps=None)
+
+    starts, stops = _profile_boundaries(trainer)
+
+    assert starts == []
+    assert stops == []
+
+
+def test_sync_trainer_profiles_required_components():
+    trainer = _make_trainer(
+        PPOTrainerSync,
+        steps=[4],
+        global_step=4,
+        use_critic=True,
+        use_reference_policy=False,
+    )
+
+    trainer._start_profiling()
+    trainer._stop_profiling()
+
+    trainer.actor_rollout_wg.start_profile.assert_called_once_with(role="e2e", profile_step=4)
+    trainer.actor_rollout_wg.stop_profile.assert_called_once_with()
+
+    trainer.llm_server_manager.start_profile.assert_called_once_with()
+    trainer.llm_server_manager.stop_profile.assert_called_once_with()
+
+    trainer.critic_wg.start_profile.assert_called_once_with(profile_step=4)
+    trainer.critic_wg.stop_profile.assert_called_once_with()
+
+    trainer.ref_policy_wg.start_profile.assert_not_called()
+    trainer.ref_policy_wg.stop_profile.assert_not_called()
+
+
+def test_colocate_async_trainer_profiles_required_components():
+    trainer = _make_trainer(
+        PPOTrainerColocateAsync,
+        steps=[4],
+        global_step=4,
+        use_critic=False,
+        use_reference_policy=True,
+    )
+
+    trainer._start_profiling()
+    trainer._stop_profiling()
+
+    trainer.actor_rollout_wg.start_profile.assert_called_once_with(role="e2e", profile_step=4)
+    trainer.actor_rollout_wg.stop_profile.assert_called_once_with()
+
+    trainer.llm_server_manager.start_profile.assert_called_once_with()
+    trainer.llm_server_manager.stop_profile.assert_called_once_with()
+
+    trainer.critic_wg.start_profile.assert_not_called()
+    trainer.critic_wg.stop_profile.assert_not_called()
+
+    trainer.ref_policy_wg.start_profile.assert_called_once_with(profile_step=4)
+    trainer.ref_policy_wg.stop_profile.assert_called_once_with()
+
+
+def test_separate_async_trainer_profiles_required_components():
+    trainer = _make_trainer(
+        PPOTrainerSeparateAsync,
+        steps=[4],
+        global_step=4,
+        use_reference_policy=True,
+        use_critic=True,
+    )
+
+    trainer._start_profiling()
+    trainer._stop_profiling()
+
+    trainer.actor_rollout_wg.start_profile.assert_called_once_with(role="e2e", profile_step=4)
+    trainer.actor_rollout_wg.stop_profile.assert_called_once_with()
+
+    trainer.ref_policy_wg.start_profile.assert_called_once_with(profile_step=4)
+    trainer.ref_policy_wg.stop_profile.assert_called_once_with()
+
+    trainer.critic_wg.start_profile.assert_called_once_with(profile_step=4)
+    trainer.critic_wg.stop_profile.assert_called_once_with()
+
+    trainer.standalone_server_manager.start_profile.assert_called_once_with()
+    trainer.standalone_server_manager.stop_profile.assert_called_once_with()
+
+    trainer.llm_server_manager.start_profile.assert_not_called()
+    trainer.llm_server_manager.stop_profile.assert_not_called()
+
+
+def test_rollout_managers_are_not_profiled_on_unselected_steps():
+    trainers_and_managers = [
+        (_make_trainer(PPOTrainerSync, steps=[4], global_step=3), "llm_server_manager"),
+        (_make_trainer(PPOTrainerColocateAsync, steps=[4], global_step=3), "llm_server_manager"),
+        (_make_trainer(PPOTrainerSeparateAsync, steps=[4], global_step=3), "standalone_server_manager"),
+    ]
+
+    for trainer, manager_name in trainers_and_managers:
+        trainer._start_profiling()
+        trainer._stop_profiling()
+
+        trainer.actor_rollout_wg.start_profile.assert_not_called()
+        trainer.actor_rollout_wg.stop_profile.assert_not_called()
+
+        manager = getattr(trainer, manager_name)
+        manager.start_profile.assert_not_called()
+        manager.stop_profile.assert_not_called()

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -430,13 +430,6 @@ class PPOTrainer(ABC):
         # SkipManager skips warmup batches in async trainers, so it doesn't conflict with reissue.
         SkipManager.set_step(self.global_steps)
         self._reissue_inflight_prompts()
-        self.prev_step_profile = False
-        self.curr_step_profile = (
-            self.global_steps in self.config.global_profiler.steps
-            if self.config.global_profiler.steps is not None
-            else False
-        )
-        self.next_step_profile = False
 
         self.on_train_begin()
         last_val_metrics = None
@@ -1275,15 +1268,34 @@ class PPOTrainer(ABC):
 
         return metric_dict
 
+    def _should_start_profiling(self) -> bool:
+        if self.config.global_profiler.steps is None:
+            return False
+
+        curr_step_profiled = self.global_steps in self.config.global_profiler.steps
+
+        if self.config.global_profiler.profile_continuous_steps:
+            prev_step_profiled = (self.global_steps - 1) in self.config.global_profiler.steps
+            return curr_step_profiled and (not prev_step_profiled)
+
+        return curr_step_profiled
+
+    def _should_stop_profiling(self) -> bool:
+        if self.config.global_profiler.steps is None:
+            return False
+
+        curr_step_profiled = self.global_steps in self.config.global_profiler.steps
+
+        if self.config.global_profiler.profile_continuous_steps:
+            next_step_profiled = (self.global_steps + 1) in self.config.global_profiler.steps
+            return curr_step_profiled and (not next_step_profiled)
+
+        return curr_step_profiled
+
     def _start_profiling(self) -> None:
         """Start profiling for all worker groups if profiling is enabled."""
-        do_profile = (
-            not self.prev_step_profile and self.curr_step_profile
-            if self.config.global_profiler.profile_continuous_steps
-            else self.curr_step_profile
-        )
-
-        if do_profile:
+        if self._should_start_profiling():
+            self.llm_server_manager.start_profile()
             self.actor_rollout_wg.start_profile(role="e2e", profile_step=self.global_steps)
             if self.use_reference_policy:
                 self.ref_policy_wg.start_profile(profile_step=self.global_steps)
@@ -1292,20 +1304,8 @@ class PPOTrainer(ABC):
 
     def _stop_profiling(self) -> None:
         """Stop profiling for all worker groups if profiling is enabled."""
-        self.next_step_profile = (
-            self.global_steps + 1 in self.config.global_profiler.steps
-            if self.config.global_profiler.steps is not None
-            else False
-        )
-        do_profile = (
-            self.curr_step_profile and not self.next_step_profile
-            if self.config.global_profiler.profile_continuous_steps
-            else self.curr_step_profile
-        )
-        self.prev_step_profile = self.curr_step_profile
-        self.curr_step_profile = self.next_step_profile
-
-        if do_profile:
+        if self._should_stop_profiling():
+            self.llm_server_manager.stop_profile()
             self.actor_rollout_wg.stop_profile()
             if self.use_reference_policy:
                 self.ref_policy_wg.stop_profile()

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -205,3 +205,25 @@ class PPOTrainerSeparateAsync(PPOTrainer):
     def should_switch_to_rollout(self):
         # TODO: Implement switch strategy by checking replay buffer and switch overhead
         return False
+
+    def _start_profiling(self):
+        # Overridden to make sure standalone_server_manager is used and not
+        # llm_server_manager.
+        if self._should_start_profiling():
+            self.standalone_server_manager.start_profile()
+            self.actor_rollout_wg.start_profile(role="e2e", profile_step=self.global_steps)
+            if self.use_reference_policy:
+                self.ref_policy_wg.start_profile(profile_step=self.global_steps)
+            if self.use_critic:
+                self.critic_wg.start_profile(profile_step=self.global_steps)
+
+    def _stop_profiling(self):
+        # Overridden to make sure standalone_server_manager is used and not
+        # llm_server_manager.
+        if self._should_stop_profiling():
+            self.standalone_server_manager.stop_profile()
+            self.actor_rollout_wg.stop_profile()
+            if self.use_reference_policy:
+                self.ref_policy_wg.stop_profile()
+            if self.use_critic:
+                self.critic_wg.stop_profile()


### PR DESCRIPTION
### What does this PR do?

This PR modifies the v1 trainer to enable rollout-side profiling.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: "rollout profiling"
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Added unit tests in `tests/trainer/ppo/v1/test_trainer_profiler.py`.
Validated profiles were saved correctly with [this](https://gist.github.com/rao-ashish/79d592a01c0fb1aca214d1ba205d9718) Qwen2.5-based E2E test.

### API and Usage Example

The PPOTrainer base class removes tracking of state variables like `prev_step_profile` and `curr_step_profile`. It instead adds stateless functions `_should_start_profiling` and `_should_stop_profiling` to control profiling behavior.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.