### PR TITLE
[fsdp, trainer] feat: support WSD LR scheduling

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -3,7 +3,7 @@
 Config Explanation
 ===================
 
-Last updated: 06/18/2025.
+Last updated: 08/13/2026.
 
 ppo_trainer.yaml for RL FSDP Backend
 -------------------------------------
@@ -145,9 +145,10 @@ Actor/Rollout/Reference Policy
         lr: 1e-6
         lr_warmup_steps: -1 # Prioritized. Negative values mean delegating to lr_warmup_steps_ratio.
         lr_warmup_steps_ratio: 0.  # the total steps will be injected during runtime
-        min_lr_ratio: 0.0   # only used with cosine lr scheduler, default to 0.0
-        num_cycles: 0.5     # only used with cosine lr scheduler, default to 0.5
-        lr_scheduler_type: constant  # select from constant/cosine
+        min_lr_ratio: 0.0   # used with cosine/wsd lr schedulers, default to 0.0
+        num_cycles: 0.5     # used with cosine/wsd lr schedulers, default to 0.5
+        lr_scheduler_type: constant  # select from constant/cosine/wsd
+        lr_wsd_stable_steps_ratio: 0.9  # fraction of non-warmup steps kept stable before WSD decay
         total_training_steps: -1  # must be override by program
       fsdp_config:
         wrap_policy:
@@ -692,7 +693,10 @@ Optim
      weight_decay: 0.01
      lr_warmup_steps_ratio: 0.1
      clip_grad: 1.0
-     lr_scheduler: cosine
+     min_lr_ratio: 0.0
+     num_cycles: 0.5
+     lr_scheduler_type: constant
+     lr_wsd_stable_steps_ratio: 0.9
      override_optimizer_config: null
 
 - ``optimizer``: Optimizer class name (e.g., ``"AdamW"``, ``"AdamW8bit"``, ``"_AdamW"``). The class name as it appears in the module.
@@ -701,10 +705,15 @@ Optim
 - ``optim.weight_decay``: Weight decay for the optimizer.
 - ``optim.lr_warmup_steps_ratio``: Ratio of warmup steps to total training steps.
 - ``optim.clip_grad``: Gradient clipping value.
-- ``optim.lr_scheduler``: Learning rate scheduler type. Options:
+- ``optim.min_lr_ratio``: Minimum learning-rate ratio used by the ``cosine`` and ``wsd`` schedulers.
+- ``optim.num_cycles``: Number of cosine cycles used during cosine decay. With the default ``0.5``, decay reaches ``min_lr_ratio`` at the configured endpoint.
+- ``optim.lr_scheduler_type``: Learning rate scheduler type. Options:
 
-  - ``cosine``: Cosine learning rate scheduler with warmup (default).
-  - ``wsd``: Warmup-Stable-Decay scheduler that provides a stable learning rate phase between warmup and decay phases.
+  - ``constant``: Constant learning rate after warmup (default).
+  - ``cosine``: Cosine learning rate scheduler with warmup.
+  - ``wsd``: Warmup-Stable-Decay scheduler that provides a stable learning-rate phase between warmup and cosine decay. Setting ``lr_wsd_stable_steps_ratio`` to ``0.0`` matches the cosine schedule over the configured training interval.
+
+- ``optim.lr_wsd_stable_steps_ratio``: Fraction of non-warmup steps assigned to WSD's stable phase. The remainder is assigned to cosine decay.
 
 - ``override_optimizer_config``: Dictionary of additional optimizer-specific keyword arguments. For example, to use ``torchao.optim``'s ``_AdamW`` with BF16 stochastic rounding: ``{"bf16_stochastic_round": true}``
 

--- a/tests/workers/config/test_optim_config_on_cpu.py
+++ b/tests/workers/config/test_optim_config_on_cpu.py
@@ -23,13 +23,14 @@ class TestFSDPOptimizerConfigCPU:
         assert config.min_lr_ratio is None
         assert config.lr_scheduler_type == "constant"
         assert config.num_cycles == 0.5
+        assert config.lr_wsd_stable_steps_ratio == 0.9
 
