### PR TITLE
[data] fix: avoid retaining image bytes after decoding

### DIFF
--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -14,6 +14,7 @@
 import json
 import os
 from copy import deepcopy
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -106,6 +107,26 @@ def test_build_messages_accepts_image_path():
         {"type": "text", "text": "Describe "},
         {"type": "image", "image": image_path},
     ]
+
+
+def test_build_messages_drops_image_bytes_without_mutating_source():
+    dataset = _mock_rlhf_dataset()
+    buffer = BytesIO()
+    Image.new("RGB", (2, 2), color="red").save(buffer, format="PNG")
+    source_image = {"bytes": buffer.getvalue()}
+    example = {
+        "prompt": [{"role": "user", "content": "Describe <image>"}],
+        "images": [source_image],
+    }
+
+    messages = dataset._build_messages(example, key=dataset.prompt_key)
+    image_content = messages[0]["content"][1]
+
+    assert isinstance(image_content["image"], Image.Image)
+    assert image_content["image"].getpixel((0, 0)) == (255, 0, 0)
+    assert "bytes" not in image_content
+    assert "bytes" in source_image
+    assert "image" not in source_image
 
 
 @pytest.mark.parametrize(

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -337,8 +337,11 @@ class RLHFDataset(Dataset):
                         image = image.convert("RGB")
                         content_list.append({"type": "image", "image": image})
                     elif isinstance(image, dict):
+                        image = dict(image)
                         if "bytes" in image:
-                            image["image"] = Image.open(BytesIO(image["bytes"]))
+                            with Image.open(BytesIO(image.pop("bytes"))) as decoded_image:
+                                # Pillow loads lazily, so detach the image before closing the byte stream.
+                                image["image"] = decoded_image.copy()
                         content_list.append({"type": "image", **image})
                     elif isinstance(image, str | os.PathLike):
                         content_list.append({"type": "image", "image": os.fspath(image)})


### PR DESCRIPTION
```markdown
### What does this PR do?

Addresses #7391.

`RLHFDataset._build_messages()` previously retained both the compressed
image bytes and the decoded PIL image in `raw_prompt`. This could
substantially increase host-memory and Ray serialization overhead during
multimodal RL training.

This PR:

- copies the image payload instead of mutating the source dictionary;
- removes `bytes` from the payload added to `raw_prompt`;
- fully detaches the decoded PIL image from its `BytesIO` stream, because
  Pillow loads image data lazily;
- adds a regression test covering payload cleanup, image readability, and
  source-dictionary immutability.

This is intentionally a dataset-side fix. It does not attempt to change
AgentLoop, DataProto, or actor-dispatch behavior.

### Checklist Before Starting

- [x] Searched for similar open PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22raw_prompt%22+%22image+bytes%22
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+RLHFDataset+image+memory
- [x] No open PR implementing the same fix was found.
- [x] PR title follows the required format:
  `[data] fix: avoid retaining image bytes after decoding`

### Test

```bash
VERL_USE_EXTERNAL_PLUGINS=none python -m pytest -q \
  tests/utils/dataset/test_rl_dataset_on_cpu.py \
  -k "build_messages"
```

Result:

```text
5 passed, 5 deselected
```

The new regression test was also run independently:

```bash
VERL_USE_EXTERNAL_PLUGINS=none python -m pytest -q \
  tests/utils/dataset/test_rl_dataset_on_cpu.py::test_build_messages_drops_image_bytes_without_mutating_source
```

Result:

```text
1 passed
```

Pre-commit was run on the modified files:

```bash
pre-commit run --files \
  verl/utils/dataset/rl_dataset.py \
  tests/utils/dataset/test_rl_dataset_on_cpu.py
```

Result: all hooks passed.

### API and Usage Example

No public API or configuration changes.

Bytes-backed image entries remain supported:

```python
{"bytes": image_bytes}
```

The resulting image content contains a usable PIL image without retaining
the original `bytes` field.

### Design & Code Changes

Before:

```python
image["image"] = Image.open(BytesIO(image["bytes"]))
```

This mutated the source object and retained both representations.

After:

```python
image = dict(image)
with Image.open(BytesIO(image.pop("bytes"))) as decoded_image:
    image["image"] = decoded_image.copy()
```

The copy detaches the decoded image from Pillow's lazy backing stream before
the stream is closed.

### Documentation

No documentation update is required because this is an internal memory
management fix without API or configuration changes.

### AI-Assisted Contribution

AI assistance was used for code analysis, test drafting, and PR description
drafting. I reviewed every changed line and validated the behavior with the
tests listed above.