### PR TITLE
[ckpt, fsdp] fix: enforce max-one SFT retention after restart

### DIFF
--- a/tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py
+++ b/tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py
@@ -137,3 +137,89 @@ class TestCheckpointCleanupLogic:
         manager.register_checkpoint(ckpt_300, 1)
         assert not os.path.exists(ckpt_200)
         assert manager.previous_saved_paths == [ckpt_300]
+
+    def test_loaded_checkpoint_restores_retention_after_restart(self, manager):
+        ckpt_100 = self._create_checkpoint_dir(100)
+
+        manager.record_loaded_checkpoint(ckpt_100)
+        ckpt_200 = self._create_checkpoint_dir(200)
+        manager.register_checkpoint(ckpt_200, max_ckpt_to_keep=1)
+        manager.finalize_loaded_checkpoint_retention(ckpt_200, max_ckpt_to_keep=1)
+
+        assert not os.path.exists(ckpt_100)
+        assert os.path.exists(ckpt_200)
+        assert manager.previous_saved_paths == [ckpt_200]
+
+    def test_loaded_checkpoint_accepts_relative_registered_path(self, manager, monkeypatch):
+        ckpt_100 = self._create_checkpoint_dir(100)
+        ckpt_200 = self._create_checkpoint_dir(200)
+        monkeypatch.chdir(self.test_dir)
+
+        manager.record_loaded_checkpoint(ckpt_100)
+        manager.register_checkpoint("global_step_200", max_ckpt_to_keep=1)
+        manager.finalize_loaded_checkpoint_retention(ckpt_200, max_ckpt_to_keep=1)
+
+        assert not os.path.exists(ckpt_100)
+        assert os.path.exists(ckpt_200)
+
+    def test_loaded_checkpoint_retention_does_not_scan_siblings(self, manager):
+        ckpt_100 = self._create_checkpoint_dir(100)
+        ckpt_200 = self._create_checkpoint_dir(200)
+        ckpt_300 = os.path.join(self.test_dir, "global_step_300")
+
+        manager.record_loaded_checkpoint(ckpt_200)
+        os.makedirs(ckpt_300)
+        manager.register_checkpoint(ckpt_300, max_ckpt_to_keep=1)
+        manager.finalize_loaded_checkpoint_retention(ckpt_300, max_ckpt_to_keep=1)
+
+        assert manager.previous_saved_paths == [ckpt_300]
+        assert not os.path.exists(ckpt_200)
+        assert os.path.exists(ckpt_100)
+
+    @pytest.mark.parametrize("max_ckpt_to_keep", [None, 0, 2])
+    def test_loaded_checkpoint_retention_is_limited_to_max_one(self, manager, max_ckpt_to_keep):
+        ckpt_100 = self._create_checkpoint_dir(100)
+        manager.record_loaded_checkpoint(ckpt_100)
+        ckpt_200 = os.path.join(self.test_dir, "global_step_200")
+        os.makedirs(ckpt_200)
+        manager.register_checkpoint(ckpt_200, max_ckpt_to_keep=max_ckpt_to_keep)
+
+        manager.finalize_loaded_checkpoint_retention(ckpt_200, max_ckpt_to_keep=max_ckpt_to_keep)
+
+        assert os.path.exists(ckpt_100)
+
+    def test_loaded_checkpoint_retention_ignores_different_series(self, manager):
+        external_root = tempfile.mkdtemp()
+        try:
+            loaded_path = os.path.join(external_root, "global_step_100")
+            os.makedirs(loaded_path)
+            manager.record_loaded_checkpoint(loaded_path)
+            ckpt_200 = self._create_checkpoint_dir(200)
+            manager.register_checkpoint(ckpt_200, max_ckpt_to_keep=1)
+
+            manager.finalize_loaded_checkpoint_retention(ckpt_200, max_ckpt_to_keep=1)
+
+            assert os.path.exists(loaded_path)
+        finally:
+            shutil.rmtree(external_root, ignore_errors=True)
+
+    @pytest.mark.parametrize("new_step", [100, 50])
+    def test_loaded_checkpoint_retention_ignores_same_or_newer_loaded_step(self, manager, new_step):
+        loaded_path = self._create_checkpoint_dir(100)
+        manager.record_loaded_checkpoint(loaded_path)
+        new_path = os.path.join(self.test_dir, f"global_step_{new_step}")
+        os.makedirs(new_path, exist_ok=True)
+        manager.register_checkpoint(new_path, max_ckpt_to_keep=1)
+
+        manager.finalize_loaded_checkpoint_retention(new_path, max_ckpt_to_keep=1)
+
+        assert os.path.exists(loaded_path)
+
+    def test_loaded_checkpoint_retention_requires_registered_replacement(self, manager):
+        loaded_path = self._create_checkpoint_dir(100)
+        new_path = self._create_checkpoint_dir(200)
+        manager.record_loaded_checkpoint(loaded_path)
+
+        manager.finalize_loaded_checkpoint_retention(new_path, max_ckpt_to_keep=1)
+
+        assert os.path.exists(loaded_path)

