### PR TITLE
[vllm] fix: surface bucketed receiver failures

### DIFF
--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -61,9 +61,14 @@ def _generate_weights(weight_specs, seed):
 class _FakeSocket:
     def __init__(self):
         self.messages = []
+        self.poll_calls = []
 
     def send_pyobj(self, message):
         self.messages.append(message)
+
+    def poll(self, timeout, flags):
+        self.poll_calls.append((timeout, flags))
+        return flags
 
     def recv(self):
         return b""
@@ -117,6 +122,37 @@ def test_sender_accepts_strided_tensor(monkeypatch):
     assert buffer.dtype == torch.uint8
     assert buffer.numel() == weight.nbytes
     assert torch.equal(recovered, weight)
+    assert socket.poll_calls == [(sender.ack_timeout_ms, bucketed_weight_transfer.zmq.POLLIN)]
+
+
+def test_sender_ack_supports_recv_only_socket():
+    from verl.workers.rollout.vllm_rollout import bucketed_weight_transfer
+
+    class _RecvOnlySocket:
+        def recv(self):
+            return b""
+
+    sender = bucketed_weight_transfer.BucketedWeightSender("ipc:///tmp/test-bwt-unused.sock")
+    sender.socket = _RecvOnlySocket()
+
+    sender._receive_ack("test")
+
+
+def test_sender_ack_timeout_raises():
+    from verl.workers.rollout.vllm_rollout import bucketed_weight_transfer
+
+    class _TimeoutSocket:
+        def poll(self, _timeout, _flags):
+            return 0
+
+        def recv(self):
+            raise AssertionError("recv must not be called after a timeout")
+
+    sender = bucketed_weight_transfer.BucketedWeightSender("ipc:///tmp/test-bwt-unused.sock", ack_timeout_ms=1)
+    sender.socket = _TimeoutSocket()
+
+    with pytest.raises(RuntimeError, match="timed out waiting 1ms"):
+        sender._receive_ack("test")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -125,36 +125,6 @@ def test_sender_accepts_strided_tensor(monkeypatch):
     assert socket.poll_calls == [(sender.ack_timeout_ms, bucketed_weight_transfer.zmq.POLLIN)]
 
 
-def test_sender_ack_supports_recv_only_socket():
-    from verl.workers.rollout.vllm_rollout import bucketed_weight_transfer
-
-    class _RecvOnlySocket:
-        def recv(self):
-            return b""
-
-    sender = bucketed_weight_transfer.BucketedWeightSender("ipc:///tmp/test-bwt-unused.sock")
-    sender.socket = _RecvOnlySocket()
-
-    sender._receive_ack("test")
-
-
-def test_sender_ack_timeout_raises():
-    from verl.workers.rollout.vllm_rollout import bucketed_weight_transfer
-
-    class _TimeoutSocket:
-        def poll(self, _timeout, _flags):
-            return 0
-
-        def recv(self):
-            raise AssertionError("recv must not be called after a timeout")
-
-    sender = bucketed_weight_transfer.BucketedWeightSender("ipc:///tmp/test-bwt-unused.sock", ack_timeout_ms=1)
-    sender.socket = _TimeoutSocket()
-
-    with pytest.raises(RuntimeError, match="timed out waiting 1ms"):
-        sender._receive_ack("test")
-
-
 # ---------------------------------------------------------------------------
 # Process entry points (must be module-level for pickling with spawn)
 # ---------------------------------------------------------------------------

--- a/tests/workers/config/test_rollout_config_on_cpu.py
+++ b/tests/workers/config/test_rollout_config_on_cpu.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import pytest
+
+from verl.workers.config import CheckpointEngineConfig
+
+
+def test_checkpoint_engine_ack_timeout_default():
+    assert CheckpointEngineConfig().update_weights_ack_timeout_seconds == 30.0
+
+
+@pytest.mark.parametrize("timeout", [0, -1, math.inf, -math.inf, math.nan])
+def test_checkpoint_engine_rejects_invalid_ack_timeout(timeout):
+    with pytest.raises(ValueError, match="positive finite"):
+        CheckpointEngineConfig(update_weights_ack_timeout_seconds=timeout)

