### PR TITLE
[megatron] fix: Modify the VLM attention mask shape in TND format for NPU

### DIFF
--- a/examples/grpo_trainer/run_qwen3_5_35b_megatron.sh
+++ b/examples/grpo_trainer/run_qwen3_5_35b_megatron.sh
@@ -41,7 +41,6 @@
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 export VLLM_USE_V1=1
 export VLLM_ALLREDUCE_USE_SYMM_MEM=0
-
 set -xeuo pipefail
 
 ########################### Quick Config ###########################
@@ -193,14 +192,27 @@ case "${DEVICE}" in
     npu)
         export CPU_AFFINITY_CONF=1
         ACTOR+=(
+            actor_rollout_ref.actor.use_dynamic_bsz=True
             actor_rollout_ref.actor.megatron.vanilla_mbridge=False
             actor_rollout_ref.actor.checkpoint.strict=False
+            actor_rollout_ref.actor.megatron.use_remove_padding=True
             +actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn=True
             +actor_rollout_ref.actor.megatron.override_transformer_config.moe_token_dispatcher_type=alltoall
             +actor_rollout_ref.actor.megatron.override_transformer_config.use_naive_l2norm=True
+
+            +actor_rollout_ref.actor.megatron.override_transformer_config.use_triton_gdn=False
+            +actor_rollout_ref.actor.megatron.override_transformer_config.use_ascend_gdn=True
         )
         ROLLOUT+=(
+            actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True
+            actor_rollout_ref.rollout.gpu_memory_utilization=0.65
             +actor_rollout_ref.rollout.engine_kwargs.vllm.mm_processor_cache_gb=0
+        )
+        MODEL+=(
+            actor_rollout_ref.model.use_remove_padding=True
+        )
+        REF+=(
+            actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True
         )
         ;;
     *)

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -849,17 +849,13 @@ def postprocess_bshd_engine(
 
 
 def build_vlm_attn_mask_thd(input_ids: torch.Tensor, pad_token_id: int = None):
-    input_ids_rmpad = input_ids.to_padded_tensor(pad_token_id)
-
-    if is_npu_available:
-        return input_ids_rmpad, None
-
+    input_ids_with_pad = input_ids.to_padded_tensor(pad_token_id)
     seqlens_in_batch = input_ids.offsets().diff()
-    attention_mask = torch.zeros_like(input_ids_rmpad, dtype=torch.bool)
+    attention_mask = torch.zeros_like(input_ids_with_pad, dtype=torch.bool)
     for i, seqlen in enumerate(seqlens_in_batch):
         attention_mask[i, :seqlen] = True
 
-    return input_ids_rmpad, attention_mask
+    return input_ids_with_pad, attention_mask
 
 
 def build_vlm_attn_mask_bshd(


### PR DESCRIPTION
### What does this PR do?

- After the use_remove_padding option is enabled for a model with vision_model, the construction mode of the VLM attention mask is modified.
- This issue occurs because when the qwen3.5 vl model uses the mindspeed bridge backend, the GND module needs to identify the padding attention mask. If the returned attention mask is None, the padding information is discarded, and the padding part is also considered as a valid part during subsequent construction of the attention mask. Similarly, the megatron bridge is the same. The VLM attention mask needs to be restored to the [B,S] format, which is also necessary for subsequent processing logic. This is because VLM needs to identify the special markers of each sample, such as "image," in the [B,S] format. Therefore, analyzing the subsequent processing logic, it is reasonable to remove the early return here.
- In addition, the variable name input_ids_rmpad is ambiguous and should be expressed as a variable with pad.
- Updates the Qwen3.5 Megatron NPU example with the required dependencies and enables dynamic batching, remove-padding, and Ascend GDN configurations.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