--- a/tests/utils/ckpt/test_checkpoint_handler_on_cpu.py
+++ b/tests/utils/ckpt/test_checkpoint_handler_on_cpu.py
@@ -1,0 +1,211 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+import torch
+
+from verl.utils.checkpoint.checkpoint_handler import CheckpointHandler, OrchestrationMode
+from verl.utils.checkpoint.checkpoint_manager import BaseCheckpointManager
+
+
+class _Dataloader:
+    def __init__(self, fail_on_save=False, events=None):
+        self.fail_on_save = fail_on_save
+        self.events = events
+
+    def state_dict(self):
+        if self.events is not None:
+            self.events.append("dataloader")
+        if self.fail_on_save:
+            raise RuntimeError("dataloader save failed")
+        return {"position": 1}
+
+    def load_state_dict(self, state_dict):
+        assert state_dict == {"position": 1}
+
+
+class _Engine:
+    def __init__(self, manager, events=None):
+        self.manager = manager
+        self.events = events
+
+    def save_checkpoint(self, local_path, hdfs_path=None, global_step=0, max_ckpt_to_keep=None):
+        if self.events is not None:
+            self.events.append("model")
+        os.makedirs(local_path, exist_ok=True)
+        torch.save({"step": global_step}, os.path.join(local_path, "model.pt"))
+        self.manager.register_checkpoint(local_path, max_ckpt_to_keep)
+
+    def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=False):
+        assert os.path.isdir(local_path)
+
+    def prepare_checkpoint_retention(self, loaded_path):
+        self.manager.record_loaded_checkpoint(loaded_path)
+
+    def finalize_checkpoint_retention(self, new_path, max_ckpt_to_keep=None):
+        if self.events is not None:
+            self.events.append("finalize")
+        self.manager.finalize_loaded_checkpoint_retention(new_path, max_ckpt_to_keep)
+
+    def is_mp_src_rank_with_outputs(self):
+        return True
+
+    def get_data_parallel_rank(self):
+        return 0
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+    return BaseCheckpointManager(model=object(), optimizer=object())
+
+
+def _write_checkpoint(root, step):
+    checkpoint_path = root / f"global_step_{step}"
+    checkpoint_path.mkdir()
+    torch.save({"step": step}, checkpoint_path / "model.pt")
+    torch.save({"position": 1}, checkpoint_path / "data_0.pt")
+    return checkpoint_path
+
+
+def _write_tracker(root, step):
+    (root / "latest_checkpointed_iteration.txt").write_text(str(step))
+
+
+def _handler(root, manager, dataloader=None, **kwargs):
+    return CheckpointHandler(
+        engine=_Engine(manager),
+        train_dataloader=dataloader or _Dataloader(),
+        default_local_dir=str(root),
+        max_ckpt_to_keep=kwargs.pop("max_ckpt_to_keep", 1),
+        mode=kwargs.pop("mode", OrchestrationMode.RAY),
+        **kwargs,
+    )
+
+
+def test_restart_loaded_checkpoint_is_removed_after_replacement_commits(tmp_path, manager):
+    old_checkpoint = _write_checkpoint(tmp_path, 1)
+    _write_tracker(tmp_path, 1)
+    handler = _handler(tmp_path, manager)
+
+    assert handler.load_checkpoint() == 1
+    handler.save_checkpoint(2)
+
+    assert not old_checkpoint.exists()
+    assert (tmp_path / "global_step_2").is_dir()
+    assert (tmp_path / "latest_checkpointed_iteration.txt").read_text() == "2"
+
+
+def test_restart_loaded_checkpoint_survives_dataloader_save_failure(tmp_path, manager):
+    old_checkpoint = _write_checkpoint(tmp_path, 1)
+    _write_tracker(tmp_path, 1)
+    handler = _handler(tmp_path, manager, dataloader=_Dataloader(fail_on_save=True))
+    assert handler.load_checkpoint() == 1
+
+    with pytest.raises(RuntimeError, match="dataloader save failed"):
+        handler.save_checkpoint(2)
+
+    assert old_checkpoint.is_dir()
+    assert (tmp_path / "latest_checkpointed_iteration.txt").read_text() == "1"
+
+
+def test_restart_loaded_checkpoint_is_not_rotated_when_retention_exceeds_one(tmp_path, manager):
+    old_checkpoint = _write_checkpoint(tmp_path, 1)
+    _write_tracker(tmp_path, 1)
+    handler = _handler(tmp_path, manager, max_ckpt_to_keep=2)
+
+    assert handler.load_checkpoint() == 1
+    handler.save_checkpoint(2)
+
+    assert old_checkpoint.is_dir()
+    assert (tmp_path / "global_step_2").is_dir()
+
+
+def test_external_resume_checkpoint_is_not_deleted(tmp_path, manager):
+    checkpoint_root = tmp_path / "run"
+    checkpoint_root.mkdir()
+    external_root = tmp_path / "external"
+    external_root.mkdir()
+    old_checkpoint = _write_checkpoint(external_root, 1)
+    handler = _handler(
+        checkpoint_root,
+        manager,
+        resume_mode="resume_path",
+        resume_from_path=str(old_checkpoint),
+    )
+
+    assert handler.load_checkpoint() == 1
+    handler.save_checkpoint(2)
+
+    assert old_checkpoint.is_dir()
+    assert (checkpoint_root / "global_step_2").is_dir()
+
+
+def test_restart_loaded_checkpoint_survives_tracker_update_failure(tmp_path, manager, monkeypatch):
+    old_checkpoint = _write_checkpoint(tmp_path, 1)
+    _write_tracker(tmp_path, 1)
+    handler = _handler(tmp_path, manager)
+    assert handler.load_checkpoint() == 1
+
+    def fail_rename(src, dst):
+        raise OSError("tracker update failed")
+
+    monkeypatch.setattr(os, "rename", fail_rename)
+    with pytest.raises(OSError, match="tracker update failed"):
+        handler.save_checkpoint(2)
+
+    assert old_checkpoint.is_dir()
+    assert (tmp_path / "latest_checkpointed_iteration.txt").read_text() == "1"
+
+
+def test_restart_loaded_checkpoint_survives_failed_hdfs_copy(tmp_path, manager, monkeypatch):
+    old_checkpoint = _write_checkpoint(tmp_path, 1)
+    _write_tracker(tmp_path, 1)
+    handler = _handler(tmp_path, manager, default_hdfs_dir="hdfs://checkpoints")
+    assert handler.load_checkpoint() == 1
+    monkeypatch.setattr("verl.utils.checkpoint.checkpoint_handler.hdfs_io.makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr("verl.utils.checkpoint.checkpoint_handler.hdfs_io.copy", lambda *args, **kwargs: False)
+
+    handler.save_checkpoint(2)
+
+    assert old_checkpoint.is_dir()
+    assert (tmp_path / "latest_checkpointed_iteration.txt").read_text() == "2"
+
+
+def test_spmd_waits_for_dataloader_before_finalizing_retention(tmp_path, manager, monkeypatch):
+    events = []
+    dataloader = _Dataloader(events=events)
+    engine = _Engine(manager, events=events)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: events.append("barrier"))
+    real_rename = os.rename
+
+    def record_rename(src, dst):
+        events.append("tracker")
+        real_rename(src, dst)
+
+    monkeypatch.setattr(os, "rename", record_rename)
+    handler = CheckpointHandler(
+        engine=engine,
+        train_dataloader=dataloader,
+        default_local_dir=str(tmp_path),
+        max_ckpt_to_keep=1,
+        mode=OrchestrationMode.SPMD,
+    )
+
+    handler.save_checkpoint(1)
+
+    assert events == ["model", "dataloader", "tracker", "barrier", "finalize"]