--- a/tests/workers/rollout/test_bucketed_weight_transfer_on_cpu.py
+++ b/tests/workers/rollout/test_bucketed_weight_transfer_on_cpu.py
@@ -1,0 +1,259 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import importlib.util
+import multiprocessing as mp
+import os
+import sys
+import types
+import uuid
+from multiprocessing import shared_memory
+from pathlib import Path
+
+import pytest
+import torch
+import zmq
+
+PROCESS_TIMEOUT = 10
+ACK_TIMEOUT_MS = 1_000
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _handle():
+    return f"ipc:///tmp/verl-bwt-{uuid.uuid4().hex}.sock"
+
+
+def _transfer_module():
+    module_path = _REPO_ROOT / "verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py"
+    spec = importlib.util.spec_from_file_location("bucketed_weight_transfer", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    module.get_torch_device = lambda: _CpuDevice()
+    module.is_support_ipc = lambda: False
+    return module
+
+
+class _CpuDevice:
+    def synchronize(self):
+        pass
+
+    def empty_cache(self):
+        pass
+
+
+def _install_rollout_utils():
+    module = types.ModuleType("verl.workers.rollout.utils")
+
+    async def ensure_async_iterator(iterable):
+        if hasattr(iterable, "__aiter__"):
+            async for item in iterable:
+                yield item
+        else:
+            for item in iterable:
+                yield item
+
+    module.ensure_async_iterator = ensure_async_iterator
+    sys.modules[module.__name__] = module
+
+
+def _send_weights(handle, ready_event, weights, result_queue):
+    try:
+        _install_rollout_utils()
+        uuid.uuid4 = lambda: types.SimpleNamespace(hex=f"{os.getpid():x}")
+        sender = _transfer_module().BucketedWeightSender(
+            handle, bucket_size_mb=1, use_shm=True, ack_timeout_ms=ACK_TIMEOUT_MS
+        )
+        init_socket = sender._init_socket
+
+        def signal_ready():
+            init_socket()
+            ready_event.set()
+
+        sender._init_socket = signal_ready
+        asyncio.run(sender.async_send_weights(iter(weights)))
+    except Exception as exc:
+        result_queue.put((type(exc).__name__, str(exc)))
+        ready_event.set()
+    else:
+        result_queue.put(None)
+
+
+def _receive_weights(handle, result_queue, failure):
+    bucketed_weight_transfer = _transfer_module()
+
+    if failure == "init":
+
+        def fail_rebuild(*_args, **_kwargs):
+            raise ValueError("failed to initialize receiver buffer")
+
+        bucketed_weight_transfer.rebuild_shared_memory = fail_rebuild
+
+    receiver = bucketed_weight_transfer.BucketedWeightReceiver(handle, device=torch.device("cpu"), use_shm=True)
+    received = []
+
+    def on_bucket_received(weights, is_last):
+        received.extend(name for name, _ in weights)
+        if failure == "callback":
+            raise KeyError("embed_tokens.weight")
+
+    try:
+        receiver.receive_weights(on_bucket_received)
+    except Exception as exc:
+        result_queue.put((type(exc).__name__, str(exc)))
+    else:
+        result_queue.put(("ok", received))
+
+
+def _reply_then_exit(handle):
+    socket = zmq.Context.instance().socket(zmq.REP)
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.connect(handle)
+    socket.recv_pyobj()
+    socket.send(b"")
+    socket.recv_pyobj()
+    socket.close()
+    os._exit(0)
+
+
+def _wait(process):
+    process.join(PROCESS_TIMEOUT)
+    if process.is_alive():
+        process.terminate()
+        process.join()
+        pytest.fail(f"process {process.pid} did not exit within {PROCESS_TIMEOUT}s")
+
+
+def _stop(process):
+    if process is not None and process.is_alive():
+        process.terminate()
+        process.join()
+
+
+def _assert_no_transfer_artifacts(handle, sender_pid):
+    assert not os.path.exists(handle.removeprefix("ipc://"))
+    with pytest.raises(FileNotFoundError):
+        shared_memory.SharedMemory(name=f"verl_weights_{sender_pid:x}")
+
+
+def _run_sender_and_receiver(weights, failure):
+    ctx = mp.get_context("spawn")
+    handle = _handle()
+    sender_ready = ctx.Event()
+    sender_result = ctx.Queue()
+    receiver_result = ctx.Queue()
+    sender = ctx.Process(target=_send_weights, args=(handle, sender_ready, weights, sender_result))
+    receiver = None
+    try:
+        sender.start()
+        assert sender_ready.wait(PROCESS_TIMEOUT), "sender did not bind its ZMQ socket"
+        receiver = ctx.Process(target=_receive_weights, args=(handle, receiver_result, failure))
+        receiver.start()
+        _wait(sender)
+        sender_result_value = sender_result.get(timeout=1)
+        _wait(receiver)
+        return sender.exitcode, receiver.exitcode, sender_result_value, receiver_result.get(timeout=1)
+    finally:
+        sender_pid = sender.pid
+        _stop(sender)
+        _stop(receiver)
+        if sender_pid is not None:
+            _assert_no_transfer_artifacts(handle, sender_pid)
+
+
+class _ReceiveFailureSocket:
+    def recv_pyobj(self):
+        raise ValueError("invalid weight metadata")
+
+    def send(self, message, flags=0):
+        self.message = message
+
+
+def test_cpu_receiver_preserves_decode_failure(monkeypatch):
+    receiver = _transfer_module().BucketedWeightReceiver("ipc:///tmp/unused.sock", torch.device("cpu"), use_shm=True)
+    socket = _ReceiveFailureSocket()
+
+    monkeypatch.setattr(receiver, "_init_socket", lambda: setattr(receiver, "socket", socket))
+    monkeypatch.setattr(receiver, "_init_buffer", lambda: None)
+    monkeypatch.setattr(receiver, "_cleanup", lambda: None)
+
+    with pytest.raises(ValueError, match="invalid weight metadata"):
+        receiver.receive_weights(lambda _weights, _is_last: None)
+
+    assert socket.message == b"error:ValueError: invalid weight metadata"
+
+
+def test_cpu_shared_memory_transfer_acknowledges_success():
+    sender_exit, receiver_exit, sender_result, receiver_result = _run_sender_and_receiver(
+        [("weight", torch.ones(2))], failure=None
+    )
+
+    assert sender_exit == 0
+    assert receiver_exit == 0
+    assert sender_result is None
+    assert receiver_result == ("ok", ["weight"])
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        ("init", "ValueError: failed to initialize receiver buffer"),
+        ("callback", "KeyError: 'embed_tokens.weight'"),
+    ],
+)
+def test_cpu_receiver_failure_is_sent_to_sender(failure, expected):
+    sender_exit, receiver_exit, sender_result, receiver_result = _run_sender_and_receiver([], failure)
+
+    assert sender_exit == 0
+    assert receiver_exit == 0
+    assert sender_result == ("RuntimeError", f"weight receiver failed: {expected}")
+    assert receiver_result[0] in {"ValueError", "KeyError"}
+
+
+def test_cpu_receiver_failure_on_intermediate_bucket_reaches_sender():
+    weights = [("first", torch.ones(150_000)), ("second", torch.ones(150_000))]
+    sender_exit, receiver_exit, sender_result, receiver_result = _run_sender_and_receiver(weights, failure="callback")
+
+    assert sender_exit == 0
+    assert receiver_exit == 0
+    assert sender_result == ("RuntimeError", "weight receiver failed: KeyError: 'embed_tokens.weight'")
+    assert receiver_result == ("KeyError", "'embed_tokens.weight'")
+
+
+def test_cpu_sender_times_out_after_peer_loss():
+    ctx = mp.get_context("spawn")
+    handle = _handle()
+    sender_ready = ctx.Event()
+    sender_result = ctx.Queue()
+    sender = ctx.Process(target=_send_weights, args=(handle, sender_ready, [], sender_result))
+    peer = ctx.Process(target=_reply_then_exit, args=(handle,))
+    try:
+        sender.start()
+        assert sender_ready.wait(PROCESS_TIMEOUT), "sender did not bind its ZMQ socket"
+        peer.start()
+        _wait(sender)
+        _wait(peer)
+
+        assert sender.exitcode == 0
+        assert peer.exitcode == 0
+        assert sender_result.get(timeout=1) == (
+            "RuntimeError",
+            f"timed out waiting {ACK_TIMEOUT_MS}ms for weight receiver acknowledgement (final bucket)",
+        )
+    finally:
+        _stop(sender)
+        _stop(peer)
+        if sender.pid is not None:
+            _assert_no_transfer_artifacts(handle, sender.pid)

