### PR TITLE
[ci, hardware] fix: stabilize ROCm PPO trainer CI

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
@@ -92,7 +92,8 @@ jobs:
     runs-on: [rocm-mi300]
     timeout-minutes: 60 # Increase this timeout value as needed
     container:
-      image: "verlai/verl:rocm702-vllm020-te210-20260518"
+      # built from https://github.com/mingjielu/Training-dockerfile/blob/main/ubuntu/rocm7.14_verl_0810_py312/Dockerfile
+      image: "verlai/verl:rocm7.14_torch2.12_release_0724"
       options: >-
         --device /dev/kfd
         --device /dev/dri
@@ -111,6 +112,8 @@ jobs:
       # /root and the verl scripts reference $HOME, so pin HOME back to /root to
       # match the local `docker run` behavior and the volume mounts above.
       HOME: "/root"
+      # currently custom all reduce has some bugs on ROCM, disable it for verl CI on rocm
+      VLLM_ROCM_OVERRIDE: "+actor_rollout_ref.rollout.engine_kwargs.vllm.disable_custom_all_reduce=True"
     steps:
       - name: Check ROCm and GPU info
         run: |
@@ -139,11 +142,11 @@ jobs:
       - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm with validation and saving (FSDP_SIZE=8)
         run: |
           ray stop --force
-          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh "${VLLM_ROCM_OVERRIDE}"
       - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm after resuming
         run: |
           ray stop --force
-          RESUME_MODE=auto VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+          RESUME_MODE=auto VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh "${VLLM_ROCM_OVERRIDE}"
       - name: Test merging FSDP checkpoints (Qwen Actor)
         run: |
           exp_name="qwen2.5-0.5b-function-reward-minimal-fsdp-size8"
@@ -151,7 +154,7 @@ jobs:
       - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm with validation and saving (DDP_SIZE=2, FSDP_SIZE=4)
         run: |
           ray stop --force
-          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True FSDP_SIZE=4 USE_KL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-ddp-size2-fsdp-size4" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True FSDP_SIZE=4 USE_KL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-ddp-size2-fsdp-size4" bash tests/special_e2e/ppo_trainer/run_function_reward.sh "${VLLM_ROCM_OVERRIDE}"
       - name: Test merging DDP+FSDP checkpoints (Qwen Actor)
         run: |
           exp_name="qwen2.5-0.5b-function-reward-minimal-ddp-size2-fsdp-size4"
@@ -159,7 +162,7 @@ jobs:
       - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm with validation and saving (FSDP2)
         run: |
           ray stop --force
-          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp2-size8" STRATEGY=fsdp2 bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp2-size8" STRATEGY=fsdp2 bash tests/special_e2e/ppo_trainer/run_function_reward.sh "${VLLM_ROCM_OVERRIDE}"
       - name: Test merging FSDP2 checkpoints (Qwen Actor)
         run: |
           exp_name="qwen2.5-0.5b-function-reward-minimal-fsdp2-size8"
@@ -167,11 +170,11 @@ jobs:
       - name: Running GSM8K E2E without rmpad using function rm
         run: |
           ray stop --force
-          RM_PAD=False bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+          RM_PAD=False bash tests/special_e2e/ppo_trainer/run_function_reward.sh "${VLLM_ROCM_OVERRIDE}"
       - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm (GRPO)
         run: |
           ray stop --force
-          CUSTOM_REWARD_FN=True ADV_ESTIMATOR=grpo USE_KL=True bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+          CUSTOM_REWARD_FN=True ADV_ESTIMATOR=grpo USE_KL=True bash tests/special_e2e/ppo_trainer/run_function_reward.sh "${VLLM_ROCM_OVERRIDE}"
       - name: Clean up
         run: |
           rm -rf checkpoints
@@ -181,7 +184,7 @@ jobs:
     runs-on: [rocm-mi300]
     timeout-minutes: 60 # Increase this timeout value as needed
     container:
-      image: "verlai/verl:rocm702-vllm020-te210-20260518"
+      image: "verlai/verl:rocm7.14_torch2.12_release_0724"
       options: >-
         --device /dev/kfd
         --device /dev/dri
@@ -197,6 +200,7 @@ jobs:
     env:
       HF_HUB_ENABLE_HF_TRANSFER: "0"
       HOME: "/root"
+      VLLM_ROCM_OVERRIDE: "+actor_rollout_ref.rollout.engine_kwargs.vllm.disable_custom_all_reduce=True"
     steps:
       - name: Check ROCm and GPU info
         run: |
@@ -214,10 +218,6 @@ jobs:
         run: |
           pip install --no-deps -e .
           pip install --no-deps TransferQueue==0.1.8