--- a/verl/utils/checkpoint/checkpoint_handler.py
+++ b/verl/utils/checkpoint/checkpoint_handler.py
@@ -133,12 +133,27 @@ class CheckpointHandler:
             print(f"Updated checkpoint tracker: {tracker_file}")
 
         # Copy to HDFS if configured
+        remote_copy_succeeded = True
         if self.rank == 0 and self.default_hdfs_dir:
             hdfs_io.makedirs(self.default_hdfs_dir, exist_ok=True)
-            hdfs_io.copy(src=local_global_step_folder, dst=self.default_hdfs_dir, dirs_exist_ok=True)
+            remote_copy_succeeded = (
+                hdfs_io.copy(src=local_global_step_folder, dst=self.default_hdfs_dir, dirs_exist_ok=True) is not False
+            )
+            if not remote_copy_succeeded:
+                logger.warning(
+                    "Checkpoint copy to %s failed; preserving the loaded local checkpoint",
+                    self.default_hdfs_dir,
+                )
 
+        # Reuse the existing save barrier so rank 0 cannot remove the loaded
+        # checkpoint while another rank is still writing dataloader state.
         if self.mode == OrchestrationMode.SPMD:
             torch.distributed.barrier()
+
+        # Only rank 0 mutates retention state. Other SPMD ranks still call the
+        # hook so engines can keep a uniform interface without another collective.
+        if self.rank != 0 or remote_copy_succeeded:
+            self.engine.finalize_checkpoint_retention(local_global_step_folder, max_ckpt_to_keep)
 
     def load_checkpoint(self):
         # Determine resume path based on configuration
