### PR TITLE
[perf] feat: add pre-packed Ulysses QKV API

### DIFF
--- a/.github/workflows/model.yml
+++ b/.github/workflows/model.yml
@@ -48,6 +48,7 @@ on:
       # Entrypoints
       - ".github/workflows/model.yml"
       - "tests/special_distributed/test_fsdp_ckpt.py"
+      - "tests/special_distributed/test_packed_qkv_ulysses.py"
       - "tests/special_distributed/test_tensor_dict.py"
       - "tests/models/**"
       - "tests/special_distributed/run_all.sh"
@@ -117,6 +118,10 @@ jobs:
       - name: Running transformers ulysses tests on 8 L20 GPUs + latest transformers
         run: |
           $UV_RUN torchrun --nproc_per_node=8 -m pytest tests/models/test_transformers_ulysses.py
+      - name: Running packed QKV Ulysses tests on 2 L20 GPUs
+        run: |
+          $UV_RUN torchrun --standalone --nproc-per-node=2 -m pytest -q \
+            tests/special_distributed/test_packed_qkv_ulysses.py
       # `--with` layers 4.54.1 over the synced env for this step alone, so the
       # downgrade no longer leaks into the steps below and needs no restore after.
       - name: Running transformers ulysses tests on 8 L20 GPUs + transformers 4.54.1