-    @pytest.mark.parametrize("lr_scheduler_type", ["constant", "cosine"])
+    @pytest.mark.parametrize("lr_scheduler_type", ["constant", "cosine", "wsd"])
     def test_valid_lr_scheduler_types(self, lr_scheduler_type):
         config = FSDPOptimizerConfig(lr_scheduler_type=lr_scheduler_type, lr=0.1)
         assert config.lr_scheduler_type == lr_scheduler_type
 
-    @pytest.mark.parametrize("warmup_style", ["constant", "cosine"])
+    @pytest.mark.parametrize("warmup_style", ["constant", "cosine", "wsd"])
     def test_valid_warmup_style_types(self, warmup_style):
         config = FSDPOptimizerConfig(warmup_style=warmup_style, lr=0.1)
         assert config.lr_scheduler_type == warmup_style
@@ -46,6 +47,57 @@ class TestFSDPOptimizerConfigCPU:
     def test_num_cycles_configuration(self, num_cycles):
         config = FSDPOptimizerConfig(num_cycles=num_cycles, lr=0.1)
         assert config.num_cycles == num_cycles
+
+    @pytest.mark.parametrize("stable_ratio", [0.0, 0.5, 1.0])
+    def test_valid_wsd_stable_steps_ratio(self, stable_ratio):
+        config = FSDPOptimizerConfig(lr_scheduler_type="wsd", lr_wsd_stable_steps_ratio=stable_ratio, lr=0.1)
+        assert config.lr_wsd_stable_steps_ratio == stable_ratio
+
+    @pytest.mark.parametrize("stable_ratio", [-0.1, 1.1])
+    def test_invalid_wsd_stable_steps_ratio(self, stable_ratio):
+        with pytest.raises(AssertionError, match="lr_wsd_stable_steps_ratio"):
+            FSDPOptimizerConfig(lr_scheduler_type="wsd", lr_wsd_stable_steps_ratio=stable_ratio, lr=0.1)
+
+    @pytest.mark.parametrize("lr_scheduler_type", ["constant", "cosine"])
+    def test_unused_wsd_stable_ratio_is_not_validated(self, lr_scheduler_type):
+        config = FSDPOptimizerConfig(
+            lr_scheduler_type=lr_scheduler_type,
+            lr_wsd_stable_steps_ratio=1.1,
+            lr=0.1,
+        )
+        assert config.lr_wsd_stable_steps_ratio == 1.1
+
+    def test_legacy_positional_arguments_keep_their_meaning(self):
+        legacy_args = (
+            "",
+            0.123,
+            0.2,
+            100,
+            0.02,
+            3,
+            (0.8, 0.9),
+            0.7,
+            None,
+            "AdamW",
+            "torch.optim",
+            0.1,
+            None,
+            "cosine",
+            0.25,
+            {"eps": 1e-8},
+            False,
+        )
+
+        config = FSDPOptimizerConfig(*legacy_args)
+
+        assert config.override_optimizer_config == {"eps": 1e-8}
+        assert config.zero_indexed_step is False
+        assert config.lr_wsd_stable_steps_ratio == 0.9
+
+    @pytest.mark.parametrize("min_lr_ratio", [-0.1, 1.1])
+    def test_invalid_min_lr_ratio(self, min_lr_ratio):
+        with pytest.raises(AssertionError, match="min_lr_ratio"):
+            FSDPOptimizerConfig(lr_scheduler_type="wsd", min_lr_ratio=min_lr_ratio, lr=0.1)
 
 
 class TestMcoreOptimizerConfigMuonCPU:

