### PR TITLE
[ckpt, trainer] fix: resume SFT after epoch checkpoints

### DIFF
--- a/tests/trainer/test_sft_resume_on_cpu.py
+++ b/tests/trainer/test_sft_resume_on_cpu.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.trainer.sft_trainer import SFTTrainer as SpmdSFTTrainer
+from verl.trainer.sft_trainer_ray import SFTTrainer as RaySFTTrainer
+
+
+@pytest.mark.parametrize("trainer_cls", [SpmdSFTTrainer, RaySFTTrainer])
+def test_fit_does_not_train_past_completed_step_target(trainer_cls):
+    trainer = trainer_cls.__new__(trainer_cls)
+    trainer.resume_global_step = 4
+    trainer.total_training_steps = 4
+    trainer.rank = 0
+
+    assert trainer.fit() is None

--- a/tests/utils/ckpt/test_checkpoint_handler_on_cpu.py
+++ b/tests/utils/ckpt/test_checkpoint_handler_on_cpu.py
@@ -1,0 +1,228 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+import torch
+from torch.utils.data import DistributedSampler, TensorDataset
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from verl.utils.checkpoint import CheckpointHandler, OrchestrationMode
+
+
+class _FakeEngine:
+    def save_checkpoint(self, local_path, global_step, max_ckpt_to_keep=None):
+        os.makedirs(local_path, exist_ok=True)
+
+    def load_checkpoint(self, local_path):
+        assert os.path.isdir(local_path)
+
+    def is_mp_src_rank_with_outputs(self):
+        return True
+
+    def get_data_parallel_rank(self):
+        return 0
+
+
+class _RecordingEngine(_FakeEngine):
+    def __init__(self, events):
+        self.events = events
+
+    def save_checkpoint(self, local_path, global_step, max_ckpt_to_keep=None):
+        self.events.append("model")
+        super().save_checkpoint(local_path, global_step, max_ckpt_to_keep)
+
+
+class _RecordingLoader:
+    def __init__(self, events):
+        self.events = events
+
+    def __len__(self):
+        return 4
+
+    def state_dict(self):
+        self.events.append("dataloader")
+        return {"position": 4}
+
+
+def _make_loader(dataset_size=8, batch_size=2):
+    dataset = TensorDataset(torch.arange(dataset_size))
+    sampler = DistributedSampler(dataset, num_replicas=1, rank=0, shuffle=True, seed=0, drop_last=True)
+    loader = StatefulDataLoader(
+        dataset,
+        batch_size=batch_size,
+        sampler=sampler,
+        num_workers=0,
+        drop_last=True,
+    )
+    return sampler, loader
+
+
+def _batch_values(loader):
+    return [batch[0].tolist() for batch in loader]
+
+
+def _save_after_batches(checkpoint_dir, batches, *, dataset_size=8, batch_size=2, mode=OrchestrationMode.RAY):
+    _, loader = _make_loader(dataset_size=dataset_size, batch_size=batch_size)
+    iterator = iter(loader)
+    consumed = [next(iterator)[0].tolist() for _ in range(batches)]
+    handler = CheckpointHandler(
+        engine=_FakeEngine(),
+        train_dataloader=loader,
+        default_local_dir=checkpoint_dir,
+        resume_mode="disable",
+        mode=mode,
+    )
+    handler.save_checkpoint(step=batches)
+    remaining = [batch[0].tolist() for batch in iterator]
+    return consumed, remaining
+
+
+def _resume(checkpoint_dir, *, dataset_size=8, batch_size=2, mode=OrchestrationMode.RAY):
+    sampler, loader = _make_loader(dataset_size=dataset_size, batch_size=batch_size)
+    handler = CheckpointHandler(
+        engine=_FakeEngine(),
+        train_dataloader=loader,
+        default_local_dir=checkpoint_dir,
+        resume_mode="auto",
+        mode=mode,
+    )
+    resume_step = handler.load_checkpoint()
+    sampler.set_epoch(resume_step // len(loader))
+    return resume_step, _batch_values(loader)
+
+
+@pytest.mark.parametrize("mode", [OrchestrationMode.RAY, OrchestrationMode.SPMD])
+def test_epoch_boundary_resume_starts_next_sft_epoch(tmp_path, monkeypatch, mode):
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+    checkpoint_dir = str(tmp_path / "boundary")
+    _, remaining = _save_after_batches(checkpoint_dir, batches=4, mode=mode)
+    assert remaining == []
+
+    fresh_sampler, fresh_loader = _make_loader()
+    fresh_sampler.set_epoch(1)
+    expected_next_epoch = _batch_values(fresh_loader)
+
+    resume_step, resumed_batches = _resume(checkpoint_dir, mode=mode)
+
+    assert resume_step == 4
+    assert resumed_batches == expected_next_epoch
+
+
+@pytest.mark.parametrize("mode", [OrchestrationMode.RAY, OrchestrationMode.SPMD])
+def test_mid_epoch_resume_restores_sft_dataloader_position(tmp_path, monkeypatch, mode):
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+    checkpoint_dir = str(tmp_path / "mid_epoch")
+    consumed, expected_remaining = _save_after_batches(checkpoint_dir, batches=2, mode=mode)
+
+    resume_step, resumed_batches = _resume(checkpoint_dir, mode=mode)
+
+    assert resume_step == 2
+    assert len(consumed) == 2
+    assert resumed_batches == expected_remaining
+
+
+def test_saved_geometry_prevents_false_epoch_boundary(tmp_path):
+    checkpoint_dir = str(tmp_path / "changed_geometry")
+    _save_after_batches(checkpoint_dir, batches=4, dataset_size=12, batch_size=2)
+
+    with pytest.raises(ValueError, match="different number of batches per epoch"):
+        _resume(checkpoint_dir, dataset_size=12, batch_size=3)
+
+
+def test_legacy_epoch_boundary_checkpoint_is_supported(tmp_path):
+    checkpoint_dir = str(tmp_path / "legacy")
+    _save_after_batches(checkpoint_dir, batches=4)
+    os.remove(os.path.join(checkpoint_dir, "global_step_4", "data_0.pt.meta.json"))
+
+    resume_step, resumed_batches = _resume(checkpoint_dir)
+
+    assert resume_step == 4
+    assert len(resumed_batches) == 4
+
+
+def test_legacy_mid_epoch_checkpoint_restores_position(tmp_path):
+    checkpoint_dir = str(tmp_path / "legacy_mid_epoch")
+    _, expected_remaining = _save_after_batches(checkpoint_dir, batches=2)
+    os.remove(os.path.join(checkpoint_dir, "global_step_2", "data_0.pt.meta.json"))
+
+    resume_step, resumed_batches = _resume(checkpoint_dir)
+
+    assert resume_step == 2
+    assert resumed_batches == expected_remaining
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        "not-json",
+        "[]",
+        '{"version": true, "global_step": 2, "steps_per_epoch": 4, "step_in_epoch": 2}',
+        '{"version": 1, "global_step": true, "steps_per_epoch": 4, "step_in_epoch": 0}',
+    ],
+)
+def test_invalid_dataloader_metadata_fails_with_context(tmp_path, metadata):
+    checkpoint_dir = str(tmp_path / "invalid_metadata")
+    _save_after_batches(checkpoint_dir, batches=2)
+    metadata_path = os.path.join(checkpoint_dir, "global_step_2", "data_0.pt.meta.json")
+    with open(metadata_path, "w", encoding="utf-8") as f:
+        f.write(metadata)
+
+    with pytest.raises(ValueError, match="SFT dataloader metadata"):
+        _resume(checkpoint_dir)
+
+
+def test_spmd_publishes_checkpoint_after_all_dataloader_files(tmp_path, monkeypatch):
+    events = []
+    real_replace = os.replace
+
+    def record_replace(src, dst):
+        events.append("metadata" if dst.endswith(".meta.json") else "tracker")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: events.append("barrier"))
+    monkeypatch.setattr(os, "replace", record_replace)
+    monkeypatch.setattr(
+        "verl.utils.checkpoint.checkpoint_handler.hdfs_io.makedirs",
+        lambda *args, **kwargs: events.append("hdfs_makedirs"),
+    )
+    monkeypatch.setattr(
+        "verl.utils.checkpoint.checkpoint_handler.hdfs_io.copy",
+        lambda *args, **kwargs: events.append("hdfs_copy"),
+    )
+    handler = CheckpointHandler(
+        engine=_RecordingEngine(events),
+        train_dataloader=_RecordingLoader(events),
+        default_local_dir=str(tmp_path),
+        default_hdfs_dir="hdfs://checkpoints",
+        resume_mode="disable",
+        mode=OrchestrationMode.SPMD,
+    )
+
+    handler.save_checkpoint(step=4)
+
+    assert events == [
+        "model",
+        "dataloader",
+        "metadata",
+        "barrier",
+        "tracker",
+        "hdfs_makedirs",
+        "hdfs_copy",
+        "barrier",
+    ]

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -306,6 +306,17 @@ class SFTTrainer:
         return batch_seqlens
 
     def fit(self):
