### PR TITLE
[rollout, trainer] feat: add pluggable rollout data backends

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -778,6 +778,9 @@ def test_from_tensordict():
     assert torch.all(torch.eq(data.batch["obs"], tensor_dict["obs"])).item()
     assert data.meta_info["name"] == "abdce"
 
+    non_tensor_only = DataProto.from_tensordict(tu.get_tensordict({"labels": tensor_dict["labels"]}, {}))
+    assert len(non_tensor_only) == len(tensor_dict["labels"])
+
 
 @pytest.mark.skipif(
     parse_version(tensordict.__version__) < parse_version("0.10"), reason="requires at least tensordict 0.10"
@@ -902,6 +905,10 @@ def test_to_tensordict_and_back_with_nested_data():
 
     # Verify non-tensor data is preserved
     assert reconstructed_data.non_tensor_batch["labels"].tolist() == labels
+    assert all(
+        reconstructed_data.non_tensor_batch[key].shape == (len(labels),)
+        for key in ("turn_scores", "reward_extra_info", "raw_prompt")
+    )
 
     # Verify nested structures are preserved
     assert len(reconstructed_data.non_tensor_batch["turn_scores"]) == len(turn_scores)

--- a/tests/trainer/ppo/v1/test_reissue_inflight_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_reissue_inflight_on_cpu.py
@@ -30,7 +30,7 @@ to build a full trainer.
 A second group of tests covers the ``tq.save_checkpoint``/``tq.load_checkpoint``
 round-trip that backs checkpoint consistency (matching ``_save_checkpoint``/
 ``_load_checkpoint``). These call the real checkpoint APIs, so they skip on
-builds that lack them (the same ``_tq_supports_checkpoint`` gate the trainer uses
+builds that lack them (the same backend capability gate the trainer uses
 to decide whether to save/load); one test additionally asserts the trainer
 short-circuits re-issue when the gate reports the feature unsupported.
 """
@@ -43,13 +43,15 @@ import transfer_queue as tq
 from omegaconf import OmegaConf
 from tensordict import TensorDict
 
-from verl.trainer.ppo.v1 import trainer_base
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+from verl.utils import rollout_data_backend
 from verl.utils import tensordict_utils as tu
 
 # Capture the real compatibility guard before the autouse fixture patches it. The save/load round-trip
 # tests call the real APIs, so they must skip on builds that do not provide them.
-_REAL_TQ_SUPPORTS_CHECKPOINT = trainer_base._tq_supports_checkpoint
+_REAL_TQ_SUPPORTS_CHECKPOINT = (
+    rollout_data_backend.TransferQueueBackend().supports_checkpoint
+)
 requires_tq_checkpoint = pytest.mark.skipif(
     not _REAL_TQ_SUPPORTS_CHECKPOINT(),
     reason="TransferQueue >= 0.1.9 with save_checkpoint/load_checkpoint is required",
@@ -58,9 +60,10 @@ requires_tq_checkpoint = pytest.mark.skipif(
 
 @pytest.fixture(scope="module")
 def tq_init():
-    tq.init()
+    rollout_data_backend.configure_runtime({"name": "transfer_queue"})
+    rollout_data_backend.init()
     yield
-    tq.close()
+    rollout_data_backend.close()
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +73,7 @@ def _force_tq_checkpoint_supported(monkeypatch):
     The locally installed TransferQueue may not support checkpointing, which short-circuits re-issue.
     The save/load round-trip tests instead use ``requires_tq_checkpoint`` and call the actual APIs.
     """
-    monkeypatch.setattr(trainer_base, "_tq_supports_checkpoint", lambda: True)
+    monkeypatch.setattr(rollout_data_backend, "supports_checkpoint", lambda: True)
 
 
 @pytest.fixture
@@ -180,7 +183,9 @@ def test_async_submission_persists_reissuable_prompt_fields(monkeypatch):
     )
     tu.assign_non_tensor_data(batch, "global_steps", stub.global_steps)
     puts = []
-    monkeypatch.setattr(trainer_base.tq, "kv_batch_put", lambda **kwargs: puts.append(kwargs))
+    monkeypatch.setattr(
+        rollout_data_backend, "batch_put", lambda **kwargs: puts.append(kwargs)
+    )
 
     assert stub._submit_batch_to_rollout(batch) == 2
     assert len(puts) == 1
@@ -348,7 +353,7 @@ def test_reissue_noop_for_sync_mode(tq_init, partition_id):
 # tq.save_checkpoint / tq.load_checkpoint round-trip
 #
 # These call the real TransferQueue checkpoint APIs (matching _save_checkpoint/_load_checkpoint),
-# so they skip on builds that lack them. The defensive gate (_tq_supports_checkpoint) is what the
+# so they skip on builds that lack them. The backend capability gate is what the
 # trainer uses to decide whether to save/load at all; here we skip on the same condition and
 # additionally assert the trainer short-circuits when the gate reports unsupported.
 # --------------------------------------------------------------------------- #
@@ -424,7 +429,7 @@ def test_reissue_short_circuits_when_checkpoint_unsupported(tq_init, partition_i
     This overrides the autouse fixture (which forces the gate open) to assert the real guard, so
     an old TransferQueue never tries to read back / re-submit prompts that were never persisted.
     """
-    monkeypatch.setattr(trainer_base, "_tq_supports_checkpoint", lambda: False)
+    monkeypatch.setattr(rollout_data_backend, "supports_checkpoint", lambda: False)
     _submit_prompt(partition_id, _uid(), "running", global_steps=1)
 
     stub = _make_trainer_stub()

--- a/tests/trainer/ppo/v1/test_replay_buffer_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_replay_buffer_on_cpu.py
@@ -27,9 +27,10 @@ from dataclasses import dataclass, field
 import pytest
 import torch
 import transfer_queue as tq
-from transfer_queue import KVBatchMeta
 
+from verl.protocol import RolloutDataRef
 from verl.trainer.ppo.v1.replay_buffer import ReplayBuffer, ReplayBufferAsync
+from verl.utils import rollout_data_backend
 
 # Small poll interval so the blocking consumer reacts to producer writes quickly.
 POLL_INTERVAL = 0.05
@@ -37,9 +38,10 @@ POLL_INTERVAL = 0.05
 
 @pytest.fixture(scope="module")
 def tq_init():
-    tq.init()
+    rollout_data_backend.configure_runtime({"name": "transfer_queue"})
+    rollout_data_backend.init()
     yield
-    tq.close()
+    rollout_data_backend.close()
 
 
 @pytest.fixture
@@ -109,7 +111,7 @@ class FakeRefiller:
         return num_prompts
 
 
-def _sample(rb: ReplayBuffer, partition_id: str, batch_size: int, global_steps: int = 0) -> KVBatchMeta:
+def _sample(rb: ReplayBuffer, partition_id: str, batch_size: int, global_steps: int = 0) -> RolloutDataRef:
     """Call ``sample`` and return just the batch (dropping the metrics dict)."""
     batch, _metrics = rb.sample(global_steps=global_steps, partition_id=partition_id, batch_size=batch_size)
     return batch
@@ -199,7 +201,7 @@ class SampleConsumer(threading.Thread):
         self.partition_id = partition_id
         self.batch_size = batch_size
         self.global_steps = global_steps
-        self.result: KVBatchMeta | None = None
+        self.result: RolloutDataRef | None = None
         self.metrics: dict | None = None
         self.error: Exception | None = None
 
@@ -213,7 +215,7 @@ class SampleConsumer(threading.Thread):
         except Exception as e:
             self.error = e
 
-    def result_or_raise(self, timeout: float = 10.0) -> KVBatchMeta:
+    def result_or_raise(self, timeout: float = 10.0) -> RolloutDataRef:
         self.join(timeout)
         assert not self.is_alive(), "SampleConsumer thread did not finish in time"
         if self.error is not None:

--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -21,8 +21,10 @@ from verl.workers.utils.padding import (
     embeds_padding_2_no_padding,
     left_right_2_no_padding,
     no_padding_2_padding,
+    padded_tensor,
     response_from_nested,
     response_to_nested,
+    sequence_lengths,
 )
 
 
@@ -323,6 +325,19 @@ def test_response_from_nested():
         torch.testing.assert_close(tensor, expected)
 
 
+def test_response_from_nested_accepts_equal_length_dense_mask():
+    log_probs = [torch.arange(10, dtype=torch.float32), torch.arange(20, dtype=torch.float32)]
+    log_probs_nt = torch.nested.as_nested_tensor(log_probs, layout=torch.jagged)
+    response_mask = torch.ones((2, 4), dtype=torch.int64)
+
+    response_log_probs = response_from_nested(log_probs_nt, response_mask)
+
+    assert response_log_probs.is_nested
+    assert response_log_probs.offsets().diff().tolist() == [4, 4]
+    torch.testing.assert_close(response_log_probs[0], log_probs[0][-5:-1])
+    torch.testing.assert_close(response_log_probs[1], log_probs[1][-5:-1])
+
+
 def test_response_to_nested():
     batch_size = 10
     log_probs = torch.rand(batch_size, 100)
@@ -336,6 +351,48 @@ def test_response_to_nested():
         response_len = response_mask[i].shape[0]
         expected = log_probs[i, :response_len]
         torch.testing.assert_close(tensor, expected)
+
+
+def test_response_to_nested_accepts_equal_length_dense_mask():
+    values = torch.arange(12, dtype=torch.float32).reshape(2, 6)
+    response_mask = torch.ones((2, 4), dtype=torch.int64)
+
+    nested = response_to_nested(values, response_mask)
+
+    assert nested.is_nested
+    assert nested.offsets().diff().tolist() == [4, 4]
+    torch.testing.assert_close(nested[0], values[0, :4])
+    torch.testing.assert_close(nested[1], values[1, :4])
+
+
+def test_no_padding_2_padding_accepts_equal_length_dense_responses():
+    prompts = torch.nested.as_nested_tensor(
+        [torch.tensor([1, 2]), torch.tensor([3, 4, 5])], layout=torch.jagged
+    )
+    responses = torch.ones((2, 4), dtype=torch.int64)
+    data = TensorDict(
+        {"prompts": prompts, "responses": responses}, batch_size=[2]
+    )
+
+    padded = no_padding_2_padding(torch.arange(13, dtype=torch.float32), data)
+
+    torch.testing.assert_close(
+        padded, torch.tensor([[1, 2, 3, 4], [8, 9, 10, 11]], dtype=torch.float32)
+    )
+
+
+def test_sequence_helpers_accept_jagged_and_equal_length_dense_tensors():
+    jagged = torch.nested.as_nested_tensor(
+        [torch.tensor([1, 2]), torch.tensor([3, 4, 5])], layout=torch.jagged
+    )
+    dense = torch.tensor([[1, 2, 3], [4, 5, 6]])
+
+    assert sequence_lengths(jagged, 2, "values").tolist() == [2, 3]
+    assert sequence_lengths(dense, 2, "values").tolist() == [3, 3]
+    torch.testing.assert_close(
+        padded_tensor(jagged, 0), torch.tensor([[1, 2, 0], [3, 4, 5]])
+    )
+    assert padded_tensor(dense, 0) is dense
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_rollout_data_backend_on_cpu.py
+++ b/tests/utils/test_rollout_data_backend_on_cpu.py
@@ -1,0 +1,370 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import threading
+import uuid
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl.protocol import BatchData, DataProto, RolloutDataRef
+from verl.utils import rollout_data_backend, transferqueue_utils
+from verl.utils.mooncake_rollout_backend import MooncakeRolloutDataBackend
+from verl.utils.transferqueue_utils import BatchMeta, tqbridge
+
+
+@pytest.fixture(autouse=True)
+def reset_backend():
+    rollout_data_backend._backend = None
+    os.environ.pop(rollout_data_backend.ROLLOUT_DATA_BACKEND_ENV, None)
+    yield
+    if rollout_data_backend._backend is not None:
+        rollout_data_backend.close()
+    rollout_data_backend._backend = None
+    os.environ.pop(rollout_data_backend.ROLLOUT_DATA_BACKEND_ENV, None)
+
+
+def test_transfer_queue_adapter_preserves_native_api():
+    tq = pytest.importorskip("transfer_queue")
+    ray = pytest.importorskip("ray")
+    partition = f"test-{uuid.uuid4().hex}"
+    keys = [f"key-{uuid.uuid4().hex}" for _ in range(2)]
+    started_ray = not ray.is_initialized()
+    if started_ray:
+        ray.init(include_dashboard=False)
+    rollout_data_backend.configure_runtime({"name": "transfer_queue"})
+    rollout_data_backend.init(host_catalog=True)
+    try:
+        ref = rollout_data_backend.batch_put(
+            keys=keys,
+            partition_id=partition,
+            tags=[{"status": "success"}] * 2,
+            fields=TensorDict({"value": torch.tensor([[1], [2]])}, batch_size=[2]),
+        )
+        assert isinstance(ref, RolloutDataRef)
+        assert all(isinstance(chunk, BatchMeta) for chunk in BatchData(ref).chunk(2))
+        result = rollout_data_backend.batch_get(
+            keys=keys, partition_id=partition, select_fields=["value"]
+        )
+        assert torch.equal(result["value"], torch.tensor([[1], [2]]))
+        assert rollout_data_backend.list_entries(partition)[partition][keys[0]]["status"] == "success"
+    finally:
+        remaining = tq.kv_list(partition_id=partition).get(partition, {})
+        if remaining:
+            tq.kv_clear(keys=list(remaining), partition_id=partition)
+        rollout_data_backend.close()
+        if started_ray:
+            ray.shutdown()
+
+
+def test_backend_close_can_retry_after_shutdown_failure():
+    class Backend:
+        calls = 0
+
+        def shutdown(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("temporary shutdown failure")
+
+    backend = Backend()
+    rollout_data_backend._backend = backend
+    with pytest.raises(RuntimeError, match="temporary shutdown failure"):
+        rollout_data_backend.close()
+    assert rollout_data_backend._backend is backend
+    rollout_data_backend.close()
+    assert rollout_data_backend._backend is None
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+def test_rollout_ref_bridge_materializes_writes_and_releases(monkeypatch, asynchronous):
+    source = TensorDict({"value": torch.tensor([[1], [2]])}, batch_size=[2])
+    writes, releases = [], []
+    monkeypatch.setattr(rollout_data_backend, "batch_get", lambda **_: source)
+    monkeypatch.setattr(rollout_data_backend, "release_result", releases.append)
+
+    def put(**kwargs):
+        writes.append(kwargs["fields"])
+        return RolloutDataRef(
+            keys=kwargs["keys"], tags=[{}, {}], partition_id=kwargs["partition_id"]
+        )
+
+    monkeypatch.setattr(rollout_data_backend, "batch_put", put)
+    ref = RolloutDataRef(keys=["a", "b"], tags=[{}, {}], partition_id="train")
+    if asynchronous:
+
+        @tqbridge()
+        async def transform(batch):
+            return batch.apply(lambda value: value * 2)
+
+        result = asyncio.run(transform(ref))
+    else:
+
+        @tqbridge()
+        def transform(batch):
+            return batch.apply(lambda value: value * 2)
+
+        result = transform(ref)
+
+    assert isinstance(result, RolloutDataRef)
+    assert torch.equal(writes[0]["value"], torch.tensor([[2], [4]]))
+    assert releases == [source]
+
+
+def test_materialized_batch_releases_on_exit(monkeypatch):
+    source = TensorDict({"value": torch.tensor([1])}, batch_size=[1])
+    releases = []
+    monkeypatch.setattr(rollout_data_backend, "batch_get", lambda **_: source)
+    monkeypatch.setattr(rollout_data_backend, "release_result", releases.append)
+    with rollout_data_backend.materialized_batch(keys=["a"]) as result:
+        assert result is source
+    assert releases == [source]
+
+
+def test_rollout_ref_chunk_and_concat_preserve_order():
+    ref = RolloutDataRef(
+        keys=["a", "b", "c"],
+        tags=[{"i": 0}, {"i": 1}, {"i": 2}],
+        partition_id="train",
+        fields=["value"],
+    )
+    chunks = ref.chunk(2)
+    chunks[0].extra_info = {"rank": 0}
+    chunks[1].extra_info = {"rank": 2}
+    merged = RolloutDataRef.concat(
+        [chunks[0], RolloutDataRef(extra_info={"rank": 1}), chunks[1]]
+    )
+    assert merged.keys == ref.keys
+    assert merged.extra_info == {"rank": [0, 1, 2]}
+
+
+def test_cancelled_mooncake_put_waits_for_worker():
+    started, finish = threading.Event(), threading.Event()
+    backend = MooncakeRolloutDataBackend({})
+
+    def put(**_kwargs):
+        started.set()
+        finish.wait()
+
+    backend.put_batch = put
+
+    async def run():
+        task = asyncio.create_task(backend.put_batch_async(keys=["a"]))
+        while not started.is_set():
+            await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        try:
+            assert not task.done()
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+        finally:
+            finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())
+
+
+def test_rollout_ref_metadata_failure_releases_result(monkeypatch):
+    source = TensorDict({"value": torch.tensor([1])}, batch_size=[1])
+    releases = []
+    monkeypatch.setattr(rollout_data_backend, "batch_get", lambda **_: source)
+    monkeypatch.setattr(rollout_data_backend, "release_result", releases.append)
+
+    def fail_metadata(**_kwargs):
+        raise RuntimeError("metadata failed")
+
+    monkeypatch.setattr(transferqueue_utils.tu, "assign_non_tensor_data", fail_metadata)
+    ref = RolloutDataRef(keys=["a"], tags=[{}], partition_id="train", extra_info={"meta": 1})
+    with pytest.raises(RuntimeError, match="metadata failed"):
+        transferqueue_utils._rollout_ref_to_realdata(ref)
+    assert releases == [source]
+
+
+def test_backend_specific_row_layout():
+    rollout_data_backend.configure_runtime({"name": "mooncake", "config": {}})
+    fields = rollout_data_backend.rows_to_fields(
+        [
+            {
+                "responses": torch.tensor([1, 2]),
+                "position_ids": torch.tensor([[0, 1], [0, 1]]),
+            },
+            {
+                "responses": torch.tensor([3, 4]),
+                "position_ids": torch.tensor([[2, 3], [2, 3]]),
+            },
+        ]
+    )
+    assert fields["responses"].is_nested
+    assert torch.equal(fields["responses"].offsets().diff(), torch.tensor([2, 2]))
+    assert not fields["position_ids"].is_nested
+    assert fields["position_ids"].shape == (2, 2, 2)
+
+
+class CatalogTransferStub:
+    def __init__(self, plan):
+        self.plan = plan
+        self.released_reads = []
+        self.discarded = []
+
+    def resolve(self, *_args):
+        return self.plan
+
+    def release_read(self, token):
+        self.released_reads.append(token)
+        if getattr(self, "release_failures", 0):
+            self.release_failures -= 1
+            raise RuntimeError("release failed")
+
+    def attach_results(self, output, results):
+        output._mooncake_catalog_results = results
+
+    def discard_results(self, results):
+        self.discarded.extend(results)
+
+    def release_result(self, output):
+        self.discarded.extend(getattr(output, "_mooncake_catalog_results", []))
+
+    def close(self):
+        pass
+
+    def drain(self):
+        pass
+
+
+class FragmentTransferStub:
+    def __init__(self, fragments, fail_on=None):
+        self.fragments = fragments
+        self.fail_on = fail_on
+
+    def get(self, handle, *, fields, rows, **_kwargs):
+        name = handle["name"]
+        if name == self.fail_on:
+            raise RuntimeError(f"{name} failed")
+        data = self.fragments[name].select(*fields)
+        if rows is not None:
+            data = data[rows]
+        return DataProto.from_tensordict(data)
+
+
+def _plan(*, second_field="score"):
+    return {
+        "fields": ["tokens", second_field],
+        "field_groups": [
+            {"fields": ["tokens"], "locations": [("base", 0), ("base", 1)]},
+            {"fields": [second_field], "locations": [("second", 1), ("second", 0)]},
+        ],
+        "handles": {
+            "base": {"name": "base", "batch_size": 2},
+            "second": {"name": "second", "batch_size": 2},
+        },
+        "meta_info": {"stage": "rollout"},
+        "read_token": 7,
+    }
+
+
+def test_mooncake_backend_reassembles_fragmented_fields():
+    fragments = {
+        "base": TensorDict(
+            {"tokens": torch.nested.as_nested_tensor([torch.tensor([1, 2]), torch.tensor([3])], layout=torch.jagged)},
+            batch_size=[2],
+        ),
+        "second": TensorDict({"score": torch.tensor([10, 20])}, batch_size=[2]),
+    }
+    backend = MooncakeRolloutDataBackend({})
+    backend.catalog_transfer = CatalogTransferStub(_plan())
+    backend.transfer = FragmentTransferStub(fragments)
+    result = backend.get_batch(keys=["a", "b"], partition_id="train")
+    assert result["tokens"].is_nested
+    assert torch.equal(result["score"], torch.tensor([20, 10]))
+    assert result["stage"] == "rollout"
+    assert backend.catalog_transfer.released_reads == [7]
+    backend.release_result(result)
+    assert len(backend.catalog_transfer.discarded) == 2
+
+
+def test_mooncake_read_pin_release_retries_rpc():
+    backend = MooncakeRolloutDataBackend({})
+    backend.catalog_transfer = CatalogTransferStub(_plan())
+    backend.catalog_transfer.release_failures = 1
+    backend._release_read(7)
+    assert backend.catalog_transfer.released_reads == [7, 7]
+
+    backend.catalog_transfer.release_failures = 2
+    with pytest.raises(RuntimeError, match="release failed"):
+        backend._release_read(8)
+    assert backend._pending_read_tokens == {8}
+    backend.shutdown()
+    assert backend._pending_read_tokens == set()
+
+
+def test_mooncake_shutdown_keeps_store_after_pool_failure():
+    calls = []
+
+    class Resource:
+        def __init__(self, name, fail=False):
+            self.name = name
+            self.fail = fail
+
+        def close(self):
+            calls.append(self.name)
+            if self.fail:
+                raise RuntimeError(f"{self.name} failed")
+
+    backend = MooncakeRolloutDataBackend({})
+    backend.catalog_transfer = CatalogTransferStub(_plan())
+    backend.buffer_pool = Resource("pool", fail=True)
+    backend.store = Resource("store")
+    with pytest.raises(RuntimeError, match="pool failed"):
+        backend.shutdown()
+    assert calls == ["pool"]
+
+
+def test_mooncake_shutdown_keeps_catalog_handle_when_kill_fails(monkeypatch):
+    import ray
+
+    catalog = object()
+    backend = MooncakeRolloutDataBackend({}, host_catalog=True)
+    backend.catalog = catalog
+    backend.catalog_transfer = CatalogTransferStub(_plan())
+
+    def fail_kill(*_args, **_kwargs):
+        raise RuntimeError("kill failed")
+
+    monkeypatch.setattr(ray, "kill", fail_kill)
+    with pytest.raises(RuntimeError, match="kill failed"):
+        backend.shutdown()
+    assert backend.catalog is catalog
+
+    monkeypatch.setattr(ray, "kill", lambda *_args, **_kwargs: None)
+    backend.shutdown()
+    assert backend.catalog is None
+
+
+def test_mooncake_get_failure_discards_partial_result_and_read_pin():
+    fragments = {
+        "base": TensorDict({"tokens": torch.tensor([[1], [2]])}, batch_size=[2]),
+        "second": TensorDict({"score": torch.tensor([10, 20])}, batch_size=[2]),
+    }
+    backend = MooncakeRolloutDataBackend({})
+    backend.catalog_transfer = CatalogTransferStub(_plan())
+    backend.transfer = FragmentTransferStub(fragments, fail_on="second")
+    with pytest.raises(RuntimeError, match="second failed"):
+        backend.get_batch(keys=["a", "b"], partition_id="train")
+    assert len(backend.catalog_transfer.discarded) == 1
+    assert backend.catalog_transfer.released_reads == [7]

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -40,7 +40,7 @@ from verl.utils.py_functional import list_of_dict_to_dict_of_list, union_two_dic
 from verl.utils.torch_functional import allgather_dict_tensors
 from verl.utils.transferqueue_utils import BatchMeta, KVBatchMeta
 
-__all__ = ["DataProto", "union_tensor_dict"]
+__all__ = ["DataProto", "RolloutDataRef", "union_tensor_dict"]
 
 with contextlib.suppress(Exception):
     tensordict.set_lazy_legacy(False).set()
@@ -566,14 +566,14 @@ class DataProto:
             meta_info = {}
         batch = {}
         non_tensor_batch = {}
-        batch_size = None
+        batch_size = tensor_dict.batch_size[:num_batch_dims]
         for key, val in tensor_dict.items():
             if isinstance(val, torch.Tensor):
                 batch[key] = val
-                if batch_size is None:
-                    batch_size = val.shape[:num_batch_dims]
             elif isinstance(val, NonTensorStack):
-                non_tensor_batch[key] = np.array([elem.data for elem in val], dtype=object)
+                rows = np.empty((len(val),), dtype=object)
+                rows[:] = [elem.data for elem in val]
+                non_tensor_batch[key] = rows
             elif isinstance(val, NonTensorData):
                 meta_info[key] = val.data
 
@@ -1108,7 +1108,7 @@ class DataProto:
         assert parse_version(tensordict.__version__) >= parse_version("0.10"), (
             "Convert DataProto to TensorDict at least requires tensordict version 0.10"
         )
-        tensor_batch = self.batch.to_dict()
+        tensor_batch = {} if self.batch is None else self.batch.to_dict()
         non_tensor_batch = self.non_tensor_batch
 
         from tensordict.tensorclass import NonTensorData, NonTensorStack
@@ -1228,6 +1228,85 @@ class DataProtoFuture:
         return output
 
 
+@dataclass
+class RolloutDataRef:
+    """Backend-neutral reference to rollout rows stored outside the controller."""
+
+    keys: list[str] = field(default_factory=list)
+    tags: list[dict[str, Any]] = field(default_factory=list)
+    partition_id: str | None = None
+    fields: list[str] | None = None
+    extra_info: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if len(self.keys) != len(self.tags):
+            raise ValueError("keys and tags must have the same length")
+        if len(self.keys) != len(set(self.keys)):
+            raise ValueError("rollout data keys must be unique")
+        if self.keys and (not isinstance(self.partition_id, str) or not self.partition_id):
+            raise ValueError("non-empty rollout data requires a partition_id")
+        if self.fields is not None and len(self.fields) != len(set(self.fields)):
+            raise ValueError("rollout data fields must be unique")
+        self.tags = list(self.tags)
+        self.extra_info = dict(self.extra_info)
+
+    @property
+    def size(self) -> int:
+        return len(self.keys)
+
+    def __len__(self) -> int:
+        return self.size
+
+    def reorder(self, indexes: list[int]) -> None:
+        if len(indexes) != self.size or set(indexes) != set(range(self.size)):
+            raise ValueError("reorder indexes must be a permutation of the batch")
+        self.keys = [self.keys[index] for index in indexes]
+        self.tags = [self.tags[index] for index in indexes]
+
+    def chunk(self, chunks: int) -> list["RolloutDataRef"]:
+        if chunks <= 0:
+            raise ValueError("chunks must be positive")
+        base_size, remainder = divmod(self.size, chunks)
+        result = []
+        start = 0
+        for index in range(chunks):
+            end = start + base_size + (index < remainder)
+            result.append(
+                RolloutDataRef(
+                    keys=self.keys[start:end],
+                    tags=self.tags[start:end],
+                    partition_id=self.partition_id,
+                    fields=self.fields,
+                    extra_info=self.extra_info,
+                )
+            )
+            start = end
+        return result
+
+    @classmethod
+    def concat(cls, refs: list["RolloutDataRef"]) -> "RolloutDataRef":
+        extra_info = {}
+        for ref in refs:
+            for key, value in ref.extra_info.items():
+                extra_info.setdefault(key, []).append(value)
+        refs = [ref for ref in refs if ref.size]
+        if not refs:
+            return cls(extra_info=extra_info)
+        partition_id = refs[0].partition_id
+        fields = refs[0].fields
+        if any(ref.partition_id != partition_id for ref in refs):
+            raise ValueError("cannot concatenate rollout data from different partitions")
+        if any(ref.fields != fields for ref in refs):
+            raise ValueError("cannot concatenate rollout data with different fields")
+        return cls(
+            keys=[key for ref in refs for key in ref.keys],
+            tags=[tag for ref in refs for tag in ref.tags],
+            partition_id=partition_id,
+            fields=fields,
+            extra_info=extra_info,
+        )
+
+
 class BatchData:
     """Uniform dispatch wrapper for batch data operations.
 
@@ -1246,9 +1325,6 @@ class BatchData:
         assert BatchData(arg).is_chunkable()
         assert BatchData(output_list).is_concatable()
     """
-
-    _CHUNKABLE_TYPES = (TensorDict, KVBatchMeta, BatchMeta)  # lazily extended with DataProto etc.
-    _CONCATABLE_TYPES = (TensorDict, KVBatchMeta, BatchMeta)
 
     def __init__(self, data):
         self._data = data
@@ -1279,6 +1355,10 @@ class BatchData:
 
             raw_chunks = chunk_tensordict(data, chunks)
             return tuple(contiguous(val).consolidate() for val in raw_chunks)
+        if isinstance(data, RolloutDataRef):
+            from verl.utils.rollout_data_backend import prepare_for_dispatch
+
+            data = prepare_for_dispatch(data)
         if isinstance(data, KVBatchMeta):
             # early translate KVBatchMeta -> BatchMeta to prevent frequent
             # controller communication during PUT/GET in each rank
@@ -1324,11 +1404,11 @@ class BatchData:
 
     @classmethod
     def _chunkable_types(cls):
-        return (DataProto, DataProtoFuture, TensorDict, KVBatchMeta, BatchMeta)
+        return (DataProto, DataProtoFuture, TensorDict, RolloutDataRef, KVBatchMeta, BatchMeta)
 
     @classmethod
     def _concatable_types(cls):
-        return (DataProto, ray.ObjectRef, TensorDict, KVBatchMeta, BatchMeta)
+        return (DataProto, ray.ObjectRef, TensorDict, RolloutDataRef, KVBatchMeta, BatchMeta)
 
 
 def all_gather_data_proto(data: DataProto, process_group):

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -346,3 +346,10 @@ class Worker(WorkerHelper):
         """
         result = func(*args, **kwargs)
         return result
+
+    @register(dispatch_mode=Dispatch.ALL_TO_ALL, execute_mode=Execute.ALL)
+    def close_rollout_data_backend(self):
+        """Close a rollout-data client initialized in this worker process."""
+        from verl.utils import rollout_data_backend
+
+        rollout_data_backend.close()

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -638,8 +638,15 @@ class RayWorkerGroup(WorkerGroup):
             "MASTER_ADDR": self._master_addr,
             "MASTER_PORT": self._master_port,
         }
+        rollout_backend = os.getenv("VERL_ROLLOUT_DATA_BACKEND")
+        if rollout_backend is not None:
+            env_vars["VERL_ROLLOUT_DATA_BACKEND"] = rollout_backend
         if worker_env is not None:
-            logging.debug(f"Appending ray class env, origin: {env_vars}, customized env: {worker_env}")
+            logging.debug(
+                "Appending ray class env keys, origin: %s, customized: %s",
+                sorted(env_vars),
+                sorted(worker_env),
+            )
             conflict_env_vars = set(env_vars.keys()) & set(worker_env.keys())
             if len(conflict_env_vars) > 0:
                 logging.error(

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -1013,6 +1013,9 @@ trainer:
     separate_async:
       num_warmup_batches: 1
       parameter_sync_step: 4
+    rollout_data_backend:
+      name: transfer_queue
+      config: {}
     sampler:
       max_off_policy_threshold: 8
       max_off_policy_strategy: drop

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -905,6 +905,9 @@ trainer:
     separate_async:
       num_warmup_batches: 1
       parameter_sync_step: 4
+    rollout_data_backend:
+      name: transfer_queue
+      config: {}
     sampler:
       max_off_policy_threshold: 8
       max_off_policy_strategy: drop

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -929,6 +929,9 @@ trainer:
     separate_async:
       num_warmup_batches: 1
       parameter_sync_step: 4
+    rollout_data_backend:
+      name: transfer_queue
+      config: {}
     sampler:
       max_off_policy_threshold: 8
       max_off_policy_strategy: drop

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -936,6 +936,9 @@ trainer:
     separate_async:
       num_warmup_batches: 1
       parameter_sync_step: 4
+    rollout_data_backend:
+      name: transfer_queue
+      config: {}
     sampler:
       max_off_policy_threshold: 8
       max_off_policy_strategy: drop

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -245,6 +245,15 @@ trainer:
       # Frequency of parameter synchronization between trainer and rollout
       parameter_sync_step: 4
 
+    # Rollout data plane backend. TransferQueue remains the default.
+    rollout_data_backend:
+
+      # Rollout data backend: transfer_queue or mooncake
+      name: transfer_queue
+
+      # Backend-specific options passed to the implementation
+      config: {}
+
     # Replay buffer sampling strategy
     sampler:
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import os
+import sys
 from pprint import pprint
 
 import hydra
@@ -21,6 +22,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
 from verl.trainer.ppo.utils import need_critic, need_reference_policy
+from verl.utils import rollout_data_backend
 from verl.utils.config import validate_config
 from verl.utils.device import auto_set_device, is_cuda_available
 from verl.utils.import_utils import load_class_from_fqn
@@ -28,6 +30,16 @@ from verl.utils.logging_utils import configure_verl_logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+
+def _config_for_log(config: DictConfig) -> dict:
+    logged = OmegaConf.to_container(config, resolve=True)
+    backend = logged["trainer"]["v1"]["rollout_data_backend"].get("config")
+    if isinstance(backend, dict):
+        for key in ("store_init_kwargs", "store"):
+            if key in backend:
+                backend[key] = "<redacted>"
+    return logged
 
 
 # Define a function to run the PPO-like training process
@@ -53,26 +65,37 @@ def run_ppo(config, task_runner_class) -> None:
     if "rl_insight" in ([trainer_logger] if isinstance(trainer_logger, str) else trainer_logger or []):
         os.environ["VERL_RL_INSIGHT_ENABLE"] = "1"
 
+    ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
+    runtime_env = OmegaConf.to_container(
+        OmegaConf.merge(
+            get_ppo_ray_runtime_env(config),
+            ray_init_kwargs.get("runtime_env", {}),
+        ),
+        resolve=True,
+    )
+    runtime_env_vars = runtime_env.setdefault("env_vars", {})
+
+    use_v1 = bool(config.trainer.use_v1)
+    if use_v1:
+        backend_config = rollout_data_backend.configure_runtime(config.trainer.v1.rollout_data_backend)
+        config.transfer_queue.enable = (
+            backend_config.get("name", rollout_data_backend.TRANSFER_QUEUE_BACKEND)
+            == rollout_data_backend.TRANSFER_QUEUE_BACKEND
+        )
+        runtime_env_vars[rollout_data_backend.ROLLOUT_DATA_BACKEND_ENV] = os.environ[
+            rollout_data_backend.ROLLOUT_DATA_BACKEND_ENV
+        ]
+    if config.transfer_queue.enable:
+        runtime_env_vars["TRANSFER_QUEUE_ENABLE"] = "1"
+
     # Check if Ray is not initialized
     if not ray.is_initialized():
         # Initialize Ray with a local cluster configuration
         # Set environment variables in the runtime environment to control tokenizer parallelism,
         # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
-        default_runtime_env = get_ppo_ray_runtime_env(config)
-        ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
-        runtime_env_kwargs = ray_init_kwargs.get("runtime_env", {})
-
-        if config.transfer_queue.enable:
-            # Add runtime environment variables for transfer queue
-            runtime_env_vars = runtime_env_kwargs.get("env_vars", {})
-            runtime_env_vars["TRANSFER_QUEUE_ENABLE"] = "1"
-            runtime_env_kwargs["env_vars"] = runtime_env_vars
-
-        runtime_env = OmegaConf.merge(default_runtime_env, runtime_env_kwargs)
-        ray_init_kwargs = OmegaConf.create({**ray_init_kwargs, "runtime_env": runtime_env})
-        print(f"ray init kwargs: {ray_init_kwargs}")
-        ray.init(**OmegaConf.to_container(ray_init_kwargs))
+        ray_init_options = {**ray_init_kwargs, "runtime_env": runtime_env}
+        ray.init(**ray_init_options)
 
     # Create a remote instance of the TaskRunner class, and
     # Execute the `run` method of the TaskRunner instance remotely and wait for it to complete
@@ -88,9 +111,8 @@ def run_ppo(config, task_runner_class) -> None:
         nsight_options = OmegaConf.to_container(
             config.global_profiler.global_tool_config.nsys.controller_nsight_options
         )
-        runner = task_runner_class.options(runtime_env={"nsight": nsight_options}).remote()
-    else:
-        runner = task_runner_class.remote()
+        runtime_env["nsight"] = nsight_options
+    runner = task_runner_class.options(runtime_env=runtime_env).remote()
     ray.get(runner.run.remote(config))
 
     # [Optional] get the path of the timeline trace file from the configuration, default to None
@@ -114,7 +136,9 @@ class TaskRunnerV1:
 
         NOTE: User can customize their own agent loop manager, the only requirement is:
         1. implement `generate_sequences` method
-        2. put agent loop outputs into TransferQueue
+        2. put agent loop outputs into the configured rollout data backend
+        3. for Mooncake, implement `quiesce` and `close_clients` so the Catalog host can
+           drain Store objects only after all readers and writers stop
         """
         from verl.trainer.ppo.v1 import AgentLoopManagerTQ
 
@@ -123,6 +147,19 @@ class TaskRunnerV1:
             agent_loop_manager_cls = load_class_from_fqn(manager_class_fqn, "AgentLoopManager")
         else:
             agent_loop_manager_cls = AgentLoopManagerTQ
+
+        selected_backend = rollout_data_backend.backend_name(self.config.trainer.v1.rollout_data_backend)
+        if selected_backend == rollout_data_backend.MOONCAKE_BACKEND:
+            missing = [
+                name
+                for name in ("quiesce", "close_clients")
+                if not callable(getattr(agent_loop_manager_cls, name, None))
+            ]
+            if missing:
+                raise TypeError(
+                    f"Mooncake agent loop manager {agent_loop_manager_cls.__name__} "
+                    f"must implement: {', '.join(missing)}"
+                )
 
         self.agent_loop_manager = agent_loop_manager_cls.create(
             config=self.config,
@@ -135,19 +172,24 @@ class TaskRunnerV1:
         """Run the PPO training process."""
         configure_verl_logging()
 
-        import transfer_queue as tq
-
         from verl.trainer.ppo.v1 import get_trainer_cls
 
         trainer_cls = get_trainer_cls(config.trainer.v1.trainer_mode)
 
-        config.transfer_queue.enable = True
-        pprint(OmegaConf.to_container(config, resolve=True))
+        selected_backend = rollout_data_backend.backend_name(config.trainer.v1.rollout_data_backend)
+        if selected_backend == rollout_data_backend.MOONCAKE_BACKEND and config.trainer.save_freq > 0:
+            logger.warning(
+                "The Mooncake rollout backend does not checkpoint in-flight "
+                "rollout data; resume restores model and dataloader state only."
+            )
+        pprint(_config_for_log(config))
         OmegaConf.resolve(config)
         self.config = config
 
-        # initialize transfer queue
-        tq.init(config.transfer_queue)
+        rollout_data_backend.init(
+            transfer_queue_config=config.transfer_queue,
+            host_catalog=True,
+        )
         succeeded = False
         try:
             self.trainer = trainer_cls(config=config)
@@ -156,12 +198,47 @@ class TaskRunnerV1:
             self.trainer.fit(self.agent_loop_manager)
             succeeded = True
         finally:
-            try:
-                tracking = getattr(self.trainer, "logger", None)
-                if tracking is not None:
-                    tracking.finish(exit_code=0 if succeeded else 1)
-            finally:
-                tq.close()
+            run_failed = sys.exc_info()[0] is not None
+            cleanup_error = None
+
+            def cleanup(name, callback, *args, **kwargs):
+                nonlocal cleanup_error
+                try:
+                    callback(*args, **kwargs)
+                    return True
+                except BaseException as exc:
+                    logger.exception("Failed to %s", name)
+                    if cleanup_error is None:
+                        cleanup_error = exc
+                    return False
+
+            drain_ready = True
+            if self.agent_loop_manager is not None:
+                quiesce = getattr(self.agent_loop_manager, "quiesce", None)
+                if callable(quiesce):
+                    drain_ready = cleanup("quiesce rollout producers", quiesce)
+            if self.trainer is not None:
+                drain_ready &= cleanup(
+                    "close trainer rollout-data clients",
+                    self.trainer.close_rollout_data_clients,
+                )
+            if self.agent_loop_manager is not None:
+                close_manager = getattr(self.agent_loop_manager, "close_clients", None)
+                if not callable(close_manager):
+                    close_manager = getattr(self.agent_loop_manager, "close", None)
+                if callable(close_manager):
+                    drain_ready &= cleanup("close rollout-manager clients", close_manager)
+
+            if selected_backend != rollout_data_backend.MOONCAKE_BACKEND or drain_ready:
+                cleanup("close rollout-data backend", rollout_data_backend.close)
+            else:
+                logger.error("Skipping Mooncake Catalog drain because a producer or client did not stop cleanly")
+
+            tracking = getattr(self.trainer, "logger", None)
+            if tracking is not None:
+                cleanup("finish experiment tracking", tracking.finish, exit_code=0 if succeeded else 1)
+            if cleanup_error is not None and not run_failed:
+                raise cleanup_error
 
 
 @hydra.main(config_path="config", config_name="ppo_trainer", version_base=None)

--- a/verl/trainer/ppo/padding_utils.py
+++ b/verl/trainer/ppo/padding_utils.py
@@ -28,14 +28,9 @@ from typing import Any
 
 import torch
 
-try:
-    import transfer_queue as tq
-    from transfer_queue import KVBatchMeta
-except ImportError:
-    from verl.utils.transferqueue_utils import KVBatchMeta, tq
-
+from verl.protocol import RolloutDataRef
+from verl.utils import rollout_data_backend
 from verl.utils.model import compute_position_id_with_mask
-from verl.utils.tensordict_utils import list_of_dict_to_tensordict
 
 logger = logging.getLogger(__name__)
 
@@ -125,10 +120,10 @@ def construct_minimal_padding_template(
 
 
 def upsample_batch_to_divisible_size(
-    batch: KVBatchMeta,
+    batch: RolloutDataRef,
     batch_multiple: int,
     eos_token_id: int,
-) -> KVBatchMeta:
+) -> RolloutDataRef:
     """Append synthetic no-op samples so the batch size becomes divisible by *batch_multiple*.
 
     The synthetic samples reuse the first real sample as a metadata template,
@@ -138,12 +133,12 @@ def upsample_batch_to_divisible_size(
     downstream metrics filtering.
 
     Args:
-        batch: The current KVBatchMeta from TransferQueue.
+        batch: The current RolloutDataRef from TransferQueue.
         batch_multiple: The required divisor (e.g. lcm of dp_size and mini-batch sizes).
         eos_token_id: The EOS token id from the tokenizer.
 
     Returns:
-        The (possibly enlarged) KVBatchMeta.
+        The (possibly enlarged) RolloutDataRef.
     """
     remainder = len(batch) % batch_multiple
     if remainder == 0:
@@ -152,10 +147,12 @@ def upsample_batch_to_divisible_size(
     # Take the first trajectory as the metadata template for padding data.
     source_idx = 0
     source_key = batch.keys[source_idx]
-    source_td = tq.kv_batch_get(keys=[source_key], partition_id=batch.partition_id)[0]
-
-    # Construct the minimal padding template of one prompt token and one response token
-    template_sample, template_tag = construct_minimal_padding_template(source_td, batch.tags[source_idx], eos_token_id)
+    with rollout_data_backend.materialized_batch(
+        keys=[source_key], partition_id=batch.partition_id
+    ) as source_batch:
+        template_sample, template_tag = construct_minimal_padding_template(
+            source_batch[0], batch.tags[source_idx], eos_token_id
+        )
 
     # All padding data use the same uid (also the same trajectory_id 0 but with ascending session_ids)
     # This uid is not identical to any of the actual data, so it won't affect the grpo advantage value.
@@ -176,10 +173,10 @@ def upsample_batch_to_divisible_size(
         pad_fields.append(sample)
         pad_tags.append(copy.deepcopy(template_tag))
 
-    tq.kv_batch_put(
+    rollout_data_backend.batch_put(
         keys=pad_keys,
         partition_id=batch.partition_id,
-        fields=list_of_dict_to_tensordict(pad_fields),
+        fields=rollout_data_backend.rows_to_fields(pad_fields),
         tags=pad_tags,
     )
     logger.info(
@@ -189,7 +186,7 @@ def upsample_batch_to_divisible_size(
         pad_size,
         batch_multiple,
     )
-    return KVBatchMeta(
+    return RolloutDataRef(
         keys=batch.keys + pad_keys,
         tags=batch.tags + pad_tags,
         partition_id=batch.partition_id,

--- a/verl/trainer/ppo/v1/agent_loop_tq.py
+++ b/verl/trainer/ppo/v1/agent_loop_tq.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # TODO: move this file to verl.experimental.agent_loop after V1 is stable
-"""TransferQueue adapter for AgentLoopManager and AgentLoopWorker"""
+"""External rollout-data adapter for AgentLoopManager and AgentLoopWorker."""
 
 import asyncio
 import logging
@@ -22,7 +22,6 @@ from typing import Any
 
 import ray
 import torch
-import transfer_queue as tq
 from tensordict import NonTensorData, NonTensorStack, TensorDict
 
 from verl.experimental.agent_loop import (
@@ -31,8 +30,8 @@ from verl.experimental.agent_loop import (
     AgentLoopWorker,
     get_trajectory_info,
 )
+from verl.utils import rollout_data_backend
 from verl.utils.ray_utils import auto_await
-from verl.utils.tensordict_utils import list_of_dict_to_tensordict
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -53,8 +52,28 @@ async def _settle_session_tasks(tasks: list[asyncio.Task[Any]]) -> list[BaseExce
 class AgentLoopWorkerTQ(AgentLoopWorker):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        tq.init()
+        rollout_data_backend.init(
+            transfer_queue_config=self.config.transfer_queue,
+        )
         self.background_tasks = set()
+
+    async def _settle_background_tasks(self) -> list[BaseException]:
+        tasks = list(self.background_tasks)
+        errors = await _settle_session_tasks(tasks)
+        self.background_tasks.difference_update(tasks)
+        return errors
+
+    def _discard_successful_background_task(self, task: asyncio.Task[Any]) -> None:
+        if task.cancelled() or task.exception() is None:
+            self.background_tasks.discard(task)
+
+    async def quiesce(self) -> None:
+        errors = await self._settle_background_tasks()
+        if errors:
+            raise RuntimeError("agent-loop tasks failed during shutdown") from errors[0]
+
+    async def close_client(self) -> None:
+        rollout_data_backend.close()
 
     async def generate_sequences(self, batch: TensorDict) -> None:
         """Spawn agent loop for each sample in the batch without waiting for the results."""
@@ -102,12 +121,16 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                 self._run_prompt(prompt, sampling_params, trajectory=trajectory_info[i], trace=trace_this_sample)
             )
             self.background_tasks.add(task)
-            task.add_done_callback(self.background_tasks.discard)
+            task.add_done_callback(self._discard_successful_background_task)
 
     async def _run_prompt(self, prompt: dict, sampling_params: dict, trajectory: dict, trace: bool = False) -> None:
         """Spawn multiple agent loops in parallel according to rollout.n or rollout.val_kwargs.n."""
         uid, partition_id = prompt["uid"], "train" if not trajectory["validate"] else "val"
-        await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "running"})
+        await rollout_data_backend.async_batch_put(
+            keys=[uid],
+            partition_id=partition_id,
+            tags=[{"status": "running"}],
+        )
         tasks = []
         try:
             # NOTE: user can dynamically adjust n for each sample here, e.g according to task difficulty.
@@ -119,7 +142,6 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             if not trajectory["validate"] and not do_sample:
                 apply_greedy_sampling_params(run_sampling_params)
 
-            tasks = []
             for i in range(n):
                 task = asyncio.create_task(
                     self._run_agent_loop(
@@ -140,17 +162,21 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                 status = "failure"
             else:
                 status = "finished"
-            await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": status})
+            await rollout_data_backend.async_batch_put(
+                keys=[uid], partition_id=partition_id, tags=[{"status": status}]
+            )
         except Exception as e:
             logger.exception(f"Error in _run_prompt: {e}")
             if tasks:
                 await _settle_session_tasks(tasks)
-            await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "failure"})
+            await rollout_data_backend.async_batch_put(
+                keys=[uid], partition_id=partition_id, tags=[{"status": "failure"}]
+            )
 
     async def _agent_loop_postprocess(
         self, output: AgentLoopOutput | list[AgentLoopOutput], validate, **kwargs
     ) -> None:
-        """Put agent loop outputs into TransferQueue."""
+        """Put agent loop outputs into the configured rollout data backend."""
         uid, session_id = kwargs["uid"], kwargs["session_id"]
         outputs = output if isinstance(output, list) else [output]
         if not outputs:
@@ -174,7 +200,7 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                 output.reward_score = final_output.reward_score
                 output.extra_fields["reward_extra_info"] = final_output.extra_fields["reward_extra_info"]
 
-        # NOTE: agent loop may has multiple outputs, put each output into TransferQueue.
+        # NOTE: an agent loop may have multiple outputs; store each one independently.
         # key format: {uid}_{session_id}_{index}
         # - uid: raw prompt uid from dataset
         # - session_id: session id for rollout.n sampling
@@ -219,9 +245,9 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                 }
             )
 
-        await tq.async_kv_batch_put(
+        await rollout_data_backend.async_batch_put(
             keys=keys,
-            fields=list_of_dict_to_tensordict(fields),
+            fields=rollout_data_backend.rows_to_fields(fields),
             tags=tags,
             partition_id="train" if not validate else "val",
         )
@@ -243,7 +269,7 @@ class AgentLoopManagerTQ(AgentLoopManager):
     def generate_sequences(self, prompts: TensorDict) -> None:
         """
         Dispatch input batch to agent loop workers without blocking. Workers should put agent loop outputs
-        into TransferQueue once an agent loop finished.
+        into the configured data backend once an agent loop finishes.
 
         Args:
             prompts (TensorDict): Input batch from train or validation dataset.
@@ -255,3 +281,9 @@ class AgentLoopManagerTQ(AgentLoopManager):
                 for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=False)
             ]
         )
