### PR TITLE
[megatron] fix: per-name, mapper-aware .base_layer strip in resolve_weight_name

### DIFF
--- a/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
+++ b/tests/utils/test_vllm_weight_name_normalization_on_cpu.py
@@ -272,6 +272,76 @@ def test_vision_merger_base_layer_is_stripped():
 
 
 # ---------------------------------------------------------------------------
+# Mixed LoRA model: language layers are LoRA-wrapped (have .base_layer), but
+# the vision merger is a plain linear (no base_layer child). On vLLM 0.26.0
+# the suffix must be stripped ONLY for the merger, not kept model-wide.
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_model_vision_merger_strips_on_released_vllm():
+    """vLLM 0.26.0 (_HAS_LORA_LOAD_WEIGHTS=False) with a mixed model: the
+    vision merger's ``.base_layer.`` is stripped (no real base_layer child),
+    while a coexisting LoRA-wrapped language leaf keeps the suffix."""
+    # _HAS_LORA_LOAD_WEIGHTS defaults to False here (stub base layer), matching
+    # vLLM 0.26.0.
+    model = _FakeModel(
+        {
+            "merger.linear_fc1.weight": torch.empty(0),
+            "merger.linear_fc1.bias": torch.empty(0),
+            "language_model.model.layers.0.self_attn.q_proj.base_layer.weight": torch.empty(0),
+        }
+    )
+    worker = _make_worker(model)
+
+    assert _resolve(worker, model, "merger.linear_fc1.base_layer.weight") == "merger.linear_fc1.weight"
+    assert _resolve(worker, model, "merger.linear_fc1.base_layer.bias") == "merger.linear_fc1.bias"
+    # The language leaf keeps .base_layer on vLLM 0.26.0.
+    name = "language_model.model.layers.0.self_attn.q_proj.base_layer.weight"
+    assert _resolve(worker, model, name) == name
+
+
+def test_mixed_model_with_prefix_rewriting_mapper():
+    """The Qwen3.5-VL regression: the Bridge exports language params under
+    ``model.language_model.`` and the merger under ``model.visual.``, while the
+    live vLLM namespace is ``language_model.model.`` / ``visual.``. vLLM's
+    ``hf_to_vllm_mapper`` rewrites the prefixes (``orig_to_new_prefix``).
+
+    The parent-has-base-layer check must consult the *mapper-rewritten* name --
+    otherwise the LoRA-wrapped language leaf's real ``base_layer`` is invisible
+    under the Bridge prefix and gets wrongly stripped, crashing
+    ``AutoWeightsLoader`` (it then can't find ``layers.0.mlp.gate.weight``
+    inside ``Qwen3_5Model``)."""
+    mapper = _FakeMapper(
+        {
+            # substring replacements approximating WeightsMapper orig_to_new_prefix
+            "model.visual.": "visual.",
+            "model.language_model.": "language_model.model.",
+        }
+    )
+    model = _FakeModel(
+        {
+            "language_model.model.layers.0.mlp.gate.base_layer.weight": torch.empty(0),
+            "visual.merger.linear_fc1.weight": torch.empty(0),
+            "visual.merger.linear_fc1.bias": torch.empty(0),
+        },
+        mapper=mapper,
+    )
+    worker = _make_worker(model)
+
+    # Language leaf: incoming Bridge prefix differs from vLLM's; the real
+    # base_layer child exists under the rewritten prefix -> KEEP the suffix.
+    name = "model.language_model.layers.0.mlp.gate.base_layer.weight"
+    assert _resolve(worker, model, name) == name
+    # Merger: no base_layer child under either prefix -> STRIP.
+    assert _resolve(worker, model, "model.visual.merger.linear_fc1.base_layer.weight") == (
+        "model.visual.merger.linear_fc1.weight"
+    )
+    assert _resolve(worker, model, "model.visual.merger.linear_fc1.base_layer.bias") == (
+        "model.visual.merger.linear_fc1.bias"
+    )
+
+
+# ---------------------------------------------------------------------------
 # LoRA-wrapped language params KEEP .base_layer (the suffix is real there).
 # ---------------------------------------------------------------------------
 

--- a/verl/utils/vllm/utils.py
+++ b/verl/utils/vllm/utils.py
@@ -194,20 +194,20 @@ def resolve_weight_name(model, name: str, model_weight_names: set[str]) -> str:
                             return True
         return False
 