--- a/scripts/benchmark_packed_qkv_ulysses.py
+++ b/scripts/benchmark_packed_qkv_ulysses.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Microbenchmark packed versus three-call Ulysses QKV all-to-all.
+
+Example:
+    torchrun --standalone --nproc-per-node=2 scripts/benchmark_packed_qkv_ulysses.py \
+        --local-seq-lens 256 1024 4096
+"""
+
+import argparse
+import os
+from collections.abc import Callable
+
+import torch
+import torch.distributed as dist
+
+from verl.utils.ulysses import gather_seq_scatter_heads, set_ulysses_sequence_parallel_group
+
+_DTYPES = {
+    "fp32": torch.float32,
+    "bf16": torch.bfloat16,
+    "fp8_e4m3fn": getattr(torch, "float8_e4m3fn", None),
+    "fp8_e5m2": getattr(torch, "float8_e5m2", None),
+}
+_DEFAULT_DTYPES = [name for name, dtype in _DTYPES.items() if dtype is not None]
+
+
+def _time_ms(fn: Callable[[], object], warmup: int, iterations: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def _measure_packed_parts(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, warmup: int, iterations: int
+) -> tuple[float, float, float, float]:
+    def pack():
+        return torch.cat((q, k, v), dim=0)
+
+    pack_ms = _time_ms(pack, warmup, iterations)
+    packed = pack()
+
+    def all_to_all():
+        return gather_seq_scatter_heads(packed, seq_dim=2, head_dim=1)
+
+    packed_a2a_ms = _time_ms(all_to_all, warmup, iterations)
+    output = all_to_all()
+
+    def unpack():
+        return output.chunk(3, dim=0)
+
+    unpack_ms = _time_ms(unpack, warmup, iterations)
+    return pack_ms, packed_a2a_ms, unpack_ms, pack_ms + packed_a2a_ms + unpack_ms
+
+
+def _random_tensor(shape: tuple[int, ...], dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+    # torch.randn does not directly create FP8 tensors. FP32 initialization plus
+    # casting represents the FP8 activation buffer handed to the collective.
+    return torch.randn(shape, device=device, dtype=torch.float32).to(dtype)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--heads", type=int, default=16)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--local-seq-lens", type=int, nargs="+", default=[256, 1024, 4096])
+    parser.add_argument("--dtypes", nargs="+", choices=_DTYPES, default=_DEFAULT_DTYPES)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=100)
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    dist.init_process_group("nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    world_size = dist.get_world_size()
+    if args.heads % world_size:
+        raise ValueError(f"--heads ({args.heads}) must be divisible by world size ({world_size})")
+    set_ulysses_sequence_parallel_group(dist.group.WORLD)
+
+    if dist.get_rank() == 0:
+        print(
+            "| WS | dtype | S_local | heads | head_dim | 3xA2A ms | pack ms | 1xA2A ms | "
+            "unpack ms | packed total ms | speedup |"
+        )
+        print("|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+
+    for dtype_name in args.dtypes:
+        dtype = _DTYPES[dtype_name]
+        if dtype is None:
+            raise RuntimeError(f"{dtype_name} is unavailable in this PyTorch build")
+
+        for local_seq_len in args.local_seq_lens:
+            shape = (args.batch_size, args.heads, local_seq_len, args.head_dim)
+            q = _random_tensor(shape, dtype, device)
+            k = _random_tensor(shape, dtype, device)
+            v = _random_tensor(shape, dtype, device)
+
+            def three_all_to_all(q=q, k=k, v=v):
+                return (
+                    gather_seq_scatter_heads(q, seq_dim=2, head_dim=1),
+                    gather_seq_scatter_heads(k, seq_dim=2, head_dim=1),
+                    gather_seq_scatter_heads(v, seq_dim=2, head_dim=1),
+                )
+
+            torch.cuda.reset_peak_memory_stats(device)
+            legacy_ms = _time_ms(three_all_to_all, args.warmup, args.iterations)
+            legacy_peak = torch.cuda.max_memory_allocated(device)
+            torch.cuda.reset_peak_memory_stats(device)
+            pack_ms, packed_a2a_ms, unpack_ms, packed_total_ms = _measure_packed_parts(
+                q, k, v, args.warmup, args.iterations
+            )
+            packed_peak = torch.cuda.max_memory_allocated(device)
+
+            if dist.get_rank() == 0:
+                speedup = legacy_ms / packed_total_ms
+                print(
+                    f"| {world_size} | {dtype_name} | {local_seq_len} | {args.heads} | {args.head_dim} | "
+                    f"{legacy_ms:.3f} | {pack_ms:.3f} | {packed_a2a_ms:.3f} | {unpack_ms:.3f} | "
+                    f"{packed_total_ms:.3f} | {speedup:.3f}x |"
+                )
+                print(f"  peak HBM: three-A2A={legacy_peak / 2**20:.1f} MiB, packed={packed_peak / 2**20:.1f} MiB")
+
+    set_ulysses_sequence_parallel_group(None)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_packed_qkv_ulysses.py
+++ b/scripts/benchmark_packed_qkv_ulysses.py
@@ -139,12 +139,16 @@ def main():
 
             if dist.get_rank() == 0:
                 speedup = legacy_ms / packed_total_ms
+                prepacked_total_ms = packed_a2a_ms + unpack_ms
                 print(
                     f"| {world_size} | {dtype_name} | {local_seq_len} | {args.heads} | {args.head_dim} | "
                     f"{legacy_ms:.3f} | {pack_ms:.3f} | {packed_a2a_ms:.3f} | {unpack_ms:.3f} | "
                     f"{packed_total_ms:.3f} | {speedup:.3f}x |"
                 )
                 print(f"  peak HBM: three-A2A={legacy_peak / 2**20:.1f} MiB, packed={packed_peak / 2**20:.1f} MiB")
+                print(
+                    f"  pre-packed API: {prepacked_total_ms:.3f} ms, {legacy_ms / prepacked_total_ms:.3f}x vs three-A2A"
+                )
 
     set_ulysses_sequence_parallel_group(None)
     dist.destroy_process_group()

--- a/tests/special_distributed/test_packed_qkv_ulysses.py
+++ b/tests/special_distributed/test_packed_qkv_ulysses.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Distributed correctness tests for packed Ulysses QKV all-to-all.
+
+Run on 2 or more GPUs:
+    torchrun --standalone --nproc-per-node=2 -m pytest -svv \
+        tests/special_distributed/test_packed_qkv_ulysses.py
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from verl.utils import ulysses
+from verl.utils.ulysses import (
+    gather_qkv_seq_scatter_heads,
+    gather_seq_scatter_heads,
+    set_ulysses_sequence_parallel_group,
+)
+
+pytestmark = pytest.mark.skipif("LOCAL_RANK" not in os.environ, reason="run with torchrun")
+
+_FP8_DTYPE_NAMES = ("float8_e4m3fn", "float8_e5m2")
+_FP8_DTYPES = [dtype for name in _FP8_DTYPE_NAMES if (dtype := getattr(torch, name, None)) is not None]
+_TEST_DTYPES = [torch.float32, torch.bfloat16, *_FP8_DTYPES]
+_TEST_DTYPE_IDS = [
+    "fp32",
+    "bf16",
+    *[name.replace("float8_", "fp8_") for name in _FP8_DTYPE_NAMES if getattr(torch, name, None)],
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_dist():
+    assert torch.cuda.is_available(), "CUDA is required"
+    initialized_here = not dist.is_initialized()
+    if initialized_here:
+        dist.init_process_group("nccl")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    assert dist.get_world_size() >= 2, "need at least 2 GPUs"
+    set_ulysses_sequence_parallel_group(dist.group.WORLD)
+    try:
+        yield
+    finally:
+        set_ulysses_sequence_parallel_group(None)
+        if initialized_here:
+            dist.destroy_process_group()
+
+
+def _make_qkv(dtype: torch.dtype, head_dim: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    torch.manual_seed(1234 + rank)
+    device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    heads = max(8, 2 * world_size)
+    heads = ((heads + world_size - 1) // world_size) * world_size
+    shape = [2, 8, 8, 16]
+    shape[head_dim] = heads
+
+    def random(shape: list[int]) -> torch.Tensor:
+        # torch.randn does not support FP8 directly. Creating FP32 samples then
+        # casting mirrors how FP8 activation buffers are normally produced.
+        return torch.randn(shape, device=device, dtype=torch.float32).to(dtype)
+
+    return random(shape), random(shape), random(shape)
+
+
+@pytest.mark.parametrize("dtype", _TEST_DTYPES, ids=_TEST_DTYPE_IDS)
+@pytest.mark.parametrize(("seq_dim", "head_dim"), [(2, 1), (1, 2)])
+def test_packed_qkv_matches_three_all_to_all_in_forward_and_backward(dtype: torch.dtype, seq_dim: int, head_dim: int):
+    q, k, v = _make_qkv(dtype, head_dim)
+    legacy_inputs = [x.detach().clone().requires_grad_(True) for x in (q, k, v)]
+    packed_inputs = [x.detach().clone().requires_grad_(True) for x in (q, k, v)]
+
+    with patch.object(ulysses, "all_to_all_tensor", wraps=ulysses.all_to_all_tensor) as all_to_all:
+        packed_outputs = gather_qkv_seq_scatter_heads(*packed_inputs, seq_dim=seq_dim, head_dim=head_dim)
+        assert all_to_all.call_count == 1
+
+    with patch.object(ulysses, "all_to_all_tensor", wraps=ulysses.all_to_all_tensor) as all_to_all:
+        legacy_outputs = tuple(gather_seq_scatter_heads(x, seq_dim=seq_dim, head_dim=head_dim) for x in legacy_inputs)
+        assert all_to_all.call_count == 3
+
+    for packed, legacy in zip(packed_outputs, legacy_outputs, strict=True):
+        torch.testing.assert_close(packed, legacy, atol=0, rtol=0)
+
+    packed_loss = sum(x.float().square().mean() for x in packed_outputs)
+    legacy_loss = sum(x.float().square().mean() for x in legacy_outputs)
+    packed_loss.backward()
+    legacy_loss.backward()
+
+    for packed, legacy in zip(packed_inputs, legacy_inputs, strict=True):
+        torch.testing.assert_close(packed.grad, legacy.grad, atol=0, rtol=0)

--- a/tests/special_distributed/test_packed_qkv_ulysses.py
+++ b/tests/special_distributed/test_packed_qkv_ulysses.py
@@ -27,6 +27,7 @@ import torch.distributed as dist
 
 from verl.utils import ulysses
 from verl.utils.ulysses import (
+    gather_packed_qkv_seq_scatter_heads,
     gather_qkv_seq_scatter_heads,
     gather_seq_scatter_heads,
     set_ulysses_sequence_parallel_group,
@@ -104,3 +105,21 @@ def test_packed_qkv_matches_three_all_to_all_in_forward_and_backward(dtype: torc
 
     for packed, legacy in zip(packed_inputs, legacy_inputs, strict=True):
         torch.testing.assert_close(packed.grad, legacy.grad, atol=0, rtol=0)
+
+
+def test_prepacked_qkv_api_matches_three_all_to_all():
+    q, k, v = _make_qkv(torch.float32, head_dim=1)
+    packed = torch.cat((q, k, v), dim=0)
+
+    with patch.object(ulysses, "all_to_all_tensor", wraps=ulysses.all_to_all_tensor) as all_to_all:
+        outputs = gather_packed_qkv_seq_scatter_heads(
+            packed,
+            (q.size(0), k.size(0), v.size(0)),
+            seq_dim=2,
+            head_dim=1,
+        )
+        assert all_to_all.call_count == 1
+
+    legacy_outputs = tuple(gather_seq_scatter_heads(x, seq_dim=2, head_dim=1) for x in (q, k, v))
+    for actual, expected in zip(outputs, legacy_outputs, strict=True):
+        torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/verl/models/transformers/apertus.py
+++ b/verl/models/transformers/apertus.py
@@ -30,7 +30,7 @@ from transformers.utils import logging
 # Import compatibility wrapper for flash_attn_supports_top_left_mask
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
-    gather_seq_scatter_heads,
+    gather_qkv_seq_scatter_heads,
     get_ulysses_sequence_parallel_world_size,
     validate_ulysses_config,
 )
@@ -73,9 +73,9 @@ def apertus_attn_forward(
     if ulysses_sp_size > 1:
         validate_ulysses_config(self.config.num_attention_heads, ulysses_sp_size)
 
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=2, head_dim=1)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=2, head_dim=1)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=2, head_dim=1)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=2, head_dim=1
+        )
 
     full_q_len = query_states.size(2)
 

--- a/verl/models/transformers/glm4v.py
+++ b/verl/models/transformers/glm4v.py
@@ -32,7 +32,7 @@ from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_
 from verl.utils.device import is_npu_available
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
-    gather_seq_scatter_heads,
+    gather_qkv_seq_scatter_heads,
     get_ulysses_sequence_parallel_group,
     get_ulysses_sequence_parallel_world_size,
     validate_ulysses_config,
@@ -234,9 +234,9 @@ def _custom_flash_attention_forward(
     if sp_size > 1:
         # qkv: (batch_size, seq_length / sp_size, num_head, head_size)
         validate_ulysses_config(query_states.size(2), sp_size)
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=1, head_dim=2)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=1, head_dim=2)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=1, head_dim=2)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=1, head_dim=2
+        )
         position_ids_lst = [torch.empty_like(position_ids) for _ in range(sp_size)]
         position_ids = dist.all_gather(position_ids_lst, position_ids, group=get_ulysses_sequence_parallel_group())
         position_ids = torch.cat(position_ids_lst, dim=-1)  # (batch_size, seq_length)

--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -31,7 +31,7 @@ from transformers.utils import logging
 from verl.utils.transformers_compat import flash_attn_supports_top_left_mask
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
-    gather_seq_scatter_heads,
+    gather_qkv_seq_scatter_heads,
     get_ulysses_sequence_parallel_world_size,
     validate_ulysses_config,
 )
@@ -82,9 +82,9 @@ def llama_flash_attn_forward(
         validate_ulysses_config(self.num_heads, ulysses_sp_size)
 
         # (bsz, n_head, seq_len/n, head_dim) -> (bsz, n_head/n, seq_len, head_dim)
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=2, head_dim=1)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=2, head_dim=1)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=2, head_dim=1)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=2, head_dim=1
+        )
 
     full_q_len = query_states.size(2)  # full seq length
 
@@ -196,9 +196,9 @@ def llama_attn_forward(
     if ulysses_sp_size > 1:
         validate_ulysses_config(self.config.num_attention_heads, ulysses_sp_size)
 
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=2, head_dim=1)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=2, head_dim=1)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=2, head_dim=1)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=2, head_dim=1
+        )
 
     full_q_len = query_states.size(2)
 

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -27,7 +27,7 @@ from verl.utils.import_utils import is_trl_available
 from verl.utils.transformers_compat import is_transformers_version_in_range
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
-    gather_seq_scatter_heads,
+    gather_qkv_seq_scatter_heads,
     get_ulysses_sequence_parallel_group,
     get_ulysses_sequence_parallel_world_size,
     slice_input_tensor,
@@ -128,9 +128,9 @@ def _ulysses_flash_attention_forward(
         value_states = repeat_kv(value_states, repeats)
 
         # (bsz, seq_len/n, n_head, head_dim) -> (bsz, seq_len, n_head/n, head_dim)
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=1, head_dim=2)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=1, head_dim=2)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=1, head_dim=2)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=1, head_dim=2
+        )
 
         # TODO: all_gather position_ids because `prepare_fa2_from_position_ids` needs it, we can eliminate
         # this all_gather by passing cu_seq_lens_q, cu_seq_lens_k, max_length_k, max_length_q explicitly.

--- a/verl/models/transformers/qwen2.py
+++ b/verl/models/transformers/qwen2.py
@@ -24,7 +24,7 @@ from transformers.utils import logging
 from verl.utils.transformers_compat import flash_attn_supports_top_left_mask
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
-    gather_seq_scatter_heads,
+    gather_qkv_seq_scatter_heads,
     get_ulysses_sequence_parallel_world_size,
     validate_ulysses_config,
 )
@@ -65,9 +65,9 @@ def qwen2_flash_attn_forward(
         validate_ulysses_config(self.num_heads, ulysses_sp_size)
 
         # (bsz, n_head, seq_len/n, head_dim) -> (bsz, n_head/n, seq_len, head_dim)
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=2, head_dim=1)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=2, head_dim=1)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=2, head_dim=1)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=2, head_dim=1
+        )
 
     full_q_len = query_states.size(2)  # full seq length
 
@@ -186,9 +186,9 @@ def qwen2_attn_forward(
         validate_ulysses_config(self.config.num_attention_heads, ulysses_sp_size)
 
         # (bsz, n_head, seq_len/n, head_dim) -> (bsz, n_head/n, seq_len, head_dim)
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=2, head_dim=1)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=2, head_dim=1)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=2, head_dim=1)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=2, head_dim=1
+        )
 
     full_q_len = query_states.size(2)
 

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -32,7 +32,7 @@ from verl.utils.device import is_npu_available
 from verl.utils.transformers_compat import is_transformers_version_in_range, unpack_visual_output
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
-    gather_seq_scatter_heads,
+    gather_qkv_seq_scatter_heads,
     get_ulysses_sequence_parallel_group,
     get_ulysses_sequence_parallel_world_size,
     validate_ulysses_config,
@@ -218,9 +218,9 @@ def _custom_flash_attention_forward(
     if sp_size > 1:
         # qkv: (batch_size, seq_length / sp_size, num_head, head_size)
         validate_ulysses_config(query_states.size(2), sp_size)
-        query_states = gather_seq_scatter_heads(query_states, seq_dim=1, head_dim=2)
-        key_states = gather_seq_scatter_heads(key_states, seq_dim=1, head_dim=2)
-        value_states = gather_seq_scatter_heads(value_states, seq_dim=1, head_dim=2)
+        query_states, key_states, value_states = gather_qkv_seq_scatter_heads(
+            query_states, key_states, value_states, seq_dim=1, head_dim=2
+        )
         position_ids_lst = [torch.empty_like(position_ids) for _ in range(sp_size)]
         position_ids = dist.all_gather(position_ids_lst, position_ids, group=get_ulysses_sequence_parallel_group())
         position_ids = torch.cat(position_ids_lst, dim=-1)  # (batch_size, seq_length)

--- a/verl/utils/ulysses.py
+++ b/verl/utils/ulysses.py
@@ -87,6 +87,54 @@ def gather_seq_scatter_heads(
     return x
 
 
+def gather_qkv_seq_scatter_heads(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    seq_dim: int,
+    head_dim: int,
+    unpadded_dim_size: int = 0,
+    group: ProcessGroup = None,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Gather sequence and scatter heads for Q/K/V with one all-to-all when possible.
+
+    Equal-layout Q/K/V tensors are concatenated along batch dimension, which is
+    not partitioned by the Ulysses collective. Incompatible layouts retain the
+    existing three-call behavior.
+    """
+    group = get_ulysses_sequence_parallel_group() if group is None else group
+    if group is None:
+        return query, key, value
+
+    ndim = query.ndim
+    seq_dim %= ndim
+    head_dim %= ndim
+    equal_layout = (
+        query.shape == key.shape == value.shape
+        and query.dtype == key.dtype == value.dtype
+        and query.device == key.device == value.device
+        and seq_dim != 0
+        and head_dim != 0
+    )
+    if equal_layout:
+        batch_sizes = (query.size(0), key.size(0), value.size(0))
+        packed_qkv = torch.cat((query, key, value), dim=0)
+        packed_qkv = gather_seq_scatter_heads(
+            packed_qkv,
+            seq_dim=seq_dim,
+            head_dim=head_dim,
+            unpadded_dim_size=unpadded_dim_size,
+            group=group,
+        )
+        return packed_qkv.split(batch_sizes, dim=0)
+
+    return (
+        gather_seq_scatter_heads(query, seq_dim, head_dim, unpadded_dim_size, group),
+        gather_seq_scatter_heads(key, seq_dim, head_dim, unpadded_dim_size, group),
+        gather_seq_scatter_heads(value, seq_dim, head_dim, unpadded_dim_size, group),
+    )
+
+
 def gather_heads_scatter_seq(x: Tensor, head_dim: int, seq_dim: int, group: ProcessGroup = None) -> Tensor:
     """
     A func to sync attention result with alltoall in sequence parallel

--- a/verl/utils/ulysses.py
+++ b/verl/utils/ulysses.py
@@ -87,6 +87,43 @@ def gather_seq_scatter_heads(
     return x
 
 
+def gather_packed_qkv_seq_scatter_heads(
+    packed_qkv: Tensor,
+    qkv_batch_sizes: tuple[int, int, int],
+    seq_dim: int,
+    head_dim: int,
+    unpadded_dim_size: int = 0,
+    group: ProcessGroup = None,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Redistribute a pre-packed equal-layout QKV buffer with one all-to-all.
+
+    ``packed_qkv`` stores Q, K, and V consecutively along dimension zero.
+    ``qkv_batch_sizes`` records their dimension-zero extents so the communicated
+    buffer can be returned as views without another copy.
+    """
+    if len(qkv_batch_sizes) != 3 or any(size < 0 for size in qkv_batch_sizes):
+        raise ValueError(f"qkv_batch_sizes must contain three non-negative sizes, got {qkv_batch_sizes}")
+    if sum(qkv_batch_sizes) != packed_qkv.size(0):
+        raise ValueError(
+            f"qkv_batch_sizes sum to {sum(qkv_batch_sizes)}, but packed_qkv.size(0) is {packed_qkv.size(0)}"
+        )
+
+    ndim = packed_qkv.ndim
+    seq_dim %= ndim
+    head_dim %= ndim
+    if seq_dim == 0 or head_dim == 0:
+        raise ValueError("dimension zero is reserved for pre-packed Q/K/V batches")
+
+    packed_qkv = gather_seq_scatter_heads(
+        packed_qkv,
+        seq_dim=seq_dim,
+        head_dim=head_dim,
+        unpadded_dim_size=unpadded_dim_size,
+        group=group,
+    )
+    return packed_qkv.split(qkv_batch_sizes, dim=0)
+
+
 def gather_qkv_seq_scatter_heads(
     query: Tensor,
     key: Tensor,
@@ -119,14 +156,14 @@ def gather_qkv_seq_scatter_heads(
     if equal_layout:
         batch_sizes = (query.size(0), key.size(0), value.size(0))
         packed_qkv = torch.cat((query, key, value), dim=0)
-        packed_qkv = gather_seq_scatter_heads(
+        return gather_packed_qkv_seq_scatter_heads(
             packed_qkv,
-            seq_dim=seq_dim,
-            head_dim=head_dim,
-            unpadded_dim_size=unpadded_dim_size,
-            group=group,
+            batch_sizes,
+            seq_dim,
+            head_dim,
+            unpadded_dim_size,
+            group,
         )
-        return packed_qkv.split(batch_sizes, dim=0)
 
     return (
         gather_seq_scatter_heads(query, seq_dim, head_dim, unpadded_dim_size, group),


### PR DESCRIPTION
<!-- Title: [perf] feat: add pre-packed Ulysses QKV API -->

### What does this PR do?

Add `gather_packed_qkv_seq_scatter_heads`, an API for producers that already own
a dimension-zero packed QKV buffer. It validates the Q/K/V extents, runs one
Ulysses collective, and returns split views without an additional packing copy.

The equal-layout helper introduced in PR 1 is refactored to use the new API.
This PR deliberately does not alter model projections. Direct packed projection
is left outside this series until it demonstrates a stable end-to-end benefit.

This is PR 2 of 3 and depends on [PR 1](https://github.com/verl-project/verl/pull/7417).
This is a stacked PR, so its diff includes PR 1 until that dependency merges.

### Checklist Before Starting

- [x] Searched open PRs for similar work:
  https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ulysses+qkv
  Existing results do not expose a pre-packed QKV Ulysses communication API.
- [x] Title follows `[{modules}] {type}: {description}`:
  `[perf] feat: add pre-packed Ulysses QKV API`.

### Test

Run on 2 x NVIDIA A100-SXM4-40GB:

```bash
NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 \
torchrun --standalone --nproc-per-node=2 -m pytest -q \
  tests/special_distributed/test_packed_qkv_ulysses.py
```

Result: `9 passed` on each rank. The added test compares the pre-packed API with
three legacy collectives and asserts that it launches one collective.

The final three-PR stack was also tested on 2 x NVIDIA H200 NVL with default
NCCL settings: `14 passed` on each rank in 9.11 seconds.

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

Result on the rebased series head: every hook passed.

Microbenchmark: 2 x A100, world size 2, local sequence 256, 16 heads, head
dimension 128, 20 warmups, and 100 iterations. The pre-packed time includes the
collective and view split but excludes producer-side packing.

| dtype | 3 x A2A | pre-packed API | speedup |
|---|---:|---:|---:|
| FP32 | 3.428 ms | 2.703 ms | 1.268x |
| BF16 | 1.698 ms | 1.442 ms | 1.177x |
| FP8 e4m3 | 0.984 ms | 0.819 ms | 1.201x |
| FP8 e5m2 | 0.912 ms | 0.803 ms | 1.136x |

These are topology-specific measurements with NCCL P2P/SHM disabled for the
rented A100 machine.

### API and Usage Example

```python
from verl.utils.ulysses import gather_packed_qkv_seq_scatter_heads

# packed_qkv is laid out as [Q rows, K rows, V rows] along dimension zero.
q, k, v = gather_packed_qkv_seq_scatter_heads(
    packed_qkv,
    q_size=q_rows,
    k_size=k_rows,
    v_size=v_rows,
    seq_dim=2,
    head_dim=1,
)
```

### Design & Code Changes

- Validate the pre-packed buffer and individual Q/K/V extents.
- Run the existing autograd-safe Ulysses redistribution once.
- Return split views, avoiding a producer-side `torch.cat` when a producer can
  create the packed layout directly now or in a future fused implementation.
- Refactor the PR 1 helper to delegate to this API without changing behavior.
- Extend distributed tests and the benchmark with the pre-packed path.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied the required full pre-commit command; all hooks passed.
- [x] Documentation is covered by the API docstring and usage example above;
  there is no new end-user configuration or CLI surface.
- [x] The model CI workflow added in PR 1 runs this PR's expanded distributed
  test file.
- [ ] Human submitter has reviewed every changed line and can defend the change
  end-to-end.
- [ ] After the PR is opened and ready, request CI in the verl `ci-request`
  Slack channel or Feishu group.
- [x] Recipe submodule update is not applicable.

This change was developed with OpenAI Codex assistance. The test and benchmark
commands and their results are disclosed above.

### L20 pre-packed API boundary (2026-09-03)

The full L20 topology/scaling matrix and Nsight evidence are recorded in
#7417. On the same-NUMA WS3 BF16 run, excluding producer-side packing yielded
speedups of 1.006×, 0.948×, 0.988×, and 0.995× at local sequence lengths
256/2K/8K/32K. FP8 e4m3 was 1.234× at 256 and 0.974× at 2K.

This supports keeping the pre-packed API as a producer contract, but does not
yet support wiring projections directly to it: even after removing `torch.cat`,
the measured collective path is not a stable end-to-end win on L20 PCIe.