+
+    def quiesce(self) -> None:
+        ray.get([worker.quiesce.remote() for worker in self.agent_loop_workers])
+
+    def close_clients(self) -> None:
+        ray.get([worker.close_client.remote() for worker in self.agent_loop_workers])

--- a/verl/trainer/ppo/v1/replay_buffer.py
+++ b/verl/trainer/ppo/v1/replay_buffer.py
@@ -17,10 +17,10 @@ import time
 from collections import Counter, defaultdict
 
 import numpy as np
-import transfer_queue as tq
 from omegaconf import DictConfig
-from transfer_queue import KVBatchMeta
 
+from verl.protocol import RolloutDataRef
+from verl.utils import rollout_data_backend
 from verl.utils.skip import SkipManager
 
 logger = logging.getLogger(__name__)
@@ -194,7 +194,7 @@ class ReplayBuffer:
         self.failure_keys.clear()
         self.prompt_global_steps.clear()
 
-        data = tq.kv_list()
+        data = rollout_data_backend.list_entries()
         if data is None:
             return
 
@@ -231,7 +231,7 @@ class ReplayBuffer:
             return
 
         trajectory_keys = {key for key in self.partitions[partition_id] if key.split("_")[0] in uids}
-        tq.kv_clear(
+        rollout_data_backend.clear(
             partition_id=partition_id,
             keys=[*uids, *trajectory_keys],
         )
@@ -266,23 +266,27 @@ class ReplayBuffer:
         missing_metric_uids = new_finished_uids - {key.split("_")[0] for key in trajectory_keys}
 
         if trajectory_keys:
-            data = tq.kv_batch_get(
+            with rollout_data_backend.materialized_batch(
                 keys=trajectory_keys,
                 partition_id=partition_id,
                 select_fields=["extra_fields"],
-            )
-            extra_fields_list = list(data["extra_fields"])
-        else:
-            extra_fields_list = []
-
-        for key, extra_fields in zip(trajectory_keys, extra_fields_list, strict=True):
-            uid = key.split("_")[0]
-            extra_fields = getattr(extra_fields, "data", extra_fields)
-            reward_extra_info = extra_fields.get("reward_extra_info", {}) if isinstance(extra_fields, dict) else {}
-            if self.filter_groups_metric not in reward_extra_info:
-                missing_metric_uids.add(uid)
-            else:
-                metrics_by_uid[uid].append(float(reward_extra_info[self.filter_groups_metric]))
+            ) as data:
+                for key, extra_fields in zip(
+                    trajectory_keys, data["extra_fields"], strict=True
+                ):
+                    uid = key.split("_")[0]
+                    extra_fields = getattr(extra_fields, "data", extra_fields)
+                    reward_extra_info = (
+                        extra_fields.get("reward_extra_info", {})
+                        if isinstance(extra_fields, dict)
+                        else {}
+                    )
+                    if self.filter_groups_metric not in reward_extra_info:
+                        missing_metric_uids.add(uid)
+                    else:
+                        metrics_by_uid[uid].append(
+                            float(reward_extra_info[self.filter_groups_metric])
+                        )
 
         if missing_metric_uids:
             raise RuntimeError(
@@ -376,8 +380,8 @@ class ReplayBuffer:
 
     def _materialize_batch(
         self, partition_id: str, selected_prompt_uids: list[str], partition_snapshot: dict[str, dict]
-    ) -> KVBatchMeta:
-        tq.kv_clear(partition_id=partition_id, keys=selected_prompt_uids)
+    ) -> RolloutDataRef:
+        rollout_data_backend.clear(partition_id=partition_id, keys=selected_prompt_uids)
 
         keys, tags = [], []
         selected = set(selected_prompt_uids)
@@ -386,7 +390,7 @@ class ReplayBuffer:
             if uid in selected:
                 keys.append(key)
                 tags.append(tag)
-        return KVBatchMeta(partition_id=partition_id, keys=keys, tags=tags)
+        return RolloutDataRef(partition_id=partition_id, keys=keys, tags=tags)
 
     def _wait_for_next_poll(self, partition_id: str, last_debug_time: float) -> float:
         time.sleep(self.poll_interval)
@@ -402,7 +406,7 @@ class ReplayBuffer:
         return last_debug_time
 
     @SkipManager.annotate_tq(role="rollout_tq", phase="sample")
-    def sample(self, global_steps: int, partition_id: str, batch_size: int) -> tuple[KVBatchMeta, dict]:
+    def sample(self, global_steps: int, partition_id: str, batch_size: int) -> tuple[RolloutDataRef, dict]:
         """Sample a batch using synchronous rollout semantics.
 
         NOTE: user can customize sampling strategy by setting:
@@ -417,7 +421,7 @@ class ReplayBuffer:
             batch_size (int, optional): Batch size.
 
         Returns:
-            KVBatchMeta: A batch of data.
+            RolloutDataRef: A batch of data.
             dict: Auxiliary metrics.
         """
         last_debug_time = time.time()
@@ -539,7 +543,7 @@ class ReplayBufferAsync(ReplayBuffer):
         return len(sampleable_keys) >= batch_size
 
     @SkipManager.annotate_tq(role="rollout_tq", phase="sample")
-    def sample(self, global_steps: int, partition_id: str, batch_size: int) -> tuple[KVBatchMeta, dict]:
+    def sample(self, global_steps: int, partition_id: str, batch_size: int) -> tuple[RolloutDataRef, dict]:
         """Sample a batch while evicting and replacing stale, DAPO-filtered, or failed groups."""
         last_debug_time = time.time()
         eviction_metrics: dict = {}

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -27,20 +27,17 @@ from typing import Any, Optional
 import numpy as np
 import ray
 import torch
-import transfer_queue as tq
 from omegaconf import DictConfig, OmegaConf, open_dict
-from packaging.version import InvalidVersion, Version
 from tensordict import TensorDict
 from tensordict.tensorclass import NonTensorData
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
-from transfer_queue import KVBatchMeta
 
 from verl.checkpoint_engine import CheckpointEngineManager
 from verl.experimental.agent_loop import AgentLoopManager
 from verl.experimental.reward_loop import RewardLoopManager
 from verl.experimental.teacher_loop import MultiTeacherModelManager
-from verl.protocol import DataProto, DataProtoFuture
+from verl.protocol import DataProto, DataProtoFuture, RolloutDataRef
 from verl.single_controller.ray import (
     RayClassWithInitArgs,
     RayWorkerGroup,
@@ -73,6 +70,7 @@ from verl.trainer.ppo.utils import (
 )
 from verl.trainer.ppo.v1.replay_buffer import DAPO_FILTERED_REWARD_COUNTS_KEY, ReplayBuffer, ReplayBufferAsync
 from verl.trainer.ppo.v1.utils import MetricsAggregator, compute_advantage_for_multi_trajectories
+from verl.utils import rollout_data_backend
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
 from verl.utils.config import omega_conf_to_dataclass
@@ -89,7 +87,12 @@ from verl.workers.config import CriticConfig, DistillationConfig, HFModelConfig
 from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker, TrainingWorkerConfig
 from verl.workers.rollout.llm_server import LLMServerClient, LLMServerManager
 from verl.workers.utils.losses import value_loss
-from verl.workers.utils.padding import response_from_nested, response_to_nested
+from verl.workers.utils.padding import (
+    padded_tensor,
+    response_from_nested,
+    response_to_nested,
+    sequence_lengths,
+)
 
 
 def apply_greedy_sampling_params(params: dict[str, Any]) -> None:
@@ -100,19 +103,6 @@ def apply_greedy_sampling_params(params: dict[str, Any]) -> None:
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
-
-
-def _tq_supports_checkpoint() -> bool:
-    """Whether the installed TransferQueue can snapshot/restore its state for checkpoint consistency."""
-    try:
-        version_supported = Version(getattr(tq, "__version__", "")) >= Version("0.1.9")
-    except InvalidVersion:
-        return False
-    return (
-        version_supported
-        and callable(getattr(tq, "save_checkpoint", None))
-        and callable(getattr(tq, "load_checkpoint", None))
-    )
 
 
 class PPOTrainer(ABC):
@@ -384,6 +374,23 @@ class PPOTrainer(ABC):
         """Get the handles of reward loop workers."""
         return self.reward_loop_manager.reward_loop_worker_handles
 
+    def close_rollout_data_clients(self) -> None:
+        """Close rollout-data clients created lazily in model workers."""
+        closed = set()
+        first_error = None
+        for name in ("actor_rollout_wg", "critic_wg", "ref_policy_wg"):
+            worker_group = getattr(self, name, None)
+            if worker_group is None or id(worker_group) in closed:
+                continue
+            closed.add(id(worker_group))
+            try:
+                worker_group.close_rollout_data_backend()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
+
     def fit(self, agent_loop_manager: AgentLoopManager):
         """Fit the trainer with the agent loop manager.
 
@@ -484,7 +491,7 @@ class PPOTrainer(ABC):
                 self._log_rollout_data(batch, self.timing_raw, rollout_data_dir)
 
             # 7. cleanup transfer queue
-            tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
+            rollout_data_backend.clear(keys=batch.keys, partition_id=batch.partition_id)
 
             dapo_filtered_reward_counts = metrics.pop(DAPO_FILTERED_REWARD_COUNTS_KEY, None)
             self.logger.log(data=metrics, step=self.global_steps)
@@ -506,7 +513,7 @@ class PPOTrainer(ABC):
         # Ensure dump executor is shut down when training loop ends without reaching is_last_step
         self._shutdown_dump_executor()
 
-    def step(self, metrics: dict, timing_raw: dict) -> KVBatchMeta:
+    def step(self, metrics: dict, timing_raw: dict) -> RolloutDataRef:
         train_batch_size = self.config.data.train_batch_size
         assert train_batch_size % self.parameter_sync_step == 0, (
             f"train_batch_size ({train_batch_size}) must be divisible by "
@@ -531,9 +538,9 @@ class PPOTrainer(ABC):
             combined_partition_id = batch.partition_id
 
         metrics.update(metrics_aggregator.get_aggregated_metrics())
-        return KVBatchMeta(partition_id=combined_partition_id, keys=combined_keys, tags=combined_tags)
+        return RolloutDataRef(partition_id=combined_partition_id, keys=combined_keys, tags=combined_tags)
 
-    def _step_once(self, metrics: dict, timing_raw: dict, sample_batch_size: int) -> KVBatchMeta:
+    def _step_once(self, metrics: dict, timing_raw: dict, sample_batch_size: int) -> RolloutDataRef:
         """Run a single local update: sample one mini-batch and perform the full PPO pipeline once."""
         # 1. sample batch from replay buffer
         with marked_timer("gen", timing_raw, color="red"):
@@ -838,17 +845,17 @@ class PPOTrainer(ABC):
 
         # 5. restore TransferQueue state (async modes). Re-issuing the restored in-flight prompts is
         # deferred to fit() to use the agent_loop_manager.
-        if self.trainer_mode != "sync" and _tq_supports_checkpoint():
+        if self.trainer_mode != "sync" and rollout_data_backend.supports_checkpoint():
             tq_ckpt_path = os.path.join(global_step_folder, "transfer_queue")
             if os.path.exists(tq_ckpt_path):
                 logger.info(f"Loading TransferQueue state from {tq_ckpt_path}")
-                tq.load_checkpoint(tq_ckpt_path)
+                rollout_data_backend.load_checkpoint(tq_ckpt_path)
 
     def _reissue_inflight_prompts(self, partition_id: str = "train") -> int:
         """Restart checkpointed pending/running prompt groups from their persisted prompt data."""
-        if self.trainer_mode == "sync" or not _tq_supports_checkpoint():
+        if self.trainer_mode == "sync" or not rollout_data_backend.supports_checkpoint():
             return 0
-        data = tq.kv_list(partition_id)
+        data = rollout_data_backend.list_entries(partition_id)
         if not data:
             return 0
         items = data.get(partition_id, {})
@@ -860,21 +867,24 @@ class PPOTrainer(ABC):
         if not inflight_uids:
             return 0
 
-        batch = tq.kv_batch_get(keys=inflight_uids, partition_id=partition_id)
-        inflight_uid_set = set(inflight_uids)
-        old_trajectory_keys = [
-            key
-            for key, tag in items.items()
-            if not tag.get("is_prompt", False) and key.split("_", 1)[0] in inflight_uid_set
-        ]
-        if old_trajectory_keys:
-            tq.kv_clear(keys=old_trajectory_keys, partition_id=partition_id)
+        with rollout_data_backend.materialized_batch(keys=inflight_uids, partition_id=partition_id) as batch:
+            inflight_uid_set = set(inflight_uids)
+            old_trajectory_keys = [
+                key
+                for key, tag in items.items()
+                if not tag.get("is_prompt", False) and key.split("_", 1)[0] in inflight_uid_set
+            ]
+            if old_trajectory_keys:
+                rollout_data_backend.clear(keys=old_trajectory_keys, partition_id=partition_id)
 
-        # Treat this as a new dispatch attempt for the resumed training step.
-        tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
-        tags = [{"is_prompt": True, "status": "pending", "global_steps": self.global_steps} for _ in inflight_uids]
-        tq.kv_batch_put(keys=inflight_uids, partition_id=partition_id, tags=tags)
-        self.agent_loop_manager.generate_sequences(batch)
+            # Treat this as a new dispatch attempt for the resumed training step.
+            tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
+            tags = [
+                {"is_prompt": True, "status": "pending", "global_steps": self.global_steps}
+                for _ in inflight_uids
+            ]
+            rollout_data_backend.batch_put(keys=inflight_uids, partition_id=partition_id, tags=tags)
+            self.agent_loop_manager.generate_sequences(batch)
 
         logger.info(
             f"Re-issued {len(inflight_uids)} in-flight prompts for step {self.global_steps}; "
@@ -938,9 +948,9 @@ class PPOTrainer(ABC):
         # save TransferQueue state for async modes so in-flight prompts (already fetched from the
         # dataloader but not yet trained into this checkpoint's weights) survive a restart:
         # finished trajectories are restored as-is, pending/running prompts are re-issued on resume.
-        # Requires a TransferQueue release with checkpoint support (see _tq_supports_checkpoint).
-        if self.trainer_mode != "sync" and _tq_supports_checkpoint():
-            tq.save_checkpoint(
+        # Persist data-plane state when the selected backend supports it.
+        if self.trainer_mode != "sync" and rollout_data_backend.supports_checkpoint():
+            rollout_data_backend.save_checkpoint(
                 os.path.join(local_global_step_folder, "transfer_queue"),
                 metadata={"global_steps": self.global_steps},
             )
@@ -984,7 +994,7 @@ class PPOTrainer(ABC):
             tags = [
                 {"is_prompt": True, "status": "pending", "global_steps": self.global_steps} for _ in range(len(batch))
             ]
-            tq.kv_batch_put(keys=list(batch["uid"]), partition_id="val", tags=tags)
+            rollout_data_backend.batch_put(keys=list(batch["uid"]), partition_id="val", tags=tags)
             self.agent_loop_manager.generate_sequences(batch)
 
             # 2. sample batch from replay buffer: one prompt (GRPO group) per submitted row.
@@ -1019,59 +1029,64 @@ class PPOTrainer(ABC):
                 {session_key: base_offset + j for j, (session_key, _) in enumerate(sorted_sessions)}
             )
 
-            text_data = tq.kv_batch_get(
-                keys=batch.keys, partition_id=batch.partition_id, select_fields=["prompts", "responses"]
-            )
-            text_data["prompts"] = text_data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
-            text_data["responses"] = text_data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
-            all_inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["prompts"]]
-            all_outputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["responses"]]
+            with rollout_data_backend.materialized_batch(
+                keys=batch.keys,
+                partition_id=batch.partition_id,
+                select_fields=["prompts", "responses"],
+            ) as text_data:
+                text_data["prompts"] = padded_tensor(text_data["prompts"], self.tokenizer.pad_token_id)
+                text_data["responses"] = padded_tensor(text_data["responses"], self.tokenizer.pad_token_id)
+                all_inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["prompts"]]
+                all_outputs = [
+                    self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["responses"]
+                ]
 
             fields = ["uid", "rm_scores", "num_turns", "reward_model", "data_source", "extra_fields"]
-            data = tq.kv_batch_get(keys=final_keys, partition_id=batch.partition_id, select_fields=fields)
+            with rollout_data_backend.materialized_batch(
+                keys=final_keys, partition_id=batch.partition_id, select_fields=fields
+            ) as data:
+                sample_uids.extend(data.pop("uid").tolist())
+                sample_outputs.extend(all_outputs[i] for i in final_indices)
+                sample_inputs.extend(all_inputs[i] for i in final_indices)
+                scores = data["rm_scores"].sum(dim=1).tolist()
+                sample_scores.extend(scores)
+                sample_turns.extend(data.pop("num_turns").tolist())
+                reward_extra_infos_dict["reward"].extend(scores)
 
-            sample_uids.extend(data.pop("uid").tolist())
-            sample_outputs.extend(all_outputs[i] for i in final_indices)
-            sample_inputs.extend(all_inputs[i] for i in final_indices)
-            scores = data["rm_scores"].sum(dim=1).tolist()
-            sample_scores.extend(scores)
-            sample_turns.extend(data.pop("num_turns").tolist())
-            reward_extra_infos_dict["reward"].extend(scores)
+                extra_fields_list = data.pop("extra_fields", None)
+                if extra_fields_list is not None:
+                    n_prior = len(reward_extra_infos_dict["reward"]) - len(extra_fields_list.tolist())
+                    for extra_field in extra_fields_list.tolist():
+                        reward_extra_info = (
+                            extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
+                        )
+                        for key in reward_extra_infos_dict:
+                            if key != "reward" and key not in reward_extra_info:
+                                reward_extra_infos_dict[key].append(None)
+                        for key, value in reward_extra_info.items():
+                            if key not in reward_extra_infos_dict:
+                                reward_extra_infos_dict[key] = [None] * n_prior
+                            reward_extra_infos_dict[key].append(value)
+                        n_prior += 1
 
-            extra_fields_list = data.pop("extra_fields", None)
-            if extra_fields_list is not None:
-                n_prior = len(reward_extra_infos_dict["reward"]) - len(extra_fields_list.tolist())
-                for extra_field in extra_fields_list.tolist():
-                    reward_extra_info = (
-                        extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
-                    )
-                    for key in reward_extra_infos_dict:
-                        if key != "reward" and key not in reward_extra_info:
-                            reward_extra_infos_dict[key].append(None)
-                    for key, value in reward_extra_info.items():
-                        if key not in reward_extra_infos_dict:
-                            reward_extra_infos_dict[key] = [None] * n_prior
-                        reward_extra_infos_dict[key].append(value)
-                    n_prior += 1
+                reward_model = data.pop("reward_model", None)
+                if reward_model is not None:
+                    sample_gts.extend([item.get("ground_truth", None) for item in reward_model.tolist()])
+                else:
+                    sample_gts.extend([None] * len(final_indices))
 
-            reward_model = data.pop("reward_model", None)
-            if reward_model is not None:
-                sample_gts.extend([item.get("ground_truth", None) for item in reward_model.tolist()])
-            else:
-                sample_gts.extend([None] * len(final_indices))
-
-            data_source = data.pop("data_source", None)
-            if data_source is not None:
-                data_sources.extend(data_source.tolist())
-            else:
-                data_sources.extend(["unknown"] * len(final_indices))
+                data_source = data.pop("data_source", None)
+                if data_source is not None:
+                    data_sources.extend(data_source.tolist())
+                else:
+                    data_sources.extend(["unknown"] * len(final_indices))
 
             dump_all_inputs.extend(all_inputs)
             dump_all_outputs.extend(all_outputs)
             dump_all_keys.extend(batch.keys)
 
             # 5. cleanup transfer queue
-            tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
+            rollout_data_backend.clear(keys=batch.keys, partition_id=batch.partition_id)
 
         # logger to wandb
         self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
@@ -1203,24 +1218,26 @@ class PPOTrainer(ABC):
         self._dump_futures.clear()
         self._dump_executor.shutdown(wait=True)
 
-    def _log_rollout_data(self, batch: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
+    def _log_rollout_data(self, batch: RolloutDataRef, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout data from TransferQueue and dump sorted by uid."""
         with marked_timer("dump_rollout_generations", timing_raw, color="green"):
             fields = ["uid", "prompts", "responses", "rm_scores", "reward_model"]
-            data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
-            data["prompts"] = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
-            data["responses"] = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+            with rollout_data_backend.materialized_batch(
+                keys=batch.keys, partition_id=batch.partition_id, select_fields=fields
+            ) as data:
+                data["prompts"] = padded_tensor(data["prompts"], self.tokenizer.pad_token_id)
+                data["responses"] = padded_tensor(data["responses"], self.tokenizer.pad_token_id)
 
-            uids = data.pop("uid").tolist()
-            inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["prompts"]]
-            outputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["responses"]]
-            scores = data["rm_scores"].sum(dim=1).tolist()
+                uids = data.pop("uid").tolist()
+                inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["prompts"]]
+                outputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["responses"]]
+                scores = data["rm_scores"].sum(dim=1).tolist()
 
