### PR TITLE
[ray, doc] fix: make Slurm Ray network interface configurable

### DIFF
--- a/docs/start/multinode.rst
+++ b/docs/start/multinode.rst
@@ -293,6 +293,22 @@ manager available on your cluster or use other container runtimes (e.g. through 
 
 3. Modify `examples/tutorial/slurm/ray_on_slurm.slurm <https://github.com/verl-project/verl/blob/main/examples/tutorial/slurm/ray_on_slurm.slurm>`_ with your cluster's own information.
 
+   On a cluster with multiple network interfaces, hostname resolution may select a management network instead of the
+   high-speed interconnect. Set ``RAY_NETWORK_INTERFACE`` to make the example resolve the IPv4 address of that interface
+   on every node and explicitly bind both the Ray head and workers to it:
+
+   .. code:: bash
+
+       RAY_NETWORK_INTERFACE=ib0 sbatch examples/tutorial/slurm/ray_on_slurm.slurm
+
+   The interface name must exist on every allocated node. This setting controls Ray's network interface only. Distributed
+   communication backends may need their own interface settings, for example:
+
+   .. code:: bash
+
+       export GLOO_SOCKET_IFNAME=ib0
+       export NCCL_SOCKET_IFNAME=ib0
+
 4. Submit the job script to the Slurm cluster with `sbatch`.
 
 Please note that Slurm cluster setup may vary. If you encounter any issues, please refer to Ray's

--- a/examples/tutorial/slurm/ray_on_slurm.slurm
+++ b/examples/tutorial/slurm/ray_on_slurm.slurm
@@ -18,14 +18,40 @@ verl_workdir=/path/to/verl
 train_files=/path/to/gsm8k/train.parquet
 val_files=/path/to/gsm8k/test.parquet
 apptainer_image_path=/path/to/verl-ngc.sif
+
+# Optional: set this on multi-NIC clusters to bind Ray to a specific interface.
+# For example: RAY_NETWORK_INTERFACE=ib0 sbatch ray_on_slurm.slurm
+RAY_NETWORK_INTERFACE=${RAY_NETWORK_INTERFACE:-}
 # replace these information with your own
+
+get_node_ipv4() {
+    local node_name=$1
+    local node_ip
+
+    node_ip=$(
+        srun --overlap --nodes=1 --ntasks=1 -w "$node_name" \
+            ip -4 -o addr show dev "$RAY_NETWORK_INTERFACE" scope global |
+            awk 'NR == 1 {split($4, address, "/"); print address[1]}'
+    )
+
+    if [[ -z "$node_ip" ]]; then
+        echo "Cannot find an IPv4 address for interface $RAY_NETWORK_INTERFACE on $node_name." >&2
+        return 1
+    fi
+
+    printf '%s\n' "$node_ip"
+}
 
 # Getting the node names
 nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
 nodes_array=("$nodes")
 
 head_node=${nodes_array[0]}
-head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
+if [[ -n "$RAY_NETWORK_INTERFACE" ]]; then
+    head_node_ip=$(get_node_ipv4 "$head_node") || exit 1
+else
+    head_node_ip=$(srun --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
+fi
 
 # if we detect a space character in the head node IP, we'll
 # convert it to an ipv4 address. This step is optional.
@@ -43,6 +69,9 @@ port=6379
 ip_head=$head_node_ip:$port
 export ip_head
 echo "IP Head: $ip_head"
+if [[ -n "$RAY_NETWORK_INTERFACE" ]]; then
+    echo "Ray network interface: $RAY_NETWORK_INTERFACE"
+fi
 
 # make sure we set environment variables before Ray initialization
 
@@ -61,10 +90,18 @@ worker_num=$((SLURM_JOB_NUM_NODES - 1))
 
 for ((i = 1; i <= worker_num; i++)); do
     node_i=${nodes_array[$i]}
-    echo "Starting WORKER $i at $node_i"
+    worker_node_ip_args=()
+    if [[ -n "$RAY_NETWORK_INTERFACE" ]]; then
+        node_i_ip=$(get_node_ipv4 "$node_i") || exit 1
+        worker_node_ip_args=(--node-ip-address="$node_i_ip")
+        echo "Starting WORKER $i at $node_i ($node_i_ip)"
+    else
+        echo "Starting WORKER $i at $node_i"
+    fi
     srun --nodes=1 --ntasks=1 -w "$node_i" \
         apptainer run --nv --bind $verl_workdir $apptainer_image_path \
-            ray start --address "$ip_head" --num-cpus "${SLURM_CPUS_PER_TASK}" --num-gpus "${SLURM_GPUS_PER_NODE}" --block &
+            ray start --address "$ip_head" "${worker_node_ip_args[@]}" \
+            --num-cpus "${SLURM_CPUS_PER_TASK}" --num-gpus "${SLURM_GPUS_PER_NODE}" --block &
     sleep 5
 done
 


### PR DESCRIPTION
### What does this PR do?

This PR makes the network interface used by Ray configurable in the Slurm launch example.

On multi-NIC clusters, users can set `RAY_NETWORK_INTERFACE` to resolve the IPv4 address of that interface independently on every allocated node. The example then passes the resolved address to `ray start --node-ip-address` for both the head and worker nodes. If the selected interface does not have an IPv4 address on a node, the script exits with a clear error instead of silently using another interface.

The existing behavior remains unchanged when `RAY_NETWORK_INTERFACE` is not set. The multinode documentation now explains how to use the option and clarifies that Gloo and NCCL have separate interface settings.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [Slurm network interface](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+slurm+network+interface), [`RAY_NETWORK_INTERFACE`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+RAY_NETWORK_INTERFACE), and [`node-ip-address` with Slurm](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+node-ip-address+slurm). No open PR implementing this fix was found.
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[ray, doc] fix: make Slurm Ray network interface configurable`.

### Test

The following checks were run:

```bash
bash -n examples/tutorial/slurm/ray_on_slurm.slurm
git diff --check
python3 tests/special_sanity/check_docs_time_info.py
pre-commit run --all-files --show-diff-on-failure --color=always
```

The IPv4 resolver was also tested with mocked `srun` output for both successful CIDR-to-IPv4 extraction and the failure path where the selected interface has no IPv4 address.

The change was validated on a four-node Slurm cluster with a 1 Gbps management interface (`lan0`) and a 200 Gbps HDR interface (`ib0`). Before explicitly selecting the interface, Ray actors registered with `10.241.*` addresses from `lan0`. With `RAY_NETWORK_INTERFACE=ib0`, the Ray head and workers registered with `10.245.*` addresses from `ib0`, and the distributed training job completed successfully.

### API and Usage Example

The new setting is optional. Existing users do not need to change their launch command.

On a multi-NIC cluster, select the interface when submitting the job:

```bash
RAY_NETWORK_INTERFACE=ib0 \
GLOO_SOCKET_IFNAME=ib0 \
NCCL_SOCKET_IFNAME=ib0 \
sbatch examples/tutorial/slurm/ray_on_slurm.slurm
```

`RAY_NETWORK_INTERFACE` controls Ray's node addresses only. `GLOO_SOCKET_IFNAME` and `NCCL_SOCKET_IFNAME` remain explicit because they configure separate communication layers.

### Design & Code Changes

- Add the optional `RAY_NETWORK_INTERFACE` environment variable to the Slurm example.
- Resolve the selected interface's IPv4 address on each node through `srun` on the host.
- Bind both the Ray head and workers with `--node-ip-address` when the option is set.
- Fail early with the node and interface name when address resolution fails.
- Preserve the original address-discovery behavior when the option is unset.
- Document multi-NIC usage and the boundary between Ray, Gloo, and NCCL settings.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to the CI workflow, or explain why this is not feasible: an end-to-end test requires a multi-node Slurm allocation with multiple network interfaces. The shell logic was tested with mocked `srun` output and validated on a real four-node Slurm cluster.
- [x] Once the PR is ready for CI, send a message in the `ci-request` channel in the verl Slack workspace or the Feishu group.
- [x] Recipe submodule update: not applicable.

### AI assistance disclosure

OpenAI Codex assisted with the implementation and documentation. I reviewed every changed line and ran the validation described above.
