### PR TITLE
[megatron] fix: avoid duplicate training hook registration with VPP

### DIFF
--- a/tests/utils/megatron/test_training_hooks_on_cpu.py
+++ b/tests/utils/megatron/test_training_hooks_on_cpu.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for Megatron training hook registration."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from verl.utils import megatron_utils
+
+
+class _FakeDDP:
+    def __init__(self, config, *, overlap_grad_reduce=True, align_param_gather=True):
+        self.config = config
+        self.ddp_config = SimpleNamespace(
+            overlap_grad_reduce=overlap_grad_reduce,
+            align_param_gather=align_param_gather,
+        )
+
+    def no_sync(self):
+        pass
+
+    def start_grad_sync(self):
+        pass
+
+    def start_param_sync(self):
+        pass
+
+
+@pytest.fixture
+def patch_megatron(monkeypatch):
+    finalize_model_grads = Mock(name="finalize_model_grads")
+    get_model_config = Mock(side_effect=lambda chunk: chunk.config)
+    monkeypatch.setattr(megatron_utils, "DDP", _FakeDDP)
+    monkeypatch.setattr("megatron.core.distributed.finalize_model_grads", finalize_model_grads)
+    monkeypatch.setattr("megatron.core.utils.get_model_config", get_model_config)
+    return SimpleNamespace(
+        finalize_model_grads=finalize_model_grads,
+        get_model_config=get_model_config,
+    )
+
+
+def _new_config():
+    return SimpleNamespace(
+        grad_scale_func=None,
+        finalize_model_grads_func=None,
+        no_sync_func=None,
+        grad_sync_func=None,
+        param_sync_func=None,
+    )
+
+
+def _assert_hooks_match_chunks(hooks, chunks):
+    assert len(hooks) == len(chunks)
+    assert all(hook.__self__ is chunk for hook, chunk in zip(hooks, chunks, strict=True))
+
+
+def test_register_training_hooks_once_for_shared_vpp_config(patch_megatron):
+    config = _new_config()
+    chunks = [_FakeDDP(config) for _ in range(3)]
+    scale_loss = object()
+    optimizer = SimpleNamespace(
+        scale_loss=scale_loss,
+        config=SimpleNamespace(overlap_param_gather=True),
+    )
+
+    megatron_utils.register_megatron_training_hooks(chunks, optimizer)
+
+    assert config.grad_scale_func is scale_loss
+    assert config.finalize_model_grads_func is patch_megatron.finalize_model_grads
+    patch_megatron.get_model_config.assert_called_once_with(chunks[0])
+    _assert_hooks_match_chunks(config.no_sync_func, chunks)
+    _assert_hooks_match_chunks(config.grad_sync_func, chunks)
+    _assert_hooks_match_chunks(config.param_sync_func, chunks)
+
+
+def test_register_training_hooks_uses_callables_without_vpp(patch_megatron):
+    config = _new_config()
+    chunk = _FakeDDP(config)
+    optimizer = SimpleNamespace(
+        scale_loss=object(),
+        config=SimpleNamespace(overlap_param_gather=True),
+    )
+
+    megatron_utils.register_megatron_training_hooks([chunk], optimizer)
+
+    assert callable(config.no_sync_func)
+    assert callable(config.grad_sync_func)
+    assert callable(config.param_sync_func)
+    assert config.no_sync_func.__self__ is chunk
+    assert config.grad_sync_func.__self__ is chunk
+    assert config.param_sync_func.__self__ is chunk

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -1685,33 +1685,34 @@ def register_megatron_training_hooks(model: list[torch.nn.Module], optimizer):
     except ImportError:
         megatron_FSDP = DDP
 
-    # register some callbacks for megatron training, following https://github.com/NVIDIA/Megatron-LM/blob/core_v0.15.0rc7/megatron/training/training.py#L2039-L2057
-    for one_model in model:
-        config = get_model_config(one_model)
-        config.grad_scale_func = optimizer.scale_loss
-        config.finalize_model_grads_func = finalize_model_grads
+    # Register callbacks once on the config shared by all virtual-pipeline
+    # chunks, matching Megatron's training loop. Registering once per chunk
+    # sets the shared no_sync_func on the first chunk and fails on the next.
+    config = get_model_config(model[0])
+    config.grad_scale_func = optimizer.scale_loss
+    config.finalize_model_grads_func = finalize_model_grads
 