-            reward_model = data.pop("reward_model", None)
-            if reward_model is not None:
-                gts = [item.get("ground_truth", None) for item in reward_model.tolist()]
-            else:
-                gts = [None] * len(uids)
+                reward_model = data.pop("reward_model", None)
+                if reward_model is not None:
+                    gts = [item.get("ground_truth", None) for item in reward_model.tolist()]
+                else:
+                    gts = [None] * len(uids)
 
             # Sort by uid key ({sample}_{rollout}_{output})
             sort_keys = []
@@ -1346,7 +1363,7 @@ class PPOTrainer(ABC):
         """Register prompts in TransferQueue and dispatch them for generation."""
         tags = [{"is_prompt": True, "status": "pending", "global_steps": self.global_steps} for _ in range(len(batch))]
         if self.trainer_mode != "sync":
-            tq.kv_batch_put(
+            rollout_data_backend.batch_put(
                 keys=list(batch["uid"]),
                 partition_id="train",
                 tags=tags,
@@ -1355,7 +1372,7 @@ class PPOTrainer(ABC):
                 fields=batch.select(*[key for key in batch.keys() if not isinstance(batch.get(key), NonTensorData)]),
             )
         else:
-            tq.kv_batch_put(keys=list(batch["uid"]), partition_id="train", tags=tags)
+            rollout_data_backend.batch_put(keys=list(batch["uid"]), partition_id="train", tags=tags)
 
         self.agent_loop_manager.generate_sequences(batch)
         return len(batch)
@@ -1371,58 +1388,55 @@ class PPOTrainer(ABC):
         batch = self._next_train_batch()
         self._submit_batch_to_rollout(batch)
 
-    def _compute_reward_colocate(self, batch: KVBatchMeta, metrics: dict | None = None) -> KVBatchMeta:
+    def _compute_reward_colocate(self, batch: RolloutDataRef, metrics: dict | None = None) -> RolloutDataRef:
         """Compute the reward score with a colocated reward model."""
         assert self.reward_loop_manager is not None, "RewardLoopManager is None"
 
         # 1. read the fields required by the reward model from TransferQueue.
         fields = ["prompts", "responses", "raw_prompt"]
-        data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
+        with rollout_data_backend.materialized_batch(
+            keys=batch.keys, partition_id=batch.partition_id, select_fields=fields
+        ) as data:
+            prompt_lengths = sequence_lengths(data["prompts"], len(batch), "prompts")
+            response_lengths = sequence_lengths(data["responses"], len(batch), "responses")
+            prompts = padded_tensor(data["prompts"], self.tokenizer.pad_token_id)
+            responses = padded_tensor(data["responses"], self.tokenizer.pad_token_id)
 
-        prompt_lengths = data["prompts"].offsets().diff()
-        response_lengths = data["responses"].offsets().diff()
-        prompts = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
-        responses = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+            # 2. rebuild the attention mask aligned with the [prompts | responses] layout.
+            prompt_mask = self._lengths_to_mask(prompt_lengths, prompts.size(1))
+            response_mask = self._lengths_to_mask(response_lengths, responses.size(1))
+            attention_mask = torch.cat([prompt_mask, response_mask], dim=1)
 
-        # 2. rebuild the attention mask aligned with the [prompts | responses] layout.
-        prompt_mask = self._lengths_to_mask(prompt_lengths, prompts.size(1))
-        response_mask = self._lengths_to_mask(response_lengths, responses.size(1))
-        attention_mask = torch.cat([prompt_mask, response_mask], dim=1)
+            # Normalize the backend-specific non-tensor container to plain rows.
+            raw_prompts = list(data["raw_prompt"])
+            raw_prompt_arr = np.empty(len(raw_prompts), dtype=object)
+            raw_prompt_arr[:] = raw_prompts
 
-        # `raw_prompt` is a non-tensor field; depending on the TransferQueue backend it
-        # comes back as a tensordict LinkedList (a `list` subclass), a NonTensorStack or a
-        # numpy array. `list(...)` normalizes all of them to a plain list where each element
-        # is one sample's chat-message list (whereas `.tolist()` only exists on numpy/tensors).
-        raw_prompts = list(data["raw_prompt"])
-        raw_prompt_arr = np.empty(len(raw_prompts), dtype=object)
-        raw_prompt_arr[:] = raw_prompts
+            rm_input = DataProto(
+                batch=TensorDict(
+                    {"prompts": prompts, "responses": responses, "attention_mask": attention_mask},
+                    batch_size=len(batch),
+                ),
+                non_tensor_batch={"raw_prompt": raw_prompt_arr},
+            )
 
-        rm_input = DataProto(
-            batch=TensorDict(
-                {"prompts": prompts, "responses": responses, "attention_mask": attention_mask},
-                batch_size=len(batch),
-            ),
-            non_tensor_batch={"raw_prompt": raw_prompt_arr},
-        )
+            # 3. run the reward model (wakes/sleeps the reward model internally).
+            rm_output = self.reward_loop_manager.compute_rm_score(rm_input)
 
-        # 3. run the reward model (wakes/sleeps the reward model internally).
-        rm_output = self.reward_loop_manager.compute_rm_score(rm_input)
-
-        # 4. write rm_scores (and reward extra info) back to TransferQueue.
-        padded_rm_scores = rm_output.batch["rm_scores"]
-        rm_scores = torch.nested.as_nested_tensor(
-            [padded_rm_scores[i, : response_lengths[i]] for i in range(len(batch))],
-            layout=torch.jagged,
-        )
-        write_back = {"rm_scores": rm_scores}
-        for key in rm_output.meta_info.get("reward_extra_keys", []):
-            write_back[key] = rm_output.non_tensor_batch[key]
-        tq.kv_batch_put(
-            keys=batch.keys,
-            partition_id=batch.partition_id,
-            fields=tu.get_tensordict(write_back),
-        )
-
+            # 4. write rm_scores (and reward extra info) back to TransferQueue.
+            padded_rm_scores = rm_output.batch["rm_scores"]
+            rm_scores = torch.nested.as_nested_tensor(
+                [padded_rm_scores[i, : response_lengths[i]] for i in range(len(batch))],
+                layout=torch.jagged,
+            )
+            write_back = {"rm_scores": rm_scores}
+            for key in rm_output.meta_info.get("reward_extra_keys", []):
+                write_back[key] = rm_output.non_tensor_batch[key]
+            rollout_data_backend.batch_put(
+                keys=batch.keys,
+                partition_id=batch.partition_id,
+                fields=tu.get_tensordict(write_back),
+            )
         return batch
 
     @staticmethod
@@ -1450,7 +1464,7 @@ class PPOTrainer(ABC):
         # Notice lcm(a, b, c) == lcm(lcm(a, b), c), so it is optimal.
         return required_multiple
 
-    def _balance_batch(self, batch: KVBatchMeta, metrics, logging_prefix="global_seqlen", keep_minibatch=False):
+    def _balance_batch(self, batch: RolloutDataRef, metrics, logging_prefix="global_seqlen", keep_minibatch=False):
         """Reorder the data on single controller such that each dp rank gets similar total tokens."""
         # get actor dp size
         role, worker_group = "actor", self.actor_rollout_wg
@@ -1476,7 +1490,7 @@ class PPOTrainer(ABC):
         metrics.update(global_balance_stats)
         return batch
 
-    def _compute_old_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+    def _compute_old_log_prob(self, batch: RolloutDataRef, metrics: dict) -> RolloutDataRef:
         """Compute the old log prob of the batch."""
         # Operating Mode Selection:
         # - Bypass mode: Sets old_log_probs = rollout_log_probs (2 policies: π_rollout, π_θ)
@@ -1485,11 +1499,11 @@ class PPOTrainer(ABC):
         rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
         bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
         if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
-            data = tq.kv_batch_get(
+            with rollout_data_backend.materialized_batch(
                 keys=batch.keys, partition_id=batch.partition_id, select_fields=["rollout_log_probs"]
-            )
-            data["old_log_probs"] = data.pop("rollout_log_probs")
-            tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data)
+            ) as data:
+                data["old_log_probs"] = data.pop("rollout_log_probs")
+                rollout_data_backend.batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data)
             return batch
 
         # 1. compute log probs