+        global_step = self.resume_global_step
+        if global_step >= self.total_training_steps:
+            log_with_rank(
+                f"Checkpoint step {global_step} already reached total_training_steps={self.total_training_steps}; "
+                "no additional SFT updates are needed",
+                logger=logger,
+                rank=self.rank,
+                log_only_rank_0=True,
+            )
+            return
+
         is_logging = self.engine.is_mp_src_rank_with_outputs() and self.engine.get_data_parallel_rank() == 0
 
         # TODO: add a unified tracking
@@ -317,7 +328,6 @@ class SFTTrainer:
                 config=OmegaConf.to_container(self.config, resolve=True),
             )
 
-        global_step = self.resume_global_step  # Start from resumed step
         last_valid_metric = None
 
         log_with_rank(

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -245,6 +245,17 @@ class SFTTrainer:
         return batch_seqlens
 
     def fit(self):
+        global_step = self.resume_global_step
+        if global_step >= self.total_training_steps:
+            log_with_rank(
+                f"Checkpoint step {global_step} already reached total_training_steps={self.total_training_steps}; "
+                "no additional SFT updates are needed",
+                logger=logger,
+                rank=0,
+                log_only_rank_0=True,
+            )
+            return
+
         tracking = Tracking(
             project_name=self.config.trainer.project_name,
             experiment_name=self.config.trainer.experiment_name,
@@ -252,7 +263,6 @@ class SFTTrainer:
             config=OmegaConf.to_container(self.config, resolve=True),
         )
 
-        global_step = self.resume_global_step  # Start from resumed step
         last_valid_metric = None
 
         log_with_rank(

--- a/verl/utils/checkpoint/checkpoint_handler.py
+++ b/verl/utils/checkpoint/checkpoint_handler.py
@@ -40,6 +40,8 @@ def extract_step(path):
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_SFT_LOGGING_LEVEL", "WARN"))
 
+_DATALOADER_METADATA_VERSION = 1
+
 
 class OrchestrationMode(Enum):
     SPMD = 0
@@ -121,7 +123,24 @@ class CheckpointHandler:
             # Use StatefulDataLoader's built-in state dict functionality
             dataloader_state_dict = self.train_dataloader.state_dict()
             torch.save(dataloader_state_dict, dataloader_local_path)
+            steps_per_epoch = len(self.train_dataloader)
+            dataloader_metadata = {
+                "version": _DATALOADER_METADATA_VERSION,
+                "global_step": step,
+                "steps_per_epoch": steps_per_epoch,
+                "step_in_epoch": step % steps_per_epoch if steps_per_epoch > 0 else None,
+            }
+            metadata_path = f"{dataloader_local_path}.meta.json"
+            temp_metadata_path = f"{metadata_path}.tmp"
+            with open(temp_metadata_path, "w", encoding="utf-8") as f:
+                json.dump(dataloader_metadata, f)
+            os.replace(temp_metadata_path, metadata_path)
             print(f"Saved dataloader state to: {dataloader_local_path}")
+
+        # All data-parallel ranks must finish their dataloader files before
+        # rank 0 publishes the checkpoint tracker or copies the directory.
+        if self.mode == OrchestrationMode.SPMD:
+            torch.distributed.barrier()
 
         if self.rank == 0:
             # Update latest checkpoint tracker (atomic write)
@@ -129,7 +148,7 @@ class CheckpointHandler:
             temp_tracker_file = tracker_file + ".tmp"
             with open(temp_tracker_file, "w") as f:
                 f.write(str(step))
-            os.rename(temp_tracker_file, tracker_file)
+            os.replace(temp_tracker_file, tracker_file)
             print(f"Updated checkpoint tracker: {tracker_file}")
 
         # Copy to HDFS if configured
@@ -162,17 +181,77 @@ class CheckpointHandler:
 
         # Use checkpoint manager to load model state
         self.engine.load_checkpoint(checkpoint_path)
-        # Always load dataloader state for StatefulDataLoader
-        self._load_dataloader_state(checkpoint_path)
+        # Restore mid-epoch progress while leaving an exhausted epoch-boundary
+        # dataloader fresh for the next epoch.
+        self._load_dataloader_state(checkpoint_path, resume_step)
 
         return resume_step
 
-    def _load_dataloader_state(self, checkpoint_path: str):
+    def _load_dataloader_state(self, checkpoint_path: str, resume_step: int):
         """Load dataloader state from checkpoint"""
         dp_rank = self.dp_rank
         dataloader_path = os.path.join(checkpoint_path, f"data_{dp_rank}.pt")
 
         if os.path.exists(dataloader_path):
+            steps_per_epoch = len(self.train_dataloader)
+            metadata_path = f"{dataloader_path}.meta.json"
+            if os.path.exists(metadata_path):
+                try:
+                    with open(metadata_path, encoding="utf-8") as f:
+                        metadata = json.load(f)
+                except (OSError, json.JSONDecodeError) as exc:
+                    raise ValueError(f"Cannot read SFT dataloader metadata from {metadata_path}") from exc
+                if not isinstance(metadata, dict):
+                    raise ValueError(f"Invalid SFT dataloader metadata in {metadata_path}: expected an object")
+                saved_step = metadata.get("global_step")
+                saved_steps_per_epoch = metadata.get("steps_per_epoch")
+                saved_step_in_epoch = metadata.get("step_in_epoch")
+                if type(metadata.get("version")) is not int or metadata["version"] != _DATALOADER_METADATA_VERSION:
+                    raise ValueError(f"Invalid SFT dataloader metadata version in {metadata_path}")
+                if type(saved_step) is not int:
+                    raise ValueError(f"Invalid SFT dataloader metadata in {metadata_path}")
+                if type(saved_steps_per_epoch) is not int or saved_steps_per_epoch < 0:
+                    raise ValueError(f"Invalid steps_per_epoch in {metadata_path}: {saved_steps_per_epoch!r}")
+                expected_step_in_epoch = saved_step % saved_steps_per_epoch if saved_steps_per_epoch > 0 else None
+                step_in_epoch_is_valid = (
+                    saved_step_in_epoch is None
+                    if expected_step_in_epoch is None
+                    else type(saved_step_in_epoch) is int and saved_step_in_epoch == expected_step_in_epoch
+                )
+                if saved_step != resume_step or not step_in_epoch_is_valid:
+                    raise ValueError(
+                        f"SFT dataloader metadata in {metadata_path} does not match resume step {resume_step}"
+                    )
+                if saved_steps_per_epoch != steps_per_epoch:
+                    raise ValueError(
+                        "Cannot safely resume SFT with a different number of batches per epoch: "
+                        f"checkpoint={saved_steps_per_epoch}, current={steps_per_epoch}. "
+                        "Use the same SFT dataloader geometry as the saved checkpoint."
+                    )
+                at_epoch_boundary = saved_steps_per_epoch > 0 and saved_step_in_epoch == 0
+            else:
+                # Checkpoints created before dataloader metadata was added can
+                # only infer the boundary from the current loader geometry.
+                at_epoch_boundary = steps_per_epoch > 0 and resume_step % steps_per_epoch == 0
+                log_with_rank(
+                    f"No SFT dataloader metadata found at {metadata_path}; inferring the epoch position from the "
+                    "current number of batches per epoch. Keep the SFT dataloader geometry unchanged when resuming "
+                    "this legacy checkpoint.",
+                    logger=logger,
+                    rank=self.rank,
+                    level=logging.WARNING,
+                    log_only_rank_0=True,
+                )
+            if at_epoch_boundary:
+                log_with_rank(
+                    f"Skipping dataloader state restore because resume_step={resume_step} is at an epoch boundary "
+                    f"(steps_per_epoch={steps_per_epoch}); the saved dataloader is exhausted",
+                    logger=logger,
+                    rank=self.rank,
+                    log_only_rank_0=True,
+                )
+                return
+
             # Use StatefulDataLoader's built-in state dict functionality
             dataloader_state_dict = torch.load(dataloader_path, map_location="cpu", weights_only=False)
             self.train_dataloader.load_state_dict(dataloader_state_dict)


### PR DESCRIPTION
### What does this PR do?

Fixes a silent SFT resume failure at epoch-boundary checkpoints.

SFT previously restored an exhausted `StatefulDataLoader` state at the beginning of the next epoch. The process could then exit successfully without running any remaining updates. This PR records the saved epoch position, skips restoration only at a confirmed epoch boundary, and preserves mid-epoch progress.

Closes #7401.

This does not duplicate [#5725](https://github.com/verl-project/verl/pull/5725): that merged safeguard changes only the PPO trainer, while SFT uses the shared `CheckpointHandler` path changed here.

AI assistance was used for repository auditing, reproduction, implementation, test design, four-GPU validation, duplicate searches, and preparation of this description. The human submitter must review every changed line, understand the design and limitations, and rerun the relevant tests before requesting review.

### Checklist Before Starting

- [x] Search for similar PRs: [`StatefulDataLoader epoch boundary SFT`](https://github.com/verl-project/verl/pulls?q=is%3Apr%20%22StatefulDataLoader%22%20%22epoch%20boundary%22%20SFT), [`CheckpointHandler epoch boundary`](https://github.com/verl-project/verl/pulls?q=is%3Apr%20%22CheckpointHandler%22%20%22epoch%20boundary%22), [`SFT dataloader resume`](https://github.com/verl-project/verl/pulls?q=is%3Apr%20SFT%20dataloader%20resume)
- [x] Format the PR title as `[{modules}] {type}: {description}`.

Proposed title: `[ckpt, trainer] fix: resume SFT after epoch checkpoints`

### Test

Baseline production-handler reproduction:

```bash
(cd /tmp && \
  PYTHONNOUSERSITE=1 \
  PYTHONPATH=/path/to/upstream-main \
  /path/to/python /path/to/reproduce.py --expect bug)
# 3/3: resume_step=4, resumed_batches=0
```

The same command against this branch with `--expect fixed` yielded all four next-epoch batches in 3/3 runs.

Focused tests:

```bash
python -m pytest -q \
  tests/utils/ckpt/test_checkpoint_handler_on_cpu.py \
  tests/trainer/test_sft_resume_on_cpu.py
# 14 passed
```

Focused plus related checkpoint tests:

```bash
python -m pytest -q \
  tests/utils/ckpt/test_checkpoint_handler_on_cpu.py \
  tests/trainer/test_sft_resume_on_cpu.py \
  tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py \
  tests/checkpoint_engine/test_global_steps_on_cpu.py \
  tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py \
  tests/utils/ckpt/test_esi_save_ckpt_on_cpu.py \
  tests/utils/ckpt/test_lora_custom_object_save_on_cpu.py
# 46 passed
```

Repository quality gates:

```bash
pre-commit run --all-files --show-diff-on-failure --color=never
# All 13 configured hooks passed.

git diff --check
# passed
```

Real restart A/B:

- Hardware: 4 × RTX 3090 24 GiB; driver 580.173.02.
- Software: Python 3.12.13, PyTorch 2.11.0+cu128, CUDA 12.8, torchdata 0.11.0, Ray 2.56.1, Transformers 5.10.4.
- Workload: Qwen3.5-0.8B (852.99M parameters), 64 selected samples, global batch size 16, four batches per epoch, Ray SFT, FSDP2 size 4, BF16 mixed precision, synchronous checkpoint saves.
- Revisions: upstream main `09ac37258ea66b0cb69b2738eec3074ea4e7261c`; candidate `e06deb3212cdad0ec22493a92eeb92dfe065ac50`.
- Baseline and candidate received byte-identical copies of the same complete step-4 checkpoint.

| Result | upstream main | this PR |
|---|---:|---:|
| Process exit | 0 | 0 |
| Steps after boundary resume | none | 5, 6, 7, 8 |
| Final tracker | 4 | 8 |

The main log confirms that it loaded the exhausted step-4 dataloader state, entered epoch 2, yielded zero batches, and exited successfully. The candidate skipped that boundary state and completed the expected second epoch.

A separate candidate mid-epoch control resumed step 2 and ran only steps 3–4. Its token counts (1096 and 1080) exactly matched the uninterrupted run's steps 3–4, confirming that normal mid-epoch position restoration was preserved. The final step-4 and step-8 checkpoints each contained all rank 0–3 model, optimizer, and extra-state shards plus dataloader state. The frozen formal validator passed ZIP CRC for all 13 step-8 `.pt` files. A separate independent read-only audit also checked and passed all 13 step-4 files.

All four formal phases exited 0. Their logs contained no traceback, RuntimeError, OOM, NCCL failure, worker crash, NaN, or Inf. This is a resume-correctness validation, not a throughput benchmark; `full_determinism=false` means small loss/gradient differences between separate processes are not claimed as bitwise equivalence.

### API and Usage Example

No public API or configuration change. Existing SFT resume settings continue to work:

```bash
trainer.resume_mode=auto \
trainer.default_local_dir=/path/to/checkpoints
```

New checkpoints include an internal versioned sidecar next to each `data_<dp_rank>.pt`. Checkpoints created before this PR remain loadable through a warning-backed compatibility fallback.

### Design & Code Changes

- Persist versioned checkpoint step, batches-per-epoch, and in-epoch position beside SFT dataloader state.
- Validate metadata against the selected checkpoint and reject a changed number of batches per epoch.
- Skip an exhausted dataloader state only at a confirmed epoch boundary; restore mid-epoch state normally.
- Warn and infer the boundary from current loader length for legacy checkpoints without metadata.
- Synchronize SPMD dataloader files before rank 0 publishes the tracker and optional HDFS copy.
- Avoid entering either SFT training loop when the resumed step already reached `total_training_steps`.
- Add CPU coverage for Ray/SPMD handling, boundary and mid-epoch resume, legacy checkpoints, strict metadata validation, changed batches per epoch, publication ordering, and both SFT trainer entry points.

The metadata does not claim to detect arbitrary dataset, sampler, or DP-topology changes that preserve the same number of batches. This PR also does not claim full directory-level crash atomicity. The real GPU validation covers Ray/FSDP2 with `checkpoint.async_save=false`; Megatron asynchronous finalization, HDFS, and multi-node SPMD are not part of that end-to-end test.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md`, `AGENTS.md`, and the PR template.
- [x] Applied all configured pre-commit checks.
- [x] Documentation update is not applicable; this fixes internal resume correctness without changing a public API or configuration.
- [x] Added CPU tests discovered by `cpu_unit_tests.yml` (`*_on_cpu.py`) and real four-GPU validation.
- [x] Human submitter reviewed every changed line and reran the commands claimed above.
- [x] Once ready for upstream CI, request CI in the verl Slack or Feishu channel.
- [x] Recipe submodule update evaluated as not applicable; neither recipe contents nor its gitlink changed.
