### PR TITLE
[reward, cfg] fix: remove invalid super().__post_init__() in RewardManagerConfig

### DIFF
--- a/tests/workers/config/test_reward_config_on_cpu.py
+++ b/tests/workers/config/test_reward_config_on_cpu.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.base_config import BaseConfig
+from verl.trainer.config.config import ModuleConfig
+from verl.workers.config.reward import RewardConfig, RewardManagerConfig
+
+
+class TestRewardManagerConfig:
+    """Test suite for RewardManagerConfig, a direct BaseConfig subclass."""
+
+    def test_default_instantiation(self):
+        """RewardManagerConfig() must construct without error.
+
+        Regression test: __post_init__ previously called super().__post_init__(),
+        but BaseConfig defines no __post_init__, so default construction raised
+        AttributeError: 'super' object has no attribute '__post_init__'.
+        """
+        config = RewardManagerConfig()
+        assert isinstance(config, BaseConfig)
+        assert config.source == "register"
+        assert config.name == "naive"
+
+    def test_importlib_source_requires_module_path(self):
+        """When source is importlib, module.path must be set."""
+        config = RewardManagerConfig(source="importlib", module=ModuleConfig(path="my.module"))
+        assert config.source == "importlib"
+
+        with pytest.raises(AssertionError, match="module.path should be set"):
+            RewardManagerConfig(source="importlib", module=ModuleConfig())
+
+    def test_reward_config_builds_reward_manager(self):
+        """RewardConfig builds RewardManagerConfig via its default_factory."""
+        config = RewardConfig()
+        assert isinstance(config.reward_manager, RewardManagerConfig)
+
+    def test_dict_interface(self):
+        """RewardManagerConfig provides the dict-like interface from BaseConfig."""
+        config = RewardManagerConfig()
+        assert "source" in config
+        assert config["source"] == "register"
+        assert config.get("nonexistent_key", "default") == "default"

--- a/verl/workers/config/reward.py
+++ b/verl/workers/config/reward.py
@@ -49,7 +49,6 @@ class RewardManagerConfig(BaseConfig):
     module: Optional[ModuleConfig] = field(default_factory=ModuleConfig)
 
     def __post_init__(self):
-        super().__post_init__()
         if self.source == "register":
             from verl.experimental.reward_loop.reward_manager.registry import REWARD_MANAGER
 


### PR DESCRIPTION
### What does this PR do?

`RewardManagerConfig` is a direct subclass of `BaseConfig`, but `BaseConfig` (and its full MRO, which only adds `collections.abc.Mapping`) defines no `__post_init__`. Its `__post_init__` calls `super().__post_init__()` (`verl/workers/config/reward.py:52`), so default construction raises:

```
AttributeError: 'super' object has no attribute '__post_init__'
```

This is hit on the normal path: `RewardConfig` builds a `RewardManagerConfig` via `field(default_factory=RewardManagerConfig)`.

The fix removes the erroneous `super().__post_init__()` call. This matches the existing convention: other direct `BaseConfig` subclasses (`ActorConfig`, `CriticConfig`, `EngineConfig`, `PolicyLossConfig`) run their own validation in `__post_init__` and do not call `super().__post_init__()`; only their subclasses call `super()` to reach the parent's implementation.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+RewardManagerConfig
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Minimal repro against the real `BaseConfig` MRO:

```python
from dataclasses import dataclass
from verl.base_config import BaseConfig

# BaseConfig.__mro__ contains no __post_init__:
assert not any("__post_init__" in c.__dict__ for c in BaseConfig.__mro__)

from verl.workers.config.reward import RewardManagerConfig
RewardManagerConfig()  # before: AttributeError; after: constructs fine
```

Added `tests/workers/config/test_reward_config_on_cpu.py` covering:
- default construction (regression for this bug),
- `source="importlib"` module-path validation,
- the `BaseConfig` dict-like interface.

### Design & Code Changes

- `verl/workers/config/reward.py`: remove `super().__post_init__()` from `RewardManagerConfig.__post_init__`.
- `tests/workers/config/test_reward_config_on_cpu.py`: new CPU-only tests.