-        overlap_param_gather = getattr(optimizer.config, "overlap_param_gather", False)
-        overlap_grad_reduce = getattr(one_model.ddp_config, "overlap_grad_reduce", False)
-        align_grad_reduce = True  # default to True, seldom to be false
-        align_param_gather = getattr(one_model.ddp_config, "align_param_gather", False)
+    overlap_param_gather = getattr(optimizer.config, "overlap_param_gather", False)
+    overlap_grad_reduce = getattr(model[0].ddp_config, "overlap_grad_reduce", False)
+    align_grad_reduce = True  # default to True, seldom to be false
+    align_param_gather = getattr(model[0].ddp_config, "align_param_gather", False)
 
-        if isinstance(model[0], megatron_FSDP | DDP) and overlap_grad_reduce:
-            assert config.no_sync_func is None, (
-                "When overlap_grad_reduce is True, config.no_sync_func must be None; "
-                "a custom no_sync_func is not supported when overlapping grad-reduce"
-            )
-            config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
+    if isinstance(model[0], megatron_FSDP | DDP) and overlap_grad_reduce:
+        assert config.no_sync_func is None, (
+            "When overlap_grad_reduce is True, config.no_sync_func must be None; "
+            "a custom no_sync_func is not supported when overlapping grad-reduce"
+        )
+        config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
+        if len(model) == 1:
+            config.no_sync_func = config.no_sync_func[0]
+        if align_grad_reduce:
+            config.grad_sync_func = [model_chunk.start_grad_sync for model_chunk in model]
             if len(model) == 1:
-                config.no_sync_func = config.no_sync_func[0]
-            if align_grad_reduce:
-                config.grad_sync_func = [model_chunk.start_grad_sync for model_chunk in model]
-                if len(model) == 1:
-                    config.grad_sync_func = config.grad_sync_func[0]
-        if overlap_param_gather and align_param_gather:
-            config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
-            if len(model) == 1:
-                config.param_sync_func = config.param_sync_func[0]
+                config.grad_sync_func = config.grad_sync_func[0]
+    if overlap_param_gather and align_param_gather:
+        config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
+        if len(model) == 1:
+            config.param_sync_func = config.param_sync_func[0]
 
 
 def mapping_string_to_attn_backend(args: dict) -> dict:


### PR DESCRIPTION
### What does this PR do?

Fixes Megatron initialization when virtual pipeline parallelism (VPP) and `overlap_grad_reduce` are enabled together.

VPP model chunks share one `TransformerConfig`. The existing implementation registers the same training hooks once per chunk: the first iteration sets `config.no_sync_func`, and the next iteration fails with:

```text
AssertionError: When overlap_grad_reduce is True, config.no_sync_func must be None
```

This PR registers the hooks once on the shared config from `model[0]`, matching [Megatron's training loop](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/training/training.py#L3646-L3666). The hooks still contain callbacks for every VPP chunk, while the single-chunk behavior remains unchanged.

### Checklist Before Starting

- [x] Searched for similar PRs and found no duplicate: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%28register_megatron_training_hooks+OR+no_sync_func+OR+%22overlap_grad_reduce%22+VPP%29
- [x] PR title follows the required format: `[megatron] fix: avoid duplicate training hook registration with VPP`

### Test

Added CPU regression tests covering:

- Three VPP chunks sharing one `TransformerConfig`.
- Correct `no_sync_func`, `grad_sync_func`, and `param_sync_func` callback lists.
- The existing single-chunk callable behavior.

Commands:

```bash
pytest -s -x --asyncio-mode=auto \
  tests/utils/megatron/test_training_hooks_on_cpu.py

python3 tests/special_sanity/validate_structure.py
```

The structure check and Python compilation check pass locally. The full pytest test requires the standard verl CI environment with PyTorch and Megatron installed.

### API and Usage Example

No API or configuration changes.

Existing configurations using VPP and gradient-reduce overlap can now initialize correctly:

```yaml
virtual_pipeline_model_parallel_size: 3
override_ddp_config:
  overlap_grad_reduce: true
```

### Design & Code Changes

- Register Megatron training hooks once using the config associated with `model[0]`.
- Preserve one callback per VPP chunk in the hook lists.
- Preserve scalar callbacks when the model has only one chunk.
- Add CPU regression tests for both VPP and non-VPP cases.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [ ] Run the complete pre-commit checks:
  `pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Documentation is not required because this is an internal bug fix with no user-facing API or configuration changes.
- [x] Added a CPU unit test. The existing CPU workflow automatically collects files matching `*_on_cpu.py`, so no workflow change is required.
- [ ] Request CI after the PR is ready for review.
- [x] No recipe submodule changes.

AI assistance was used during debugging and implementation. I reviewed the final changes and take responsibility for the submitted code.