@@ -164,6 +179,7 @@ class CheckpointHandler:
         self.engine.load_checkpoint(checkpoint_path)
         # Always load dataloader state for StatefulDataLoader
         self._load_dataloader_state(checkpoint_path)
+        self.engine.prepare_checkpoint_retention(checkpoint_path)
 
         return resume_step
 

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -14,6 +14,7 @@
 
 import os
 import random
+import re
 import shutil
 
 import numpy as np
@@ -57,6 +58,7 @@ class BaseCheckpointManager:
             checkpoint_save_contents = ["model", "optimizer", "extra"]
         self.previous_global_step = None
         self.previous_saved_paths = []
+        self._loaded_checkpoint_path = None
 
         self.model = model
         self.optimizer = optimizer
@@ -192,6 +194,41 @@ class BaseCheckpointManager:
             keep_start = len(self.previous_saved_paths) - max_ckpt_to_keep
             self.remove_previous_save_local_path(self.previous_saved_paths[:keep_start])
             self.previous_saved_paths = self.previous_saved_paths[keep_start:]
+
+    def record_loaded_checkpoint(self, loaded_path: str):
+        """Remember an exact local checkpoint after it has loaded successfully."""
+        if loaded_path and not loaded_path.startswith("hdfs://") and os.path.isdir(loaded_path):
+            self._loaded_checkpoint_path = os.path.abspath(loaded_path)
+
+    def finalize_loaded_checkpoint_retention(self, new_path: str, max_ckpt_to_keep: int):
+        """Delete a loaded SFT checkpoint after its max-one replacement is committed."""
+        loaded_path = self._loaded_checkpoint_path
+        self._loaded_checkpoint_path = None
+        new_path = os.path.abspath(new_path)
+        registered_paths = {os.path.abspath(path) for path in self.previous_saved_paths}
+        if (
+            max_ckpt_to_keep != 1
+            or loaded_path is None
+            or new_path not in registered_paths
+            or not os.path.isdir(new_path)
+        ):
+            return
+
+        loaded_step = self._sft_checkpoint_series_step(loaded_path)
+        new_step = self._sft_checkpoint_series_step(new_path)
+        if loaded_step is None or new_step is None:
+            return
+        loaded_series, loaded_step_number = loaded_step
+        new_series, new_step_number = new_step
+        if loaded_series == new_series and new_step_number > loaded_step_number:
+            self.remove_previous_save_local_path(loaded_path)
+
+    @staticmethod
+    def _sft_checkpoint_series_step(path: str):
+        """Return the parent checkpoint series and step for an SFT checkpoint path."""
+        path = os.path.abspath(path)
+        match = re.fullmatch(r"global_step_(\d+)", os.path.basename(path))
+        return (os.path.dirname(path), int(match.group(1))) if match else None
 
     @staticmethod
     def get_rng_state():

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -282,6 +282,14 @@ class BaseEngine:
         """
         raise NotImplementedError
 
+    def prepare_checkpoint_retention(self, loaded_path: str) -> None:
+        """Record a loaded checkpoint whose retention is finalized by the orchestration layer."""
+        return None
+
+    def finalize_checkpoint_retention(self, new_path: str, max_ckpt_to_keep: Optional[int] = None) -> None:
+        """Finalize retention of a restart-loaded checkpoint after its replacement is committed."""
+        return None
+
     def is_mp_src_rank_with_outputs(self):
         """
         Whether the current rank is the first rank in model parallel group that contains model outputs

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -887,6 +887,14 @@ class FSDPEngine(BaseEngine):
         if self._is_offload_optimizer:
             offload_fsdp_optimizer(self.optimizer)
 