--- a/tests/workers/rollout/test_bucketed_weight_transfer_on_cpu.py
+++ b/tests/workers/rollout/test_bucketed_weight_transfer_on_cpu.py
@@ -181,6 +181,34 @@ class _ReceiveFailureSocket:
         self.message = message
 
 
+class _RecvOnlySocket:
+    def recv(self):
+        return b""
+
+
+class _TimeoutSocket:
+    def poll(self, _timeout, _flags):
+        return 0
+
+    def recv(self):
+        raise AssertionError("recv must not be called after a timeout")
+
+
+def test_cpu_sender_ack_supports_recv_only_socket():
+    sender = _transfer_module().BucketedWeightSender("ipc:///tmp/test-bwt-unused.sock")
+    sender.socket = _RecvOnlySocket()
+
+    sender._receive_ack("test")
+
+
+def test_cpu_sender_ack_timeout_raises():
+    sender = _transfer_module().BucketedWeightSender("ipc:///tmp/test-bwt-unused.sock", ack_timeout_ms=1)
+    sender.socket = _TimeoutSocket()
+
+    with pytest.raises(RuntimeError, match="timed out waiting 1ms"):
+        sender._receive_ack("test")
+
+
 def test_cpu_receiver_preserves_decode_failure(monkeypatch):
     receiver = _transfer_module().BucketedWeightReceiver("ipc:///tmp/unused.sock", torch.device("cpu"), use_shm=True)
     socket = _ReceiveFailureSocket()

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -385,6 +385,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      update_weights_ack_timeout_seconds: 30.0
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -327,6 +327,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      update_weights_ack_timeout_seconds: 30.0
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -338,6 +338,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      update_weights_ack_timeout_seconds: 30.0
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -343,6 +343,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      update_weights_ack_timeout_seconds: 30.0
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -291,6 +291,9 @@ checkpoint_engine:
   # when using Tensor Parallelism (TP) >= 8.
   update_weights_bucket_megabytes: 2048
 
