### PR TITLE
[worker] fix: NCCL deadlock in async disaggregated weight sync

### DIFF
--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -763,6 +763,22 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 torch.distributed.barrier()
                 per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
                 metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
+                # Drain EP and PP NCCL streams before the world exit barrier.
+                # The world barrier uses a different communicator (different CUDA
+                # stream) from EXPERT_MODEL_PARALLEL_GROUP and
+                # PIPELINE_MODEL_PARALLEL_GROUP, so it can complete while
+                # gather_from_ep_ranks / broadcast_from_pp_rank ALLGATHERs are
+                # still in-flight on those streams. Explicit group barriers flush
+                # each stream first.
+                try:
+                    from megatron.core import parallel_state as mpu
+
+                    if mpu.get_expert_model_parallel_world_size() > 1:
+                        torch.distributed.barrier(group=mpu.get_expert_model_parallel_group())
+                    if mpu.get_pipeline_model_parallel_world_size() > 1:
+                        torch.distributed.barrier(group=mpu.get_pipeline_model_parallel_group())
+                except ImportError:
+                    pass
                 torch.distributed.barrier()
             finally:
                 self._distributed_group_lock.release()

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import functools
 import logging
 import os
+import threading
 from contextlib import nullcontext
 from copy import deepcopy
 from functools import partial
@@ -464,6 +466,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         self.actor: TrainingWorker | None = None
         self.ref: TrainingWorker | None = None
         self.rollout: BaseRollout = None
+        self._distributed_group_lock = threading.Lock()
         assert self.role in ["actor", "rollout", "ref", "actor_rollout", "actor_rollout_ref"]
         self._is_actor = self.role in ["actor", "actor_rollout", "actor_rollout_ref"]
         self._is_rollout = self.role in ["rollout", "actor_rollout", "actor_rollout_ref"]
@@ -703,7 +706,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     @DistProfiler.annotate(color="red", role="actor_update")
     @_with_routing_replay_flag(enabled=True)
     def update_actor(self, data: TensorDict) -> TensorDict:
-        output = self.actor.train_mini_batch(data=data)
+        with self._distributed_group_lock:
+            output = self.actor.train_mini_batch(data=data)
         return output.cpu() if output is not None else None
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
@@ -753,8 +757,15 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 # snapshot prime), so it drives the training engine itself.
                 metrics = await self.checkpoint_engine.send_weights(self.actor.engine, global_steps=global_steps)
                 return metrics or {}
-            per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
-            metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._distributed_group_lock.acquire)
+            try:
+                torch.distributed.barrier()
+                per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
+                metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
+                torch.distributed.barrier()
+            finally:
+                self._distributed_group_lock.release()
             return metrics or {}
 
         set_expandable_segments(False)


### PR DESCRIPTION
### What does this PR do?

Fixes two interleaved-NCCL deadlocks that occur during async disaggregated weight sync with Megatron (pipeline + expert parallelism).

In async training, update_actor and update_weights are dispatched to the same ActorRolloutRefWorker instance via different execution contexts: update_actor runs in a Ray thread-pool thread, while update_weights runs as a coroutine on the async event loop. Both submit collective operations to the same PP and EP NCCL communicators. Two distinct races can cause NCCL seq-number mismatches across ranks, leading to watchdog timeouts:

1. Within-actor race: an update_actor call (thread pool) and an update_weights call (event loop) overlap on the same worker, submitting ops to the PP/EP groups concurrently.
2. Cross-actor timing race: a faster actor finishes send_weights and releases any lock early, allowing a new update_actor to begin submitting training ops to the EP group — while slower EP-partner actors are still inside the weight-sync all_gather loop, causing a collective mismatch.

Fix: a threading.Lock per worker serialises update_actor and update_weights. Inside update_weights, the lock is held across entry barrier → send_weights → exit barrier, so no actor can begin a new training step until all actors have completed the weight sync collective.

### Test

Validated end-to-end with a large MoE model using Megatron TP + PP + EP with param_offload: True and async disaggregated training. Prior to this fix, NCCL watchdog timeouts occurred consistently after a small number of weight sync cycles. With the fix, weight sync completes reliably across all cycles.