+    def prepare_checkpoint_retention(self, loaded_path: str) -> None:
+        if self.checkpoint_manager.rank == 0:
+            self.checkpoint_manager.record_loaded_checkpoint(loaded_path)
+
+    def finalize_checkpoint_retention(self, new_path: str, max_ckpt_to_keep: Optional[int] = None) -> None:
+        if self.checkpoint_manager.rank == 0:
+            self.checkpoint_manager.finalize_loaded_checkpoint_retention(new_path, max_ckpt_to_keep)
+
     def get_per_tensor_param_shard(self, **kwargs):
         """Like :meth:`get_per_tensor_param`, but yields each rank's *local* FSDP shard
         ``(name, local_flat_shard_bf16, ShardSpec)`` instead of all-gathering the full

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -442,6 +442,14 @@ class TrainingWorker(Worker, DistProfilerExtension):
     def load_checkpoint(self, local_path, hdfs_path=None, del_local_after_load=False):
         return self.engine.load_checkpoint(local_path, hdfs_path, del_local_after_load)
 
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def prepare_checkpoint_retention(self, loaded_path):
+        return self.engine.prepare_checkpoint_retention(loaded_path)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def finalize_checkpoint_retention(self, new_path, max_ckpt_to_keep=None):
+        return self.engine.finalize_checkpoint_retention(new_path, max_ckpt_to_keep)
+
 
 class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     """Hybrid worker that includes actor model, rollout and optional ref model.


### PR DESCRIPTION
### What does this PR do?

Fixes SFT FSDP checkpoint rotation after a process restart when `trainer.max_ckpt_to_keep=1`.

`BaseCheckpointManager` keeps retention history only in `previous_saved_paths`, which starts empty in each process. SFT could load `global_step_1`, save and publish `global_step_2`, and still retain both complete model/optimizer checkpoints. This PR remembers the exact checkpoint that successfully loaded and removes it only after a newer replacement in the same local SFT checkpoint series is committed.

Closes #7395.

This does not duplicate an existing PR. The exact searches below found no open implementation. #4873 protects a previous checkpoint until a new model save completes in the same process; it does not restore retention state after restart.

AI assistance was used for repository auditing, reproduction, implementation, test design, four-GPU validation, duplicate searches, and preparation of this description. The human submitter must review every changed line, understand the design and limitations, and rerun the relevant tests before requesting review.

### Checklist Before Starting

- [x] Search for similar PRs: [`max_ckpt_to_keep restart`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+max_ckpt_to_keep+restart), [`previous_saved_paths`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+previous_saved_paths), [`checkpoint retention resume`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+checkpoint+retention+resume)
- [x] Format the PR title as `[{modules}] {type}: {description}`.

Proposed title: `[ckpt, fsdp] fix: enforce max-one SFT retention after restart`

### Test

Baseline regression proof:

```bash
(cd /tmp && \
  PYTHONPATH=/path/to/upstream-main /path/to/python -m pytest -q --import-mode=importlib \
    /path/to/fix/tests/utils/ckpt/test_checkpoint_handler_on_cpu.py::test_restart_loaded_checkpoint_is_removed_after_replacement_commits)
# 1 failed: global_step_1 still exists after saving global_step_2
```

Focused checkpoint tests:

```bash
python -m pytest -q \
  tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py \
  tests/utils/ckpt/test_checkpoint_handler_on_cpu.py
# 22 passed
```