@@ -1500,44 +1514,51 @@ class PPOTrainer(ABC):
                 "temperature": self.config.actor_rollout_ref.rollout.temperature,
             }
         )
-        output: KVBatchMeta = self.actor_rollout_wg.compute_log_prob(batch)
+        output: RolloutDataRef = self.actor_rollout_wg.compute_log_prob(batch)
         assert len(output) == len(batch)
 
         fields = ["entropy", "log_probs", "response_mask"]
         if self.config.actor_rollout_ref.rollout.calculate_log_probs:
             fields.extend(["responses", "rollout_log_probs"])
-        data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
+        with rollout_data_backend.materialized_batch(
+            keys=batch.keys, partition_id=batch.partition_id, select_fields=fields
+        ) as materialized:
+            # 2. write old_log_probs and entropy back to TransferQueue
+            materialized["old_log_probs"] = response_from_nested(
+                materialized.pop("log_probs"), materialized["response_mask"]
+            )
+            materialized["entropy"] = response_from_nested(
+                materialized.pop("entropy"), materialized["response_mask"]
+            )
+            batch = rollout_data_backend.batch_put(
+                keys=batch.keys,
+                partition_id=batch.partition_id,
+                fields=materialized.select("old_log_probs", "entropy"),
+            )
 
-        # 2. write old_log_probs and entropy back to TransferQueue
-        data["old_log_probs"] = response_from_nested(data.pop("log_probs"), data["response_mask"])
-        data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
-        batch = tq.kv_batch_put(
-            keys=batch.keys, partition_id=batch.partition_id, fields=data.select("old_log_probs", "entropy")
-        )
+            data = DataProto(batch=materialized.to_padded_tensor())
 
