### PR TITLE
[distillation] Add reverse KL student top-k loss

### DIFF
--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -746,8 +746,8 @@ The returned scalar loss is what `engine.train_batch` backpropagates.
 - `verl/experimental/teacher_loop/teacher_model.py` — `MultiTeacherModelManager` and `TeacherModelManager`; spin up teacher inference replicas on the dedicated teacher resource pool and expose per-teacher `LLMServerClient` factories
 - `verl/experimental/teacher_loop/teacher_manager.py` — `AsyncTeacherLLMServerManager`; routes per-sample teacher calls (single- or multi-teacher) and builds teacher sampling params
 - `verl/experimental/agent_loop/agent_loop.py` — `AgentLoopWorker._compute_teacher_logprobs`; per-sample teacher dispatch from `_agent_loop_postprocess`, packs `teacher_logprobs` into the rollout output
-- `verl/trainer/distillation/fsdp/losses.py` — FSDP backend `compute_forward_kl_topk`
-- `verl/trainer/distillation/megatron/losses.py` — Megatron backend `compute_forward_kl_topk`
+- `verl/trainer/distillation/fsdp/losses.py` — FSDP backend `compute_forward_kl_topk` and `compute_reverse_kl_student_topk`
+- `verl/trainer/distillation/megatron/losses.py` — Megatron backend `compute_forward_kl_topk` and `compute_reverse_kl_student_topk`
 - `verl/workers/engine_workers.py` — `ActorRolloutRefWorker.init_model`; binds `distillation_ppo_loss` as the actor's `loss_fn` when distillation is enabled
 - `verl/workers/engine/{fsdp,megatron}/transformer_impl.py` — training-engine forward steps; invoke `distillation_ppo_loss` first as a logits processor (top-$k$ modes) and again as the final loss
 - `verl/trainer/main_ppo.py` — `is_distillation_enabled` gate; allocates the dedicated `teacher_pool` resource pool

--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -274,3 +274,25 @@ def test_reverse_kl_student_topk_mass_uses_raw_logprobs_before_clamp():
     torch.testing.assert_close(output["teacher_mass"], expected_teacher_logprobs.exp().sum(dim=-1))
     assert output["student_mass"].item() < student_topk_logprobs.clamp_min(-10.0).exp().sum(dim=-1).item()
     assert output["teacher_mass"].item() < expected_teacher_logprobs.clamp_min(-10.0).exp().sum(dim=-1).item()
+
+
+def test_reverse_kl_student_topk_teacher_mass_ignores_missing_fallback():
+    logits = torch.tensor([[[20.0, 19.0, 0.0, -1.0]]], dtype=torch.float32)
+    teacher_ids = _nested_from_rows([[0, 2]]).to(torch.int64)
+    teacher_logprobs = _nested_from_rows([[-1.0e-6, -20.0]]).to(torch.float32)
+    config = SimpleNamespace(
+        distillation_loss=SimpleNamespace(topk=2, log_prob_min_clamp=-10.0, use_chunked_topk=False)
+    )
+
+    output = compute_fsdp_reverse_kl_student_topk(
+        student_logits=logits,
+        teacher_topk_log_probs=teacher_logprobs,
+        teacher_topk_ids=teacher_ids,
+        config=config,
+        data_format="thd",
+    )
+
+    fallback_mass = torch.tensor(config.distillation_loss.log_prob_min_clamp).exp()
+    torch.testing.assert_close(output["teacher_mass"], torch.exp(teacher_logprobs.values()[0, 0]).view(1, 1))
+    assert (output["teacher_mass"] + fallback_mass).item() > 1.0
+    assert output["overlap_count"].item() == 1

