### PR TITLE
[misc] fix: missing `save_lora_only` in actor checkpoint YAML

### DIFF
--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -143,6 +143,9 @@ checkpoint:
 
   # Whether to perform strict validation during weight export
   strict: True
+  
+  # Whether to save only LoRA adapter weights when the model has LoRA adapters
+  save_lora_only: False
 
 # optimizer configs
 optim:


### PR DESCRIPTION
### What does this PR do?

This PR fixes #7387 by adding:

- `save_lora_only: False` under checkpoint in `verl/trainer/actor/actor.yaml`.

### Why

Although `CheckpointConfig` and docs include `save_lora_only`, the actor checkpoint YAML omitted it.
In `main_ppo` resolved config, this omission caused `actor_rollout_ref.actor.checkpoint.save_lora_only` to be missing, leading to Hydra override errors.

### Repro before fix

- `CheckpointConfig` fields include `save_lora_only`.
- `python -m verl.trainer.main_ppo --cfg all --resolve` shows actor checkpoint without `save_lora_only`.
- Overriding `actor_rollout_ref.actor.checkpoint.save_lora_only=True` fails.

### Behavior after fix

- Resolved actor checkpoint now includes `save_lora_only: false`.
- Override works directly: `actor_rollout_ref.actor.checkpoint.save_lora_only=True`

### Scope

- Config-only change.
- No behavior change unless user enables `save_lora_only=True`.

### Validation

- Re-ran resolved config export and confirmed field presence.
- Hydra accepts verified override path without `+`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
