### PR TITLE
[rollout, vllm, sglang] fix: fail fast when a rollout server actor is unschedulable

### DIFF
--- a/tests/workers/rollout/test_rollout_server_schedule_guard_on_cpu.py
+++ b/tests/workers/rollout/test_rollout_server_schedule_guard_on_cpu.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fail-fast guard for unschedulable rollout server actors.
+
+A colocated rollout server actor is hard-pinned to its training worker's node; when that
+node has no free slot the actor stays PENDING_CREATION and the following ``.remote()`` call
+would block forever. ``wait_rollout_servers_scheduled`` bounds that wait.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from verl.workers.rollout import replica
+
+
+def _fake_server(hex_id: str):
+    return SimpleNamespace(_actor_id=SimpleNamespace(hex=lambda: hex_id))
+
+
+@pytest.mark.asyncio
+async def test_returns_once_actor_is_alive(monkeypatch):
+    monkeypatch.setattr(replica, "get_actor", lambda _id: {"state": "ALIVE"})
+    await replica.wait_rollout_servers_scheduled([_fake_server("a")], timeout_s=5.0, poll_interval_s=0.01)
+
+
+@pytest.mark.asyncio
+async def test_waits_through_transient_pending(monkeypatch):
+    states = iter(["PENDING_CREATION", "PENDING_CREATION", "ALIVE"])
+    monkeypatch.setattr(replica, "get_actor", lambda _id: {"state": next(states)})
+    await replica.wait_rollout_servers_scheduled([_fake_server("a")], timeout_s=5.0, poll_interval_s=0.01)
+
+
+@pytest.mark.asyncio
+async def test_raises_with_diagnostic_when_unschedulable(monkeypatch):
+    info = {
+        "name": "vllm_server_0_0",
+        "state": "PENDING_CREATION",
+        "node_id": "node0",
+        "required_resources": {"GPU": 1.0},
+        "actor_id": "a",
+    }
+    monkeypatch.setattr(replica, "get_actor", lambda _id: info)
+    with pytest.raises(RuntimeError) as excinfo:
+        await replica.wait_rollout_servers_scheduled([_fake_server("a")], timeout_s=0.05, poll_interval_s=0.01)
+    msg = str(excinfo.value)
+    assert "vllm_server_0_0" in msg
+    assert "PENDING_CREATION" in msg
+    assert "required_resources" in msg
+
+
+@pytest.mark.asyncio
+async def test_treats_missing_actor_as_unschedulable(monkeypatch):
+    monkeypatch.setattr(replica, "get_actor", lambda _id: None)
+    with pytest.raises(RuntimeError):
+        await replica.wait_rollout_servers_scheduled([_fake_server("a")], timeout_s=0.05, poll_interval_s=0.01)

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -14,6 +14,7 @@
 import asyncio
 import logging
 import os
+import time
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Callable, Optional
@@ -22,6 +23,7 @@ import ray
 from omegaconf import DictConfig
 from pydantic import BaseModel
 from ray.actor import ActorHandle
+from ray.util.state import get_actor
 
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup, ResourcePoolManager
 from verl.utils.config import omega_conf_to_dataclass
@@ -34,6 +36,54 @@ logger = logging.getLogger(__file__)
 # Max number of concurrent calls to the methods of Rollout,
 # excluding calls to generate method.
 CONTROL_METHOD_CONCURRENCY = 16
