### PR TITLE
[rollout] fix: preserve dummy load_format in disaggregated rollout

### DIFF
--- a/examples/generation/run_deepseek_llm_7b.sh
+++ b/examples/generation/run_deepseek_llm_7b.sh
@@ -7,6 +7,9 @@
 #
 # Multi-node (e.g. 2 nodes, rollout_tp=16):
 #   NNODES=2 ROLLOUT_TP=16 bash run_deepseek_llm_7b.sh
+#
+# rollout.load_format defaults to `dummy` because RL training receives weights from
+# the trainer. Generation-only runs have no trainer, so it must be set to `auto`.
 
 set -xeuo pipefail
 
@@ -34,6 +37,7 @@ python3 -m verl.trainer.main_generation_server \
     actor_rollout_ref.model.path="${MODEL_PATH}" \
     actor_rollout_ref.model.trust_remote_code=True \
     actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.load_format=auto \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.top_k=50 \
     actor_rollout_ref.rollout.top_p=0.7 \

--- a/examples/tutorial/agent_loop_get_started/agent_loop_tutorial.ipynb
+++ b/examples/tutorial/agent_loop_get_started/agent_loop_tutorial.ipynb
@@ -238,6 +238,8 @@
                 "            \"actor_rollout_ref.model.path=\" + model_path,\n",
                 "            \"actor_rollout_ref.rollout.response_length=4096\",\n",
                 "            \"actor_rollout_ref.rollout.skip_tokenizer_init=False\",\n",
+                "            # standalone server has no trainer to sync weights from\n",
+                "            \"actor_rollout_ref.rollout.load_format=auto\",\n",
                 "            \"+actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=True\",\n",
                 "            \"+actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser=hermes\",\n",
                 "            \"+actor_rollout_ref.rollout.engine_kwargs.sglang.tool_call_parser=qwen25\",\n",

--- a/tests/experimental/agent_loop/test_standalone_rollout.py
+++ b/tests/experimental/agent_loop/test_standalone_rollout.py
@@ -38,6 +38,8 @@ def init_config() -> DictConfig:
     config.actor_rollout_ref.rollout.name = os.environ["ROLLOUT_NAME"]
     config.actor_rollout_ref.rollout.mode = "async"
     config.actor_rollout_ref.rollout.skip_tokenizer_init = False
+    # No trainer to sync weights from, so the server must load them from disk.
+    config.actor_rollout_ref.rollout.load_format = "auto"
 
     return config
 

--- a/tests/experimental/reward_loop/test_agent_reward_loop_standalone.py
+++ b/tests/experimental/reward_loop/test_agent_reward_loop_standalone.py
@@ -58,6 +58,8 @@ def test_agent_reward_loop_standalone():
     config.actor_rollout_ref.rollout.response_length = 4096
     config.actor_rollout_ref.rollout.skip_tokenizer_init = True
     config.actor_rollout_ref.rollout.nnodes = 1
+    # No trainer to sync weights from, so the server must load them from disk.
+    config.actor_rollout_ref.rollout.load_format = "auto"
     config.trainer.n_gpus_per_node = 4
     config.trainer.nnodes = 1
 

--- a/tests/workers/rollout/rollout_trtllm/test_adapter.py
+++ b/tests/workers/rollout/rollout_trtllm/test_adapter.py
@@ -158,6 +158,8 @@ class TestTRTLLMServerAdapter:
             config.actor_rollout_ref.rollout.name = "trtllm"
             config.actor_rollout_ref.rollout.mode = "async"
             config.actor_rollout_ref.rollout.tensor_model_parallel_size = 2
+            # No trainer to sync weights from, so the server must load them from disk.
+            config.actor_rollout_ref.rollout.load_format = "auto"
 
             rollout_config = config.actor_rollout_ref.rollout
             model_config = config.actor_rollout_ref.model

--- a/tests/workers/rollout/rollout_trtllm/test_inter_node_rollout.py
+++ b/tests/workers/rollout/rollout_trtllm/test_inter_node_rollout.py
@@ -38,6 +38,8 @@ def init_config() -> DictConfig:
     config.actor_rollout_ref.rollout.name = "trtllm"
     config.actor_rollout_ref.rollout.mode = "async"
     config.actor_rollout_ref.rollout.skip_tokenizer_init = False