-        data = DataProto(batch=data.to_padded_tensor())
+            # 3. calculate actor entroy metrics
+            actor_config = self.config.actor_rollout_ref.actor
+            entropy_agg = agg_loss(
+                loss_mat=data.batch["entropy"],
+                loss_mask=data.batch["response_mask"],
+                loss_agg_mode=actor_config.loss_agg_mode,
+                loss_scale_factor=actor_config.loss_scale_factor,
+            )
+            old_log_prob_metrics = {
+                "actor/entropy": entropy_agg.detach().item(),
+                # "perf/mfu/actor_infer": old_log_prob_mfu,
+            }
+            metrics.update(old_log_prob_metrics)
 
-        # 3. calculate actor entroy metrics
-        actor_config = self.config.actor_rollout_ref.actor
-        entropy_agg = agg_loss(
-            loss_mat=data.batch["entropy"],
-            loss_mask=data.batch["response_mask"],
-            loss_agg_mode=actor_config.loss_agg_mode,
-            loss_scale_factor=actor_config.loss_scale_factor,
-        )
-        old_log_prob_metrics = {
-            "actor/entropy": entropy_agg.detach().item(),
-            # "perf/mfu/actor_infer": old_log_prob_mfu,
-        }
-        metrics.update(old_log_prob_metrics)
-
-        # 4. calculate rollout vs actor logprobs diff
-        if self.config.actor_rollout_ref.rollout.calculate_log_probs:
-            metrics.update(calculate_debug_metrics(data))
+            # 4. calculate rollout vs actor logprobs diff
+            if self.config.actor_rollout_ref.rollout.calculate_log_probs:
+                metrics.update(calculate_debug_metrics(data))
 
         return batch
 
-    def _compute_ref_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+    def _compute_ref_log_prob(self, batch: RolloutDataRef, metrics: dict) -> RolloutDataRef:
         """Compute the reference log prob of the batch."""
         # 1. compute log probs
         metadata = {
@@ -1555,15 +1576,17 @@ class PPOTrainer(ABC):
         assert len(output) == len(batch)
 
         # 2. write ref_log_prob and entropy back to TransferQueue
-        data = tq.kv_batch_get(
+        with rollout_data_backend.materialized_batch(
             keys=batch.keys, partition_id=batch.partition_id, select_fields=["log_probs", "response_mask"]
-        )
-        data["ref_log_prob"] = response_from_nested(data.pop("log_probs"), data["response_mask"])
-        tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data.select("ref_log_prob"))
+        ) as data:
+            data["ref_log_prob"] = response_from_nested(data.pop("log_probs"), data["response_mask"])
+            rollout_data_backend.batch_put(
+                keys=batch.keys, partition_id=batch.partition_id, fields=data.select("ref_log_prob")
+            )
 
         return batch
 
-    def _compute_values(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+    def _compute_values(self, batch: RolloutDataRef, metrics: dict) -> RolloutDataRef:
         """Compute the values of the batch."""
         # 1. compute value
         batch.extra_info.update(
@@ -1573,80 +1596,87 @@ class PPOTrainer(ABC):
             }
         )
         output = self.critic_wg.infer_batch(batch)
-        # TODO: DataProtoFuture support KVBatchMeta
+        # TODO: DataProtoFuture support RolloutDataRef
         ray.get(output.futures)
 
         # 2. write value back to TransferQueue
-        data = tq.kv_batch_get(
+        with rollout_data_backend.materialized_batch(
             keys=batch.keys, partition_id=batch.partition_id, select_fields=["values", "response_mask"]
-        )
-        data["values"] = response_from_nested(data.pop("values"), data["response_mask"])
-        tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data.select("values"))
+        ) as data:
+            data["values"] = response_from_nested(data.pop("values"), data["response_mask"])
+            rollout_data_backend.batch_put(
+                keys=batch.keys, partition_id=batch.partition_id, fields=data.select("values")
+            )
 
         return batch
 
-    def _compute_advantage(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+    def _compute_advantage(self, batch: RolloutDataRef, metrics: dict) -> RolloutDataRef:
         """Compute the advantage of the batch."""
-        fields = ["uid", "response_mask", "rm_scores", "rollout_log_probs", "old_log_probs", "ref_log_prob", "values"]
-        data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
-
-        response_mask = data["response_mask"]
-        data = DataProto(batch=data.to_padded_tensor())
-        data.batch["token_level_scores"] = data.batch["rm_scores"]
-        data.non_tensor_batch["uid"] = np.array(data.batch.pop("uid").tolist(), dtype=object)
+        fields = ["uid", "response_mask", "rm_scores", "rollout_log_probs", "old_log_probs"]
+        if self.use_reference_policy:
+            fields.append("ref_log_prob")
+        if self.use_critic:
+            fields.append("values")
+        with rollout_data_backend.materialized_batch(
+            keys=batch.keys, partition_id=batch.partition_id, select_fields=fields
+        ) as materialized:
+            response_mask = materialized["response_mask"]
+            data = DataProto(batch=materialized.to_padded_tensor())
+            data.batch["token_level_scores"] = data.batch["rm_scores"]
+            data.non_tensor_batch["uid"] = np.array(data.batch.pop("uid").tolist(), dtype=object)
 
         # 1. apply kl penalty to rewards
-        if self.config.algorithm.use_kl_in_reward:
-            data, kl_metrics = apply_kl_penalty(
-                data, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty
-            )
-            metrics.update(kl_metrics)
-        else:
-            data.batch["token_level_rewards"] = data.batch["token_level_scores"]
+            if self.config.algorithm.use_kl_in_reward:
+                data, kl_metrics = apply_kl_penalty(
+                    data, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty
+                )
+                metrics.update(kl_metrics)
+            else:
+                data.batch["token_level_rewards"] = data.batch["token_level_scores"]
 
         # 2. Compute rollout correction: IS weights, rejection sampling, and metrics
         # Only runs in decoupled mode (computes once per batch using stable π_old)
         # In bypass mode, this is skipped - actor computes metrics from evolving π_θ vs π_rollout
-        rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
-        bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
-        rollout_correction = (
-            rollout_corr_config is not None and "rollout_log_probs" in data.batch and not bypass_recomputing_logprobs
-        )
-        if rollout_correction:
-            data, is_metrics = compute_rollout_correction_and_add_to_batch(data, rollout_corr_config)
-            metrics.update(is_metrics)
+            rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
+            bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+            rollout_correction = (
+                rollout_corr_config is not None
+                and "rollout_log_probs" in data.batch
+                and not bypass_recomputing_logprobs
+            )
+            if rollout_correction:
+                data, is_metrics = compute_rollout_correction_and_add_to_batch(data, rollout_corr_config)
+                metrics.update(is_metrics)
 
         # 3. compute advantages
-        data = compute_advantage_for_multi_trajectories(
-            data,
-            batch_keys=batch.keys,
-            adv_estimator=self.config.algorithm.adv_estimator,
-            gamma=self.config.algorithm.gamma,
-            lam=self.config.algorithm.lam,
-            num_repeat=self.config.actor_rollout_ref.rollout.n,
-            norm_adv_by_std_in_grpo=self.config.algorithm.get("norm_adv_by_std_in_grpo", True),
-            config=self.config.algorithm,
-        )
+            data = compute_advantage_for_multi_trajectories(
+                data,
+                batch_keys=batch.keys,
+                adv_estimator=self.config.algorithm.adv_estimator,
+                gamma=self.config.algorithm.gamma,
+                lam=self.config.algorithm.lam,
+                num_repeat=self.config.actor_rollout_ref.rollout.n,
+                norm_adv_by_std_in_grpo=self.config.algorithm.get("norm_adv_by_std_in_grpo", True),
+                config=self.config.algorithm,
+            )
 
-        # 4. write nested advantages and returns back to TransferQueue
-        fields = ["advantages", "returns"]
-        if self.config.algorithm.use_kl_in_reward:
-            fields.append("token_level_rewards")
-        if rollout_correction:
-            fields.append("response_mask")
-            if "rollout_is_weights" in data.batch:
-                fields.append("rollout_is_weights")
+        # 4. write nested advantages, returns and rewards back to TransferQueue
+            fields = ["advantages", "returns", "token_level_rewards"]
+            if rollout_correction:
+                fields.append("response_mask")
+                if "rollout_is_weights" in data.batch:
+                    fields.append("rollout_is_weights")
 
-        output = {}
-        for field in fields:
-            output[field] = response_to_nested(data.batch[field], response_mask)
-        output = TensorDict(output, batch_size=len(batch))
+            output = {}
+            for field in fields:
+                output[field] = response_to_nested(data.batch[field], response_mask)
+            output = TensorDict(output, batch_size=len(batch))
 
-        batch = tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=output)
+            batch = rollout_data_backend.batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=output)
 
         return batch
 