--- a/tests/workers/test_fsdp_wsd_lr_scheduler_on_cpu.py
+++ b/tests/workers/test_fsdp_wsd_lr_scheduler_on_cpu.py
@@ -1,0 +1,212 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU coverage for the FSDP Warmup-Stable-Decay scheduler wiring."""
+
+import pytest
+import torch
+
+from verl.utils.torch_functional import get_wsd_schedule_with_warmup
+from verl.workers.config.optimizer import FSDPOptimizerConfig
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
+
+
+def _optimizer(lr=1.0):
+    return torch.optim.SGD([torch.nn.Parameter(torch.tensor(1.0))], lr=lr)
+
+
+def _lr_sequence(scheduler, optimizer, steps):
+    values = [scheduler.get_last_lr()[0]]
+    for _ in range(steps):
+        optimizer.step()
+        scheduler.step()
+        values.append(scheduler.get_last_lr()[0])
+    return values
+
+
+def _build_engine_scheduler(**overrides):
+    values = {
+        "lr": 1.0,
+        "lr_scheduler_type": "wsd",
+        "lr_warmup_steps": 2,
+        "total_training_steps": 10,
+        "min_lr_ratio": 0.1,
+        "lr_wsd_stable_steps_ratio": 0.5,
+    }
+    values.update(overrides)
+    engine = object.__new__(FSDPEngine)
+    engine.optimizer_config = FSDPOptimizerConfig(**values)
+    engine.rank = 1
+    optimizer = _optimizer()
+    return engine._build_lr_scheduler(optimizer), optimizer
+
+
+def test_fsdp_engine_builds_warmup_stable_decay_schedule():
+    scheduler, optimizer = _build_engine_scheduler()
+
+    lrs = _lr_sequence(scheduler, optimizer, steps=10)
+
+    assert lrs[:3] == pytest.approx([0.0, 0.5, 1.0])
+    assert lrs[2:7] == pytest.approx([1.0] * 5)
+    assert lrs[7:11] == pytest.approx([0.8681980515, 0.55, 0.2318019485, 0.1])
+
+
+def test_fsdp_wsd_honors_one_indexed_steps():
+    scheduler, optimizer = _build_engine_scheduler(zero_indexed_step=False)
+
+    lrs = _lr_sequence(scheduler, optimizer, steps=9)
+
+    assert lrs[:2] == pytest.approx([0.5, 1.0])
+    assert lrs[-1] == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize("zero_indexed_step", [True, False])
+@pytest.mark.parametrize("num_cycles", [0.25, 0.5, 1.0])
+def test_zero_stable_ratio_matches_cosine_schedule(zero_indexed_step, num_cycles):
+    overrides = {
+        "lr_wsd_stable_steps_ratio": 0.0,
+        "num_cycles": num_cycles,
+        "zero_indexed_step": zero_indexed_step,
+    }
+    wsd_scheduler, wsd_optimizer = _build_engine_scheduler(**overrides)
+    cosine_scheduler, cosine_optimizer = _build_engine_scheduler(
+        lr_scheduler_type="cosine",
+        num_cycles=num_cycles,
+        zero_indexed_step=zero_indexed_step,
+    )
+    # Include logical endpoint N for both indexing modes. In one-indexed mode,
+    # construction starts at logical step 1, so it takes one fewer scheduler step.
+    steps = 10 if zero_indexed_step else 9
+
+    assert _lr_sequence(wsd_scheduler, wsd_optimizer, steps=steps) == pytest.approx(
+        _lr_sequence(cosine_scheduler, cosine_optimizer, steps=steps)
+    )
+
+
+@pytest.mark.parametrize(
+    ("zero_indexed_step", "steps", "expected"),
+    [
+        (True, 10, [0.0, 0.5, *([1.0] * 9)]),
+        (False, 9, [0.5, *([1.0] * 9)]),
+    ],
+)
+def test_full_stable_ratio_keeps_endpoint_at_base_lr(zero_indexed_step, steps, expected):
+    scheduler, optimizer = _build_engine_scheduler(
+        lr_wsd_stable_steps_ratio=1.0,
+        zero_indexed_step=zero_indexed_step,
+    )
+
+    assert _lr_sequence(scheduler, optimizer, steps=steps) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("zero_indexed_step", [True, False])
+def test_warmup_can_fill_the_entire_training_interval(zero_indexed_step):
+    overrides = {
+        "lr_warmup_steps": 10,
+        "lr_wsd_stable_steps_ratio": 0.0,
+        "zero_indexed_step": zero_indexed_step,
+    }
+    wsd_scheduler, wsd_optimizer = _build_engine_scheduler(**overrides)
+    cosine_scheduler, cosine_optimizer = _build_engine_scheduler(
+        lr_scheduler_type="cosine",
+        lr_warmup_steps=10,
+        zero_indexed_step=zero_indexed_step,
+    )
+    steps = 10 if zero_indexed_step else 9
+    expected = [step / 10 for step in (range(11) if zero_indexed_step else range(1, 11))]
+    wsd_lrs = _lr_sequence(wsd_scheduler, wsd_optimizer, steps=steps)
+    cosine_lrs = _lr_sequence(cosine_scheduler, cosine_optimizer, steps=steps)
+
+    assert wsd_lrs == pytest.approx(expected)
+    assert wsd_lrs == pytest.approx(cosine_lrs)
+
+
+def test_fsdp_wsd_normalizes_default_min_lr_ratio():
+    scheduler, optimizer = _build_engine_scheduler(min_lr_ratio=None)
+
+    lrs = _lr_sequence(scheduler, optimizer, steps=10)
+
+    assert lrs[-1] == pytest.approx(0.0)
+
+
+def test_constant_scheduler_keeps_legacy_total_steps_behavior():
+    scheduler, optimizer = _build_engine_scheduler(
+        lr_scheduler_type="constant", total_training_steps=-1, lr_warmup_steps=2
+    )
+
+    assert _lr_sequence(scheduler, optimizer, steps=2) == pytest.approx([0.0, 0.5, 1.0])
+
+
+def test_wsd_last_epoch_matches_uninterrupted_schedule():
+    full_optimizer = _optimizer()
+    full_scheduler = get_wsd_schedule_with_warmup(
+        full_optimizer,
+        num_warmup_steps=2,
+        num_training_steps=10,
+        min_lr_ratio=0.1,
+        stable_ratio=0.5,
+    )
+    full_lrs = _lr_sequence(full_scheduler, full_optimizer, steps=10)
+
+    resumed_optimizer = _optimizer()
+    resumed_optimizer.param_groups[0]["initial_lr"] = 1.0
+    resumed_scheduler = get_wsd_schedule_with_warmup(
+        resumed_optimizer,
+        num_warmup_steps=2,
+        num_training_steps=10,
+        min_lr_ratio=0.1,
+        stable_ratio=0.5,
+        last_epoch=5,
+    )
+    resumed_lrs = _lr_sequence(resumed_scheduler, resumed_optimizer, steps=4)
+
+    assert resumed_scheduler.last_epoch == 10
+    assert resumed_lrs == pytest.approx(full_lrs[6:11])
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"total_training_steps": 0}, "total_training_steps"),
+        ({"lr_warmup_steps": 11}, "lr_warmup_steps"),
+        ({"lr_warmup_steps": -1, "lr_warmup_steps_ratio": 1.1}, "lr_warmup_steps_ratio"),
+    ],
+)
+def test_fsdp_scheduler_rejects_invalid_step_boundaries(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _build_engine_scheduler(**overrides)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"num_training_steps": 0}, "num_training_steps"),
+        ({"num_warmup_steps": 11}, "num_warmup_steps"),
+        ({"stable_ratio": -0.1}, "stable_ratio"),
+        ({"stable_ratio": 1.1}, "stable_ratio"),
+        ({"min_lr_ratio": -0.1}, "min_lr_ratio"),
+        ({"min_lr_ratio": 1.1}, "min_lr_ratio"),
+    ],
+)
+def test_wsd_helper_rejects_invalid_boundaries(overrides, message):
+    kwargs = {
+        "optimizer": _optimizer(),
+        "num_warmup_steps": 2,
+        "num_training_steps": 10,
+        "stable_ratio": 0.5,
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        get_wsd_schedule_with_warmup(**kwargs)

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -21,6 +21,7 @@ actor_rollout_ref:
       min_lr_ratio: 0.0
       num_cycles: 0.5
       lr_scheduler_type: constant
+      lr_wsd_stable_steps_ratio: 0.9
       zero_indexed_step: true
       warmup_style: null
       override_optimizer_config: null
@@ -516,6 +517,7 @@ critic:
     min_lr_ratio: 0.0
     num_cycles: 0.5
     lr_scheduler_type: constant
+    lr_wsd_stable_steps_ratio: 0.9
     zero_indexed_step: true
     warmup_style: null
     override_optimizer_config: null

--- a/verl/trainer/config/optim/fsdp.yaml
+++ b/verl/trainer/config/optim/fsdp.yaml
@@ -29,14 +29,17 @@ betas: [0.9, 0.999]
 # Clip gradient
 clip_grad: 1.0
 
-# Minimum LR ratio for cosine schedule
+# Minimum LR ratio for cosine and WSD schedules
 min_lr_ratio: 0.0
 
-# Number of cosine cycles in LR schedule
+# Number of cosine cycles in cosine and WSD schedules
 num_cycles: 0.5
 
-# LR scheduler type: "constant" or "cosine"
+# LR scheduler type: "constant", "cosine", or "wsd"
 lr_scheduler_type: constant
+
+# Fraction of post-warmup steps assigned to WSD's stable phase; the remainder is decay
+lr_wsd_stable_steps_ratio: 0.9
 
 # Whether the LR schedule uses 0-indexed steps
 zero_indexed_step: true

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -861,6 +861,7 @@ def get_wsd_schedule_with_warmup(
     num_cycles: float = 0.5,
     last_epoch: int = -1,
     stable_ratio: float = 0.9,
+    zero_indexed_step: bool = True,
 ):
     """
     Create a Warmup-Stable-Decay learning rate scheduler.