+    # No trainer to sync weights from, so the server must load them from disk.
+    config.actor_rollout_ref.rollout.load_format = "auto"
 
     return config
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_abort.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_abort.py
@@ -80,6 +80,8 @@ def test_vllm_abort():
         config.actor_rollout_ref.rollout.tensor_model_parallel_size = TP_SIZE
         config.actor_rollout_ref.rollout.prompt_length = 512
         config.actor_rollout_ref.rollout.response_length = 512  # Longer for abort test
+        # No trainer to sync weights from, so the server must load them from disk.
+        config.actor_rollout_ref.rollout.load_format = "auto"
 
         # ==================== Create Rollout Server ====================
         print("\n[3] Creating rollout server (this may take a while)...")

--- a/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
@@ -101,6 +101,9 @@ def _make_rollout_config(model_path, seed):
     config.actor_rollout_ref.rollout.full_determinism = True
     config.actor_rollout_ref.rollout.seed = seed
     config.actor_rollout_ref.rollout.scheduling_policy = "priority"
+    # Standalone servers have no trainer to sync weights from; without real weights
+    # this test would compare logprobs of a randomly initialized model.
+    config.actor_rollout_ref.rollout.load_format = "auto"
     return config
 
 

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -175,10 +175,6 @@ class SGLangHttpServer:
         self._pd_decode_peers: list[ActorHandle] = []
         self._pd_bootstrap_host: Optional[str] = None
 
-        if self.rollout_mode != RolloutMode.HYBRID and self.config.load_format == "dummy":
-            logger.warning(f"rollout mode is {self.rollout_mode}, load_format is dummy, set to auto")
-            self.config.load_format = "auto"
-
         # used for http server
         self._server_address = ray.util.get_node_ip_address().strip("[]")
         self._server_port = None

--- a/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
@@ -133,16 +133,6 @@ class TRTLLMHttpServer:
 
         self.profiler_controller = self._init_profiler_controller()
 
-        # Non-HYBRID with load_format=dummy normally needs to load from disk (auto).
-        # Exception: FP8 has no on-disk ckpt; weights are filled during first sync (keep dummy).
-        if (
-            self.rollout_mode != RolloutMode.HYBRID
-            and self.config.load_format == "dummy"
-            and self.config.quantization != "fp8"
-        ):
-            logger.warning(f"rollout mode is {self.rollout_mode}, load_format is dummy, set to auto")
-            self.config.load_format = "auto"
-
         self.is_vlm_model = (
             self.model_config.hf_config is not None and hasattr(self.model_config.hf_config, "vision_config")
         ) or hasattr(self.model_config, "vision_config")

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -147,10 +147,6 @@ class vLLMHttpServer:
         self.global_steps = None
         self._warned_missing_spec_decode_stats = False
 
-        if self.rollout_mode != RolloutMode.HYBRID and self.config.load_format == "dummy":
-            logger.warning(f"rollout mode is {self.rollout_mode}, load_format is dummy, set to auto")
-            self.config.load_format = "auto"
-
         # used for http server
         self._server_address = ray.util.get_node_ip_address().strip("[]")
         self._server_port = None


### PR DESCRIPTION
### What does this PR do?

Removes a guard in SGLangHttpServer.__init__ that silently overrode load_format = "dummy" to "auto" in non-hybrid rollout modes.

In disaggregated (async) training the rollout workers are intentionally started with load_format: dummy — they skip loading model weights at startup and receive them from the trainer via weight broadcast (NCCL or Gloo). The override defeated this: SGLang would fall back to loading weights from disk, causing every rollout worker to read the full model from the filesystem simultaneously and defeating the purpose of the dummy format.

### Test

Validated end-to-end with a disaggregated async training run using mode: async and load_format: dummy. Without this fix the rollout server reverts to "auto" and attempts to read weights from disk; with the fix the dummy format is preserved and weights are received correctly via broadcast.

Non-async (hybrid) rollout is unaffected: the removed guard only triggered when rollout_mode != HYBRID.