+
+
+# Deadline for a rollout server actor to leave PENDING_CREATION. A colocated server actor
+# is hard-pinned (NodeAffinity, soft=False) to its training worker's node; if that node has
+# no free slot the actor never schedules and the subsequent .remote() call would block
+# forever. Bounding the wait turns a silent hang into an actionable error.
+ROLLOUT_SERVER_SCHEDULE_TIMEOUT_S = 300.0
+
+_UNSCHEDULED_ACTOR_STATES = ("PENDING_CREATION", "DEPENDENCIES_UNREADY")
+
+
+async def wait_rollout_servers_scheduled(
+    servers: list[ActorHandle],
+    *,
+    timeout_s: float = ROLLOUT_SERVER_SCHEDULE_TIMEOUT_S,
+    poll_interval_s: float = 2.0,
+) -> None:
+    """Fail fast if any rollout server actor stays unschedulable past ``timeout_s``.
+
+    Returns as soon as every actor has left the PENDING_CREATION / DEPENDENCIES_UNREADY
+    states. Slow engine init is unaffected: an already-scheduled (ALIVE) actor passes
+    immediately, so only a genuine placement failure trips the deadline.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        pending = []
+        for server in servers:
+            info = get_actor(server._actor_id.hex())
+            state = info.get("state") if info else _UNSCHEDULED_ACTOR_STATES[0]
+            if state in _UNSCHEDULED_ACTOR_STATES:
+                pending.append(info or {"actor_id": server._actor_id.hex(), "state": state})
+        if not pending:
+            return
+        if time.monotonic() >= deadline:
+            detail = "; ".join(
+                f"{p.get('name') or p.get('actor_id')} state={p.get('state')} "
+                f"node={p.get('node_id')} required_resources={p.get('required_resources')}"
+                for p in pending
+            )
+            raise RuntimeError(
+                f"Rollout server actor(s) still unschedulable after {timeout_s:.0f}s: {detail}. "
+                "A colocated rollout server is hard-pinned to its training worker's node "
+                "(NodeAffinity, soft=False); that node has no free slot for it. Check "
+                "`ray list actors` for PENDING_CREATION servers and either reduce per-node "
+                "resource requests or use a layout with >=2 usable GPUs per node for "
+                "cross-node hybrid rollout."
+            )
+        await asyncio.sleep(poll_interval_s)
 
 
 class TokenOutput(BaseModel):

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -49,7 +49,7 @@ from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler, build_sglang_profiler_args
 from verl.utils.tracking import RLInsightLogger
 from verl.workers.config import HFModelConfig, RolloutConfig
-from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
+from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput, wait_rollout_servers_scheduled
 from verl.workers.rollout.sglang_rollout.sglang_rollout import _set_envs_and_config
 from verl.workers.rollout.sglang_rollout.utils import SGLANG_LORA_NAME, lora_served_as_adapter
 from verl.workers.rollout.utils import get_max_position_embeddings, run_uvicorn
@@ -834,6 +834,9 @@ class SGLangReplica(RolloutReplica):
                 base_gpu_id=base_gpu_id,
             )
             self.servers.append(server)
+
+        # Fail fast if a server actor cannot be placed, instead of blocking on the next .remote().
+        await wait_rollout_servers_scheduled(self.servers)
 
         # launch http server in each node
         master_address, master_port = None, None

--- a/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
@@ -29,7 +29,7 @@ from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.net_utils import is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler
 from verl.workers.config import HFModelConfig, RolloutConfig
-from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
+from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput, wait_rollout_servers_scheduled
 from verl.workers.rollout.utils import get_max_position_embeddings, qwen2_5_vl_dedup_image_tokens, run_uvicorn
 
 logger = logging.getLogger(__file__)
@@ -617,6 +617,9 @@ class TRTLLMReplica(RolloutReplica):
             bundle_indices=bundle_indices,
         )
         self.servers.append(server)
+
+        # Fail fast if a server actor cannot be placed, instead of blocking on the next .remote().
+        await wait_rollout_servers_scheduled(self.servers)
 
         # launch http server in each node
         await asyncio.gather(*[server.launch_server.remote() for server in self.servers])

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -46,7 +46,7 @@ from verl.utils.tokenizer import normalize_token_ids
 from verl.utils.tracking import RLInsightLogger
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
-from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
+from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput, wait_rollout_servers_scheduled
 from verl.workers.rollout.utils import (
     get_max_position_embeddings,
     get_vision_placeholder_token_ids,
@@ -1176,6 +1176,9 @@ class vLLMReplica(RolloutReplica):
                 cuda_visible_devices=node_cuda_visible_devices,
             )
             self.servers.append(server)
+
+        # Fail fast if a server actor cannot be placed, instead of blocking on the next .remote().
+        await wait_rollout_servers_scheduled(self.servers)
 
         # launch http server in each node
         master_address, master_port, dp_rpc_port = await self.servers[0].get_master_address.remote()


### PR DESCRIPTION
### What does this PR do?

Fail fast when a rollout server actor cannot be scheduled, instead of hanging forever.

A hybrid/colocated rollout replica creates its per-node server actor with a hard
`NodeAffinitySchedulingStrategy(soft=False)` pinned to its training worker's node. If that
node has no free slot, the actor stays `PENDING_CREATION` and the first `.remote()` call on
it (e.g. `get_master_address`) blocks forever, so `LLMServerManager.create()` hangs at first
init with no timeout and no diagnostic. The whole job then holds its GPUs doing nothing until
an external watchdog kills it.

Closes #7381.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/issues?q=PENDING_CREATION+rollout+replica (no existing issue/PR)
- [x] PR title formatted as `[{modules}] {type}: {description}`.

### Test

Added `tests/workers/rollout/test_rollout_server_schedule_guard_on_cpu.py` (CPU-only), covering:

- returns immediately once the actor is `ALIVE`;
- tolerates transient `PENDING_CREATION` then `ALIVE`;
- raises a diagnostic `RuntimeError` (actor name, state, node, required resources) when an actor
  stays unschedulable past the deadline;
- treats a missing actor as unschedulable.

```
$ pytest tests/workers/rollout/test_rollout_server_schedule_guard_on_cpu.py -q
4 passed
```

### Design & Code Changes

- `verl/workers/rollout/replica.py`: add `wait_rollout_servers_scheduled(servers, *, timeout_s, poll_interval_s)`.
  It polls Ray actor state (`ray.util.state.get_actor`) and returns as soon as every server actor has
  left `PENDING_CREATION` / `DEPENDENCIES_UNREADY`. Only a genuine placement failure trips the deadline;
  an already-scheduled actor passes immediately, so slow engine init is unaffected. On timeout it raises
  a `RuntimeError` naming each stuck actor, its state, node, and `required_resources`, and suggests
  reducing per-node resource requests or using a layout with >=2 usable GPUs per node for cross-node
  hybrid rollout.
- Wired the guard into `launch_servers` of the vLLM, SGLang, and TensorRT-LLM backends, right after the
  server actors are created and before the first blocking `.remote()` call.

Default deadline is `ROLLOUT_SERVER_SCHEDULE_TIMEOUT_S = 300s`. Happy to make it configurable via
`RolloutConfig` if preferred.