Related existing checkpoint tests:

```bash
python -m pytest -q \
  tests/checkpoint_engine/test_global_steps_on_cpu.py \
  tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py \
  tests/utils/ckpt/test_esi_save_ckpt_on_cpu.py \
  tests/utils/ckpt/test_lora_custom_object_save_on_cpu.py
# 27 passed
```

Repository quality gates:

```bash
pre-commit run --all-files --show-diff-on-failure --color=never
# All 13 configured hooks passed.

git diff --check
# passed
```

Real restart A/B:

- Hardware: 4 × RTX 3090 24 GiB; driver 580.173.02.
- Software: Python 3.12.13, PyTorch 2.11.0+cu128, Ray 2.56.1, Transformers 5.10.4.
- Workload: Qwen3.5-0.8B (852.99M parameters), Ray SFT, FSDP2 size 4, synchronous save, fixed data/config/seed, one step per process.
- The recorded GPU A/B used latest main `09ac37258ea66b0cb69b2738eec3074ea4e7261c` and candidate `8a1a031a9c03105839dcc6659e15cd975bfd5246`. The candidate is exactly one commit ahead of that base; its stable patch ID is `7c7443b7c5cc1ec75ff2454bcfe14548ba3f0274`.

| Result | upstream main | this PR |
|---|---:|---:|
| Tracker after restart | 2 | 2 |
| Retained steps | 1 and 2 | only 2 |
| Logical bytes | 20,518,092,555 | 10,259,046,150 |
| Allocated bytes | 20,518,244,352 | 10,259,124,224 |
| `.pt` files CRC-checked | 26 | 13 |

The candidate removed 10,259,046,405 logical bytes (9.554 GiB, 50.0%) from the two-checkpoint case. All model, optimizer, and extra-state shards for ranks 0–3 were present, and a SHA-256 manifest was captured before rotation. A second new process successfully loaded candidate step-2 model, optimizer, RNG, and scheduler state, trained step 3, and left only step 3; all 13 step-3 `.pt` files passed CRC validation. All five training phases exited with status 0. Logs contained no traceback, OOM, NCCL error, worker crash, NaN, or Inf.

The independent baseline/candidate runs used `full_determinism=false`; their small loss and gradient-norm differences are not claimed as bitwise equivalence. This is a retention correctness and disk-usage validation, not a speed or throughput benchmark.

### API and Usage Example

No user-facing API or configuration change. Existing SFT configuration now enforces the requested behavior across one restart:

```bash
trainer.resume_mode=auto \
trainer.max_ckpt_to_keep=1 \
trainer.default_local_dir=/path/to/checkpoints
```

This patch intentionally limits deferred restart retention to local SFT FSDP/FSDP2 checkpoints with `max_ckpt_to_keep=1`. It does not change PPO actor/critic retention, Megatron/TorchTitan behavior, async saving, external checkpoint series, or `max_ckpt_to_keep > 1`.

### Design & Code Changes

- Record the exact local FSDP checkpoint after the handler's resume sequence completes (including dataloader restoration when that state exists).
- Add Ray `ONE_TO_ALL` hooks so the SFT driver can prepare/finalize retention on the worker-side FSDP manager; other engines use safe no-op defaults.
- After the replacement model is registered, dataloader state is saved, tracker is atomically updated, optional HDFS copy succeeds, and SPMD ranks synchronize, delete only the loaded older step in the same checkpoint series.
- Never scan sibling directories. Preserve external paths, different series, same/rollback steps, missing/unregistered replacements, HDFS-copy failures, and all values other than `max_ckpt_to_keep=1`.
- Add CPU coverage for the restart lifecycle, failure atomicity, distributed ordering, path normalization, and scope guards.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md`, `AGENTS.md`, and the PR template.
- [x] Applied all configured pre-commit checks.
- [x] No user-facing documentation change is needed; the existing option now follows its documented retention meaning in the covered path.
- [x] Added CPU tests discovered by `cpu_unit_tests.yml` (`*_on_cpu.py`) and a real 4-GPU restart validation.
- [x] Human submitter reviewed every changed line and reran the commands claimed above.
- [ ] Once ready for upstream CI, request CI in the verl Slack or Feishu channel.
- [ ] Recipe submodule update. Not applicable; this PR does not modify `recipe`.
