### PR TITLE
[hardware, fsdp, vllm] feat: add Intel GPU (XPU) support

### DIFF
--- a/docker/intel_gpu/Dockerfile.intel_gpu
+++ b/docker/intel_gpu/Dockerfile.intel_gpu
@@ -1,0 +1,179 @@
+# syntax=docker/dockerfile:1
+
+# verl on Intel GPU
+#
+# Design goals:
+# - Match vLLM's Intel GPU container workflow (DLE base + uv + oneCCL setup).
+# - Keep versions explicit and reproducible.
+# - Keep torch/vLLM alignment owned by vLLM requirements/xpu.txt.
+#
+# Build:
+#   docker build -t verl-intel-gpu:latest -f docker/intel_gpu/Dockerfile.intel_gpu .
+#
+# Behind a corporate proxy:
+#   docker build --build-arg http_proxy=... --build-arg https_proxy=... ...
+#
+# Run (mount GPU devices + render + video groups; by-path and ipc=host for oneCCL):
+#   RENDER_GID=$(getent group render | cut -d: -f3)
+#   VIDEO_GID=$(getent group video | cut -d: -f3)
+#   docker run -it --rm \
+#     --device /dev/dri \
+#     --group-add ${RENDER_GID} \
+#     --group-add ${VIDEO_GID} \
+#     -v /dev/dri/by-path:/dev/dri/by-path \
+#     --ipc=host \
+#     --shm-size 16g \
+#     -v $HOME/data:/root/data \
+#     verl-intel-gpu:latest
+#
+# Quick Intel GPU sanity check:
+#   docker run --rm --device /dev/dri --group-add ${RENDER_GID} --group-add ${VIDEO_GID} \
+#     -v /dev/dri/by-path:/dev/dri/by-path --ipc=host \
+#     verl-intel-gpu:latest \
+#     python3 -c "import torch; print(torch.__version__); print(torch.xpu.is_available()); print(torch.xpu.device_count())"
+
+# Base: DLE 2026.1.0 / ubuntu24.04. UBUNTU flavor is load-bearing — the 2026.1
+# ubuntu26.04 variant SIGSEGVs on torch init (glibc/SYCL ABI mismatch on that
+# beta distro). ubuntu24.04 is stable and ships python3.12-dev as an apt package,
+# which the vLLM CMake build requires.
+#
+# oneCCL: intentionally NOT installed separately. The 2026.1.0 DLE base already
+# ships a torch-2.13-compatible oneCCL (Gold-2022.1.0, linked against the base's
+# libsycl.so.9) at /opt/intel/oneapi/ccl/2022.1, and bakes CCL_ROOT,
+# LD_LIBRARY_PATH, and CMAKE_PREFIX_PATH (lib/cmake/oneCCL) into the image ENV
+# with no sourcing required. The torch 2.13.0+xpu wheel also bundles its own
+# oneCCL, but the base's 2022.1.0 takes precedence via LD_LIBRARY_PATH and is
+# the one torch-xpu-ops links against at wheel-build time — so they match.
+# The old Battlemage oneCCL 2021.15.7 offline bundle is removed: it was built
+# for an older SYCL ABI, torch never linked it anyway, and its /root/.bashrc
+# sourcing + ccl/latest symlink override actively shadowed the base's good env.
+FROM intel/deep-learning-essentials:2026.1.0-devel-ubuntu24.04
+
+LABEL org.opencontainers.image.title="verl-intel-gpu"
+LABEL org.opencontainers.image.description="verl development image for Intel GPU"
+LABEL org.opencontainers.image.vendor="verl"
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.12
+
+# vLLM pinned to the v0.27.0 release tag — the first stable release that carries
+# the XPU torch==2.13.0 + vllm_xpu_kernels 0.1.12 pairing. requirements/xpu.txt at
+# v0.27.0 is byte-identical to the previously-pinned commit 5b29c958 (which is
+# v0.27.0rc1~173, i.e. an ancestor of this tag), so the torch/oneCCL/driver stack
+# below is unchanged — this just swaps the commit pin for the stable tag.
+ARG VLLM_VERSION=v0.27.0
+
+# torch version is intentionally not pinned here. vLLM's requirements/xpu.txt
+# owns the tested torch+xpu pairing for each vLLM commit.
+ARG PIP_INDEX_URL="https://download.pytorch.org/whl/xpu"
+ARG PIP_EXTRA_INDEX_URL="https://pypi.org/simple"
+
+# Intel userspace driver/component versions (explicit for reproducible builds).
+ARG IGC_VERSION=2.34.4
+ARG IGC_BUILD=21428
+ARG COMPUTE_RUNTIME_VERSION=26.18.38308.1
+ARG IGDGMM_VERSION=22.10.0
+ARG LEVEL_ZERO_VERSION=1.28.2+u24.04
+
+WORKDIR /workspace
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# --- System dependencies ---
+# python${PYTHON_VERSION}-dev is required: vLLM's XPU extension is compiled from
+# source (uv pip install --no-build-isolation .), and its CMake step needs the
+# CPython development headers (Python_INCLUDE_DIRS / Development.Module). The
+# ubuntu24.04 DLE base ships python3.12 + python3.12-dev as apt packages.
+RUN set -eux && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        g++ \
+        gcc \
+        git \
+        libnuma-dev \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python3-pip \
+        wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- uv: fast, deterministic resolver ---
+ENV PATH="/root/.local/bin:${PATH}"
+ENV VIRTUAL_ENV="/opt/venv"
+ENV UV_PYTHON_INSTALL_DIR="/opt/uv/python"
+RUN set -eux && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    uv venv --python ${PYTHON_VERSION} --seed ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+# --- Intel GPU user-mode drivers (UMD) ---
+# Bumped to compute-runtime 26.18: fixes vllm's request_memory reading free=0 on
+# device xpu:0 with 26.09 (getMemoryInfo bug). 26.18 reports free memory correctly.
+RUN set -eux && \
+    tmp_dir="$(mktemp -d)" && \
+    cd "${tmp_dir}" && \
+    wget -q "https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION}/intel-igc-core-2_${IGC_VERSION}+${IGC_BUILD}_amd64.deb" && \
+    wget -q "https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION}/intel-igc-opencl-2_${IGC_VERSION}+${IGC_BUILD}_amd64.deb" && \
+    wget -q "https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/intel-ocloc_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" && \
+    wget -q "https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/intel-opencl-icd_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" && \
+    wget -q "https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/libigdgmm12_${IGDGMM_VERSION}_amd64.deb" && \
+    wget -q "https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}/libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" && \
+    wget -q "https://github.com/oneapi-src/level-zero/releases/download/v${LEVEL_ZERO_VERSION%%+*}/level-zero_${LEVEL_ZERO_VERSION}_amd64.deb" && \
+    wget -q "https://github.com/oneapi-src/level-zero/releases/download/v${LEVEL_ZERO_VERSION%%+*}/level-zero-devel_${LEVEL_ZERO_VERSION}_amd64.deb" && \
+    dpkg -i --force-overwrite ./*.deb && \
+    cd / && \
+    rm -rf "${tmp_dir}"
+
+# No oneAPI/oneCCL sourcing needed: the 2026.1.0 base bakes CCL_ROOT,
+# LD_LIBRARY_PATH and CMAKE_PREFIX_PATH (ccl/2022.1/lib/cmake/oneCCL) into the
+# image ENV, so vLLM's XPU build finds oneCCL headers/cmake directly.
+
+ENV UV_HTTP_TIMEOUT=500
+# XPU index is primary, PyPI is extra. This avoids pulling CPU-only torch from PyPI.
+ENV UV_INDEX_URL="${PIP_INDEX_URL}"
+ENV UV_EXTRA_INDEX_URL="${PIP_EXTRA_INDEX_URL}"
+ENV UV_INDEX_STRATEGY="unsafe-best-match"
+ENV UV_LINK_MODE="copy"
+ENV VLLM_TARGET_DEVICE="xpu"
+
+# --- Layer 1: vLLM + torch Intel GPU ---
+# vLLM is fetched at the pinned release tag (${VLLM_VERSION}), which carries:
+#   - torch==2.13.0 + vllm_xpu_kernels 0.1.12 in requirements/xpu.txt
+#   - XPU sleep-mode (device_allocator/xpumem.py + xpumem kernels wiring)
+# We fetch the tag with its history so setuptools-scm resolves the version from
+# the annotated tag directly (SETUPTOOLS_SCM_PRETEND_VERSION derives it from the
+# tag name as a backstop for the shallow --depth 1 fetch).
+RUN set -ex && \
+    git init /opt/vllm && \
+    cd /opt/vllm && \
+    git remote add origin https://github.com/vllm-project/vllm.git && \
+    git fetch --depth 1 origin tag "${VLLM_VERSION}" && \
+    git checkout "${VLLM_VERSION}" && \
+    SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_VERSION#v}" \
+    uv pip install --upgrade pip setuptools wheel && \
+    SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_VERSION#v}" \
+    uv pip install -r requirements/xpu.txt && \
+    SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_VERSION#v}" \
+    uv pip install --no-build-isolation .
+
+# --- Layer 2: verl Python dependencies ---
+COPY requirements-intel-gpu.txt /tmp/requirements-intel-gpu.txt
+RUN set -eux && uv pip install -r /tmp/requirements-intel-gpu.txt
+
+# --- Layer 3: verl source ---
+COPY . /workspace/verl
+WORKDIR /workspace/verl
+RUN set -eux && uv pip install --no-deps -e .
+
+# xgrammar (via vLLM's common.txt) pulls in plain triton as a transitive dep.
+# Plain triton is for NVIDIA only — replace with triton-xpu per official vLLM XPU docs.
+# See: https://docs.vllm.ai/en/latest/getting_started/xpu-installation.html
+RUN uv pip uninstall triton triton-xpu -y 2>/dev/null || true && \
+    uv pip install triton-xpu==3.7.1 --extra-index-url https://download.pytorch.org/whl/xpu
+
+CMD ["bash", "-c", "exec bash"]

--- a/docker/intel_gpu/README.md
+++ b/docker/intel_gpu/README.md
@@ -1,0 +1,95 @@
+# verl on Intel GPU
+
+## Supported Hardware
+
+- Intel Arc Pro B-Series (Battlemage)
+
+## Quick Start
+
+### Build the Docker image
+
+```bash
+# Standard build
+docker build -t verl-intel-gpu:latest -f docker/intel_gpu/Dockerfile.intel_gpu .
+
+# Behind a corporate proxy
+docker build \
+  --build-arg http_proxy=$http_proxy \
+  --build-arg https_proxy=$https_proxy \
+  -t verl-intel-gpu:latest -f docker/intel_gpu/Dockerfile.intel_gpu .
+```
+
+### Run with GPU access
+
+```bash
+RENDER_GID=$(getent group render | cut -d: -f3)
+VIDEO_GID=$(getent group video | cut -d: -f3)
+
+docker run -it --rm \
+  --device /dev/dri \
+  --group-add ${RENDER_GID} \
+  --group-add ${VIDEO_GID} \
+  -v /dev/dri/by-path:/dev/dri/by-path \
+  --ipc=host \
+  --shm-size 16g \
+  -v $HOME/data:/root/data \
+  -v $HOME/.cache:/root/.cache \
+  verl-intel-gpu:latest
+```
+
+> **Note:** `--group-add ${VIDEO_GID}`, `-v /dev/dri/by-path:/dev/dri/by-path`,
+> and `--ipc=host` are required for oneCCL's `ze_fd_manager` drmfd path. Without
+> them multi-GPU runs fail at FSDP init with
+> `RuntimeError: oneCCL: ze_fd_manager.cpp:144 init_device_fds: opendir failed`.
+
+### Runtime env override
+
+For machine-specific or temporary settings (proxy, debug flags), inject them
+explicitly at `docker run` time with `-e`/`--env-file` instead of baking values
+into the image:
+
+```bash
+docker run -it --rm \
+  --device /dev/dri \
+  --group-add ${RENDER_GID} \
+  --group-add ${VIDEO_GID} \
+  -v /dev/dri/by-path:/dev/dri/by-path \
+  --ipc=host \
+  --shm-size 16g -v $HOME/data:/root/data \
+  -e CCL_ATL_SHM=1 \
+  verl-intel-gpu:latest
+```
+
+### Run e2e tests inside the container
+
+```bash
+# SFT smoke test (4 GPU)
+NUM_GPUS=4 bash tests/special_intel_gpu/run_sft_intel_gpu.sh
+
+# GRPO e2e with vLLM rollout (2 GPU)
+NUM_GPUS=2 bash tests/special_intel_gpu/run_grpo_intel_gpu.sh
+
+# PPO e2e with critic model (4 GPU)
+NUM_GPUS=4 bash tests/special_intel_gpu/run_ppo_intel_gpu.sh
+```
+
+## Dependencies
+
+| Package | Version | Source |
+|---------|---------|--------|
+| PyTorch XPU | from vLLM xpu requirements | `https://download.pytorch.org/whl/xpu` |
+| oneCCL runtime | installed in image via oneAPI / oneCCL bundle | bundled in image |
+| vLLM | from Dockerfile `VLLM_VERSION` | built from source with `VLLM_TARGET_DEVICE=xpu` |
+| verl deps | from `requirements-intel-gpu.txt` | PyPI and extra indexes |
+
+Runtime sanity checks validated on this image:
+
+- `torch.xpu.is_available() == True`
+- `from vllm.platforms import current_platform` reports `xpu`
+- oneCCL runtime is available via `CCL_ROOT` and `libccl.so.1`
+
+## Backend Policy
+
+- Default rollout backend on Intel GPU is vLLM.
+- sglang is not the default path for Intel GPU in this image.
+- Separate image/profile will be released when SGLang is validated on Intel GPU.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,7 +167,9 @@ verl is fast with:
 
    hardware/multi_chip_support
    amd_tutorial/index.rst
-   ascend_tutorial/index.rst 
+   intel_gpu_tutorial/intel_gpu_build_dockerfile_page.rst
+   intel_gpu_tutorial/intel_gpu_quick_start.rst
+   ascend_tutorial/index.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/intel_gpu_tutorial/intel_gpu_build_dockerfile_page.rst
+++ b/docs/intel_gpu_tutorial/intel_gpu_build_dockerfile_page.rst
@@ -1,0 +1,192 @@
+Intel GPU Docker Build Guide
+=============================
+
+Last updated: 08/11/2026.
+
+Author: `Kah Lun Teoh <https://github.com/kahlun>`_
+
+Overview
+--------
+
+This page describes how to build and run the Intel GPU Docker image for verl.
+The image bundles all required Intel software stack components in exact versions known to work together on Battlemage (Arc Pro B60, Arc Pro B70).
+
+Software Stack
+--------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Component
+     - Version
+     - Purpose
+   * - Base image
+     - ``intel/deep-learning-essentials:2026.1.0-devel-ubuntu24.04``
+     - oneAPI 2026.1, MKL, DPC++
+   * - Intel compute-runtime
+     - 26.18.38308.1
+     - Level Zero / OpenCL GPU driver (user-space)
+   * - Intel IGC (GPU compiler)
+     - 2.34.4
+     - SPIRV → ISA JIT compilation
+   * - Level Zero loader
+     - 1.28.2
+     - ``libze_loader`` — driver dispatch
+   * - oneAPI oneCCL
+     - 2022.1.0 (bundled in DLE base)
+     - XCCL collective backend for distributed training
+   * - PyTorch (XPU wheel)
+     - from vLLM ``requirements/xpu.txt`` (current image: 2.13.0+xpu)
+     - ``torch.xpu`` device support
+   * - vLLM
+     - v0.27.0
+     - Rollout engine with XPU platform support
+   * - triton-xpu
+     - from vLLM ``requirements/xpu.txt`` (current image: 3.7.1)
+     - JIT kernel compilation for XPU
+   * - Python
+     - 3.12
+     - —
+
+.. note::
+
+   - compute-runtime 26.18 is required: fixes vLLM free-memory reporting (26.09
+     returned ``free=0``, causing vLLM to refuse to start).
+   - IGC 2.34.4 matches that compute-runtime release.
+   - oneCCL 2022.1.0 is bundled in the DLE 2026.1.0 base image and is linked
+     against the base's ``libsycl.so.9``. No separate oneCCL install is needed.
+
+
+docker/intel_gpu/Dockerfile.intel_gpu
+-------------------------------------
+
+The full Dockerfile is at
+`docker/intel_gpu/Dockerfile.intel_gpu <https://github.com/verl-project/verl/blob/main/docker/intel_gpu/Dockerfile.intel_gpu>`_.
+
+Build the Image
+---------------
+
+.. code-block:: bash
+
+    # From the verl repo root:
+    docker build -t verl-intel-gpu:latest -f docker/intel_gpu/Dockerfile.intel_gpu .
+
+Behind a corporate proxy:
+
+.. code-block:: bash
+
+    docker build \
+      --build-arg http_proxy=$http_proxy \
+      --build-arg https_proxy=$https_proxy \
+      -t verl-intel-gpu:latest \
+      -f docker/intel_gpu/Dockerfile.intel_gpu .
+
+Build time: approximately 20–30 minutes (downloads compute-runtime debs,
+builds vLLM from source).
+
+Run the Container
+-----------------
+
+.. code-block:: bash
+
+    RENDER_GID=$(getent group render | cut -d: -f3)
+    VIDEO_GID=$(getent group video | cut -d: -f3)
+
+    docker run -it --rm \
+      --device /dev/dri \
+      --group-add ${RENDER_GID} \
+      --group-add ${VIDEO_GID} \
+      -v /dev/dri/by-path:/dev/dri/by-path \
+      --ipc=host \
+      --shm-size 16g \
+      -v $HOME/data:/root/data \
+      -v $HOME/.cache:/root/.cache \
+      -w /workspace \
+      verl-intel-gpu:latest \
+      /bin/bash
+
+Mount additional paths as needed (e.g. ``-v $HOME/models:/root/models``).
+
+.. note::
+
+   ``--group-add ${VIDEO_GID}``, ``-v /dev/dri/by-path:/dev/dri/by-path``, and
+   ``--ipc=host`` are required for oneCCL's ``ze_fd_manager`` drmfd path.
+   Without them multi-GPU runs crash at FSDP init with
+   ``RuntimeError: oneCCL: ze_fd_manager.cpp:144 init_device_fds: opendir failed``.
+
+Host Hardware Check
+-------------------------------------
+
+To confirm that GPU is visible to the host before launching the container: 
+
+.. code-block:: bash
+
+    # List Intel GPU render nodes
+    ls /dev/dri/renderD*
+
+    # Show GPU name and driver info (requires intel-gpu-tools)
+    # apt install intel-gpu-tools
+    lspci | grep -i "VGA\|Display\|3D" | grep -i intel
+
+    # Check render group GID (must exist before docker run)
+    getent group render
+
+Expected (2× Arc Pro B60):
+
+.. code-block:: text
+
+    /dev/dri/renderD128  /dev/dri/renderD129
+    ...Intel Corporation Battlemage [Arc Pro B60]...
+    render:x:993:
+
+Quick Sanity Check (Inside Container)
+--------------------------------------
+
+After entering the container:
+
+.. code-block:: bash
+
+    python3 - <<'PY'
+    import torch
+    print("torch:", torch.__version__)
+    print("xpu_available:", torch.xpu.is_available())
+    print("device_count:", torch.xpu.device_count())
+    for i in range(torch.xpu.device_count()):
+        print(f"  device_{i}:", torch.xpu.get_device_name(i))
+    PY
+
+    # oneCCL runtime env and shared library
+    python3 - <<'PY'
+    import ctypes.util
+    import os
+    print("CCL_ROOT:", os.environ.get("CCL_ROOT"))
+    print("libccl:", ctypes.util.find_library("ccl"))
+    PY
+
+    # vLLM XPU platform
+    python3 -c "from vllm.platforms import current_platform; print('vLLM platform:', current_platform.device_type)"
+
+Expected output (2× Arc Pro B60):
+
+.. code-block:: text
+
+    torch: 2.13.0+xpu
+    xpu_available: True
+    device_count: 2
+      device_0: Intel(R) Arc(TM) Pro B60 Graphics
+      device_1: Intel(R) Arc(TM) Pro B60 Graphics
+    CCL_ROOT: /opt/intel/oneapi/ccl/2022.1
+    libccl: libccl.so.1
+    vLLM platform: xpu
+
+  .. note::
+
+     oneCCL 2022.1.0 is baked into the DLE base image — no separate Python
+     binding module or ``source`` step is required. Use the runtime probe above
+     to validate oneCCL setup; real training runs also emit oneCCL startup logs.
+
+
+Next Steps
+----------
+
+See :doc:`intel_gpu_quick_start` for training examples (GRPO, PPO, SFT).

--- a/docs/intel_gpu_tutorial/intel_gpu_quick_start.rst
+++ b/docs/intel_gpu_tutorial/intel_gpu_quick_start.rst
@@ -1,0 +1,208 @@
+Getting Started with Intel GPU
+==============================
+
+Last updated: 08/11/2026.
+
+Author: `Kah Lun Teoh <https://github.com/kahlun>`_
+
+Overview
+--------
+
+This document is a quick-start tutorial for running verl on Intel GPU
+(Arc / Arc Pro).
+
+It covers environment verification and training examples using FSDP + vLLM
+rollout in colocated mode.
+
+Current software and hardware scope:
+
+- Runtime mode: **Colocate** (FSDP actor + vLLM rollout on the same device).
+- Inference engine: **vLLM** validated.
+- Trainer backend: **FSDP**, **FSDP2**.
+- Algorithms: GRPO, PPO, SFT.
+- Hardware targets:
+
+  - Intel Arc Pro B60 (Battlemage, 24 GB)
+  - Intel Arc Pro B70 (2× GPU, 32 GB each)
+
+For the Docker image software stack (vLLM v0.27.0, compute-runtime 26.18, and
+the corresponding torch/triton XPU versions resolved from vLLM
+``requirements/xpu.txt``), build instructions, and environment variables
+reference, see :doc:`intel_gpu_build_dockerfile_page`.
+
+Environment Check (Inside Container)
+--------------------------------------
+
+After launching the container (see :doc:`intel_gpu_build_dockerfile_page`):
+
+.. code-block:: bash
+
+    # Confirm Intel GPU devices are visible
+    python3 - <<'PY'
+    import torch
+    print("torch:", torch.__version__)
+    print("xpu_available:", torch.xpu.is_available())
+    print("device_count:", torch.xpu.device_count())
+    for i in range(torch.xpu.device_count()):
+        print(f"  device_{i}:", torch.xpu.get_device_name(i))
+    PY
+
+    # Confirm oneCCL runtime env and shared library are available.
+    # The Docker image does not currently ship a separate Python binding module.
+    python3 - <<'PY'
+    import ctypes.util
+    import os
+    print("CCL_ROOT:", os.environ.get("CCL_ROOT"))
+    print("libccl:", ctypes.util.find_library("ccl"))
+    PY
+
+Expected output (2× Arc Pro B60):
+
+.. code-block:: text
+
+    torch: 2.13.0+xpu
+    xpu_available: True
+    device_count: 2
+      device_0: Intel(R) Arc(TM) Pro B60 Graphics
+      device_1: Intel(R) Arc(TM) Pro B60 Graphics
+    CCL_ROOT: /opt/intel/oneapi/ccl/2022.1
+    libccl: libccl.so.1
+
+  .. note::
+
+     oneCCL 2022.1.0 is bundled in the DLE 2026.1.0 base image — no separate
+     Python binding module is needed. During GRPO/PPO launches you should also
+     see oneCCL startup messages in the worker logs.
+
+Feature Support Matrix
+-----------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Category
+     - Status
+     - Notes
+   * - Runtime mode
+     - Colocate
+     - FSDP/FSDP2 actor + vLLM rollout on same GPU(s)
+   * - Inference engine
+     - vLLM validated
+     - SGLang: weight sync (``update_weights``) not yet supported on Intel GPU
+   * - Trainer backend
+     - FSDP, FSDP2
+     - Megatron not yet validated
+   * - Algorithms
+     - GRPO, PPO, SFT
+     - Validated on GSM8K / Qwen2.5
+   * - Hardware (1-GPU)
+     - Validated
+     - Arc Pro B60: 51.2 s/step, 148.2 tok/s (batch 16, Qwen2.5-0.5B)
+   * - Hardware (2-GPU)
+     - Validated
+     - Arc Pro B60 ×2: 93.0 s/step at same batch size; scales with larger batch
+   * - Multi-node
+     - Not yet tested
+     - —
+
+
+Example Workflow
+-----------------
+
+Prepare data (run once)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    python3 examples/data_preprocess/gsm8k.py --local_save_dir ~/data/gsm8k
+
+1) GRPO — 1 GPU
+~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    NUM_GPUS=1 bash tests/special_intel_gpu/run_grpo_intel_gpu.sh
+
+Expected output (Qwen2.5-0.5B-Instruct, GSM8K, batch 16, 1 step):
+
+.. code-block:: text
+
+    timing_s/step: ~51  timing_per_token_ms/gen: ~0.35
+    perf/throughput: ~148 tok/s
+
+  Verified on this image: the command launches successfully through dataset load,
+  FSDP initialization, and vLLM server startup on a 1-GPU run.
+
+2) GRPO — 2 GPUs
+~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   The script defaults to the same batch size as the 1-GPU run to keep the
+   comparison apples-to-apples. Increase ``data.train_batch_size`` to see
+   the full throughput benefit of the second GPU.
+
+.. code-block:: bash
+
+    NUM_GPUS=2 bash tests/special_intel_gpu/run_grpo_intel_gpu.sh
+
+Expected output (same batch size as 1-GPU baseline):
+
+.. code-block:: text
+
+    timing_s/step: ~93  perf/throughput: ~41 tok/s
+
+3) PPO
+~~~~~~
+
+The PPO script defaults to 4 GPUs (critic model doubles the memory footprint).
+Pass ``NUM_GPUS=2`` to run on a 2× GPU workstation with CPU offload enabled:
+
+.. code-block:: bash
+
+    NUM_GPUS=2 bash tests/special_intel_gpu/run_ppo_intel_gpu.sh
+
+4) SFT
+~~~~~~
+
+The SFT script defaults to 4 GPUs. Pass ``NUM_GPUS=2`` for a 2× GPU workstation:
+
+.. code-block:: bash
+
+    NUM_GPUS=2 bash tests/special_intel_gpu/run_sft_intel_gpu.sh
+
+Manual Training Launch
+-----------------------
+
+To launch training directly, use the following instructions.
+
+.. code-block:: bash
+
+    export ZE_AFFINITY_MASK=0,1          # select physical device indices
+    unset ONEAPI_DEVICE_SELECTOR         # must NOT be set
+    export RAY_memory_monitor_refresh_ms=0
+    export RAY_NUM_PRESTART_PYTHON_WORKERS=0
+
+    python3 -m verl.trainer.main_ppo \
+        algorithm.adv_estimator=grpo \
+        data.train_files=$HOME/data/gsm8k/train.parquet \
+        data.val_files=$HOME/data/gsm8k/test.parquet \
+        data.train_batch_size=16 \
+        data.max_prompt_length=512 \
+        data.max_response_length=128 \
+        actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B-Instruct \
+        actor_rollout_ref.actor.optim.lr=5e-7 \
+        actor_rollout_ref.model.use_remove_padding=False \
+        +actor_rollout_ref.model.override_config.attn_implementation=eager \
+        actor_rollout_ref.actor.use_kl_loss=True \
+        actor_rollout_ref.actor.kl_loss_coef=0.001 \
+        actor_rollout_ref.actor.fsdp_config.param_offload=True \
+        actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+        actor_rollout_ref.rollout.name=vllm \
+        actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+        actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+        actor_rollout_ref.rollout.enforce_eager=True \
+        trainer.n_gpus_per_node=1 \
+        trainer.nnodes=1 \
+        trainer.total_epochs=1 \
+        +ray_kwargs.ray_init.num_gpus=1

--- a/requirements-intel-gpu.txt
+++ b/requirements-intel-gpu.txt
@@ -1,0 +1,44 @@
+# Requirements for Intel XPU
+#
+# PyTorch with XPU support is installed by docker/intel_gpu/Dockerfile.intel_gpu, NOT here.
+# Version must match vLLM XPU requirements (vLLM v0.27.0 pins torch==2.13.0+xpu).
+# Pinned here as a hard backstop so uv/pip cannot drift to a CUDA or CPU wheel.
+# Do NOT remove this pin.
+torch==2.13.0+xpu
+# Runtime deps imported directly by the verl XPU rollout/training paths.
+cachetools
+#
+# vLLM >= 0.17 with XPU support must be built from source:
+#   VLLM_TARGET_DEVICE=xpu pip install --no-build-isolation -v .
+#
+# flash-attn CUDA package is NOT needed — XPU uses SDPA for now. XPU flash-attn enablement in progress.
+# to Intel's SYCL-TLA Flash kernel automatically (10-22x faster than eager).
+accelerate
+codetiming
+datasets
+dill
+dpctl
+einops
+fastapi
+hydra-core
+latex2sympy2_extended
+math_verify
+mathruler
+msgspec
+numpy<2.0.0
+packaging>=20.0
+pandas
+peft>=0.15.2
+pyarrow>=15.0.0
+pybind11
+pylatexenc
+qwen_vl_utils
+ray[default]
+TransferQueue==0.1.8
+tensorboard
+tensordict>=0.10.0
+torchdata
+transformers
+trl<=0.9.6
+uvicorn
+wandb

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -23,13 +23,12 @@ from transformers import (
     Qwen2Config,
 )
 
+# verl's attention dispatcher already routes to flash_attn on CUDA and to the
+# device-agnostic pure-PyTorch impl on NPU/XPU, so import it unconditionally (matching
+# how verl's own source uses it). Upstream branched on cuda/npu only, leaving these
+# names unbound on XPU -> NameError.
+from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
 from verl.utils.device import get_device_name
-
-if get_device_name() == "cuda":
-    from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
-elif get_device_name() == "npu":
-    from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
-
 from verl.utils.model import compute_position_id_with_mask, create_random_mask
 from verl.utils.torch_functional import log_probs_from_logits_all_rmpad, masked_mean
 

--- a/tests/models/test_transformers_ulysses.py
+++ b/tests/models/test_transformers_ulysses.py
@@ -25,6 +25,7 @@ from transformers import AutoModelForCausalLM, LlamaConfig, PretrainedConfig, Qw
 
 from verl.models.transformers.monkey_patch import apply_monkey_patch
 from verl.protocol import DataProto
+from verl.utils.attention_utils import index_first_axis, rearrange, unpad_input
 from verl.utils.device import get_device_name, get_torch_device
 from verl.utils.distributed import initialize_global_process_group
 from verl.utils.model import compute_position_id_with_mask, create_random_mask
@@ -35,11 +36,6 @@ from verl.utils.ulysses import (
     set_ulysses_sequence_parallel_group,
     ulysses_pad_and_slice_inputs,
 )
-
-if get_device_name() == "cuda":
-    from flash_attn.bert_padding import index_first_axis, rearrange, unpad_input
-elif get_device_name() == "npu":
-    from verl.utils.attention_utils import index_first_axis, rearrange, unpad_input
 
 # TODO(sgm): add more models for test
 # we only need one scale for each model

--- a/tests/plugin/test_platform_abstraction.py
+++ b/tests/plugin/test_platform_abstraction.py
@@ -127,7 +127,7 @@ class TestPlatformDetection:
 
     def test_empty_triggers_auto_detection(self):
         with mock.patch.dict(os.environ, {"VERL_PLATFORM": ""}):
-            assert _detect_platform_name() in ("nvidia", "huawei")
+            assert _detect_platform_name() in ("nvidia", "huawei", "intel")
 
 
 class TestPlatformCreation:

--- a/tests/special_intel_gpu/run_grpo_colocate_rm_intel_gpu.sh
+++ b/tests/special_intel_gpu/run_grpo_colocate_rm_intel_gpu.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# E2E GRPO test on Intel GPU with a COLOCATED reward model — mirrors
+# tests/special_e2e/run_v1_colocate_async_disrm.sh.
+#
+# Unlike run_grpo_intel_gpu.sh (which goes through RolloutReplica.init_hybrid()
+# for the policy rollout), this script also enables a discriminative reward
+# model with reward.reward_model.enable_resource_pool=False, so the reward
+# model's rollout replica shares the same GPUs as training and is initialized
+# via RolloutReplica.init_colocated() (verl/workers/rollout/replica.py).
+#
+# Use this to exercise the init_colocated()/init_standalone() device_name path
+# on XPU (the buggy `device_name="cuda" if not is_torch_npu_available(...) ...`
+# ternary), which run_grpo_intel_gpu.sh never reaches.
+#
+# GPU allocation: all GPUs are shared between training, rollout and the
+# reward model (colocate); 2 GPUs is enough for this smoke test.
+#
+# Usage:
+#   NUM_GPUS=2 bash tests/special_intel_gpu/run_grpo_colocate_rm_intel_gpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-2}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+RM_MODEL_ID=${RM_MODEL_ID:-Skywork/Skywork-Reward-V2-Llama-3.2-1B}
+RM_MODEL_PATH=${RM_MODEL_PATH:-${RM_MODEL_ID}}
+
+adv_estimator=grpo
+n_resp_per_prompt=4
+num_reward_workers=${NUM_REWARD_WORKERS:-4}
+train_prompt_bsz=${TRAIN_PROMPT_BSZ:-8}
+train_prompt_mini_bsz=${TRAIN_PROMPT_MINI_BSZ:-${train_prompt_bsz}}
+max_prompt_length=${MAX_PROMPT_LENGTH:-512}
+max_response_length=${MAX_RESPONSE_LENGTH:-128}
+# Reward-model rollout must fit the full chat (prompt + response + RM template overhead).
+rm_prompt_length=$(( max_prompt_length + max_response_length + 512 ))
+
+python3 -m verl.trainer.main_ppo \
+    trainer.use_v1=True \
+    trainer.v1.trainer_mode=colocate_async \
+    trainer.v1.colocate_async.num_warmup_batches=1 \
+    transfer_queue.enable=True \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.prompt_key=prompt \
+    data.truncation='left' \
+    data.return_raw_chat=True \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.train_batch_size=${train_prompt_bsz} \
+    algorithm.adv_estimator=${adv_estimator} \
+    algorithm.use_kl_in_reward=False \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.model.use_remove_padding=False \
+    +actor_rollout_ref.model.override_config.attn_implementation=eager \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.prompt_length=${max_prompt_length} \
+    actor_rollout_ref.rollout.response_length=${max_response_length} \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    reward.num_workers=${num_reward_workers} \
+    reward.reward_manager.name=dapo \
+    reward.reward_model.enable=True \
+    reward.reward_model.enable_resource_pool=False \
+    reward.reward_model.model_path="${RM_MODEL_PATH}" \
+    reward.reward_model.rollout.name=vllm \
+    reward.reward_model.rollout.tensor_model_parallel_size=1 \
+    reward.reward_model.rollout.gpu_memory_utilization=0.4 \
+    reward.reward_model.rollout.enforce_eager=True \
+    reward.reward_model.rollout.free_cache_engine=False \
+    reward.reward_model.rollout.skip_tokenizer_init=False \
+    reward.reward_model.rollout.prompt_length=${rm_prompt_length} \
+    reward.reward_model.rollout.response_length=${max_response_length} \
+    trainer.logger=console \
+    trainer.project_name='verl_intel_gpu_grpo_colocate_rm_e2e' \
+    trainer.experiment_name='qwen2_5_05b_intel_gpu_grpo_colocate_rm' \
+    trainer.val_before_train=False \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=1 \
+    trainer.resume_mode=disable \
+    +ray_kwargs.ray_init.num_gpus=${NUM_GPUS} $@

--- a/tests/special_intel_gpu/run_grpo_intel_gpu.sh
+++ b/tests/special_intel_gpu/run_grpo_intel_gpu.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# E2E GRPO test on Intel GPU — mirrors tests/special_npu/run_qwen2_5_05b_grpo.sh
+#
+# Validates the full RL training loop on XPU:
+#   FSDP training (actor + ref) → vLLM rollout → reward → train
+#
+# Prerequisites:
+#   - PyTorch with XPU support (torch.xpu.is_available() == True)
+#   - vLLM >= 0.17 with XPU platform support
+#   - oneCCL for xccl distributed backend
+#
+# Usage:
+#   NUM_GPUS=2 bash tests/special_intel_gpu/run_grpo_intel_gpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-2}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+DATA_DIR=${DATA_DIR:-$HOME/data}
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$DATA_DIR/gsm8k/train.parquet \
+    data.val_files=$DATA_DIR/gsm8k/test.parquet \
+    data.train_batch_size=16 \
+    data.max_prompt_length=512 \
+    data.max_response_length=128 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=5e-7 \
+    actor_rollout_ref.model.use_remove_padding=False \
+    +actor_rollout_ref.model.override_config.attn_implementation=eager \
+    actor_rollout_ref.actor.ppo_mini_batch_size=8 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.ref.use_torch_compile=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    +actor_rollout_ref.rollout.enable_sleep_mode=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.n=2 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    trainer.critic_warmup=0 \
+    trainer.logger=console \
+    trainer.project_name='verl_intel_gpu_grpo_e2e' \
+    trainer.experiment_name='qwen2_5_05b_intel_gpu_grpo' \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=1 \
+    +ray_kwargs.ray_init.num_gpus=${NUM_GPUS} $@

--- a/tests/special_intel_gpu/run_ppo_intel_gpu.sh
+++ b/tests/special_intel_gpu/run_ppo_intel_gpu.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# E2E PPO (GAE) test on Intel GPU — mirrors tests/special_npu/run_qwen3_06b_ppo.sh
+#
+# Validates PPO training with critic model on XPU:
+#   FSDP training (actor + critic + ref) → vLLM rollout → GAE reward → train
+#
+# Usage:
+#   NUM_GPUS=4 bash tests/special_intel_gpu/run_ppo_intel_gpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-4}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=gae \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.train_batch_size=16 \
+    data.max_prompt_length=512 \
+    data.max_response_length=128 \
+    data.shuffle=False \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.use_remove_padding=False \
+    +actor_rollout_ref.model.override_config.attn_implementation=sdpa \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=8 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    critic.optim.lr=1e-5 \
+    critic.model.use_remove_padding=False \
+    critic.model.path="${MODEL_PATH}" \
+    +critic.model.override_config.attn_implementation=sdpa \
+    critic.model.enable_gradient_checkpointing=True \
+    critic.ppo_micro_batch_size_per_gpu=1 \
+    critic.fsdp.param_offload=True \
+    critic.fsdp.optimizer_offload=True \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console"]' \
+    trainer.project_name='verl_intel_gpu_ppo_e2e' \
+    trainer.experiment_name='qwen2_5_05b_intel_gpu_ppo' \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=1 \
+    +ray_kwargs.ray_init.num_gpus=${NUM_GPUS} $@

--- a/tests/special_intel_gpu/run_sft_intel_gpu.sh
+++ b/tests/special_intel_gpu/run_sft_intel_gpu.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SFT smoke test on Intel GPU — validates FSDP multi-GPU training without vLLM.
+#
+# Usage:
+#   NUM_GPUS=4 bash tests/special_intel_gpu/run_sft_intel_gpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-4}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+
+# Use python -m torch.distributed.run instead of torchrun so the correct
+# Python interpreter is used regardless of PATH (e.g. inside conda envs).
+PYTHON3=$(python3 -c "import torch; import sys; print(sys.executable)" 2>/dev/null || command -v python3)
+$PYTHON3 -m torch.distributed.run --nproc-per-node=${NUM_GPUS} --standalone \
+    -m verl.trainer.sft_trainer \
+    data.train_files=$HOME/data/gsm8k/train_sft.parquet \
+    data.val_files=$HOME/data/gsm8k/test_sft.parquet \
+    data.train_batch_size=8 \
+    data.max_length=1024 \
+    model.path="${MODEL_PATH}" \
+    model.trust_remote_code=True \
+    model.use_remove_padding=False \
+    +model.override_config.attn_implementation=sdpa \
+    trainer.default_local_dir=./checkpoints/xpu_sft_test \
+    trainer.project_name='verl_intel_gpu_sft_e2e' \
+    trainer.experiment_name='qwen2_5_05b_intel_gpu_sft' \
+    trainer.logger=console \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=5 \
+    data.micro_batch_size_per_gpu=1 \
+    trainer.save_freq=-1 \
+    trainer.n_gpus_per_node=${NUM_GPUS} $@

--- a/tests/special_intel_gpu/run_standalone_gen_intel_gpu.sh
+++ b/tests/special_intel_gpu/run_standalone_gen_intel_gpu.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Standalone rollout-only generation on Intel GPU — mirrors examples/generation/run_deepseek_llm_7b.sh.
+#
+# This path calls verl.trainer.main_generation_server, which ALWAYS calls
+# RolloutReplica.init_standalone() (no trainer worker_group involved), unlike
+# run_grpo_intel_gpu.sh / run_ppo_intel_gpu.sh which go through init_hybrid().
+# Use this to exercise the init_standalone()/init_colocated() device_name path
+# in verl/workers/rollout/replica.py on XPU.
+#
+# Usage:
+#   NUM_GPUS=2 bash tests/special_intel_gpu/run_standalone_gen_intel_gpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-2}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+DATA_PATH=${DATA_PATH:-$HOME/data/gsm8k/test.parquet}
+OUTPUT_PATH=${OUTPUT_PATH:-$HOME/data/gsm8k/qwen2_5_05b_intel_gpu_gen_test.parquet}
+
+python3 -m verl.trainer.main_generation_server \
+    trainer.nnodes=1 \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    data.train_files="${DATA_PATH}" \
+    data.prompt_key=prompt \
+    +data.output_path="${OUTPUT_PATH}" \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.trust_remote_code=True \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.top_k=50 \
+    actor_rollout_ref.rollout.top_p=0.7 \
+    actor_rollout_ref.rollout.prompt_length=512 \
+    actor_rollout_ref.rollout.response_length=128 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${NUM_GPUS} \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    +actor_rollout_ref.rollout.enable_sleep_mode=False \
+    actor_rollout_ref.rollout.n=1 $@

--- a/tests/special_standalone/test_memory_buffers.py
+++ b/tests/special_standalone/test_memory_buffers.py
@@ -22,8 +22,15 @@ import gc
 import torch
 from transformers import LlamaConfig, LlamaModel
 
+# Device-agnostic accelerator handle: torch.cuda on NVIDIA, torch.xpu on Intel GPU, etc.
+# Previously this test hardcoded torch.cuda / .cuda(), so it errored on XPU before running.
+from verl.utils.device import get_device_name, get_torch_device
+
 
 def test_memory_buffers():
+    device = get_device_name()
+    dev_module = get_torch_device()
+
     llama_config = LlamaConfig(
         vocab_size=256,
         hidden_size=4096,
@@ -33,24 +40,24 @@ def test_memory_buffers():
         num_key_value_heads=16,
     )
 
-    model = LlamaModel(config=llama_config).cuda()
-    model_copy = LlamaModel(config=llama_config).cuda()
+    model = LlamaModel(config=llama_config).to(device)
+    model_copy = LlamaModel(config=llama_config).to(device)
     model_copy.load_state_dict(model.state_dict())
 
     norm_factor = 1024**3
 
-    t_before = torch.cuda.get_device_properties(0).total_memory / norm_factor
-    r_before = torch.cuda.memory_reserved(0) / norm_factor
-    a_before = torch.cuda.memory_allocated(0) / norm_factor
+    t_before = dev_module.get_device_properties(0).total_memory / norm_factor
+    r_before = dev_module.memory_reserved(0) / norm_factor
+    a_before = dev_module.memory_allocated(0) / norm_factor
 
     print(f"Before Total memory: {t_before} GB, reserved: {r_before} GB, allocated: {a_before} GB")
 
-    t = torch.cuda.get_device_properties(0).total_memory / norm_factor
-    r = torch.cuda.memory_reserved(0) / norm_factor
-    a = torch.cuda.memory_allocated(0) / norm_factor
+    t = dev_module.get_device_properties(0).total_memory / norm_factor
+    r = dev_module.memory_reserved(0) / norm_factor
+    a = dev_module.memory_allocated(0) / norm_factor
 
     gc.collect()
-    torch.cuda.empty_cache()
+    dev_module.empty_cache()
 
     print(f"After Total memory: {t} GB, reserved: {r} GB, allocated: {a} GB")
 

--- a/verl/plugin/platform/platform_manager.py
+++ b/verl/plugin/platform/platform_manager.py
@@ -172,3 +172,4 @@ def set_platform(platform: PlatformBase) -> None:
 from .platform_cuda import PlatformCUDA  # noqa: E402, F401
 from .platform_npu import PlatformNPU  # noqa: E402, F401
 from .platform_rocm import PlatformROCm  # noqa: E402, F401
+from .platform_xpu import PlatformXPU  # noqa: E402, F401

--- a/verl/plugin/platform/platform_xpu.py
+++ b/verl/plugin/platform/platform_xpu.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Intel GPU (PyTorch XPU) platform implementation."""
+
+import logging
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any, Optional
+
+import torch
+
+from .platform_base import PlatformBase
+from .platform_manager import PlatformRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _has_torch_xpu() -> bool:
+    """Return True if the ``torch.xpu`` namespace is present."""
+    return hasattr(torch, "xpu")
+
+
+@PlatformRegistry.register(platform="intel")
+class PlatformXPU(PlatformBase):
+    """Platform backend for Intel GPU (Level Zero / SYCL via ``torch.xpu``)."""
+
+    # ------------------------------------------------------------------
+    # Core device management
+    # ------------------------------------------------------------------
+
+    @property
+    def device_name(self) -> str:
+        return "xpu"
+
+    @property
+    def vendor_name(self) -> str:
+        return "intel"
+
+    @property
+    def device_module(self) -> ModuleType:
+        return torch.xpu
+
+    def is_available(self) -> bool:
+        return _has_torch_xpu() and torch.xpu.is_available()
+
+    def is_platform_available(self, use_smi_check=False) -> bool:
+        if not _has_torch_xpu():
+            return False
+        if use_smi_check:
+            # torch.xpu namespace present — Intel GPU environment confirmed even
+            # in CPU-only Ray actors where is_available() may report False.
+            return True
+        return torch.xpu.is_available()
+
+    def current_device(self) -> int:
+        return torch.xpu.current_device()
+
+    def device_count(self) -> int:
+        return torch.xpu.device_count()
+
+    def set_device(self, device_index: int) -> None:
+        torch.xpu.set_device(device_index)
+
+    def synchronize(self, device_index: Optional[int] = None) -> None:
+        torch.xpu.synchronize(device_index)
+
+    # ------------------------------------------------------------------
+    # Random number generator
+    # ------------------------------------------------------------------
+
+    def manual_seed(self, seed: int) -> None:
+        torch.xpu.manual_seed(seed)
+
+    def manual_seed_all(self, seed: int) -> None:
+        torch.xpu.manual_seed_all(seed)
+
+    # ------------------------------------------------------------------
+    # Memory management
+    # ------------------------------------------------------------------
+
+    def set_allocator_settings(self, settings: str) -> None:
+        # torch.xpu does not expose an allocator-settings hook yet; no-op.
+        logger.debug("set_allocator_settings is a no-op on Intel GPU: %s", settings)
+
+    def empty_cache(self) -> None:
+        torch.xpu.empty_cache()
+
+    # ------------------------------------------------------------------
+    # Device properties
+    # ------------------------------------------------------------------
+
+    def get_device_capability(self, device_index: int = 0) -> tuple[Optional[int], Optional[int]]:
+        # Intel GPU does not expose a CUDA-style (major, minor) compute capability.
+        return (None, None)
+
+    # ------------------------------------------------------------------
+    # Distributed communication
+    # ------------------------------------------------------------------
+
+    def communication_backend_name(self) -> str:
+        # oneCCL collective backend for Intel GPU.
+        return "xccl"
+
+    def visible_devices_envvar(self) -> str:
+        # bare IDs work; ONEAPI_DEVICE_SELECTOR needs a level_zero: prefix.
+        return "ZE_AFFINITY_MASK"
+
+    # ------------------------------------------------------------------
+    # Ray integration
+    # ------------------------------------------------------------------
+
+    def ray_resource_name(self) -> str:
+        # Ray's IntelGPUAccelerator registers XPU under the "GPU" key, same as CUDA.
+        return "GPU"
+
+    def ray_resource_options(self, num_gpus: float) -> dict[str, Any]:
+        return {"num_gpus": num_gpus}
+
+    def ray_noset_envvars(self) -> list[str]:
+        return ["RAY_EXPERIMENTAL_NOSET_ZE_AFFINITY_MASK"]
+
+    # ------------------------------------------------------------------
+    # IPC support
+    # ------------------------------------------------------------------
+
+    def is_ipc_supported(self) -> bool:
+        # rebuild_ipc() assumes a CUDA 8-element IPC handle tuple (index 6 = device_id).
+        # XPU uses a different SYCL IPC handle format, so the CUDA path would corrupt
+        # data. Fall back to shared memory until XPU IPC handle support is added.
+        return False
+
+    # ------------------------------------------------------------------
+    # Profiling helpers
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def nvtx_range(self, msg: str):
+        # Intel GPU has no NVTX equivalent; log for debugging and yield.
+        logger.debug("NVTX range (no-op on Intel GPU): %s", msg)
+        yield
+
+    def profiler_start(self) -> None:
+        pass
+
+    def profiler_stop(self) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Low-level runtime API
+    # ------------------------------------------------------------------
+
+    def cudart(self) -> Any:
+        return None

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -429,7 +429,15 @@ class SFTTrainer:
                         # average over data parallel group
                         dp_group = self.engine.get_data_parallel_group()
                         if dp_group is not None:
-                            torch.distributed.all_reduce(val_loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
+                            # temporary workaround for XPU devices
+                            # tracked internal, estimate end of 2026 will be able to resolve this issue
+                            if val_loss.device.type == "xpu":
+                                torch.distributed.all_reduce(val_loss, group=dp_group)
+                                val_loss /= torch.distributed.get_world_size(group=dp_group)
+                            else:
+                                torch.distributed.all_reduce(
+                                    val_loss, op=torch.distributed.ReduceOp.AVG, group=dp_group
+                                )
 
                     if is_logging:
                         metric = {"val/loss": val_loss.detach().item()}

--- a/verl/utils/attention_utils.py
+++ b/verl/utils/attention_utils.py
@@ -20,11 +20,12 @@ _index_first_axis, _pad_input, _rearrange, _unpad_input = None, None, None, None
 def _get_attention_functions() -> tuple[Callable, Callable, Callable, Callable]:
     """Dynamically import attention functions based on available hardware."""
 
+    from verl.plugin.platform.platform_manager import get_platform
     from verl.utils.device import is_torch_npu_available
 
     global _index_first_axis, _pad_input, _rearrange, _unpad_input
 
-    if is_torch_npu_available(check_device=False):
+    if is_torch_npu_available(check_device=False) or get_platform().device_name == "xpu":
         from verl.utils.npu_flash_attn_utils import index_first_axis, pad_input, rearrange, unpad_input
     else:
         from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -631,7 +631,7 @@ def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad
         logits_rmpad: [total_nnz, vocab_size]
         response_length: int
     """
-    from flash_attn.bert_padding import pad_input, unpad_input
+    from verl.utils.attention_utils import pad_input, unpad_input
 
     batch_size, seqlen = input_ids.shape
     input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)
@@ -660,10 +660,7 @@ def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batc
         seqlen: int
         response_length: int
     """
-    if get_device_name() == "cuda":
-        from flash_attn.bert_padding import pad_input
-    elif get_device_name() == "npu":
-        from verl.utils.attention_utils import pad_input
+    from verl.utils.attention_utils import pad_input
 
     input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # transpose back to [total_nnz, 1]
     input_ids_rmpad = input_ids_rmpad.squeeze(-1)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1112,7 +1112,7 @@ class EngineTrainModeCtx(BaseEngineCtx):
         super().__exit__(exc_type, exc_value, traceback)
 
 
-@EngineRegistry.register(model_type="language_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
+@EngineRegistry.register(model_type="language_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu", "xpu"])
 class FSDPEngineWithLMHead(FSDPEngine):
     def prepare_model_inputs(self, micro_batch: TensorDict):
         if self.pad_to_length and tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False):
@@ -1559,7 +1559,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
             return loss, output
 
 
-@EngineRegistry.register(model_type="value_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
+@EngineRegistry.register(model_type="value_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu", "xpu"])
 class FSDPEngineWithValueHead(FSDPEngineWithLMHead):
     """
     The only difference between critic and actor is how the raw model output is processed

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -194,7 +194,13 @@ class TrainingWorker(Worker, DistProfilerExtension):
         loss = torch.sum(torch.tensor(output.pop("loss"), device=self.device_name))
         dp_group = self.engine.get_data_parallel_group()
         if dp_group is not None:
-            torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
+            # temporary workaround for XPU devices: use all_reduce with default op and then divide manually
+            # tracked internal, estimate end of 2026 will be able to resolve this issue
+            if loss.device.type == "xpu":
+                torch.distributed.all_reduce(loss, group=dp_group)
+                loss /= torch.distributed.get_world_size(group=dp_group)
+            else:
+                torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
         loss = loss.item()
 
         # For grad_norm, we do not perform all reduce because it is already been done when clipping grad


### PR DESCRIPTION
### What does this PR do?

Adds **Intel GPU (PyTorch XPU)** as a hardware backend for verl, enabling end-to-end **GRPO, PPO, and SFT** training with **FSDP/FSDP2** actors and **vLLM** colocated rollout. Intel GPU is integrated through the existing platform-abstraction layer (the same path used by CUDA / Ascend NPU), so no algorithm or trainer code is forked — device dispatch is resolved generically via the platform registry and `get_device_name()`.

Validated end-to-end on Intel Arc Pro B-series (Battlemage) hardware, single-GPU through multi-GPU.

### Checklist Before Starting

- [x] Search for similar PRs. No existing PR adds Intel GPU / `torch.xpu` support.
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[hardware, fsdp, vllm] feat: add Intel GPU (XPU) support`.

### Test

CI cannot cover this change: **Intel GPU hardware is not available in GitHub Actions.** Validated manually with Qwen2.5-0.5B-Instruct on GSM8K. Repro scripts are added under `tests/special_intel_gpu/`.

| Workload | Topology | Result |
|----------|----------|--------|
| GRPO | 1 GPU | ✅ pass (step metrics; rollout↔actor pearson ≈ 0.999) |
| GRPO | 2 GPU | ✅ pass |
| GRPO | 4 GPU | ✅ pass |
| PPO  | 2 GPU (pass `NUM_GPUS=2`; script default is 4) | ✅ pass |
| SFT  | 2 GPU (pass `NUM_GPUS=2`; script default is 4) | ✅ pass |

Commands:

```bash
NUM_GPUS=2 bash tests/special_intel_gpu/run_grpo_intel_gpu.sh
NUM_GPUS=2 bash tests/special_intel_gpu/run_ppo_intel_gpu.sh
NUM_GPUS=2 bash tests/special_intel_gpu/run_sft_intel_gpu.sh
bash tests/special_intel_gpu/run_grpo_colocate_rm_intel_gpu.sh
bash tests/special_intel_gpu/run_standalone_gen_intel_gpu.sh
```

### API and Usage Example

No public API or CLI changes. Intel GPU is selected automatically when `torch.xpu` is available; existing recipes run unmodified with `trainer.device=xpu`.

```bash
# Build the image (Intel Deep Learning Essentials 2026.1.0 base, torch 2.13.0+xpu,
# vLLM v0.27.0, compute-runtime 26.18, triton-xpu 3.7.1)
docker build -f docker/intel_gpu/Dockerfile.intel_gpu -t verl-intel-gpu .

# Launch the container
RENDER_GID=$(getent group render | cut -d: -f3)
VIDEO_GID=$(getent group video | cut -d: -f3)

docker run -it --rm \
  --device /dev/dri \
  --group-add ${RENDER_GID} \
  --group-add ${VIDEO_GID} \
  -v /dev/dri/by-path:/dev/dri/by-path \
  --ipc=host \
  --shm-size 16g \
  -v $HOME/data:/root/data \
  -v $HOME/.cache:/root/.cache \
  -w /workspace/verl \
  verl-intel-gpu:latest \
  /bin/bash

# Run a colocated 2-GPU GRPO job (inside the container)
NUM_GPUS=2 bash tests/special_intel_gpu/run_grpo_intel_gpu.sh
```

### Design & Code Changes

Intel GPU plugs into the platform abstraction rather than adding device branches across the codebase.

**Platform backend (new)**
- `verl/plugin/platform/platform_xpu.py` — `PlatformXPU`: `torch.xpu` device management, `xccl` (oneCCL) collective backend via `communication_backend_name()`, `ZE_AFFINITY_MASK` device masking, Ray `"GPU"` resource mapping, and IPC disabled (falls back to shared memory pending SYCL IPC-handle support).
- `verl/plugin/platform/platform_manager.py` — register the `intel` platform.

**ReduceOp.AVG workaround**
- `verl/workers/engine_workers.py` and `verl/trainer/sft_trainer.py` — `ReduceOp.AVG` is not supported by oneCCL on the OFI scheduler path; replaced with explicit `ReduceOp.SUM` followed by manual division for XPU devices. Tracked; expected to be resolved in an end-of-year PyTorch release.

**Engine registration**
- `verl/workers/engine/fsdp/transformer_impl.py` — add `"xpu"` to the `device=` list for both `FSDPEngineWithLMHead` and `FSDPEngineWithValueHead` registry decorators.

**Device-agnostic dispatch**
- `verl/utils/attention_utils.py` — XPU is routed through the existing NPU flash-attention shim (pure-PyTorch impl) via `get_platform().device_name == "xpu"`, removing the prior cuda/npu-only branch.
- `verl/utils/torch_functional.py` — `log_probs_from_logits_response_rmpad` and `log_probs_from_logits_all_rmpad` now import padding helpers from `verl.utils.attention_utils` unconditionally, replacing the hardcoded per-device import chain.
- `tests/models/test_transformer.py`, `tests/models/test_transformers_ulysses.py` — same fix: import from `verl.utils.attention_utils` unconditionally instead of branching on `cuda`/`npu`.
- `tests/special_standalone/test_memory_buffers.py` — replaced hardcoded `torch.cuda` / `.cuda()` calls with `get_device_name()` / `get_torch_device()` so the test runs on any device.

**Test coverage**
- `tests/plugin/test_platform_abstraction.py` — extend auto-detection assertion to include `"intel"`.

**Infra, docs, tests (new)**
- `docker/intel_gpu/Dockerfile.intel_gpu` + `README.md`, `requirements-intel-gpu.txt`.
- `docs/intel_gpu_tutorial/intel_gpu_quick_start.rst`, `intel_gpu_build_dockerfile_page.rst` + `docs/index.rst`.
- `tests/special_intel_gpu/run_grpo_intel_gpu.sh`, `run_ppo_intel_gpu.sh`, `run_sft_intel_gpu.sh`, `run_grpo_colocate_rm_intel_gpu.sh`, `run_standalone_gen_intel_gpu.sh`.

**Scope / limitations**
- Rollout is validated in **colocated** mode (train + generate share GPUs). Disaggregated / non-colocated rollout is out of scope for this PR and work in progress to provide it.
- XPU IPC falls back to shared memory pending SYCL IPC-handle support, expected to be released by end of 2026.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
   Intel GPU hardware is not available in GitHub Actions; manual validation scripts are provided under `tests/special_intel_gpu/`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