-    def _update_critic(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+    def _update_critic(self, batch: RolloutDataRef, metrics: dict) -> RolloutDataRef:
         """Update the critic network."""
         ppo_mini_batch_size = self.config.critic.ppo_mini_batch_size
         ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
@@ -1669,7 +1699,7 @@ class PPOTrainer(ABC):
 
         return batch
 
-    def _update_actor(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+    def _update_actor(self, batch: RolloutDataRef, metrics: dict) -> RolloutDataRef:
         """Update the actor network."""
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
         ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
@@ -1710,126 +1740,128 @@ class PPOTrainer(ABC):
 
         return batch
 
-    def _compute_metrics(self, batch: KVBatchMeta, metrics, timing_raw, global_steps, epoch):
+    def _compute_metrics(self, batch: RolloutDataRef, metrics, timing_raw, global_steps, epoch):
         # 1. collect necessary fields from TransferQueue for computing metrics
         non_padding_mask = np.array([not tag.get("is_padding", False) for tag in batch.tags], dtype=bool)
         fields = [
             "prompts",
             "responses",
             "response_mask",
-            "values",
             "advantages",
             "returns",
             "rm_scores",
             "token_level_rewards",
             "num_turns",
         ]
+        if self.use_critic:
+            fields.append("values")
         moe_lb_metrics_interval = self.config.actor_rollout_ref.rollout.get("moe_load_balance_metrics_interval", 0)
-        data = get_metric_data_with_optional_routed_experts(
+        materialized = get_metric_data_with_optional_routed_experts(
             keys=batch.keys,
             partition_id=batch.partition_id,
             fields=fields,
             moe_lb_metrics_interval=moe_lb_metrics_interval,
             global_steps=global_steps,
             accumulator=self._rollout_moe_lb_metrics_accumulator,
-            kv_batch_get=tq.kv_batch_get,
+            kv_batch_get=rollout_data_backend.batch_get,
         )
+        try:
+            num_turns = np.array(materialized.pop("num_turns").tolist())
+            prompt_length = sequence_lengths(materialized["prompts"], len(batch), "prompts")
+            response_length = sequence_lengths(materialized["responses"], len(batch), "responses")
+            global_token_num = (prompt_length + response_length).tolist()
+            min_global_steps = np.array([tag["min_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
+            max_global_steps = np.array([tag["max_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
 
-        num_turns = np.array(data.pop("num_turns").tolist())
-        prompt_length = data["prompts"].offsets().diff()
-        response_length = data["responses"].offsets().diff()
-        global_token_num = (prompt_length + response_length).tolist()
-        min_global_steps = np.array([tag["min_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
-        max_global_steps = np.array([tag["max_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
+            # Only fetch speculative decoding stats when rollout writes them.
+            spec_drafts = spec_accepts = spec_verifies = None
+            mtp_config = getattr(self.config.actor_rollout_ref.model, "mtp", None)
+            if mtp_config is not None and mtp_config.enable and mtp_config.enable_rollout:
+                with rollout_data_backend.materialized_batch(
+                    keys=batch.keys,
+                    partition_id=batch.partition_id,
+                    select_fields=["extra_fields"],
+                ) as spec_data:
+                    extra_fields = list(spec_data["extra_fields"])
+                    if extra_fields and all(
+                        isinstance(extra_field, dict) and "spec_num_draft_tokens" in extra_field
+                        for extra_field in extra_fields
+                    ):
+                        spec_drafts = [extra_field["spec_num_draft_tokens"] for extra_field in extra_fields]
+                        spec_accepts = [extra_field["spec_num_accepted_tokens"] for extra_field in extra_fields]
+                        spec_verifies = [extra_field["spec_num_verify_steps"] for extra_field in extra_fields]
 
-        # Only fetch speculative decoding stats when rollout writes them.
-        spec_drafts = spec_accepts = spec_verifies = None
-        mtp_config = getattr(self.config.actor_rollout_ref.model, "mtp", None)
-        if mtp_config is not None and mtp_config.enable and mtp_config.enable_rollout:
-            spec_data = tq.kv_batch_get(
-                keys=batch.keys,
-                partition_id=batch.partition_id,
-                select_fields=["extra_fields"],
+            data = materialized.to_padded_tensor()
+            data["token_level_scores"] = data["rm_scores"]
+            if "token_level_rewards" not in data:
+                data["token_level_rewards"] = data["rm_scores"]
+            data["prompt_length"] = prompt_length.float()
+            data["response_length"] = response_length.float()
+            batch = DataProto(batch=data, meta_info={"global_token_num": global_token_num})
+            metrics_batch = batch.select_idxs(non_padding_mask) if non_padding_mask.any() else batch
+
+            # 2. compute metrics
+            metrics.update({"training/global_step": global_steps, "training/epoch": epoch})
+            metrics.update(
+                compute_moe_lb_metrics(
+                    metrics_batch=metrics_batch,
+                    moe_lb_metrics_interval=moe_lb_metrics_interval,
+                    global_steps=global_steps,
+                    accumulator=self._rollout_moe_lb_metrics_accumulator,
+                )
             )
-            extra_fields = spec_data.pop("extra_fields").tolist()
-            # The rollout omits the spec_* stats when the backend does not report
-            # per-request spec-decode stats; leave all three as None in that case.
-            if extra_fields and all(
-                isinstance(extra_field, dict) and "spec_num_draft_tokens" in extra_field for extra_field in extra_fields
-            ):
-                spec_drafts = [extra_field["spec_num_draft_tokens"] for extra_field in extra_fields]
-                spec_accepts = [extra_field["spec_num_accepted_tokens"] for extra_field in extra_fields]
-                spec_verifies = [extra_field["spec_num_verify_steps"] for extra_field in extra_fields]
+            metrics.update(compute_data_metrics(batch=metrics_batch, use_critic=self.use_critic))
+            metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+            n_gpus = self._get_n_gpus_for_throughput()
+            metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+            gradient_norm = metrics.get("actor/grad_norm", None)
+            metrics.update(compute_variance_proxy_metrics(batch=metrics_batch, gradient_norm=gradient_norm))
 
-        data = data.to_padded_tensor()
-        data["token_level_scores"] = data["rm_scores"]
-        if "token_level_rewards" not in data:
-            data["token_level_rewards"] = data["rm_scores"]
-        data["prompt_length"] = prompt_length.float()
-        data["response_length"] = response_length.float()
-        batch = DataProto(batch=data, meta_info={"global_token_num": global_token_num})
-        metrics_batch = batch.select_idxs(non_padding_mask) if non_padding_mask.any() else batch
-
-        # 2. compute metrics
-        metrics.update({"training/global_step": global_steps, "training/epoch": epoch})
-        metrics.update(
-            compute_moe_lb_metrics(
-                metrics_batch=metrics_batch,
-                moe_lb_metrics_interval=moe_lb_metrics_interval,
-                global_steps=global_steps,
-                accumulator=self._rollout_moe_lb_metrics_accumulator,
+            # 3. other auxiliary metrics
+            if non_padding_mask.any():
+                num_turns = num_turns[non_padding_mask]
+            metrics.update(
+                {
+                    "training/num_turns/mean": num_turns.mean(),
+                    "training/num_turns/max": num_turns.max(),
+                    "training/num_turns/min": num_turns.min(),
+                }
             )
-        )
-        metrics.update(compute_data_metrics(batch=metrics_batch, use_critic=self.use_critic))
-        metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
-        n_gpus = self._get_n_gpus_for_throughput()
-        metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
-        gradient_norm = metrics.get("actor/grad_norm", None)
-        metrics.update(compute_variance_proxy_metrics(batch=metrics_batch, gradient_norm=gradient_norm))
 
-        # 3. other auxiliary metrics
-        if non_padding_mask.any():
-            num_turns = num_turns[non_padding_mask]
-        metrics.update(
-            {
-                "training/num_turns/mean": num_turns.mean(),
-                "training/num_turns/max": num_turns.max(),
-                "training/num_turns/min": num_turns.min(),
-            }
-        )
+            # 4. per-request speculative-decoding aggregation (same metrics async PPO logs;
+            # see compute_spec_decode_metrics in verl/trainer/ppo/ray_trainer.py).
+            metrics.update(compute_spec_decode_metrics(spec_drafts, spec_accepts, spec_verifies, non_padding_mask))
 
-        # 4. per-request speculative-decoding aggregation (same metrics async PPO logs;
-        # see compute_spec_decode_metrics in verl/trainer/ppo/ray_trainer.py).
-        metrics.update(compute_spec_decode_metrics(spec_drafts, spec_accepts, spec_verifies, non_padding_mask))
-
-        # 5. off-policy staleness metrics
-        #   global_steps is the model weight version (one update_weights per global_step), and
-        #   min/max_global_steps are the versions a trajectory was generated across, so all quantities
-        #   below are already in model-version units.
-        #   - trajectory_spans: how many distinct model versions a single trajectory was
-        #     generated across (1 == fully generated on a single version). This captures the
-        #     within-trajectory policy inconsistency caused by partial rollout / continuation.
-        #   - trajectory_staleness: how many model versions the trajectory lags behind the
-        #     *current* policy. A trajectory spans versions [min_global_steps, max_global_steps],
-        #     so the lag is a range: the freshest weights used give the lower bound
-        #     (global_steps - max_global_steps) and the oldest weights the worst case
-        #     (global_steps - min_global_steps). We log the lower bound as the primary metric.
-        trajectory_spans = max_global_steps - min_global_steps + 1
-        trajectory_staleness = (global_steps - 1) - max_global_steps
-        trajectory_staleness_worst = (global_steps - 1) - min_global_steps
-        metrics.update(
-            {
-                "training/off_policy/trajectory_spans/mean": trajectory_spans.mean(),
-                "training/off_policy/trajectory_spans/max": trajectory_spans.max(),
-                "training/off_policy/trajectory_spans/min": trajectory_spans.min(),
-                "training/off_policy/trajectory_staleness/mean": trajectory_staleness.mean(),
-                "training/off_policy/trajectory_staleness/max": trajectory_staleness.max(),
-                "training/off_policy/trajectory_staleness/min": trajectory_staleness.min(),
-                "training/off_policy/trajectory_staleness_worst/mean": trajectory_staleness_worst.mean(),
-                "training/off_policy/trajectory_staleness_worst/max": trajectory_staleness_worst.max(),
-                "training/off_policy/trajectory_staleness_worst/min": trajectory_staleness_worst.min(),
-            }
-        )
+            # 5. off-policy staleness metrics
+            #   global_steps is the model weight version (one update_weights per global_step), and
+            #   min/max_global_steps are the versions a trajectory was generated across, so all quantities
+            #   below are already in model-version units.
+            #   - trajectory_spans: how many distinct model versions a single trajectory was
+            #     generated across (1 == fully generated on a single version). This captures the
+            #     within-trajectory policy inconsistency caused by partial rollout / continuation.
+            #   - trajectory_staleness: how many model versions the trajectory lags behind the
+            #     *current* policy. A trajectory spans versions [min_global_steps, max_global_steps],
+            #     so the lag is a range: the freshest weights used give the lower bound
+            #     (global_steps - max_global_steps) and the oldest weights the worst case
+            #     (global_steps - min_global_steps). We log the lower bound as the primary metric.
+            trajectory_spans = max_global_steps - min_global_steps + 1
+            trajectory_staleness = (global_steps - 1) - max_global_steps
+            trajectory_staleness_worst = (global_steps - 1) - min_global_steps
+            metrics.update(
+                {
+                    "training/off_policy/trajectory_spans/mean": trajectory_spans.mean(),
+                    "training/off_policy/trajectory_spans/max": trajectory_spans.max(),
+                    "training/off_policy/trajectory_spans/min": trajectory_spans.min(),
+                    "training/off_policy/trajectory_staleness/mean": trajectory_staleness.mean(),
+                    "training/off_policy/trajectory_staleness/max": trajectory_staleness.max(),
+                    "training/off_policy/trajectory_staleness/min": trajectory_staleness.min(),
+                    "training/off_policy/trajectory_staleness_worst/mean": trajectory_staleness_worst.mean(),
+                    "training/off_policy/trajectory_staleness_worst/max": trajectory_staleness_worst.max(),
+                    "training/off_policy/trajectory_staleness_worst/min": trajectory_staleness_worst.min(),
+                }
+            )
+        finally:
+            rollout_data_backend.release_result(materialized)
 
 
 TRAINER_REGISTRY: dict[str, type[PPOTrainer]] = {}

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -17,10 +17,10 @@ from enum import Enum
 
 import ray
 from omegaconf import DictConfig
-from transfer_queue import KVBatchMeta
 
 from verl.checkpoint_engine import CheckpointEngineManager
 from verl.experimental.separation.engine_workers import DetachActorWorker
+from verl.protocol import RolloutDataRef
 from verl.trainer.ppo.utils import Role, need_reward_model
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
 from verl.utils.config import omega_conf_to_dataclass
@@ -100,7 +100,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         self.current_mode = HybridEngineMode.ROLLOUT
         self.add_replicas_to_balancer()
 
-    def _compute_old_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
+    def _compute_old_log_prob(self, batch: RolloutDataRef, metrics: dict) -> RolloutDataRef:
         """Version-aware old_log_probs computation for Decoupled PPO.
 
         In bypass mode, delegates to the base class (copies rollout_log_probs directly).

--- a/verl/utils/mooncake_rollout_backend.py
+++ b/verl/utils/mooncake_rollout_backend.py
@@ -1,0 +1,382 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mooncake implementation of the V1 rollout data backend."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from dataclasses import asdict
+from itertools import groupby
+from typing import Any
+
+from verl.protocol import RolloutDataRef
+
+logger = logging.getLogger(__name__)
+
+
+class MooncakeRolloutDataBackend:
+    """Store rollout fragments with Mooncake and index them by logical key."""
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        host_catalog: bool = False,
+    ):
+        self.config = config or {}
+        self.host_catalog = host_catalog
+        self.store = None
+        self.transfer = None
+        self.buffer_pool = None
+        self.catalog = None
+        self.catalog_transfer = None
+        self._read_token_lock = threading.Lock()
+        self._pending_read_tokens: set[int] = set()
+
+    def _store_config(self) -> dict[str, Any]:
+        explicit = self.config.get("store_init_kwargs") or self.config.get("store")
+        if explicit:
+            config = dict(explicit)
+        else:
+            from mooncake.mooncake_config import MooncakeConfig
+
+            config = asdict(MooncakeConfig.load_from_env())
+        if "master_server_address" in config:
+            config.setdefault("master_server_addr", config.pop("master_server_address"))
+        if "device_name" in config:
+            config.setdefault("rdma_devices", config.pop("device_name"))
+        return config
+
+    def start(self, _config: Any = None) -> None:
+        import ray
+        from mooncake.buffer_pool import BufferPool
+        from mooncake.dataproto_catalog import (
+            DataProtoCatalog,
+            DataProtoCatalogTransfer,
+        )
+        from mooncake.store import MooncakeDistributedStore
+        from mooncake.structured_object_store import MooncakeBundleTransfer
+
+        self.store = MooncakeDistributedStore()
+        rc = self.store.setup(self._store_config())
+        if rc != 0:
+            raise RuntimeError(f"MooncakeDistributedStore setup failed with code {rc}")
+        self.buffer_pool = BufferPool(self.store, **dict(self.config.get("buffer_pool_kwargs") or {}))
+        self.transfer = MooncakeBundleTransfer(
+            self.store,
+            key_prefix=self.config.get("key_prefix", "verl-rollout"),
+            default_chunk_bytes=int(self.config.get("default_chunk_bytes", 64 * 1024**2)),
+            buffer_pool=self.buffer_pool,
+        )
+
+        catalog_config = dict(self.config.get("catalog") or {})
+        actor_name = catalog_config["actor_name"]
+        namespace = catalog_config.get("namespace", "verl")
+        if self.host_catalog:
+            self.catalog = (
+                ray.remote(DataProtoCatalog)
+                .options(
+                    name=actor_name,
+                    namespace=namespace,
+                )
+                .remote()
+            )
+        else:
+            try:
+                self.catalog = ray.get_actor(actor_name, namespace=namespace)
+            except Exception as exc:
+                raise RuntimeError(f"Mooncake DataProto catalog {namespace}/{actor_name} is not running") from exc
+        self.catalog_transfer = DataProtoCatalogTransfer(self.transfer, self._catalog_call)
+
+    def shutdown(self) -> None:
+        catalog_transfer = self.catalog_transfer
+        first_error = None
+
+        def cleanup(name, callback, *args, **kwargs):
+            nonlocal first_error
+            try:
+                callback(*args, **kwargs)
+                return True
+            except Exception as exc:
+                logger.exception("Failed to %s", name)
+                if first_error is None:
+                    first_error = exc
+                return False
+
+        with self._read_token_lock:
+            pending_tokens = tuple(self._pending_read_tokens)
+        catalog_ready = True
+        for token in pending_tokens:
+            released = cleanup("release Mooncake catalog read pin", self._release_read, token)
+            catalog_ready = released and catalog_ready
+        if catalog_transfer is not None:
+            catalog_ready &= cleanup("close Mooncake catalog transfer", catalog_transfer.close)
+
+        drained = not self.host_catalog or self.catalog is None
+        if catalog_ready and self.host_catalog and self.catalog is not None:
+            drained = catalog_transfer is None or cleanup("drain Mooncake catalog", catalog_transfer.drain)
+
+        if catalog_ready and drained:
+            pool_closed = self.buffer_pool is None or cleanup(
+                "close Mooncake buffer pool", self.buffer_pool.close
+            )
+            if pool_closed:
+                self.buffer_pool = None
+                if self.store is not None and cleanup("close Mooncake Store", self.store.close):
+                    self.store = None
+
+        catalog = self.catalog
+        if drained and self.host_catalog and catalog is not None:
+            import ray
+
+            if cleanup(
+                "stop drained Mooncake catalog actor",
+                ray.kill,
+                catalog,
+                no_restart=True,
+            ):
+                self.catalog = None
+        if first_error is not None:
+            raise first_error
+        self.catalog = self.catalog_transfer = None
+        self.buffer_pool = self.store = self.transfer = None
+
+    async def put_batch_async(self, **kwargs):
+        work = asyncio.create_task(asyncio.to_thread(self.put_batch, **kwargs))
+        try:
+            return await asyncio.shield(work)
+        except asyncio.CancelledError:
+            while not work.done():
+                try:
+                    await asyncio.shield(work)
+                except asyncio.CancelledError:
+                    continue
+            if not work.cancelled() and (exc := work.exception()) is not None:
+                logger.error(
+                    "Mooncake PUT failed while cancellation was pending",
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+            raise
+
+    @staticmethod
+    def _put_args(
+        kwargs: dict[str, Any],
+    ) -> tuple[list[str], str, list[dict[str, Any]] | None, Any]:
+        keys = list(kwargs.get("keys") or [])
+        raw_tags = kwargs.get("tags")
+        tags = None if raw_tags is None else [dict(tag or {}) for tag in raw_tags]
+        if not keys:
+            raise ValueError("Mooncake rollout put requires at least one key")
+        if len(keys) != len(set(keys)):
+            raise ValueError("Mooncake rollout put keys must be unique")
+        if tags is not None and len(tags) != len(keys):
+            raise ValueError("tags must have the same length as keys")
+        fields = kwargs.get("fields")
+        if fields is None and tags is None:
+            raise ValueError("Mooncake rollout put requires fields or tags")
+        return keys, kwargs.get("partition_id") or "default", tags, fields
+
+    @staticmethod
+    def _to_dataproto(fields: Any):
+        from tensordict import TensorDict
+
+        from verl.protocol import DataProto
+
+        if isinstance(fields, TensorDict):
+            if len(fields.keys()) == 0:
+                raise ValueError("Mooncake rollout fields cannot be empty")
+            fields = DataProto.from_tensordict(fields)
+        if not isinstance(fields, DataProto):
+            raise TypeError(f"Mooncake rollout fields must be TensorDict or DataProto, got {type(fields).__name__}")
+        return fields
+
+    def _catalog_call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        call = getattr(self.catalog, method)
+        remote = getattr(call, "remote", None)
+        if remote is None:
+            return call(*args, **kwargs)
+        import ray
+
+        return ray.get(remote(*args, **kwargs))
+
+    def _release_read(self, token: int) -> None:
+        for attempt in range(2):
+            try:
+                self.catalog_transfer.release_read(token)
+                with self._read_token_lock:
+                    self._pending_read_tokens.discard(token)
+                return
+            except Exception:
+                if attempt:
+                    with self._read_token_lock:
+                        self._pending_read_tokens.add(token)
+                    raise
+                logger.exception("Retrying Mooncake catalog read-pin release")
+
+    def release_result(self, result: Any) -> None:
+        self.catalog_transfer.release_result(result)
+
+    def _replicate_config(self) -> Any:
+        settings = dict(self.config.get("replicate_config") or {})
+        if not settings:
+            return None
+        if "group_ids" in settings:
+            raise ValueError("group_ids require Mooncake structured-object group semantics")
+
+        from mooncake.store import ReplicateConfig
+
+        config = ReplicateConfig()
+        for name, value in settings.items():
+            if not hasattr(config, name):
+                raise ValueError(f"unsupported Mooncake replicate config field: {name!r}")
+            setattr(config, name, value)
+        return config
+
+    def put_batch(self, **kwargs) -> RolloutDataRef:
+        keys, partition, tags, fields = self._put_args(kwargs)
+        data = None
+        put_options = {}
+        if fields is not None:
+            data = self._to_dataproto(fields)
+            chunk_bytes = kwargs.get("chunk_bytes")
+            if chunk_bytes is None:
+                chunk_bytes = self.config.get("chunk_bytes")
+            field_schemas = kwargs.get("field_schemas")
+            if field_schemas is None:
+                field_schemas = self.config.get("field_schemas")
+            put_options = {
+                "namespace": self.config.get("namespace", "verl"),
+                "stage": str(kwargs.get("stage") or "rollout"),
+                "chunk_bytes": chunk_bytes,
+                "field_schemas": field_schemas,
+                "config": self._replicate_config(),
+            }
+        result = self.catalog_transfer.put(
+            data,
+            partition=partition,
+            keys=keys,
+            tags=tags,
+            **put_options,
+        )
+        return RolloutDataRef(
+            keys=keys,
+            tags=result["tags"],
+            partition_id=partition,
+            fields=result["fields"],
+        )
+
+    def get_batch(self, **kwargs):
+        from tensordict import TensorDict
+
+        from verl.protocol import DataProto
+        from verl.utils.tensordict_utils import (
+            assign_non_tensor_data,
+            concat_tensordict,
+            index_select_tensor_dict,
+        )
+
+        keys = list(kwargs.get("keys") or [])
+        if not keys:
+            return TensorDict({}, batch_size=[0])
+        fields = kwargs.get("select_fields")
+        if isinstance(fields, str):
+            fields = [fields]
+        catalog_transfer = self.catalog_transfer
+        plan = catalog_transfer.resolve(
+            kwargs.get("partition_id") or "default",
+            keys,
+            fields,
+        )
+        read_token = plan["read_token"]
+
+        requests: dict[str, dict[str, Any]] = {}
+        for field_group in plan["field_groups"]:
+            for fragment_id, source_row in field_group["locations"]:
+                request = requests.setdefault(fragment_id, {"rows": [], "row_indexes": {}, "fields": []})
+                if source_row not in request["row_indexes"]:
+                    request["row_indexes"][source_row] = len(request["rows"])
+                    request["rows"].append(source_row)
+                for field in field_group["fields"]:
+                    if field not in request["fields"]:
+                        request["fields"].append(field)
+
+        materialized = {}
+        materialized_rows = {}
+        materialized_results = []
+        try:
+            for fragment_id, request in requests.items():
+                rows = request["rows"]
+                batch_size = int(plan["handles"][fragment_id]["batch_size"])
+                if rows == list(range(batch_size)):
+                    row_selection = None
+                elif all(row == rows[0] + offset for offset, row in enumerate(rows)):
+                    row_selection = slice(rows[0], rows[-1] + 1)
+                else:
+                    row_selection = rows
+                data = self.transfer.get(
+                    plan["handles"][fragment_id],
+                    type="dataproto",
+                    fields=request["fields"],
+                    rows=row_selection,
+                    data_cls=DataProto,
+                )
+                materialized_rows[fragment_id] = request["row_indexes"]
+                materialized_results.append(data)
+                materialized[fragment_id] = data.to_tensordict()
+
+            result = TensorDict({}, batch_size=[len(keys)])
+            for field_group in plan["field_groups"]:
+                parts = []
+                for fragment_id, group in groupby(field_group["locations"], key=lambda location: location[0]):
+                    indexes = [materialized_rows[fragment_id][source_row] for _, source_row in group]
+                    selected = materialized[fragment_id].select(*field_group["fields"])
+                    if indexes != list(range(len(selected))):
+                        selected = index_select_tensor_dict(selected, indexes)
+                    parts.append(selected)
+                merged = parts[0] if len(parts) == 1 else concat_tensordict(parts)
+                result.update(merged)
+            for name, value in plan["meta_info"].items():
+                assign_non_tensor_data(result, name, value)
+        except BaseException:
+            catalog_transfer.discard_results(materialized_results)
+            try:
+                self._release_read(read_token)
+            except Exception:
+                logger.exception("Failed to release Mooncake catalog read pin")
+            raise
+        try:
+            self._release_read(read_token)
+        except Exception:
+            catalog_transfer.discard_results(materialized_results)
+            raise
+        catalog_transfer.attach_results(result, materialized_results)
+        return result
+
+    def list(self, partition_id: str | None = None):
+        return self.catalog_transfer.list(partition_id)
+
+    def delete(self, **kwargs) -> None:
+        keys = list(kwargs.get("keys") or [])
+        if not keys:
+            return
+        self.catalog_transfer.remove(
+            kwargs.get("partition_id") or "default",
+            keys,
+        )
+
+    def supports_checkpoint(self) -> bool:
+        return False

--- a/verl/utils/rollout_data_backend.py
+++ b/verl/utils/rollout_data_backend.py
@@ -1,0 +1,260 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral data plane used by the V1 rollout pipeline."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import threading
+import uuid
+from typing import Any
+
+from omegaconf import DictConfig, OmegaConf
+from packaging.version import InvalidVersion, Version
+
+ROLLOUT_DATA_BACKEND_ENV = "VERL_ROLLOUT_DATA_BACKEND"
+TRANSFER_QUEUE_BACKEND = "transfer_queue"
+MOONCAKE_BACKEND = "mooncake"
+
+
+def _to_dict(config: Any) -> dict[str, Any]:
+    if config is None:
+        return {}
+    if isinstance(config, DictConfig):
+        return OmegaConf.to_container(config, resolve=True)
+    return dict(config)
+
+
+class TransferQueueBackend:
+    """Thin adapter that keeps the existing TransferQueue data path unchanged."""
+
+    @staticmethod
+    def _module():
+        try:
+            import transfer_queue as tq
+        except ImportError as exc:
+            raise ImportError(
+                "The transfer_queue rollout backend requires TransferQueue. Install the version documented by verl."
+            ) from exc
+        return tq
+
+    @staticmethod
+    def _to_ref(meta: Any):
+        from verl.protocol import RolloutDataRef
+
+        return RolloutDataRef(
+            keys=list(meta.keys),
+            tags=list(meta.tags),
+            partition_id=meta.partition_id,
+            fields=None if meta.fields is None else list(meta.fields),
+            extra_info=dict(meta.extra_info or {}),
+        )
+
+    def start(self, config: Any = None) -> None:
+        self._module().init(config)
+        from verl.utils import transferqueue_utils
+
+        transferqueue_utils.TQ_INITIALIZED = True
+
+    def shutdown(self) -> None:
+        try:
+            self._module().close()
+        finally:
+            from verl.utils import transferqueue_utils
+
+            transferqueue_utils.TQ_INITIALIZED = False
+
+    async def put_batch_async(self, **kwargs):
+        return self._to_ref(await self._module().async_kv_batch_put(**kwargs))
+
+    def put_batch(self, **kwargs):
+        return self._to_ref(self._module().kv_batch_put(**kwargs))
+
+    def get_batch(self, **kwargs):
+        return self._module().kv_batch_get(**kwargs)
+
+    def list(self, partition_id: str | None = None):
+        return self._module().kv_list() if partition_id is None else self._module().kv_list(partition_id)
+
+    def delete(self, **kwargs):
+        return self._module().kv_clear(**kwargs)
+
+    @staticmethod
+    def release_result(_result: Any) -> None:
+        pass
+
+    def supports_checkpoint(self) -> bool:
+        module = self._module()
+        try:
+            version_supported = Version(getattr(module, "__version__", "")) >= Version("0.1.9")
+        except InvalidVersion:
+            return False
+        return version_supported and all(
+            callable(getattr(module, name, None)) for name in ("save_checkpoint", "load_checkpoint")
+        )
+
+    def save_checkpoint(self, path: str, **kwargs) -> None:
+        self._module().save_checkpoint(path, **kwargs)
+
+    def load_checkpoint(self, path: str) -> None:
+        self._module().load_checkpoint(path)
+
+
+_backend: Any = None
+_backend_lock = threading.RLock()
+
+
+def configure_runtime(config: Any) -> dict[str, Any]:
+    """Publish backend selection before Ray starts so child processes inherit it."""
+    with _backend_lock:
+        if _backend is not None:
+            raise RuntimeError("cannot reconfigure a running rollout data backend")
+        backend_config = _to_dict(config)
+        if backend_config.get("name") == MOONCAKE_BACKEND:
+            options = dict(backend_config.get("config") or {})
+            backend_config["config"] = options
+            catalog = dict(options.get("catalog") or {})
+            options["catalog"] = catalog
+            catalog.setdefault("actor_name", f"verl_mooncake_catalog_{uuid.uuid4().hex}")
+        os.environ[ROLLOUT_DATA_BACKEND_ENV] = json.dumps(backend_config)
+        return backend_config
+
+
+def _runtime_config() -> dict[str, Any]:
+    raw = os.getenv(ROLLOUT_DATA_BACKEND_ENV)
+    return json.loads(raw) if raw else {"name": TRANSFER_QUEUE_BACKEND}
+
+
+def backend_name(config: Any = None) -> str:
+    return _to_dict(_runtime_config() if config is None else config).get("name", TRANSFER_QUEUE_BACKEND)
+
+
+def _new_backend(*, host_catalog: bool = False):
+    config = _runtime_config()
+    name = config.get("name", TRANSFER_QUEUE_BACKEND)
+    if name == TRANSFER_QUEUE_BACKEND:
+        return TransferQueueBackend()
+    if name == MOONCAKE_BACKEND:
+        from verl.utils.mooncake_rollout_backend import MooncakeRolloutDataBackend
+
+        return MooncakeRolloutDataBackend(
+            _to_dict(config.get("config")),
+            host_catalog=host_catalog,
+        )
+    raise ValueError(f"unsupported rollout data backend: {name!r}")
+
+
+def init(
+    transfer_queue_config: Any = None,
+    *,
+    host_catalog: bool = False,
+) -> None:
+    global _backend
+    with _backend_lock:
+        if _backend is not None:
+            if host_catalog and backend_name() == MOONCAKE_BACKEND and not getattr(_backend, "host_catalog", False):
+                raise RuntimeError("Mooncake rollout backend is already running as a catalog client")
+            return
+        backend = _new_backend(host_catalog=host_catalog)
+        try:
+            backend.start(transfer_queue_config if isinstance(backend, TransferQueueBackend) else None)
+        except Exception:
+            with contextlib.suppress(Exception):
+                backend.shutdown()
+            raise
+        _backend = backend
+
+
+def _ready_backend():
+    init()
+    return _backend
+
+
+def close() -> None:
+    global _backend
+    with _backend_lock:
+        if _backend is None:
+            return
+        _backend.shutdown()
+        _backend = None
+
+
+async def async_batch_put(**kwargs):
+    return await _ready_backend().put_batch_async(**kwargs)
+
+
+def batch_put(**kwargs):
+    return _ready_backend().put_batch(**kwargs)
+
+
+def batch_get(**kwargs):
+    return _ready_backend().get_batch(**kwargs)
+
+
+def release_result(result: Any) -> None:
+    _ready_backend().release_result(result)
+
+
+def prepare_for_dispatch(ref: Any) -> Any:
+    """Restore TransferQueue's native metadata path before worker dispatch."""
+    if backend_name() != TRANSFER_QUEUE_BACKEND:
+        return ref
+    from transfer_queue import KVBatchMeta
+
+    return KVBatchMeta(
+        keys=ref.keys,
+        tags=ref.tags,
+        partition_id=ref.partition_id,
+        fields=ref.fields,
+        extra_info=ref.extra_info,
+    )
+
+
+def rows_to_fields(rows: list[dict[str, Any]]):
+    """Build rollout fields using the selected backend's sequence layout."""
+    from verl.utils.tensordict_utils import list_of_dict_to_tensordict
+
+    return list_of_dict_to_tensordict(rows, jagged_1d=backend_name() == MOONCAKE_BACKEND)
+
+
+@contextlib.contextmanager
+def materialized_batch(**kwargs):
+    result = batch_get(**kwargs)
+    try:
+        yield result
+    finally:
+        release_result(result)
+
+
+def list_entries(partition_id: str | None = None):
+    return _ready_backend().list(partition_id)
+
+
+def clear(**kwargs):
+    return _ready_backend().delete(**kwargs)
+
+
+def supports_checkpoint() -> bool:
+    return _ready_backend().supports_checkpoint()
+
+
+def save_checkpoint(path: str, **kwargs) -> None:
+    _ready_backend().save_checkpoint(path, **kwargs)
+
+
+def load_checkpoint(path: str) -> None:
+    _ready_backend().load_checkpoint(path)

--- a/verl/utils/skip/rollout_skip.py
+++ b/verl/utils/skip/rollout_skip.py
@@ -19,6 +19,7 @@ import torch
 from omegaconf import OmegaConf
 
 from verl.protocol import DataProto
+from verl.utils import rollout_data_backend
 from verl.utils.skip.base_skip import BaseSkip, SkipAction, register_skip
 
 
@@ -164,17 +165,17 @@ class RolloutSkip(BaseSkip):
 
 @register_skip("rollout_tq")
 class RolloutTqSkip(RolloutSkip):
-    """Rollout skip for V1 TransferQueue-based trainer (``skip.rollout_tq``).
+    """Rollout skip for the V1 rollout data backend (``skip.rollout_tq``).
 
-    Unlike V0's decorator pattern, V1's split architecture (submit prompts to TQ,
-    then sample trajectories) requires direct method calls from the trainer:
+    Unlike V0's decorator pattern, V1's split architecture (submit prompts to
+    the rollout backend, then sample trajectories) requires direct method calls:
     - Phase one (no cache): trainer calls ``prepare_data`` after ``replay_buffer.sample``
     - Phase two (cache exists): trainer calls ``load_dump_data`` in ``_add_batch_to_generate``
 
     When ``parameter_sync_step > 1`` (separate async), one global step performs multiple
     ``sample`` calls.  Each mini-batch is saved to a separate inner sub-directory
     ``{step}/{inner_idx}/`` so the full step is captured; on load all inner dirs are
-    merged.  For ``parameter_sync_step == 1`` (sync / colocate async) the directory
+    merged. For ``parameter_sync_step == 1`` (sync / colocate async) the directory
     structure is (``{step}/{0}/tq_batch.pt``).
     """
 
@@ -297,7 +298,7 @@ class RolloutTqSkip(RolloutSkip):
         return True
 
     def prepare_data(self, step: int, batch, global_steps: int) -> None:
-        """Phase one: read batch from TransferQueue and save to disk.
+        """Phase one: read a rollout batch from the selected backend and save it.
 
         When ``parameter_sync_step > 1``, each ``sample`` call saves its mini-batch
         to ``{step}/{inner_idx}/``.  The first missing inner index is used so that
@@ -305,11 +306,9 @@ class RolloutTqSkip(RolloutSkip):
 
         Args:
             step: Current training step (used as dump directory name).
-            batch: :class:`transfer_queue.KVBatchMeta` from ``ReplayBuffer.sample()``.
+            batch: :class:`verl.protocol.RolloutDataRef` from ``ReplayBuffer.sample()``.
             global_steps: Current ``global_steps`` for metadata.
         """
-        import transfer_queue as tq
-
         # Determine which inner index to save to (-1 means all present, shouldn't happen)
         inner_idx = self._find_first_missing_inner(step)
         if inner_idx == -1:
@@ -317,16 +316,16 @@ class RolloutTqSkip(RolloutSkip):
         save_dir = self._get_v1_inner_dir(step, inner_idx)
         save_dir.mkdir(parents=True, exist_ok=True)
 
-        # Read all trajectory fields from TQ
-        data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id)
-
-        save_payload = {
-            "tensordict": data,
-            "tags": batch.tags,
-            "keys": list(batch.keys),
-            "global_steps": global_steps,
-        }
-        torch.save(save_payload, save_dir / self.tq_batch_name)
+        with rollout_data_backend.materialized_batch(
+            keys=batch.keys, partition_id=batch.partition_id
+        ) as data:
+            save_payload = {
+                "tensordict": data,
+                "tags": batch.tags,
+                "keys": list(batch.keys),
+                "global_steps": global_steps,
+            }
+            torch.save(save_payload, save_dir / self.tq_batch_name)
 
         meta_path = save_dir / self.meta_name
         meta_path.write_text(json.dumps({"global_steps": global_steps, "num_trajectories": len(batch.keys)}))
@@ -344,7 +343,7 @@ class RolloutTqSkip(RolloutSkip):
         global_steps: int,
         partition_id: str = "train",
     ) -> None:
-        """Phase two: load cached data from disk and inject into TransferQueue.
+        """Phase two: load cached data and inject it into the selected backend.
 
         Maps saved trajectories to new prompt uids in order, preserving the
         original key structure (``{uid}_{session_id}_{index}``) and GRPO group
@@ -355,10 +354,8 @@ class RolloutTqSkip(RolloutSkip):
             new_prompt_uids: Freshly generated uids for the current batch.
             n: Number of trajectories per prompt (``rollout.n``).
             global_steps: Current ``global_steps``, used to override staleness tags.
-            partition_id: TQ partition (``"train"`` or ``"val"``).
+            partition_id: Backend partition (``"train"`` or ``"val"``).
         """
-        import transfer_queue as tq
-
         load_step = self._resolve_load_step_v1(step)
         if load_step == -1:
             raise FileNotFoundError(
@@ -439,8 +436,7 @@ class RolloutTqSkip(RolloutSkip):
 
         new_fields = index_select_tensor_dict(data, traj_indices)
 
-        # Write trajectory data to TQ
-        tq.kv_batch_put(
+        rollout_data_backend.batch_put(
             keys=new_keys,
             fields=new_fields,
             tags=new_tags,
@@ -449,7 +445,7 @@ class RolloutTqSkip(RolloutSkip):
 
         # Mark prompt-level keys as finished so ReplayBuffer can pick them up immediately
         prompt_tags = [{"is_prompt": True, "status": "finished", "global_steps": global_steps}] * len(new_prompt_uids)
-        tq.kv_batch_put(
+        rollout_data_backend.batch_put(
             keys=new_prompt_uids,
             partition_id=partition_id,
             tags=prompt_tags,
@@ -458,7 +454,7 @@ class RolloutTqSkip(RolloutSkip):
         print(
             f"{self.print_mark}\033[33mInjected {len(new_keys)} cached trajectories "
             f"from step {load_step} ({len(new_prompt_uids)} prompts x {n}) "
-            f"into TQ partition '{partition_id}' at current step {step}\033[0m",
+            f"into backend partition '{partition_id}' at current step {step}\033[0m",
             flush=True,
         )
 

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -915,9 +915,13 @@ def maybe_fix_3d_position_ids(data: TensorDict):
         data["position_ids"]._ragged_idx = 2
 
 
-def list_of_dict_to_tensordict(list_of_dicts: list[dict[str, Any]]) -> TensorDict:
+def list_of_dict_to_tensordict(
+    list_of_dicts: list[dict[str, Any]], *, jagged_1d: bool = False
+) -> TensorDict:
     """
     Create a TensorDict from a list of dict of tensors and non_tensors.
+    ``jagged_1d`` keeps per-sample 1D rollout sequences jagged even when all
+    rows happen to have the same length.
     Note that this requires tensordict version at least 0.10
     """
     assert parse_version(tensordict.__version__) >= parse_version("0.10"), (
@@ -936,6 +940,7 @@ def list_of_dict_to_tensordict(list_of_dicts: list[dict[str, Any]]) -> TensorDic
             if val_list
             and all(isinstance(item, torch.Tensor) for item in val_list)
             and all(item.shape == val_list[0].shape for item in val_list)
+            and (not jagged_1d or val_list[0].ndim != 1)
             else (
                 torch.nested.as_nested_tensor(val_list, layout=torch.jagged)
                 if val_list and all(isinstance(item, torch.Tensor) for item in val_list)

--- a/verl/utils/transferqueue_utils.py
+++ b/verl/utils/transferqueue_utils.py
@@ -74,6 +74,13 @@ _ASYNC_BRIDGE_THREAD: threading.Thread | None = None
 _ASYNC_BRIDGE_LOCK = threading.Lock()
 
 
+def _ensure_tq_initialized() -> None:
+    global TQ_INITIALIZED
+    if not TQ_INITIALIZED:
+        tq.init()
+        TQ_INITIALIZED = True
+
+
 def _run_event_loop_forever(loop: asyncio.AbstractEventLoop, ready: threading.Event) -> None:
     asyncio.set_event_loop(loop)
     ready.set()
@@ -147,28 +154,23 @@ def _run_async_in_temp_loop(async_func: Callable[..., Any], *args, **kwargs) -> 
     return future.result()
 
 
+def _is_meta(value: Any) -> bool:
+    from verl.protocol import RolloutDataRef
+
+    return isinstance(value, BatchMeta | KVBatchMeta | RolloutDataRef)
+
+
 def _find_meta(*args, **kwargs):
     for arg in args:
-        if isinstance(arg, BatchMeta | KVBatchMeta):
+        if _is_meta(arg):
             return arg
     for v in kwargs.values():
-        if isinstance(v, BatchMeta | KVBatchMeta):
+        if _is_meta(v):
             return v
     return None
 
 
-async def _async_meta_to_realdata(meta: BatchMeta | KVBatchMeta) -> TensorDict:
-    if isinstance(meta, KVBatchMeta):
-        meta = await async_kv_batch_meta2batch_meta(meta)
-    meta_info = copy.deepcopy(meta.extra_info)
-    if meta.size == 0:
-        empty_td = TensorDict({}, batch_size=(0,))
-        tu.assign_non_tensor(empty_td, **meta_info)
-        return empty_td
-
-    tq_client = tq.get_client()
-    tensordict = await tq_client.async_get_data(meta)
-
+def _with_extra_info(tensordict: TensorDict, meta_info: dict[str, Any]) -> TensorDict:
     for key, val in meta_info.items():
         if isinstance(val, (NonTensorData | NonTensorStack)):
             tensordict[key] = val
@@ -177,11 +179,79 @@ async def _async_meta_to_realdata(meta: BatchMeta | KVBatchMeta) -> TensorDict:
     return tensordict
 
 
-def _meta_to_realdata(meta: BatchMeta) -> TensorDict:
+def _rollout_ref_to_realdata(meta) -> TensorDict:
+    from verl.utils import rollout_data_backend
+
+    meta_info = copy.deepcopy(meta.extra_info)
+    if meta.size == 0:
+        return _with_extra_info(TensorDict({}, batch_size=(0,)), meta_info)
+    data = rollout_data_backend.batch_get(
+        keys=meta.keys,
+        partition_id=meta.partition_id,
+        select_fields=meta.fields,
+    )
+    try:
+        return _with_extra_info(data, meta_info)
+    except BaseException:
+        rollout_data_backend.release_result(data)
+        raise
+
+
+async def _async_meta_to_realdata(meta) -> TensorDict:
+    from verl.protocol import RolloutDataRef
+
+    if isinstance(meta, RolloutDataRef):
+        return await asyncio.to_thread(_rollout_ref_to_realdata, meta)
+    if isinstance(meta, KVBatchMeta):
+        meta = await async_kv_batch_meta2batch_meta(meta)
+
+    meta_info = copy.deepcopy(meta.extra_info)
+    if meta.size == 0:
+        return _with_extra_info(TensorDict({}, batch_size=(0,)), meta_info)
+    return _with_extra_info(await tq.get_client().async_get_data(meta), meta_info)
+
+
+def _meta_to_realdata(meta) -> TensorDict:
+    from verl.protocol import RolloutDataRef
+
+    if isinstance(meta, RolloutDataRef):
+        return _rollout_ref_to_realdata(meta)
     return _run_async_in_temp_loop(_async_meta_to_realdata, meta)
 
 
-async def _async_update_meta_with_output(output: TensorDict, meta: BatchMeta, func_name=None) -> BatchMeta:
+def _materialize_meta(value: Any, materialized: list[TensorDict]) -> Any:
+    if not _is_meta(value):
+        return value
+    from verl.protocol import RolloutDataRef
+
+    result = _meta_to_realdata(value)
+    if isinstance(value, RolloutDataRef):
+        materialized.append(result)
+    return result
+
+
+async def _async_materialize_meta(value: Any, materialized: list[TensorDict]) -> Any:
+    if not _is_meta(value):
+        return value
+    from verl.protocol import RolloutDataRef
+
+    result = await _async_meta_to_realdata(value)
+    if isinstance(value, RolloutDataRef):
+        materialized.append(result)
+    return result
+
+
+def _release_materialized(values: list[TensorDict]) -> None:
+    from verl.utils import rollout_data_backend
+
+    for value in values:
+        try:
+            rollout_data_backend.release_result(value)
+        except Exception:
+            logger.exception("Failed to release materialized rollout data")
+
+
+def _split_output(output: TensorDict) -> tuple[list[str], dict[str, Any]]:
     fields, meta_data = [], {}
     for k, v in output.items():
         if isinstance(v, torch.Tensor | NonTensorStack):
@@ -190,7 +260,30 @@ async def _async_update_meta_with_output(output: TensorDict, meta: BatchMeta, fu
             meta_data[k] = v.data
         else:
             raise ValueError(f"Unsupported type {type(v)} for key {k} in output TensorDict.")
+    return fields, meta_data
 
+
+def _update_rollout_ref(output: TensorDict, meta):
+    from verl.utils import rollout_data_backend
+
+    fields, meta_data = _split_output(output)
+    if fields:
+        meta = rollout_data_backend.batch_put(
+            keys=meta.keys,
+            partition_id=meta.partition_id,
+            fields=output.select(*fields),
+        )
+    meta.extra_info = meta_data
+    return meta
+
+
+async def _async_update_meta_with_output(output: TensorDict, meta, func_name=None):
+    from verl.protocol import RolloutDataRef
+
+    if isinstance(meta, RolloutDataRef):
+        return await asyncio.to_thread(_update_rollout_ref, output, meta)
+
+    fields, meta_data = _split_output(output)
     if fields:
         t1 = time.time()
         tq_client = tq.get_client()
@@ -202,9 +295,12 @@ async def _async_update_meta_with_output(output: TensorDict, meta: BatchMeta, fu
     return meta
 
 
-def _update_meta_with_output(output: TensorDict, meta: BatchMeta, func_name=None) -> BatchMeta:
-    updated_meta = _run_async_in_temp_loop(_async_update_meta_with_output, output, meta, func_name)
-    return updated_meta
+def _update_meta_with_output(output: TensorDict, meta, func_name=None):
+    from verl.protocol import RolloutDataRef
+
+    if isinstance(meta, RolloutDataRef):
+        return _update_rollout_ref(output, meta)
+    return _run_async_in_temp_loop(_async_update_meta_with_output, output, meta, func_name)
 
 
 def _compute_need_collect(dispatch_mode: "dict | Dispatch", args: list) -> bool:
@@ -259,7 +355,7 @@ def _compute_need_collect(dispatch_mode: "dict | Dispatch", args: list) -> bool:
         return True
 
 
-def _postprocess_common(output, put_data, need_collect):
+def _postprocess_common(output, put_data, need_collect, meta=None):
     """Common post-processing logic for function outputs in TransferQueue bridge.
 
     This function handles the final return value based on whether data should be
@@ -287,10 +383,10 @@ def _postprocess_common(output, put_data, need_collect):
         across different execution paths and avoid redundant data operations in
         distributed scenarios.
     """
-    from verl.protocol import DataProto
+    from verl.protocol import DataProto, RolloutDataRef
 
     if put_data and not need_collect:
-        return BatchMeta()
+        return RolloutDataRef() if isinstance(meta, RolloutDataRef) else BatchMeta()
     elif not put_data and not need_collect and isinstance(output, DataProto):
         return DataProto()
     elif not put_data and not need_collect and isinstance(output, TensorDict):
@@ -299,11 +395,46 @@ def _postprocess_common(output, put_data, need_collect):
         return output
 
 
+def _bridge_meta_kind(meta: Any) -> tuple[bool, Any]:
+    from verl.protocol import RolloutDataRef
+
+    if not isinstance(meta, RolloutDataRef):
+        _ensure_tq_initialized()
+    is_kv_meta = isinstance(meta, KVBatchMeta)
+    return is_kv_meta, meta.tags if is_kv_meta else None
+
+
+def _bridge_output_state(
+    output: Any,
+    meta: Any,
+    dispatch_mode: "dict | Dispatch",
+    args: list[Any],
+) -> tuple[bool, bool]:
+    put_data = isinstance(output, TensorDict) and bool(output.batch_size)
+    if put_data:
+        assert output.batch_size[0] == meta.size, (
+            f"output batch size {output.batch_size} != meta size {meta.size}"
+        )
+    need_collect = (
+        _compute_need_collect(dispatch_mode, args)
+        if dispatch_mode is not None
+        else True
+    )
+    return put_data, need_collect
+
+
+def _release_if_detached(result: Any, materialized: list[TensorDict]) -> None:
+    if (
+        result is None
+        or _is_meta(result)
+        or isinstance(result, TensorDict)
+        and not result.batch_size
+    ):
+        _release_materialized(materialized)
+
+
 async def async_kv_batch_meta2batch_meta(meta: KVBatchMeta) -> BatchMeta:
-    global TQ_INITIALIZED
-    if not TQ_INITIALIZED:
-        tq.init()
-        TQ_INITIALIZED = True
+    _ensure_tq_initialized()
     tq_client = tq.get_client()
     batch_meta = await tq_client.async_kv_retrieve_meta(keys=meta.keys, partition_id=meta.partition_id, create=False)
     fields = meta.fields
@@ -321,10 +452,7 @@ def kv_batch_meta2batch_meta(meta: KVBatchMeta):
 
 
 async def async_batch_meta2kv_batch_meta(meta: BatchMeta) -> KVBatchMeta:
-    global TQ_INITIALIZED
-    if not TQ_INITIALIZED:
-        tq.init()
-        TQ_INITIALIZED = True
+    _ensure_tq_initialized()
     tq_client = tq.get_client()
     partition_id = meta.partition_ids[0]
     assert all([partition_id == pid for pid in meta.partition_ids])
@@ -345,13 +473,12 @@ def batch_meta2kv_batch_meta(meta: BatchMeta):
 
 
 def tqbridge(dispatch_mode: "dict | Dispatch" = None):
-    """Creates a decorator for bridging KVBatchMeta and TensorDict.
+    """Bridge external rollout references and worker-local TensorDict values.
 
-    This decorator automatically handles conversions between `KVBatchMeta`
-    and `TensorDict` in function parameters, and decides whether to sync function
-    output back to `KVBatchMeta` based on configuration(`put_data`). It supports
-    both synchronous and asynchronous functions (async def). When TQ is not enabled, it
-    simply calls the original function as-is.
+    The decorator materializes external rollout references before a worker call
+    and writes TensorDict results back through the selected rollout backend. It
+    preserves the existing TransferQueue metadata behavior and also manages
+    Mooncake read-buffer ownership.
 
     Args:
         dispatch_mode: Controls data collection behavior for the current worker. Passed to
@@ -377,46 +504,35 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
             if batch_meta is None:
                 return func(*args, **kwargs)
             else:
-                global TQ_INITIALIZED
-                if not TQ_INITIALIZED:
-                    tq.init()
-                    TQ_INITIALIZED = True
-
-                is_kv_batch_meta = isinstance(batch_meta, KVBatchMeta)
+                is_kv_batch_meta, tags = _bridge_meta_kind(batch_meta)
                 if is_kv_batch_meta:
-                    tags = batch_meta.tags
                     batch_meta = kv_batch_meta2batch_meta(batch_meta)
-                t1 = time.time()
-                args = [_meta_to_realdata(arg) if isinstance(arg, BatchMeta | KVBatchMeta) else arg for arg in args]
-                kwargs = {
-                    k: _meta_to_realdata(v) if isinstance(v, BatchMeta | KVBatchMeta) else v for k, v in kwargs.items()
-                }
-                t2 = time.time()
-                logger.info(
-                    f"Task {func.__name__} (pid={pid}) is getting len_samples={batch_meta.size}, cost time: {t2 - t1}"
-                )
+                materialized = []
+                try:
+                    t1 = time.time()
+                    args = [_materialize_meta(arg, materialized) for arg in args]
+                    kwargs = {key: _materialize_meta(value, materialized) for key, value in kwargs.items()}
+                    t2 = time.time()
+                    logger.info(
+                        f"Task {func.__name__} (pid={pid}) is getting "
+                        f"len_samples={batch_meta.size}, cost time: {t2 - t1}"
+                    )
 
-                output = func(*args, **kwargs)
+                    output = func(*args, **kwargs)
 
-                put_data = False
-                if isinstance(output, TensorDict):
-                    if output.batch_size:
-                        assert output.batch_size[0] == batch_meta.size, (
-                            f"output batch size {output.batch_size} != meta size {batch_meta.size}"
-                        )
-                        put_data = True
-
-                if dispatch_mode is not None:
-                    need_collect = _compute_need_collect(dispatch_mode, args)
-                else:
-                    need_collect = True
-                if put_data and need_collect:
-                    updated_meta = _update_meta_with_output(output, batch_meta, func.__name__)
-                    if is_kv_batch_meta:
-                        updated_meta = batch_meta2kv_batch_meta(updated_meta)
-                        updated_meta.tags = tags
-                    return updated_meta
-                return _postprocess_common(output, put_data, need_collect)
+                    put_data, need_collect = _bridge_output_state(output, batch_meta, dispatch_mode, args)
+                    if put_data and need_collect:
+                        result = _update_meta_with_output(output, batch_meta, func.__name__)
+                        if is_kv_batch_meta:
+                            result = batch_meta2kv_batch_meta(result)
+                            result.tags = tags
+                    else:
+                        result = _postprocess_common(output, put_data, need_collect, batch_meta)
+                except BaseException:
+                    _release_materialized(materialized)
+                    raise
+                _release_if_detached(result, materialized)
+                return result
 
         @wraps(func)
         async def async_inner(*args, **kwargs):
@@ -424,56 +540,37 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
             if batch_meta is None:
                 return await func(*args, **kwargs)
             else:
-                global TQ_INITIALIZED
-                if not TQ_INITIALIZED:
-                    tq.init()
-                    TQ_INITIALIZED = True
-
-                is_kv_batch_meta = isinstance(batch_meta, KVBatchMeta)
+                is_kv_batch_meta, tags = _bridge_meta_kind(batch_meta)
                 if is_kv_batch_meta:
-                    tags = batch_meta.tags
                     batch_meta = await async_kv_batch_meta2batch_meta(batch_meta)
 
-                t1 = time.time()
-                args = [
-                    await _async_meta_to_realdata(arg) if isinstance(arg, BatchMeta | KVBatchMeta) else arg
-                    for arg in args
-                ]
-                kwargs = {
-                    k: await _async_meta_to_realdata(v) if isinstance(v, BatchMeta | KVBatchMeta) else v
-                    for k, v in kwargs.items()
-                }
-                t2 = time.time()
-                logger.info(
-                    f"Task {func.__name__} (pid={pid}) is getting len_samples={batch_meta.size}, cost time: {t2 - t1}"
-                )
+                materialized = []
+                try:
+                    t1 = time.time()
+                    args = [await _async_materialize_meta(arg, materialized) for arg in args]
+                    kwargs = {key: await _async_materialize_meta(value, materialized) for key, value in kwargs.items()}
+                    t2 = time.time()
+                    logger.info(
+                        f"Task {func.__name__} (pid={pid}) is getting "
+                        f"len_samples={batch_meta.size}, cost time: {t2 - t1}"
+                    )
 
-                output = await func(*args, **kwargs)
+                    output = await func(*args, **kwargs)
 
-                put_data = False
-                if isinstance(output, TensorDict):
-                    if output.batch_size:
-                        assert output.batch_size[0] == batch_meta.size, (
-                            f"output batch size {output.batch_size} != meta size {batch_meta.size}"
-                        )
-                        put_data = True
+                    put_data, need_collect = _bridge_output_state(output, batch_meta, dispatch_mode, args)
+                    if put_data and need_collect:
+                        result = await _async_update_meta_with_output(output, batch_meta, func.__name__)
+                        if is_kv_batch_meta:
+                            result = await async_batch_meta2kv_batch_meta(result)
+                            result.tags = tags
+                    else:
+                        result = _postprocess_common(output, put_data, need_collect, batch_meta)
+                except BaseException:
+                    _release_materialized(materialized)
+                    raise
+                _release_if_detached(result, materialized)
+                return result
 
-                if dispatch_mode is not None:
-                    need_collect = _compute_need_collect(dispatch_mode, args)
-                else:
-                    need_collect = True
-                if put_data and need_collect:
-                    updated_meta = await _async_update_meta_with_output(output, batch_meta, func.__name__)
-                    if is_kv_batch_meta:
-                        updated_meta = await async_batch_meta2kv_batch_meta(updated_meta)
-                        updated_meta.tags = tags
-                    return updated_meta
-                return _postprocess_common(output, put_data, need_collect)
-
-        wrapper_inner = inner
-        wrapper_async_inner = async_inner
-
-        wrapper = wrapper_async_inner if inspect.iscoroutinefunction(func) else wrapper_inner
-        return wrapper
+        return async_inner if inspect.iscoroutinefunction(func) else inner
 
     return decorator

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -116,7 +116,9 @@ def no_padding_2_padding(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor
 
     if prompt_ids.is_nested:
         prompt_lens = prompt_ids.offsets().diff()
-        response_lens = response_ids.offsets().diff()
+        response_lens = sequence_lengths(
+            response_ids, len(prompt_ids), "responses"
+        )
         if max_response_len < 0:
             max_response_len = response_lens.max().item()
     else:
@@ -193,18 +195,40 @@ def embeds_padding_2_no_padding(data: TensorDict) -> TensorDict:
     return data
 
 
+def sequence_lengths(value: torch.Tensor, batch_size: int, name: str) -> torch.Tensor:
+    """Return per-row lengths for a jagged tensor or an equal-length dense tensor."""
+    if value.is_nested:
+        return value.offsets().diff()
+    if value.ndim != 2 or value.shape[0] != batch_size:
+        raise ValueError(f"dense {name} must have shape (batch_size, sequence_length)")
+    return torch.full(
+        (batch_size,),
+        value.shape[1],
+        dtype=torch.int64,
+        device=value.device,
+    )
+
+
+def padded_tensor(value: torch.Tensor, padding: int) -> torch.Tensor:
+    """Pad a jagged tensor while leaving an already-dense tensor unchanged."""
+    return value.to_padded_tensor(padding=padding) if value.is_nested else value
+
+
 def response_from_nested(tensor: torch.Tensor, response_mask: torch.Tensor) -> torch.Tensor:
     """Extract response from nested model output.
 
     Args:
         tensor: a nested tensor with shape (bsz, prompt_len + response_len)
-        response_mask: a nested tensor with shape (bsz, response_len)
+        response_mask: a nested tensor, or an equal-length dense tensor, with
+            shape (bsz, response_len)
 
     Returns:
         tensor: a nested tensor with shape (bsz, response_len)
     """
     values, offsets = tensor.values(), tensor.offsets()
-    response_lens = response_mask.offsets().diff()
+    response_lens = sequence_lengths(
+        response_mask, len(tensor), "response_mask"
+    )
     response_list = []
     for resp_len, seq_offset in zip(response_lens, offsets[1:], strict=True):
         # left-shift model output by one token for log_probs/values
@@ -217,13 +241,15 @@ def response_to_nested(tensor: torch.Tensor, response_mask: torch.Tensor) -> tor
 
     Args:
         tensor: a tensor with shape (bsz, response_len)
-        response_mask: a nested tensor with shape (bsz, response_len)
+        response_mask: a nested tensor, or an equal-length dense tensor, with
+            shape (bsz, response_len)
 
     Returns:
         tensor: a nested tensor with shape (bsz, response_len)
     """
-    assert response_mask.is_nested
-    response_lens = response_mask.offsets().diff()
+    response_lens = sequence_lengths(
+        response_mask, tensor.shape[0], "response_mask"
+    )
     response_list = []
     for i in range(tensor.shape[0]):
         response_list.append(tensor[i, : response_lens[i]])


### PR DESCRIPTION
### What does this PR do?

Extends the V1 trainer's existing TransferQueue-based rollout data path so Mooncake can be selected as an optional backend. The control/data separation, ReplayBuffer workflow, and incremental production and consumption of rollout fields remain unchanged.

TransferQueue remains the default. Shared call sites exchange a lightweight `RolloutDataRef` and use one facade for put, get, list, clear, result release, and checkpoint capability checks. The Mooncake adapter maps those existing Verl operations to Mooncake's DataProto transfer APIs and uses a shared catalog for tag updates, selected field reads, partial field updates, key ordering, and fragment lifetime. Schema-driven encoding, fragmented-object packing, BufferPool staging, optimized copies, and Store transfer remain inside Mooncake.

- RFC: https://github.com/verl-project/verl/issues/7414
- Related TransferQueue design: https://github.com/verl-project/verl/issues/5400
- Mooncake prerequisite: https://github.com/kvcache-ai/Mooncake/pull/3374

### Relationship to TransferQueue's Mooncake Backend

TransferQueue already supports Mooncake Store as a pluggable storage backend. In that configuration, verl continues to use TransferQueue's KV APIs, controller, metadata, sampling, and serialization path, while Mooncake supplies physical storage and transport underneath TransferQueue.

This PR evaluates a different integration boundary: verl selects Mooncake at the rollout-data-backend boundary and uses Mooncake's DataProto structured-object APIs directly. TransferQueue is not on the Mooncake data path. The direct path exposes Mooncake's schema-driven field encoding, incremental field updates, selective field and row reads, BufferPool-backed transfers, and explicit object/result lifecycle while preserving the existing trainer, ReplayBuffer, and scheduling workflow.

This PR is intentionally a draft until the Mooncake prerequisite lands.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout+data+backend+mooncake
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

- Changed-file Ruff checks: passed.
- `git diff --check`: passed.
- Affected CPU suite: `149 passed, 2 skipped`.
- Auto-padding test in its required isolated Ray process: `1 passed`.
- Pre-initialized Ray propagation: passed; the TaskRunner received the same Mooncake backend configuration as the driver.
- Real Mooncake Store/Ray owner-client smoke: passed, including jagged DataProto PUT, reordered and selected-field GET, clear, client close, owner drain, and catalog termination.
- Full GPU RL with Qwen3-0.6B and real rollout data: Mooncake completed 3 rollout/training steps and returned exit code 0.
- The same full GPU RL configuration with the real TransferQueue backend completed 3 steps and returned exit code 0.

### Rollout Data Transfer Benchmark

The benchmark was rerun on this PR's current commit with the Mooncake package for the prerequisite PR. It starts from one rollout sample captured during a real verl RL run and replicates that sample to 8, 64, 256, and 1024 rows. This preserves the 27-field layout, including 10 jagged tensor fields, while increasing the number of rollout objects. The logical payload sizes range from about 101 KiB to 12.44 MiB.

Both paths use their real implementations: TransferQueue 0.1.6 and Mooncake Store over TCP. No fake Store or mock backend is used. This compares verl's existing TransferQueue rollout backend with the direct Mooncake prototype; it does not benchmark TransferQueue configured with Mooncake Store. Each independent run performs one warmup followed by three measured PUT/GET rounds. The table reports the median of the average latency from three independent runs; lower is better.

| Samples | Logical size | TransferQueue PUT | Mooncake PUT | TransferQueue GET | Mooncake GET |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | 101 KiB | 19.875 ms | 13.293 ms | 11.323 ms | 17.638 ms |
| 64 | 798 KiB | 41.989 ms | 18.908 ms | 32.386 ms | 30.078 ms |
| 256 | 3.11 MiB | 121.201 ms | 38.953 ms | 104.574 ms | 70.072 ms |
| 1024 | 12.44 MiB | 478.896 ms | 143.594 ms | 581.437 ms | 234.324 ms |

Mooncake PUT is 1.50x to 3.34x faster across these sample counts. The 8-sample Mooncake GET has about 6.3 ms of additional fixed overhead; GET reaches parity at 64 samples and is 1.49x and 2.48x faster at 256 and 1024 samples, respectively. This benchmark isolates rollout-object transfer latency and is not presented as an end-to-end training throughput result.

### API and Usage Example

The existing default remains unchanged:

```yaml
trainer:
  v1:
    rollout_data_backend:
      name: transfer_queue
      config: {}
```

Select Mooncake for the V1 rollout data path:

```bash
export MOONCAKE_MASTER=<master-host:port>
export MOONCAKE_LOCAL_HOSTNAME=<reachable-worker-host-or-ip>
export MOONCAKE_TE_META_DATA_SERVER=P2PHANDSHAKE
export MOONCAKE_PROTOCOL=tcp  # or rdma
export MOONCAKE_DEVICE=<rdma-device>  # required for rdma
```

```yaml
trainer:
  v1:
    rollout_data_backend:
      name: mooncake
      config:
        namespace: verl
        key_prefix: verl-rollout
        default_chunk_bytes: 67108864
```

With `store_init_kwargs` omitted, Mooncake loads its standard environment configuration, including its default segment and local-buffer sizes. Verl connects as a Store client; it does not start or manage Mooncake master, etcd, or Redis services.

### Design & Code Changes

- Generalize the metadata already carried by `KVBatchMeta` into `RolloutDataRef` so shared Verl code does not import a backend-specific type.
- Add a small rollout-data facade with built-in TransferQueue and Mooncake adapters.
- Preserve TransferQueue as the default and convert to native TransferQueue metadata at its dispatch boundary.
- Use Mooncake `DataProtoCatalogTransfer` and structured-object APIs rather than reimplementing schema or serialization logic in verl.
- Preserve key order and support tag-only updates, batched writes, selected-field reads, and field add/overwrite across immutable fragments.
- Keep equal-length 1-D rollout sequences jagged while retaining dense higher-rank tensors.
- Propagate one backend configuration to the driver, TaskRunner, and workers, including when Ray is already initialized.
- Quiesce producers and close clients before the Mooncake owner drains the catalog; retain failed cleanup state for retry.
- Release Mooncake BufferPool-backed GET results deterministically after their last local consumer.

Mooncake catalog checkpoint/restart recovery and Mooncake infrastructure lifecycle management are outside this PR and are documented as non-goals in the RFC.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Run `pre-commit run --all-files --show-diff-on-failure --color=always`. Changed-file Ruff checks and the targeted test matrix pass; the full formatter hook is deferred while this PR is draft.
- [ ] Add / update repository documentation. The RFC and usage example are available for review; the user guide will be finalized with the Mooncake dependency version before this PR becomes ready.
- [x] Add unit or end-to-end tests to the existing CPU test structure, with real Store and full RL validation recorded above.
- [ ] Request CI after the Mooncake prerequisite lands and this draft is ready for review.
- [x] Recipe submodule update is not applicable.