+  # Maximum time to wait for each bucketed weight-transfer acknowledgement.
+  update_weights_ack_timeout_seconds: 30.0
+
   # Additional keyword arguments to pass to the checkpoint engine constructor
   engine_kwargs: {}
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 import warnings
 from dataclasses import dataclass, field
 from typing import Optional
@@ -133,12 +134,18 @@ class CheckpointEngineConfig(BaseConfig):
     backend: Optional[str] = "naive"
     # Bucket size in MB to transfer multiple weights at one time
     update_weights_bucket_megabytes: int = 2048
+    # Maximum time to wait for each bucketed weight-transfer acknowledgement.
+    update_weights_ack_timeout_seconds: float = 30.0
     # Additional keyword arguments for checkpoint engine
     engine_kwargs: dict = field(default_factory=dict)
     # If set, this Python module is imported on every worker process before the
     # backend is instantiated, allowing custom backends to register themselves
     # in CheckpointEngineRegistry.
     custom_backend_module: Optional[str] = None
+
+    def __post_init__(self):
+        if not math.isfinite(self.update_weights_ack_timeout_seconds) or self.update_weights_ack_timeout_seconds <= 0:
+            raise ValueError("update_weights_ack_timeout_seconds must be a positive finite number.")
 
 
 @dataclass

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -21,7 +21,7 @@ import gc
 import logging
 import os
 from multiprocessing import shared_memory
-from typing import Callable, TypedDict
+from typing import Callable, Protocol, TypedDict
 
 import torch
 import zmq
@@ -31,6 +31,28 @@ from verl.utils.device import get_device_id, get_device_name, get_torch_device, 
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+_RECEIVER_ERROR_PREFIX = b"error:"
+_DEFAULT_ACK_TIMEOUT_MS = 30_000
+
+
+class _AcknowledgementSocket(Protocol):
+    def recv(self) -> bytes: ...
+
+
+def _is_ack_available(socket: _AcknowledgementSocket, timeout_ms: int) -> bool:
+    poll = getattr(socket, "poll", None)
+    return poll is None or bool(poll(timeout_ms, zmq.POLLIN))
+
+
+def _encode_receiver_error(exc: Exception) -> bytes:
+    return _RECEIVER_ERROR_PREFIX + f"{type(exc).__name__}: {exc}".encode("utf-8", errors="replace")
+
+
+def _raise_on_receiver_error(response: bytes) -> None:
+    if response.startswith(_RECEIVER_ERROR_PREFIX):
+        detail = response.removeprefix(_RECEIVER_ERROR_PREFIX).decode("utf-8", errors="replace")
+        raise RuntimeError(f"weight receiver failed: {detail}")
 
 
 class TensorMetadata(TypedDict):
