### PR TITLE
[model] fix: DSA for mcore >= 0.16.2: route x/qr kwargs and add PyTorch WHT fa…

### DIFF
--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -358,6 +358,44 @@ def apply_patch():
 
     if not mcore_ge_0162:
         MultiLatentAttention.forward = patch_forward
+    else:
+        # mcore >= 0.16.2 upstream _run_core_attention does not forward the x/qr
+        # extra kwargs that DSA (experimental_attention_variant="dsa") requires.
+        # Route DSA instances through the verl patch_forward so those tensors
+        # reach core_attention; leave standard MLA on the upstream forward.
+        _mcore_forward = MultiLatentAttention.forward
+
+        def _forward_dsa_compat(self, *args, **kwargs):
+            if getattr(self.config, "experimental_attention_variant", None) == "dsa":
+                return patch_forward(self, *args, **kwargs)
+            return _mcore_forward(self, *args, **kwargs)
+
+        MultiLatentAttention.forward = _forward_dsa_compat
+
+    # DSA imports fast_hadamard_transform at module load time and falls back to
+    # hadamard_transform=None when the CUDA package is absent.  Inject a pure-
+    # PyTorch Walsh-Hadamard fallback so DSA can run without the C extension.
+    try:
+        import megatron.core.transformer.experimental_attention_variant.dsa as _dsa_mod
+
+        if _dsa_mod.hadamard_transform is None:
+
+            def _pytorch_hadamard_transform(x, scale: float = 1.0):
+                """Walsh-Hadamard transform over the last dim (must be power of 2)."""
+                n = x.shape[-1]
+                h = x.to(torch.float32)
+                s = 1
+                while s < n:
+                    shape = h.shape[:-1]
+                    h = h.reshape(*shape, n // (2 * s), 2, s)
+                    left, right = h[..., 0, :], h[..., 1, :]
+                    h = torch.stack([left + right, left - right], dim=-2).reshape(*shape, n)
+                    s *= 2
+                return h.to(x.dtype) * scale
+
+            _dsa_mod.hadamard_transform = _pytorch_hadamard_transform
+    except ImportError:
+        pass  # not a DSA model, nothing to do
 
 
 def apply_patch_mbridge():
@@ -393,24 +431,26 @@ def apply_patch_mbridge():
 def apply_patch_megatron_v012_with_torch_v28_v29() -> None:
     # Error due to missing serialization_format in _write_item of megatron v012;
     # resolved by using megatron v013's implementation.
-    import inspect
-    import logging
-    import os
-    from pathlib import Path
-
     import megatron.core
     import torch
-    from megatron.core.dist_checkpointing.strategies.async_utils import _disable_gc
-    from megatron.core.dist_checkpointing.strategies.filesystem_async import _process_memory
     from packaging import version
-    from torch import multiprocessing as mp
-    from torch.distributed.checkpoint.filesystem import _write_item
 
     if (
         version.parse(torch.__version__).base_version not in ("2.8.0", "2.9.0")
         or version.parse(megatron.core.__version__).base_version != "0.12.1"
     ):
         return
+
+    # Only import private megatron internals when we know the exact version that has them.
+    import inspect
+    import logging
+    import os
+    from pathlib import Path
+
+    from megatron.core.dist_checkpointing.strategies.async_utils import _disable_gc
+    from megatron.core.dist_checkpointing.strategies.filesystem_async import _process_memory
+    from torch import multiprocessing as mp
+    from torch.distributed.checkpoint.filesystem import _write_item
 
     WriteBucket = tuple[Path, str, tuple[list, list]]
 


### PR DESCRIPTION
### What does this PR do?

Fixes MultiLatentAttention (DSA variant) compatibility with mcore ≥ 0.16.2 and adds a pure-PyTorch Walsh-Hadamard fallback for environments that don't have the fast_hadamard_transform CUDA extension.

**Background**. verl patches MultiLatentAttention.forward to forward extra kwargs (x, qr) that DSA's core_attention requires. In mcore ≤ 0.16.1 this patch replaced the upstream forward unconditionally. Starting from mcore 0.16.2, the upstream MultiLatentAttention.forward was restructured (packed-seq + CP support), so applying the verl patch wholesale breaks standard MLA. Additionally, mcore's DSA module imports fast_hadamard_transform at module load time and silently sets hadamard_transform = None when the C extension is absent — causing a crash at the first DSA forward pass.

Changes:
1. For mcore ≥ 0.16.2, route only DSA instances (experimental_attention_variant == "dsa") through patch_forward; leave standard MLA on the upstream forward.
2. Inject a pure-PyTorch Walsh-Hadamard transform into the DSA module namespace when hadamard_transform is None, so DSA runs without the fast_hadamard_transform package.
3. Move private megatron/torch imports in apply_patch_megatron_v012_with_torch_v28_v29 behind the version guard to prevent ImportError on installations that don't have those internal APIs.

### Test

Validated by running GLM-5.1 (744B MoE, glm_moe_dsa model type, DSA attention) end-to-end training with Megatron backend on mcore 0.16.2. Without the patch, the forward pass crashes immediately; with the patch, training proceeds normally.

Standard MLA models are unaffected: the _forward_dsa_compat wrapper checks experimental_attention_variant and falls through to the upstream forward for all non-DSA instances.