-          pip uninstall -y mbridge
-          pip install git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@e2cfe7e --ignore-requires-python --no-deps --no-build-isolation
-          pip install git+https://github.com/NVIDIA/Megatron-LM.git@0823c73 --ignore-requires-python --no-deps --no-build-isolation
-          pip install "nvidia-modelopt>=0.37.0"
       - name: Check final pip list
         run: |
           pip list
@@ -235,7 +235,7 @@ jobs:
           COMMON_PP=2 COMMON_VPP=null COMMON_CP=1 COMMON_TP=4 COMMON_EP=4 COMMON_ETP=1 INFER_TP=8 \
           USE_DIST_CKPT=False ALL_OFFLOAD=True SKIP_SAVE_HF_MODEL=1 \
           bash tests/special_e2e/run_ppo_trainer_megatron.sh \
-          global_profiler.tool=null actor_rollout_ref.actor.profiler.tool=null actor_rollout_ref.ref.profiler.tool=null actor_rollout_ref.rollout.profiler.tool=null critic.profiler.tool=null
+          global_profiler.tool=null actor_rollout_ref.actor.profiler.tool=null actor_rollout_ref.ref.profiler.tool=null actor_rollout_ref.rollout.profiler.tool=null critic.profiler.tool=null "${VLLM_ROCM_OVERRIDE}"
       - name: Running GSM8K E2E training tests with 3D parallelism with FP8 rollout on 8 MI300 GPUs with Megatron-Bridge (Qwen3-30B-A3B-Instruct-2507)
         run: |
           ray stop --force
@@ -246,7 +246,7 @@ jobs:
           COMMON_PP=2 COMMON_VPP=null COMMON_CP=1 COMMON_TP=4 COMMON_EP=4 COMMON_ETP=1 INFER_TP=2 \
           USE_DIST_CKPT=False ALL_OFFLOAD=True SKIP_SAVE_HF_MODEL=1 ROLLOUT_QUANTIZATION=fp8 \
           bash tests/special_e2e/run_ppo_trainer_megatron.sh \
-          global_profiler.tool=null actor_rollout_ref.actor.profiler.tool=null actor_rollout_ref.ref.profiler.tool=null actor_rollout_ref.rollout.profiler.tool=null critic.profiler.tool=null
+          global_profiler.tool=null actor_rollout_ref.actor.profiler.tool=null actor_rollout_ref.ref.profiler.tool=null actor_rollout_ref.rollout.profiler.tool=null critic.profiler.tool=null "${VLLM_ROCM_OVERRIDE}"
       - name: clean up
         run: |
           rm -rf checkpoints
@@ -258,7 +258,7 @@ jobs:
     if: ${{ always() && github.repository_owner == 'verl-project' }}
     runs-on: [rocm-mi300]
     container:
-      image: "verlai/verl:rocm702-vllm020-te210-20260518"
+      image: "verlai/verl:rocm7.14_torch2.12_release_0724"
     steps:
       - name: Clean up leftover checkpoints
         run: |


### PR DESCRIPTION
### What does this PR do?

Updates the ROCm PPO trainer workflow to use the ROCm 7.14 image, rely on the Megatron dependencies bundled in that image, and disable vLLM custom all-reduce for the affected ROCm jobs.

This does not duplicate an existing PR: searches for [ROCm vLLM custom all-reduce](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ROCm+vLLM+custom+all+reduce), [`disable_custom_all_reduce` on ROCm](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+disable_custom_all_reduce+ROCm), and the [workflow filename](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+e2e_ppo_trainer_megatron_vllm_rocm) found no open PR addressing this fix.

AI assistance was used to analyze the failure and prepare the commit and PR metadata. The human submitter implemented and validated the ROCm CI changes and is responsible for reviewing every changed line and defending the change end-to-end.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [ROCm vLLM custom all-reduce](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ROCm+vLLM+custom+all+reduce), [`disable_custom_all_reduce` on ROCm](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+disable_custom_all_reduce+ROCm), [workflow filename](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+e2e_ppo_trainer_megatron_vllm_rocm)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `.venv/bin/pre-commit run --all-files --show-diff-on-failure --color=always` — all hooks passed.
- The affected ROCm CI workflow was validated by the human submitter.

### API and Usage Example

No API changes.

### Design & Code Changes

- Upgrade all jobs in the workflow to `verlai/verl:rocm7.14_torch2.12_release_0724`.
- Remove runtime Megatron package replacement because the updated image provides the required versions.
- Define one quoted Hydra override per training job and pass it to every vLLM training invocation to disable custom all-reduce on ROCm.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `.venv/bin/pre-commit run --all-files --show-diff-on-failure --color=always`.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed because this change only updates an internal CI workflow.
- [x] Add or update an end-to-end test in the CI workflow. This PR directly updates the affected ROCm E2E workflow, which the human submitter validated.
- [ ] Once this PR is ready for CI, request CI in the verl community channel.
- [ ] Recipe submodule update. Not applicable because this PR does not modify `recipe`.