-    # Strip ``.base_layer.``:
-    # - On models with NO ``.base_layer.`` params at all (auxiliary models like
-    #   the MTP drafter, or non-LoRA-wrapped modules such as the Qwen3.5-VL vision
-    #   merger): strip unconditionally -- there is no ``base_layer`` child to
-    #   recurse into on any vLLM version, so the inner name is the only one that
-    #   could match.
-    # - On LoRA-wrapped models (which DO have ``.base_layer.`` params): strip only
-    #   on newer vLLM, where ``BaseLayerWithLoRA.load_weights`` delegates to
-    #   ``AutoWeightsLoader(base_layer)`` expecting inner names. On released vLLM
-    #   keep the suffix (the loader recurses into ``base_layer`` and matches it)
-    #   and fall through to the leaf-add path below.
+    # Strip ``.base_layer.``: the check is *per-name*, not model-wide. A mixed
+    # model (e.g. Qwen3.5-VL with LoRA) has ``.base_layer.`` params on the
+    # LoRA-wrapped language layers but NOT on the vision merger. The suffix
+    # must be stripped when this name's ``base_layer`` isn't a real child, and
+    # kept on released vLLM when it is (the loader recurses into ``base_layer``);
+    # ``_exists`` consults the mapper's prefix rewrites so a Bridge-exported
+    # prefix (``model.language_model.``) is reconciled against the live vLLM
+    # namespace (``language_model.model.``) before checking.
     if ".base_layer." in name:
-        model_has_base_layer = any(".base_layer." in n for n in model_weight_names)
-        if not model_has_base_layer or _HAS_LORA_LOAD_WEIGHTS:
+        parent, _, _ = name.partition(".base_layer.")
+        parent_has_base_layer = _exists(parent + ".base_layer.weight") or any(
+            n.startswith(parent + ".base_layer.") for n in model_weight_names
+        )
+        if not parent_has_base_layer or _HAS_LORA_LOAD_WEIGHTS:
             return name.replace(".base_layer.", ".", 1)
 
     if _exists(name):

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -778,11 +778,11 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         # 3. sync weights: For SGLang, we need base first (when needed), then adapter/merged
         if do_lora_base_sync:
-            per_tensor_param_base, peft_config = self.actor.engine.get_per_tensor_param(
+            per_tensor_param_base, _base_peft_config = self.actor.engine.get_per_tensor_param(
                 layered_summon=self.layered_summon, base_sync_done=False
             )
             await self.rollout.update_weights(
-                per_tensor_param_base, peft_config=peft_config, base_sync_done=False, global_steps=global_steps
+                per_tensor_param_base, peft_config=_base_peft_config, base_sync_done=False, global_steps=global_steps
             )
 
         await self.rollout.update_weights(


### PR DESCRIPTION
### What does this PR do?

Fixes the `.base_layer` weight-name reconciliation in `resolve_weight_name` (`verl/utils/vllm/utils.py`) that crashed Qwen3.5-VL LoRA training at Megatron→vLLM weight sync

On vLLM 0.26.0, `_HAS_LORA_LOAD_WEIGHTS = False` — LoRA linear layers (`ReplicatedLinearWithLoRA`, etc.) define no `load_weights`, so vLLM's `AutoWeightsLoader` recurses into a real `base_layer` child. Correct `.base_layer.` handling is therefore load-bearing: the suffix must be *stripped* for non-LoRA-wrapped leaves (no `base_layer` child) and *kept* for LoRA-wrapped leaves (which do have one).

Bug 1 — `merger.linear_fc1.base_layer` ValueError

  `resolve_weight_name` used a **model-wide** check to decide the strip:
  `any(".base_layer." in n for n in model_weight_names)`. On a mixed LoRA model like
  Qwen3.5-VL, the language layers do have `.base_layer.` params, but the vision
  `merger.linear_fc1` is a plain `ColumnParallelLinear` with no `base_layer` child. The
  model-wide check saw the language layers, refused to strip the merger's bogus
  `.base_layer.`, and `AutoWeightsLoader` crashed (`merger.linear_fc1.base_layer.weight`
  matched no parameter).

  **Fix**: make the check **per-name** — `parent_has_base_layer` checks whether *this
  specific* name's parent has a real `base_layer` child, not whether the model has any.

Bug 2 — `layers.0.mlp.gate.weight` ValueError

  The naive per-name fix caused the *opposite* crash: LoRA-wrapped language leaves
  (e.g. `layers.0.mlp.gate`) must **keep** their real `.base_layer.`, but the
  Bridge-exported prefix (`model.language_model.layers...`) differs from vLLM's live
  namespace (`language_model.model.layers...`). vLLM's `hf_to_vllm_mapper` rewrites the
  prefix via `orig_to_new_prefix` during `load_weights`, but the per-name check queried
  the *pre-rewrite* namespace — so it missed the real `base_layer` child, stripped the
  suffix, and crashed.

  **Fix**: `parent_has_base_layer` now calls `_exists()` (which consults the mapper's
  prefix/substr rewrites) to reconcile the Bridge-exported prefix against the live vLLM

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