@@ -89,11 +111,15 @@ class BucketedWeightSender:
         zmq_handle: str,
         bucket_size_mb: int = 512,
         use_shm: bool = False,
+        ack_timeout_ms: int = _DEFAULT_ACK_TIMEOUT_MS,
     ):
+        if ack_timeout_ms <= 0:
+            raise ValueError("ack_timeout_ms must be positive")
         self.zmq_handle = zmq_handle
         self.bucket_size_mb = bucket_size_mb
         self.bucket_size = int(bucket_size_mb) << 20
         self.use_shm = use_shm
+        self.ack_timeout_ms = ack_timeout_ms
 
         self.zmq_context = zmq.Context.instance()
         self.socket = None
@@ -129,7 +155,7 @@ class BucketedWeightSender:
                 if offset + weight.nbytes > self.bucket_size and len(bucket_meta) > 0:
                     get_torch_device().synchronize()
                     self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
-                    self.socket.recv()
+                    self._receive_ack("intermediate bucket")
                     bucket_meta = {}
                     offset = 0
 
@@ -156,9 +182,16 @@ class BucketedWeightSender:
             # send the last bucket
             get_torch_device().synchronize()
             self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": True})
-            self.socket.recv()
+            self._receive_ack("final bucket")
         finally:
             self._cleanup()
+
+    def _receive_ack(self, phase: str) -> None:
+        if not _is_ack_available(self.socket, self.ack_timeout_ms):
+            raise RuntimeError(
+                f"timed out waiting {self.ack_timeout_ms}ms for weight receiver acknowledgement ({phase})"
+            )
+        _raise_on_receiver_error(self.socket.recv())
 
     def _init_socket(self):
         """Initialize ZMQ REQ socket and bind."""
@@ -169,6 +202,7 @@ class BucketedWeightSender:
             except OSError:
                 pass
         self.socket = self.zmq_context.socket(zmq.REQ)
+        self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.bind(self.zmq_handle)
 
     def _init_buffer(self):
@@ -189,7 +223,13 @@ class BucketedWeightSender:
             comm_metadata = {"name": shm_name, "size": self.bucket_size}
             self.socket.send_pyobj(comm_metadata)
 
-        self.socket.recv()
+        try:
+            self._receive_ack("buffer initialization")
+        except Exception:
+            if shm is not None:
+                shm.close()
+                shm.unlink()
+            raise
         self.buffer = buffer
         self.shm = shm
 
@@ -230,7 +270,7 @@ class BucketedWeightSender:
             "handle": handle,
         }
         self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
-        self.socket.recv()
+        self._receive_ack(f"oversized tensor {name}")
 
 
 class BucketedWeightReceiver:
@@ -274,28 +314,38 @@ class BucketedWeightReceiver:
         """
         try:
             self._init_socket()
-            self._init_buffer()
+            try:
+                self._init_buffer()
+            except Exception as exc:
+                self._send_error(exc)
+                raise
 
             # receive bucket and update weights
             while True:
-                metadata = self.socket.recv_pyobj()
                 weights, tensor = [], None
-                for name, meta in metadata["bucket_meta"].items():
-                    shape, dtype, offset, handle = meta["shape"], meta["dtype"], meta["offset"], meta["handle"]
-                    if handle is not None:
-                        tensor = rebuild_ipc(handle, self.device.index)
+                try:
+                    metadata = self.socket.recv_pyobj()
+                    for name, meta in metadata["bucket_meta"].items():
+                        shape, dtype, offset, handle = meta["shape"], meta["dtype"], meta["offset"], meta["handle"]
+                        if handle is not None:
+                            tensor = rebuild_ipc(handle, self.device.index)
+                            weights.append((name, tensor))
+                            continue
+                        size = dtype.itemsize * shape.numel()
+                        tensor = self.buffer[offset : offset + size].view(dtype=dtype).view(shape)
+                        if self.use_shm:
+                            tensor = tensor.to(self.device)
                         weights.append((name, tensor))
-                        continue
-                    size = dtype.itemsize * shape.numel()
-                    tensor = self.buffer[offset : offset + size].view(dtype=dtype).view(shape)
-                    if self.use_shm:
-                        tensor = tensor.to(self.device)
-                    weights.append((name, tensor))
-                is_last = metadata["is_last"]
-                on_bucket_received(weights, is_last)
-                get_torch_device().synchronize()
-                self.socket.send(b"")
-                del weights, tensor
+                    is_last = metadata["is_last"]
+                    on_bucket_received(weights, is_last)
+                    get_torch_device().synchronize()
+                except Exception as exc:
+                    self._send_error(exc)
+                    raise
+                else:
+                    self.socket.send(b"")
+                finally:
+                    del weights, tensor
                 if is_last:
                     break
         finally:
@@ -304,23 +354,35 @@ class BucketedWeightReceiver:
     def _init_socket(self):
         """Initialize ZMQ REP socket and connect."""
         self.socket = self.zmq_context.socket(zmq.REP)
+        self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.connect(self.zmq_handle)
 
     def _init_buffer(self):
         """Receive and rebuild communication buffer from sender."""
         comm_metadata = self.socket.recv_pyobj()
         buffer, shm = None, None
-        if not self.use_shm:
-            handle = comm_metadata
-            buffer = rebuild_ipc(handle, self.device.index)
-            assert buffer.dtype == torch.uint8
-        else:
-            shm_name = comm_metadata["name"]
-            shm_size = comm_metadata["size"]
-            buffer, shm = rebuild_shared_memory(shm_name, shm_size, dtype=torch.uint8)
+        try:
+            if not self.use_shm:
+                handle = comm_metadata
+                buffer = rebuild_ipc(handle, self.device.index)
+                assert buffer.dtype == torch.uint8
+            else:
+                shm_name = comm_metadata["name"]
+                shm_size = comm_metadata["size"]
+                buffer, shm = rebuild_shared_memory(shm_name, shm_size, dtype=torch.uint8)
+        except Exception:
+            if shm is not None:
+                shm.close()
+            raise
         self.socket.send(b"")
         self.buffer = buffer
         self.shm = shm
+
+    def _send_error(self, exc: Exception) -> None:
+        try:
+            self.socket.send(_encode_receiver_error(exc), flags=zmq.NOBLOCK)
+        except zmq.ZMQError:
+            logger.warning("failed to send weight receiver error acknowledgement", exc_info=True)
 
     def _cleanup(self):
         """clean up"""
@@ -333,7 +395,10 @@ class BucketedWeightReceiver:
         del self.buffer
         self.buffer = None
         if self.shm is not None:
-            self.shm.close()
+            try:
+                self.shm.close()
+            except BufferError:
+                logger.warning("shared-memory buffer still has active views during receiver cleanup")
             del self.shm
             self.shm = None
         gc.collect()

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -230,6 +230,7 @@ class ServerAdapter(BaseRollout):
             zmq_handle=self.zmq_handle,
             bucket_size_mb=bucket_size_mb,
             use_shm=self.use_shm,
+            ack_timeout_ms=int(self.config.checkpoint_engine.update_weights_ack_timeout_seconds * 1000),
         )
         await sender.async_send_weights(weights)
 


### PR DESCRIPTION
## Summary
- Defensive liveness fix for the bucketed ZMQ weight-transfer protocol: bound each ACK wait and propagate receiver exceptions to the sender through explicit error ACKs.
- Expose `rollout.checkpoint_engine.update_weights_ack_timeout_seconds` (default: 30 seconds); values must be positive and finite.

## Tests
- CPU/shared-memory coverage: successful transfer; receiver initialization, metadata-decode, and callback failures; callback failure after an intermediate bucket; and final-ACK timeout after peer loss.
- The process tests assert IPC-socket and shared-memory cleanup. Config tests cover the default and invalid timeout values.

## Limitations
- CUDA IPC and a full vLLM integration were not exercised.