@@ -868,7 +869,9 @@ def get_wsd_schedule_with_warmup(
     The schedule follows three phases:
     1. Warmup: Learning rate increases linearly from 0 to the initial LR
     2. Stable: Learning rate remains constant at the initial LR
-    3. Decay: Learning rate decreases following a cosine curve to min_lr_ratio * initial LR
+    3. Decay: Learning rate follows the same cosine curve as
+       :func:`get_cosine_schedule_with_warmup`. With the default ``num_cycles=0.5``,
+       the curve reaches ``min_lr_ratio * initial_lr`` at the configured endpoint.
 
     Args:
         optimizer (:class:`~torch.optim.Optimizer`):
@@ -883,26 +886,42 @@ def get_wsd_schedule_with_warmup(
             The number of waves in the cosine schedule during decay phase.
         last_epoch (:obj:`int`, `optional`, defaults to -1):
             The index of the last epoch when resuming training.
-        stable_ratio (:obj:`float`, `optional`, defaults to 0.0):
+        stable_ratio (:obj:`float`, `optional`, defaults to 0.9):
             The ratio of non-warmup steps that should maintain a constant learning rate.
-            Set to 0.0 to behave exactly like cosine schedule.
+            Set to 0.0 to behave exactly like the cosine schedule over the configured
+            training interval.
+        zero_indexed_step (:obj:`bool`, `optional`, defaults to True):
+            Whether the LR schedule uses 0-indexed steps. If False, evaluate each step as one-indexed.
 
     Return:
         :obj:`torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
     """
-    remaining_steps = max(0, num_training_steps - num_warmup_steps)
+    if num_training_steps <= 0:
+        raise ValueError(f"`num_training_steps` must be positive, got {num_training_steps}")
+    if not 0 <= num_warmup_steps <= num_training_steps:
+        raise ValueError(f"`num_warmup_steps` must be within [0, num_training_steps], got {num_warmup_steps}")
+    min_lr_ratio = 0.0 if min_lr_ratio is None else min_lr_ratio
+    if not 0.0 <= stable_ratio <= 1.0:
+        raise ValueError(f"`stable_ratio` must be within [0, 1], got {stable_ratio}")
+    if not 0.0 <= min_lr_ratio <= 1.0:
+        raise ValueError(f"`min_lr_ratio` must be within [0, 1], got {min_lr_ratio}")
+
+    remaining_steps = num_training_steps - num_warmup_steps
     num_stable_steps = int(remaining_steps * stable_ratio)
     num_decay_steps = remaining_steps - num_stable_steps
+    coef = (1.0 - min_lr_ratio) * 0.5
+    intercept = (1.0 + min_lr_ratio) * 0.5
 
     def lr_lambda(current_step):
-        if current_step < num_warmup_steps:
-            return float(current_step) / float(max(1, num_warmup_steps))
-        if current_step < num_warmup_steps + num_stable_steps:
+        logical_step = current_step if zero_indexed_step else current_step + 1
+        if logical_step < num_warmup_steps:
+            return float(logical_step) / float(max(1, num_warmup_steps))
+        if logical_step < num_warmup_steps + num_stable_steps:
             return 1.0
-        if current_step < num_training_steps:
-            progress = float(current_step - num_warmup_steps - num_stable_steps) / float(max(1, num_decay_steps))
-            value = max(0.0, 0.5 * (1.0 + math.cos(math.pi * float(num_cycles) * 2.0 * progress)))
-            return (1.0 - min_lr_ratio) * value + min_lr_ratio
+        if logical_step <= num_training_steps:
+            progress = float(logical_step - num_warmup_steps - num_stable_steps) / float(max(1, num_decay_steps))
+            x = math.cos(math.pi * float(num_cycles) * 2.0 * progress)
+            return max(min_lr_ratio, x * coef + intercept)
         return min_lr_ratio
 
     return LambdaLR(optimizer, lr_lambda, last_epoch)

--- a/verl/workers/config/optimizer.py
+++ b/verl/workers/config/optimizer.py
@@ -93,9 +93,10 @@ class FSDPOptimizerConfig(OptimizerConfig):
         optimizer_impl (str): Module path to import optimizer from (e.g., "torch.optim", "torchao.optim",
             "bitsandbytes.optim").
         lr (float): Learning rate.
-        min_lr_ratio (Optional[float]): Minimum LR ratio for cosine schedule.
-        lr_scheduler_type (str): LR scheduler type: "constant" or "cosine".
-        num_cycles (float): Number of cosine cycles in LR schedule.
+        min_lr_ratio (Optional[float]): Minimum LR ratio for cosine and WSD schedules.
+        lr_scheduler_type (str): LR scheduler type: "constant", "cosine", or "wsd".
+        num_cycles (float): Number of cosine cycles in cosine and WSD schedules.
+        lr_wsd_stable_steps_ratio (float): Fraction of post-warmup steps assigned to WSD's stable phase.
         zero_indexed_step (bool): Whether the LR schedule uses 0-indexed steps. If True (default),
             step counting starts at 0. If False, step counting starts at 1.
     """
@@ -112,15 +113,21 @@ class FSDPOptimizerConfig(OptimizerConfig):
     num_cycles: float = 0.5
     override_optimizer_config: Optional[dict] = None
     zero_indexed_step: bool = True
+    lr_wsd_stable_steps_ratio: float = 0.9
 
     def __post_init__(self):
+        supported_scheduler_types = ["constant", "cosine", "wsd"]
         if self.warmup_style is not None:
-            assert self.warmup_style in ["constant", "cosine"]
+            assert self.warmup_style in supported_scheduler_types
             warnings.warn(
                 "`warmup_style` is deprecated, use `lr_scheduler_type` instead.", DeprecationWarning, stacklevel=2
             )
             self.lr_scheduler_type = self.warmup_style
-        assert self.lr_scheduler_type in ["constant", "cosine"]
+        assert self.lr_scheduler_type in supported_scheduler_types
+        if self.lr_scheduler_type == "wsd":
+            if self.min_lr_ratio is not None:
+                assert 0.0 <= self.min_lr_ratio <= 1.0, "`min_lr_ratio` must be within [0, 1]"
+            assert 0.0 <= self.lr_wsd_stable_steps_ratio <= 1.0, "`lr_wsd_stable_steps_ratio` must be within [0, 1]"
         return super().__post_init__()
 
 

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -482,7 +482,11 @@ class FSDPEngine(BaseEngine):
         return optimizer
 
     def _build_lr_scheduler(self, optimizer):
-        from verl.utils.torch_functional import get_constant_schedule_with_warmup, get_cosine_schedule_with_warmup
+        from verl.utils.torch_functional import (
+            get_constant_schedule_with_warmup,
+            get_cosine_schedule_with_warmup,
+            get_wsd_schedule_with_warmup,
+        )
 
         optim_config = self.optimizer_config
 
@@ -492,9 +496,15 @@ class FSDPEngine(BaseEngine):
         min_lr_ratio = optim_config.min_lr_ratio
         num_cycles = optim_config.num_cycles
         zero_indexed_step = optim_config.zero_indexed_step
+        if lr_scheduler_type == "wsd" and total_steps <= 0:
+            raise ValueError(f"`total_training_steps` must be positive, got {total_steps}")
         if num_warmup_steps <= 0:
             num_warmup_steps_ratio = optim_config.lr_warmup_steps_ratio
+            if lr_scheduler_type == "wsd" and not 0.0 <= num_warmup_steps_ratio <= 1.0:
+                raise ValueError(f"`lr_warmup_steps_ratio` must be within [0, 1], got {num_warmup_steps_ratio}")
             num_warmup_steps = int(num_warmup_steps_ratio * total_steps)
+        if lr_scheduler_type == "wsd" and not 0 <= num_warmup_steps <= total_steps:
+            raise ValueError(f"`lr_warmup_steps` must be within [0, total_training_steps], got {num_warmup_steps}")
 
         if self.rank == 0:
             print(f"Total steps: {total_steps}, num_warmup_steps: {num_warmup_steps}")
@@ -508,6 +518,16 @@ class FSDPEngine(BaseEngine):
                 num_training_steps=total_steps,
                 min_lr_ratio=min_lr_ratio,
                 num_cycles=num_cycles,
+                zero_indexed_step=zero_indexed_step,
+            )
+        elif lr_scheduler_type == "wsd":
+            lr_scheduler = get_wsd_schedule_with_warmup(
+                optimizer=optimizer,
+                num_warmup_steps=num_warmup_steps,
+                num_training_steps=total_steps,
+                min_lr_ratio=0.0 if min_lr_ratio is None else min_lr_ratio,
+                num_cycles=num_cycles,
+                stable_ratio=optim_config.lr_wsd_stable_steps_ratio,
                 zero_indexed_step=zero_indexed_step,
             )
         else:


### PR DESCRIPTION
### What does this PR do?

Wire Warmup-Stable-Decay (WSD) learning-rate scheduling into the unified FSDP engine.

The new `optim.lr_scheduler_type=wsd` path exposes `lr_wsd_stable_steps_ratio`, reuses `min_lr_ratio` and `num_cycles` for the decay phase, validates WSD-specific boundaries, supports zero- and one-indexed schedules, and preserves `last_epoch` resume behavior. The change also updates generated PPO configuration, SFT/PPO usage documentation, and CPU-only regression coverage. Existing constant/cosine behavior and legacy positional `FSDPOptimizerConfig` arguments remain compatible.

Duplicate search: [open WSD LR scheduler PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+WSD+%22lr+scheduler%22) — no matching open PR was found immediately before submission.

> AI assistance disclosure: this change was researched and implemented with OpenAI Codex assistance. It is opened as a Draft and must receive final human-owner review before being marked ready.

### Checklist Before Starting

- [x] Searched for similar PRs; query linked above.
- [x] Title follows `[{modules}] {type}: {description}`.

### Test

```bash
python -m pytest \
  tests/workers/config/test_optim_config_on_cpu.py \
  tests/workers/test_fsdp_wsd_lr_scheduler_on_cpu.py -q

pre-commit run --all-files \
  --show-diff-on-failure --color=always
```

Results:

- CPU optimizer/scheduler tests: **49 passed**
- Full-repository pre-commit: **all hooks passed**, including Ruff, formatting, mypy, generated trainer-config verification, docs, licenses, repository structure/naming, and Python compilation.
- Additional property audit covered **7,056** valid schedule/indexing combinations.
- Independent review: **zero blockers**.

### API and Usage Example

PPO actor:

```bash
actor_rollout_ref.actor.optim.lr_scheduler_type=wsd \
actor_rollout_ref.actor.optim.lr_wsd_stable_steps_ratio=0.9
```

SFT:

```bash
optim.lr_scheduler_type=wsd \
optim.lr_wsd_stable_steps_ratio=0.9
```

`lr_warmup_steps` (or `lr_warmup_steps_ratio`) controls warmup. The stable ratio applies to post-warmup steps; the remaining steps follow the configured cosine decay toward `min_lr_ratio`.

### Design & Code Changes

- Extend `FSDPOptimizerConfig` and its generated/default YAML with the opt-in WSD mode.
- Route WSD through `FSDPEngine._build_lr_scheduler`.
- Harden `get_wsd_schedule_with_warmup` for boundary validation, index conventions, resume, and cosine parity at a zero stable ratio.
- Add focused CPU tests and user-facing configuration examples.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Ran the required full-repository pre-commit checks.
- [x] Updated documentation and generated configuration.
- [x] Added CPU unit tests covering the new scheduler path.
- [ ] CI request: intentionally deferred while this PR is Draft; the human owner will request project CI when ready.
- [x] Recipe submodule update is not applicable; no recipe-submodule files changed.