--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -31,6 +31,7 @@ of log-prob computation.
 """
 
 import os
+import sys
 
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
@@ -44,6 +45,7 @@ from tensordict import TensorDict
 from verl.trainer.distillation.fsdp.losses import compute_forward_kl_topk as compute_fsdp_forward_kl_topk
 from verl.trainer.distillation.fsdp.losses import compute_reverse_kl_student_topk as compute_fsdp_reverse_kl_student_topk
 from verl.trainer.distillation.losses import compute_forward_kl_topk as collect_forward_kl_topk_metrics
+from verl.trainer.distillation.losses import compute_topk_loss
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead
@@ -249,6 +251,51 @@ def test_forward_kl_topk_metric_aggregation_for_overlap_outputs():
 
     assert metrics["distillation/overlap_ratio"] == pytest.approx(0.75)
     assert metrics["distillation/overlap_token_advantage"] == pytest.approx(-0.3)
+
+
+def test_megatron_reverse_kl_student_topk_dispatches_reverse_backend(monkeypatch):
+    calls = []
+
+    def _forward_backend(**kwargs):
+        calls.append("forward")
+        raise AssertionError("forward_kl_topk backend should not be selected")
+
+    def _reverse_backend(student_logits, **kwargs):
+        calls.append("reverse")
+        return {
+            "distillation_losses": torch.zeros(student_logits.shape[:2]),
+            "student_mass": torch.zeros(student_logits.shape[:2]),
+            "teacher_mass": torch.zeros(student_logits.shape[:2]),
+            "overlap_count": torch.zeros(student_logits.shape[:2]),
+            "overlap_token_advantage": torch.zeros(student_logits.shape[:2]),
+        }
+
+    fake_megatron_losses = SimpleNamespace(
+        compute_forward_kl_topk=_forward_backend,
+        compute_reverse_kl_student_topk=_reverse_backend,
+    )
+    fake_megatron_package = SimpleNamespace(losses=fake_megatron_losses)
+    monkeypatch.setitem(sys.modules, "verl.trainer.distillation.megatron", fake_megatron_package)
+    monkeypatch.setitem(sys.modules, "verl.trainer.distillation.megatron.losses", fake_megatron_losses)
+
+    student_logits = torch.zeros(1, 2, 4)
+    data = TensorDict(
+        {
+            "teacher_logprobs": torch.zeros(1, 2, 2),
+            "teacher_ids": torch.zeros(1, 2, 2, dtype=torch.long),
+        },
+        batch_size=[1, 2],
+    )
+    outputs = compute_topk_loss(
+        config=SimpleNamespace(strategy="megatron"),
+        distillation_config=SimpleNamespace(distillation_loss=SimpleNamespace(loss_mode="reverse_kl_student_topk")),
+        data=data,
+        student_logits=student_logits,
+        data_format="thd",
+    )
+
+    assert calls == ["reverse"]
+    assert outputs["distillation_losses"].shape == student_logits.shape[:2]
 
 
 def test_reverse_kl_student_topk_mass_uses_raw_logprobs_before_clamp():

--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -42,6 +42,7 @@ import torch
 from tensordict import TensorDict
 
 from verl.trainer.distillation.fsdp.losses import compute_forward_kl_topk as compute_fsdp_forward_kl_topk
+from verl.trainer.distillation.fsdp.losses import compute_reverse_kl_student_topk as compute_fsdp_reverse_kl_student_topk
 from verl.trainer.distillation.losses import compute_forward_kl_topk as collect_forward_kl_topk_metrics
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
@@ -248,3 +249,28 @@ def test_forward_kl_topk_metric_aggregation_for_overlap_outputs():
 
     assert metrics["distillation/overlap_ratio"] == pytest.approx(0.75)
     assert metrics["distillation/overlap_token_advantage"] == pytest.approx(-0.3)
+
+
+def test_reverse_kl_student_topk_mass_uses_raw_logprobs_before_clamp():
+    logits = torch.tensor([[[20.0, 0.0, -1.0, -2.0]]], dtype=torch.float32)
+    teacher_ids = _nested_from_rows([[0, 1, 2, 3]]).to(torch.int64)
+    teacher_logprobs = _nested_from_rows([[-0.1, -20.0, -1.0, -2.0]]).to(torch.float32)
+    config = SimpleNamespace(
+        distillation_loss=SimpleNamespace(topk=2, log_prob_min_clamp=-10.0, use_chunked_topk=False)
+    )
+
+    output = compute_fsdp_reverse_kl_student_topk(
+        student_logits=logits,
+        teacher_topk_log_probs=teacher_logprobs,
+        teacher_topk_ids=teacher_ids,
+        config=config,
+        data_format="thd",
+    )
+
+    student_topk_logprobs, student_topk_ids = torch.topk(torch.log_softmax(logits, dim=-1), k=2, dim=-1)
+    expected_teacher_logprobs = torch.gather(teacher_logprobs.values().unsqueeze(0), dim=-1, index=student_topk_ids)
+
+    torch.testing.assert_close(output["student_mass"], student_topk_logprobs.exp().sum(dim=-1))
+    torch.testing.assert_close(output["teacher_mass"], expected_teacher_logprobs.exp().sum(dim=-1))
+    assert output["student_mass"].item() < student_topk_logprobs.clamp_min(-10.0).exp().sum(dim=-1).item()
+    assert output["teacher_mass"].item() < expected_teacher_logprobs.clamp_min(-10.0).exp().sum(dim=-1).item()

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -48,7 +48,11 @@ def _get_teacher_sampling_params(
             "on prompt_logprobs (forward pass only). Using temperature=1.0.",
             teacher_model_config.inference.temperature,
         )
-    num_logprobs = distillation_loss_config.topk if distillation_loss_config.loss_settings.use_topk else 0
+    num_logprobs = (
+        distillation_loss_config.get_teacher_logprob_topk()
+        if distillation_loss_config.loss_settings.use_topk
+        else 0
+    )
     return {
         "max_tokens": 1,
         "temperature": 1.0,

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -26,6 +26,10 @@ distillation_loss:
   # If distillation loss requires top-k logits, this is the value of k
   topk: 32
 
+  # Teacher log-prob retrieval budget for reverse_kl_student_topk. Defaults to topk.
+  # This field is only valid when loss_mode is reverse_kl_student_topk.
+  reverse_kl_teacher_logprob_topk: null
+
   # Whether to include task rewards alongside distillation loss.
   use_task_rewards: true
 

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -72,6 +72,41 @@ def kl_divergence(log_q: torch.Tensor, log_p: torch.Tensor) -> torch.Tensor:
     return kld.sum(dim=-1)
 
 
+def reverse_kl_divergence(log_q: torch.Tensor, log_p: torch.Tensor) -> torch.Tensor:
+    """Compute KL(q || p) from log probabilities on a truncated support."""
+    log_p = log_p.float()
+    log_q = log_q.float()
+    q = log_q.exp()
+    kld = q * (log_q - log_p)
+    return kld.sum(dim=-1)
+
+
+def _gather_teacher_log_probs_on_student_topk(
+    student_topk_ids: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    missing_log_prob: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather teacher log-probs on student top-k ids from returned teacher top-k entries.
+
+    The teacher inference API currently returns teacher-selected top-k log-probs.
+    For student-top-k reverse KL, use the exact teacher value when the student
+    token appears in that set and a configured lower bound otherwise.
+    """
+    matches = student_topk_ids.unsqueeze(-1) == teacher_topk_ids.unsqueeze(-2)
+    missing = torch.full(
+        student_topk_ids.shape,
+        missing_log_prob,
+        dtype=teacher_topk_log_probs.dtype,
+        device=teacher_topk_log_probs.device,
+    )
+    non_match = torch.full_like(teacher_topk_log_probs.unsqueeze(-2), torch.finfo(teacher_topk_log_probs.dtype).min)
+    matched = torch.where(matches, teacher_topk_log_probs.clamp_min(missing_log_prob).unsqueeze(-2), non_match)
+    has_match = matches.any(dim=-1)
+    matched = matched.max(dim=-1).values
+    return torch.where(has_match, matched, missing), has_match
+
+
 def compute_forward_kl_topk(
     student_logits: torch.Tensor,
     teacher_topk_log_probs: torch.Tensor,
@@ -135,6 +170,83 @@ def compute_forward_kl_topk(
     overlap_count = overlap_mask.sum(dim=-1)
     token_kl = teacher_topk_log_probs.exp() * (teacher_topk_log_probs - student_topk_log_probs)
     overlap_token_advantage_sum = (-token_kl * overlap_mask).sum(dim=-1)
+    overlap_token_advantage = overlap_token_advantage_sum / overlap_count.clamp_min(1)
+    overlap_token_advantage = torch.where(
+        overlap_count > 0, overlap_token_advantage, torch.zeros_like(overlap_token_advantage)
+    )
+
+    return {
+        "distillation_losses": distillation_losses,
+        "student_mass": student_mass,
+        "teacher_mass": teacher_mass,
+        "overlap_count": overlap_count,
+        "overlap_token_advantage": overlap_token_advantage,
+    }
+
+
+def compute_reverse_kl_student_topk(
+    student_logits: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute truncated reverse KL on the student's top-k support.
+
+    This is a censored approximation that reuses the existing teacher top-k
+    payload. Teacher log-probs for student top-k tokens outside the teacher
+    top-k set are approximated by ``distillation_loss.log_prob_min_clamp``.
+    """
+    assert teacher_topk_log_probs.is_nested and teacher_topk_ids.is_nested
+    teacher_topk_log_probs = teacher_topk_log_probs.values().unsqueeze(0)  # (1, total_nnz, topk)
+    teacher_topk_ids = teacher_topk_ids.values().unsqueeze(0)  # (1, total_nnz, topk)
+
+    if get_ulysses_sequence_parallel_world_size() > 1:
+        teacher_topk_log_probs = slice_input_tensor(teacher_topk_log_probs, dim=1)
+        teacher_topk_ids = slice_input_tensor(teacher_topk_ids, dim=1)
+    assert teacher_topk_log_probs.shape[:2] == teacher_topk_ids.shape[:2] == student_logits.shape[:2]
+
+    loss_config: DistillationLossConfig = config.distillation_loss
+    if loss_config.log_prob_min_clamp is None:
+        raise ValueError("reverse_kl_student_topk requires distillation_loss.log_prob_min_clamp.")
+
+    student_topk = loss_config.topk
+    if student_topk is None:
+        raise ValueError("reverse_kl_student_topk requires distillation_loss.topk.")
+    teacher_logprob_topk = teacher_topk_ids.shape[-1]
+    if teacher_logprob_topk < student_topk:
+        raise ValueError(
+            "Teacher log-prob payload for reverse_kl_student_topk must be at least as wide as "
+            f"distillation_loss.topk, but got {teacher_logprob_topk} < {student_topk}."
+        )
+    use_chunked_topk = getattr(loss_config, "use_chunked_topk", False)
+    if use_chunked_topk:
+        student_topk_ids = torch.topk(student_logits, k=student_topk, dim=-1).indices
+        student_topk_log_probs = _chunked_topk_log_probs(
+            student_logits,
+            student_topk_ids,
+            chunk_size=getattr(loss_config, "chunked_topk_chunk_size", 4096),
+        )
+    else:
+        student_log_probs = F.log_softmax(student_logits, dim=-1)
+        student_topk_log_probs, student_topk_ids = torch.topk(student_log_probs, k=student_topk, dim=-1)
+
+    teacher_log_probs_on_student_topk, overlap_mask = _gather_teacher_log_probs_on_student_topk(
+        student_topk_ids=student_topk_ids,
+        teacher_topk_ids=teacher_topk_ids,
+        teacher_topk_log_probs=teacher_topk_log_probs,
+        missing_log_prob=loss_config.log_prob_min_clamp,
+    )
+    student_topk_log_probs = student_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
+    teacher_log_probs_on_student_topk = teacher_log_probs_on_student_topk.clamp_min(loss_config.log_prob_min_clamp)
+
+    student_mass = student_topk_log_probs.exp().sum(dim=-1)
+    teacher_mass = teacher_log_probs_on_student_topk.exp().sum(dim=-1)
+    distillation_losses = reverse_kl_divergence(log_q=student_topk_log_probs, log_p=teacher_log_probs_on_student_topk)
+
+    overlap_count = overlap_mask.sum(dim=-1)
+    token_advantage = teacher_log_probs_on_student_topk - student_topk_log_probs
+    overlap_token_advantage_sum = (token_advantage * overlap_mask).sum(dim=-1)
     overlap_token_advantage = overlap_token_advantage_sum / overlap_count.clamp_min(1)
     overlap_token_advantage = torch.where(
         overlap_count > 0, overlap_token_advantage, torch.zeros_like(overlap_token_advantage)

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -101,7 +101,7 @@ def _gather_teacher_log_probs_on_student_topk(
         device=teacher_topk_log_probs.device,
     )
     non_match = torch.full_like(teacher_topk_log_probs.unsqueeze(-2), torch.finfo(teacher_topk_log_probs.dtype).min)
-    matched = torch.where(matches, teacher_topk_log_probs.clamp_min(missing_log_prob).unsqueeze(-2), non_match)
+    matched = torch.where(matches, teacher_topk_log_probs.unsqueeze(-2), non_match)
     has_match = matches.any(dim=-1)
     matched = matched.max(dim=-1).values
     return torch.where(has_match, matched, missing), has_match
@@ -237,11 +237,13 @@ def compute_reverse_kl_student_topk(
         teacher_topk_log_probs=teacher_topk_log_probs,
         missing_log_prob=loss_config.log_prob_min_clamp,
     )
-    student_topk_log_probs = student_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
-    teacher_log_probs_on_student_topk = teacher_log_probs_on_student_topk.clamp_min(loss_config.log_prob_min_clamp)
 
     student_mass = student_topk_log_probs.exp().sum(dim=-1)
     teacher_mass = teacher_log_probs_on_student_topk.exp().sum(dim=-1)
+
+    student_topk_log_probs = student_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
+    teacher_log_probs_on_student_topk = teacher_log_probs_on_student_topk.clamp_min(loss_config.log_prob_min_clamp)
+
     distillation_losses = reverse_kl_divergence(log_q=student_topk_log_probs, log_p=teacher_log_probs_on_student_topk)
 
     overlap_count = overlap_mask.sum(dim=-1)

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -239,7 +239,7 @@ def compute_reverse_kl_student_topk(
     )
 
     student_mass = student_topk_log_probs.exp().sum(dim=-1)
-    teacher_mass = teacher_log_probs_on_student_topk.exp().sum(dim=-1)
+    teacher_mass = (teacher_log_probs_on_student_topk.exp() * overlap_mask).sum(dim=-1)
 
     student_topk_log_probs = student_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
     teacher_log_probs_on_student_topk = teacher_log_probs_on_student_topk.clamp_min(loss_config.log_prob_min_clamp)

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -139,11 +139,17 @@ def compute_topk_loss(
         case "fsdp" | "veomni":
             import verl.trainer.distillation.fsdp.losses as fsdp_losses
 
-            distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
+            if distillation_config.distillation_loss.loss_mode == "reverse_kl_student_topk":
+                distillation_loss_fn = fsdp_losses.compute_reverse_kl_student_topk
+            else:
+                distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
         case "megatron":
             import verl.trainer.distillation.megatron.losses as megatron_losses
 
-            distillation_loss_fn = megatron_losses.compute_forward_kl_topk
+            if distillation_config.distillation_loss.loss_mode == "reverse_kl_student_topk":
+                distillation_loss_fn = megatron_losses.compute_reverse_kl_student_topk
+            else:
+                distillation_loss_fn = megatron_losses.compute_forward_kl_topk
         case _:
             raise NotImplementedError(f"Unsupported strategy: {config.strategy=}")
 
@@ -302,7 +308,9 @@ def distillation_loss(
     return distillation_loss, distillation_metrics
 
 
-@register_distillation_loss(DistillationLossSettings(names=["forward_kl_topk"], use_topk=True))  # type: ignore[arg-type]
+@register_distillation_loss(
+    DistillationLossSettings(names=["forward_kl_topk", "reverse_kl_student_topk"], use_topk=True)
+)  # type: ignore[arg-type]
 def compute_forward_kl_topk(
     config: ActorConfig,
     distillation_config: DistillationConfig,
@@ -339,7 +347,9 @@ def compute_forward_kl_topk(
         # Diagnostics for tracking teacher/student top-k overlap in OPD, following
         # "Rethinking On-Policy Distillation of Large Language Models" (arXiv:2604.13016):
         # overlap ratio and average teacher-token KL contribution on overlapped tokens.
-        overlap_metrics["distillation/overlap_ratio"] = (valid_overlap_count.float().mean() / k).item()
+        overlap_ratio = (valid_overlap_count.float().mean() / k).item()
+        overlap_metrics["distillation/overlap_ratio"] = overlap_ratio
+        overlap_metrics["distillation/missing_ratio"] = 1.0 - overlap_ratio
         overlap_position_mask = response_mask_bool & (overlap_count > 0)
         if overlap_position_mask.any():
             overlap_metrics["distillation/overlap_token_advantage"] = (

--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -310,3 +310,13 @@ def compute_forward_kl_topk(
         "overlap_count": overlap_count,
         "overlap_token_advantage": overlap_token_advantage,
     }
+
+
+def compute_reverse_kl_student_topk(
+    student_logits: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> dict[str, torch.Tensor]:
+    raise NotImplementedError("reverse_kl_student_topk is currently implemented for fsdp/veomni only.")

--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -55,6 +55,27 @@ def vocab_parallel_log_softmax(
     return vp_logits - log_sum_exp_logits.unsqueeze(dim=-1)
 
 
+def _gather_teacher_log_probs_on_student_topk(
+    student_topk_ids: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    missing_log_prob: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather teacher log-probs on student top-k ids from returned teacher top-k entries."""
+    matches = student_topk_ids.unsqueeze(-1) == teacher_topk_ids.unsqueeze(-2)
+    missing = torch.full(
+        student_topk_ids.shape,
+        missing_log_prob,
+        dtype=teacher_topk_log_probs.dtype,
+        device=teacher_topk_log_probs.device,
+    )
+    non_match = torch.full_like(teacher_topk_log_probs.unsqueeze(-2), torch.finfo(teacher_topk_log_probs.dtype).min)
+    matched = torch.where(matches, teacher_topk_log_probs.unsqueeze(-2), non_match)
+    has_match = matches.any(dim=-1)
+    matched = matched.max(dim=-1).values
+    return torch.where(has_match, matched, missing), has_match
+
+
 class _VocabParallelKLDivergence(torch.autograd.Function):
     """
     Adapted from:
@@ -261,6 +282,123 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
         return grad_input, None, None, None
 
 
+class _VocabParallelReverseKLDivergenceOnStudentTopK(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        vp_logits: torch.Tensor,
+        teacher_topk_log_probs: torch.Tensor,
+        teacher_topk_ids: torch.Tensor,
+        student_topk: int,
+        log_prob_min_clamp: float,
+    ):
+        from megatron.core.parallel_state import (
+            get_tensor_model_parallel_group,
+            get_tensor_model_parallel_rank,
+            get_tensor_model_parallel_world_size,
+        )
+        from megatron.core.tensor_parallel.utils import VocabUtility
+
+        vp_source_logps = vocab_parallel_log_softmax(vp_logits).float()
+        vp_source_probs = vp_source_logps.exp()
+
+        rank = get_tensor_model_parallel_rank()
+        world_size = get_tensor_model_parallel_world_size()
+        partition_vocab_size = vp_logits.size(-1)
+        vocab_start_index, vocab_end_index = VocabUtility.vocab_range_from_per_partition_vocab_size(
+            partition_vocab_size, rank, world_size
+        )
+
+        local_topk = min(student_topk, partition_vocab_size)
+        local_student_topk_logps, local_student_topk_ids = torch.topk(vp_source_logps, k=local_topk, dim=-1)
+        local_student_topk_ids = local_student_topk_ids + vocab_start_index
+        gathered_student_topk_logps = [torch.empty_like(local_student_topk_logps) for _ in range(world_size)]
+        gathered_student_topk_ids = [torch.empty_like(local_student_topk_ids) for _ in range(world_size)]
+        torch.distributed.all_gather(
+            gathered_student_topk_logps, local_student_topk_logps, group=get_tensor_model_parallel_group()
+        )
+        torch.distributed.all_gather(
+            gathered_student_topk_ids, local_student_topk_ids, group=get_tensor_model_parallel_group()
+        )
+        student_topk_logps = torch.cat(gathered_student_topk_logps, dim=-1)
+        student_topk_ids = torch.cat(gathered_student_topk_ids, dim=-1)
+        student_topk_logps, student_topk_positions = torch.topk(student_topk_logps, k=student_topk, dim=-1)
+        student_topk_ids = torch.gather(student_topk_ids, dim=-1, index=student_topk_positions)
+
+        teacher_logps_on_student_topk, overlap_mask = _gather_teacher_log_probs_on_student_topk(
+            student_topk_ids=student_topk_ids,
+            teacher_topk_ids=teacher_topk_ids,
+            teacher_topk_log_probs=teacher_topk_log_probs,
+            missing_log_prob=log_prob_min_clamp,
+        )
+
+        student_mass = student_topk_logps.exp().sum(dim=-1)
+        teacher_mass = (teacher_logps_on_student_topk.exp() * overlap_mask).sum(dim=-1)
+
+        student_topk_ids_in_vocab_mask = (student_topk_ids >= vocab_start_index) & (
+            student_topk_ids < vocab_end_index
+        )
+        student_topk_local_ids = student_topk_ids - vocab_start_index
+        student_topk_local_ids = student_topk_local_ids.clone()
+        student_topk_local_ids[~student_topk_ids_in_vocab_mask] = 0
+
+        active_topk_mask = student_topk_logps > log_prob_min_clamp
+        active_mask = student_topk_ids_in_vocab_mask & active_topk_mask
+        student_topk_logps = student_topk_logps.clamp_min(log_prob_min_clamp)
+        teacher_logps_on_student_topk = teacher_logps_on_student_topk.clamp_min(log_prob_min_clamp)
+
+        student_topk_probs = student_topk_logps.exp()
+        distillation_losses = torch.sum(
+            student_topk_probs * (student_topk_logps - teacher_logps_on_student_topk), dim=-1
+        )
+
+        grad_coeff = student_topk_probs * (student_topk_logps - teacher_logps_on_student_topk + 1.0)
+        active_grad_coeff = grad_coeff * active_mask.to(grad_coeff.dtype)
+        grad_coeff_sum = (grad_coeff * active_topk_mask.to(grad_coeff.dtype)).sum(dim=-1)
+
+        overlap_count = overlap_mask.sum(dim=-1)
+        token_advantage = teacher_logps_on_student_topk - student_topk_logps
+        overlap_token_advantage_sum = (token_advantage * overlap_mask).sum(dim=-1)
+        overlap_token_advantage = overlap_token_advantage_sum / overlap_count.clamp_min(1)
+        overlap_token_advantage = torch.where(
+            overlap_count > 0, overlap_token_advantage, torch.zeros_like(overlap_token_advantage)
+        )
+
+        ctx.save_for_backward(vp_source_probs, student_topk_local_ids, active_grad_coeff, active_mask, grad_coeff_sum)
+
+        student_mass = student_mass.detach()
+        teacher_mass = teacher_mass.detach()
+        overlap_count = overlap_count.detach()
+        overlap_token_advantage = overlap_token_advantage.detach()
+        ctx.mark_non_differentiable(student_mass, teacher_mass, overlap_count, overlap_token_advantage)
+
+        return distillation_losses, student_mass, teacher_mass, overlap_count, overlap_token_advantage
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_loss: torch.Tensor,
+        grad_student_mass: torch.Tensor,
+        grad_teacher_mass: torch.Tensor,
+        grad_overlap_count: torch.Tensor,
+        grad_overlap_token_advantage: torch.Tensor,
+    ):
+        vp_source_probs, student_topk_local_ids, active_grad_coeff, active_mask, grad_coeff_sum = ctx.saved_tensors
+
+        grad_input = -vp_source_probs * grad_coeff_sum.unsqueeze(-1)
+
+        topk = student_topk_local_ids.size(-1)
+        grad_input_2d = grad_input.view(-1, grad_input.size(-1))
+        student_topk_local_ids_flat = student_topk_local_ids.view(-1, topk)
+        active_grad_coeff_flat = active_grad_coeff.view(-1, topk) * active_mask.view(-1, topk).to(
+            active_grad_coeff.dtype
+        )
+        grad_input_2d.scatter_add_(dim=1, index=student_topk_local_ids_flat, src=active_grad_coeff_flat)
+
+        grad_input.mul_(grad_loss.unsqueeze(dim=-1))
+        return grad_input, None, None, None, None
+
+
 def compute_forward_kl_topk(
     student_logits: torch.Tensor,
     teacher_topk_log_probs: torch.Tensor,
@@ -319,4 +457,45 @@ def compute_reverse_kl_student_topk(
     config: DistillationConfig,
     data_format: str,
 ) -> dict[str, torch.Tensor]:
-    raise NotImplementedError("reverse_kl_student_topk is currently implemented for fsdp/veomni only.")
+    """Compute truncated reverse KL on the student's top-k support."""
+    assert teacher_topk_log_probs.is_nested and teacher_topk_ids.is_nested
+
+    if data_format == "thd":
+        teacher_topk_log_probs_cp_split, *_ = preprocess_thd_engine(teacher_topk_log_probs, pre_process=True)
+        teacher_topk_ids_cp_split, *_ = preprocess_thd_engine(teacher_topk_ids, pre_process=True)
+    else:
+        teacher_topk_log_probs_cp_split, *_ = preprocess_bshd_engine(teacher_topk_log_probs, pre_process=True)
+        teacher_topk_ids_cp_split, *_ = preprocess_bshd_engine(teacher_topk_ids, pre_process=True)
+    assert teacher_topk_log_probs_cp_split.shape[:2] == teacher_topk_ids_cp_split.shape[:2] == student_logits.shape[:2]
+
+    loss_config: DistillationLossConfig = config.distillation_loss
+    if loss_config.log_prob_min_clamp is None:
+        raise ValueError("reverse_kl_student_topk requires distillation_loss.log_prob_min_clamp.")
+
+    student_topk = loss_config.topk
+    if student_topk is None:
+        raise ValueError("reverse_kl_student_topk requires distillation_loss.topk.")
+    teacher_logprob_topk = teacher_topk_ids_cp_split.shape[-1]
+    if teacher_logprob_topk < student_topk:
+        raise ValueError(
+            "Teacher log-prob payload for reverse_kl_student_topk must be at least as wide as "
+            f"distillation_loss.topk, but got {teacher_logprob_topk} < {student_topk}."
+        )
+
+    distillation_losses, student_mass, teacher_mass, overlap_count, overlap_token_advantage = (
+        _VocabParallelReverseKLDivergenceOnStudentTopK.apply(
+            student_logits,
+            teacher_topk_log_probs_cp_split,
+            teacher_topk_ids_cp_split,
+            student_topk,
+            loss_config.log_prob_min_clamp,
+        )
+    )
+
+    return {
+        "distillation_losses": distillation_losses,
+        "student_mass": student_mass,
+        "teacher_mass": teacher_mass,
+        "overlap_count": overlap_count,
+        "overlap_token_advantage": overlap_token_advantage,
+    }

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1316,6 +1316,11 @@ class RayPPOTrainer:
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_loss_mode = (
+            self.distillation_config.distillation_loss.loss_mode
+            if is_distillation_enabled(self.config.get("distillation"))
+            else None
+        )
         distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
         if is_distillation_enabled(self.config.get("distillation")):
             distillation_loss_cfg = self.distillation_config.distillation_loss
@@ -1333,6 +1338,7 @@ class RayPPOTrainer:
             batch_td,
             calculate_entropy=calculate_entropy,
             distillation_use_topk=distillation_use_topk,
+            distillation_loss_mode=distillation_loss_mode,
             distillation_only=distillation_only,
             global_batch_size=ppo_mini_batch_size,
             mini_batch_size=ppo_mini_batch_size,

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1681,6 +1681,11 @@ class PPOTrainer(ABC):
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_loss_mode = (
+            self.distillation_config.distillation_loss.loss_mode
+            if is_distillation_enabled(self.config.get("distillation"))
+            else None
+        )
         distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
         if is_distillation_enabled(self.config.get("distillation")):
             distillation_loss_cfg = self.distillation_config.distillation_loss
@@ -1692,6 +1697,7 @@ class PPOTrainer(ABC):
         extra_info = {
             "calculate_entropy": calculate_entropy,
             "distillation_use_topk": distillation_use_topk,
+            "distillation_loss_mode": distillation_loss_mode,
             "distillation_only": distillation_only,
             "global_batch_size": ppo_mini_batch_size,
             "mini_batch_size": ppo_mini_batch_size,

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -36,6 +36,9 @@ class DistillationLossConfig(BaseConfig):
         Distillation loss function to use.
     topk (int, optional):
         Number of top tokens to consider for top-k distillation losses.
+    reverse_kl_teacher_logprob_topk (int, optional):
+        Teacher log-prob retrieval budget for reverse_kl_student_topk. Defaults
+        to topk. This is not used by other loss modes.
     use_task_rewards (bool):
         Whether to include task rewards alongside distillation loss.
     distillation_loss_coef (float):
@@ -49,7 +52,8 @@ class DistillationLossConfig(BaseConfig):
         Whether to incorporate distillation loss as a reward, as done
         by https://thinkingmachines.ai/blog/on-policy-distillation/. Recommended to use loss_mode=k1.
         Otherwise, distillation loss is directly backpropagated as a supervised loss,
-        as in https://arxiv.org/abs/2306.13649. Recommended to use loss_mode=k3 or forward_kl_topk.
+        as in https://arxiv.org/abs/2306.13649. Recommended to use loss_mode=k3, forward_kl_topk, or
+        reverse_kl_student_topk.
     policy_loss_mode (str):
         Name of the policy loss to use when use_policy_gradient is true.
     clip_ratio (float):
@@ -64,13 +68,14 @@ class DistillationLossConfig(BaseConfig):
 
     loss_mode: str = "k3"
     topk: Optional[int] = 128
+    reverse_kl_teacher_logprob_topk: Optional[int] = None
     use_task_rewards: bool = True
     distillation_loss_coef: float = 1.0
     loss_max_clamp: Optional[float] = 10.0
     log_prob_min_clamp: Optional[float] = -10.0
 
     # Chunked top-K log-probs (opt-in, avoids [B, T, V] log_softmax buffer
-    # at long context). Only consumed by ``loss_mode='forward_kl_topk'``.
+    # at long context). Consumed by top-k distributional losses.
     # Default ``False`` to preserve short-context performance (chunked path
     # has ~6x time overhead at N=14K, V=152K). Set ``True`` when hitting OOM
     # at long context (>=64K tokens, V=152K) where the baseline path OOMs.
@@ -116,12 +121,49 @@ class DistillationLossConfig(BaseConfig):
                 " token's logprob ∇logπ(a), so the top-k distributional signal (how non-sampled logits "
                 "should move) is largely unused."
             )
+        if self.use_policy_gradient and self.loss_mode == "reverse_kl_student_topk":
+            raise ValueError(
+                "reverse_kl_student_topk is a distributional top-k loss and should be used with "
+                "use_policy_gradient=False."
+            )
+        if self.reverse_kl_teacher_logprob_topk is not None and self.loss_mode != "reverse_kl_student_topk":
+            raise ValueError(
+                "distillation_loss.reverse_kl_teacher_logprob_topk is only supported with "
+                "loss_mode=reverse_kl_student_topk."
+            )
+        if self.loss_mode == "reverse_kl_student_topk":
+            if self.topk is None or self.topk <= 0:
+                raise ValueError("reverse_kl_student_topk requires distillation_loss.topk to be a positive integer.")
+            teacher_logprob_topk = self.get_teacher_logprob_topk()
+            if teacher_logprob_topk == -1:
+                raise NotImplementedError(
+                    "reverse_kl_teacher_logprob_topk=-1 is reserved for exact teacher log-prob retrieval, "
+                    "but exact retrieval is not implemented yet."
+                )
+            if teacher_logprob_topk <= 0:
+                raise ValueError(
+                    "distillation_loss.reverse_kl_teacher_logprob_topk must be positive when set, or -1 "
+                    "for exact retrieval once supported."
+                )
+            if teacher_logprob_topk < self.topk:
+                raise ValueError(
+                    "distillation_loss.reverse_kl_teacher_logprob_topk must be >= distillation_loss.topk "
+                    f"for reverse_kl_student_topk, but got {teacher_logprob_topk} < {self.topk}."
+                )
 
         if not self.use_policy_gradient and self.loss_mode == "k1":
             raise ValueError(
                 "Directly backpropagating k1 loss is incorrect since gradient of k1 loss"
                 " wrt model weights does not depend on teacher log probabilities."
             )
+
+    def get_teacher_logprob_topk(self) -> Optional[int]:
+        """Return how many teacher top log-probs to request for this loss mode."""
+        if self.loss_mode == "reverse_kl_student_topk":
+            if self.reverse_kl_teacher_logprob_topk is None:
+                return self.topk
+            return self.reverse_kl_teacher_logprob_topk
+        return self.topk
 
 
 @dataclass
@@ -202,7 +244,7 @@ class DistillationTeacherModelConfig(BaseConfig):
                     max_logprobs = topk
                 if max_logprobs < topk:
                     raise ValueError(
-                        f"VLLM max_logprobs ({max_logprobs}) must be >= distillation_loss topk "
+                        f"VLLM max_logprobs ({max_logprobs}) must be >= requested teacher logprob top-k "
                         f"({topk}) to enable distillation loss computation."
                     )
                 engine_kwargs["vllm"] = vllm_engine_kwargs
@@ -275,7 +317,7 @@ class DistillationConfig(BaseConfig):
         for teacher_model in self.teacher_models.values():
             teacher_model.validate_and_prepare_for_distillation(
                 use_topk=self.distillation_loss.loss_settings.use_topk,
-                topk=self.distillation_loss.topk,
+                topk=self.distillation_loss.get_teacher_logprob_topk(),
             )
             teacher_world_size_sum += teacher_model.world_size
         total_pool_size = self.n_gpus_per_node * self.nnodes

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -827,6 +827,15 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
         if use_fused_kernels and use_remove_padding:
+            distillation_loss_mode = tu.get_non_tensor_data(data=micro_batch, key="distillation_loss_mode", default=None)
+            distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
+            if distillation_use_topk and distillation_loss_mode is None:
+                raise ValueError("Top-k distillation with fused kernels requires distillation_loss_mode in the batch.")
+            if distillation_loss_mode == "reverse_kl_student_topk":
+                raise NotImplementedError(
+                    "reverse_kl_student_topk needs student logits to build the student top-k support. "
+                    "Set actor_rollout_ref.model.use_fused_kernels=False for this loss mode."
+                )
             input_ids_rmpad = model_inputs["input_ids"]
             shift_labels = output_args["input_ids_rmpad_rolled"].unsqueeze(0)
             model_inputs["labels"] = input_ids_rmpad
@@ -837,7 +846,6 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             # chunk_topk_distill_function for fused distillation. TD keys
             # teacher_ids / teacher_logprobs are populated by verl's native
             # distillation pipeline (see verl/trainer/distillation/losses.py).
-            distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
             if distillation_use_topk and "teacher_ids" in micro_batch.keys():
                 if "teacher_logprobs" not in micro_batch.keys():
                     raise ValueError(


### PR DESCRIPTION
## What

Add `reverse_kl_student_topk` as a top-k distillation loss mode.

This includes:
- FSDP/VeOmni reverse KL student top-k support
- Megatron reverse KL student top-k support
- teacher log-prob lookup on student top-k ids
- raw mass metrics before clamp
- missing teacher fallback excluded from teacher mass
- CPU regression coverage for metrics and Megatron dispatch

## Tests

- `pytest -q tests/workers/test_distillation_topk_symmetry_on_cpu.py`
- Megatron world-size=1 mock forward/backward parity against a pure PyTorch reference