### PR TITLE
[cfg, ckpt] fix: expose every CheckpointConfig field in the trainer YAMLs

### DIFF
--- a/tests/special_sanity/test_checkpoint_config_parity.py
+++ b/tests/special_sanity/test_checkpoint_config_parity.py
@@ -1,0 +1,76 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Every ``CheckpointConfig`` field must be reachable from the command line.
+
+Hydra composes the trainer configs in struct mode, so a key that is absent from
+the YAML cannot be set with a plain ``a.b.c=value`` override -- the user gets
+``Could not override ... To append to your config use +a.b.c=value`` even though
+the dataclass declares the field and the docs describe it. Adding a field to
+``CheckpointConfig`` without adding it to the YAML therefore ships a knob that
+looks configurable and is not.
+
+This walks the composed configs, finds every node whose ``_target_`` is
+``CheckpointConfig`` or a subclass, and asserts the node exposes every field the
+dataclass declares.
+"""
+
+import os
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+from hydra import compose, initialize_config_dir
+from hydra.utils import get_class
+from omegaconf import DictConfig
+
+from verl.trainer.config import CheckpointConfig
+
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "verl" / "trainer" / "config"
+
+# Top-level configs that own at least one checkpoint block.
+TRAINER_CONFIGS = ["ppo_trainer", "ppo_megatron_trainer", "sft_trainer_engine"]
+
+
+def _checkpoint_nodes(node: DictConfig, path: str = ""):
+    """Yield ``(path, node, cls)`` for every CheckpointConfig node under ``node``."""
+    target = node["_target_"] if "_target_" in node else None
+    if target:
+        cls = get_class(str(target))
+        if isinstance(cls, type) and issubclass(cls, CheckpointConfig):
+            yield path, node, cls
+
+    for key in node:
+        child = node._get_node(key)
+        if isinstance(child, DictConfig):
+            yield from _checkpoint_nodes(child, f"{path}.{key}" if path else key)
+
+
+@pytest.mark.parametrize("config_name", TRAINER_CONFIGS)
+def test_checkpoint_config_fields_are_all_in_yaml(config_name):
+    with initialize_config_dir(config_dir=os.fspath(CONFIG_DIR), version_base=None):
+        cfg = compose(config_name=config_name)
+
+    found = list(_checkpoint_nodes(cfg))
+    assert found, f"no CheckpointConfig node found in {config_name}.yaml"
+
+    missing = {
+        path: sorted(f.name for f in fields(cls) if f.name not in node)
+        for path, node, cls in found
+        if any(f.name not in node for f in fields(cls))
+    }
+    assert not missing, (
+        f"{config_name}.yaml: checkpoint fields declared on the dataclass but absent from the YAML, "
+        f"so `{config_name}.py ... <path>.<field>=<value>` is rejected by Hydra: {missing}"
+    )

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -143,6 +143,7 @@ actor_rollout_ref:
       load_contents: ${.save_contents}
       async_save: false
       strict: true
+      save_lora_only: false
       mbridge_config: {}
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
@@ -660,6 +661,8 @@ critic:
     - extra
     load_contents: ${.save_contents}
     async_save: false
+    strict: true
+    save_lora_only: false
     mbridge_config: {}
   profiler:
     _target_: verl.utils.profiler.ProfilerConfig

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -96,6 +96,7 @@ actor_rollout_ref:
       load_contents: ${.save_contents}
       async_save: false
       strict: true
+      save_lora_only: false
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig
@@ -557,6 +558,8 @@ critic:
     - extra
     load_contents: ${.save_contents}
     async_save: false
+    strict: true
+    save_lora_only: false
   profiler:
     _target_: verl.utils.profiler.ProfilerConfig
     tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -120,6 +120,7 @@ actor_rollout_ref:
       load_contents: ${.save_contents}
       async_save: false
       strict: true
+      save_lora_only: false
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig
@@ -622,6 +623,8 @@ critic:
     - extra
     load_contents: ${.save_contents}
     async_save: false
+    strict: true
+    save_lora_only: false
   profiler:
     _target_: verl.utils.profiler.ProfilerConfig
     tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -112,6 +112,7 @@ actor_rollout_ref:
       load_contents: ${.save_contents}
       async_save: false
       strict: true
+      save_lora_only: false
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig
@@ -591,6 +592,8 @@ critic:
     - extra
     load_contents: ${.save_contents}
     async_save: false
+    strict: true
+    save_lora_only: false
   profiler:
     _target_: verl.utils.profiler.ProfilerConfig
     tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -144,6 +144,11 @@ checkpoint:
   # Whether to perform strict validation during weight export
   strict: True
 
+  # When the model has LoRA adapters, save only the adapter weights instead of the
+  # full model state dict. LoRA-only checkpoints are detected and merged on load.
+  # No effect when the model has no LoRA adapters.
+  save_lora_only: False
+
 # optimizer configs
 optim:
 

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -83,6 +83,14 @@ checkpoint:
   # Whether to save checkpoints asynchronously. Only effective for Megatron as of now.
   async_save: False
 
+  # Whether to perform strict validation during weight export
+  strict: True
+
+  # When the model has LoRA adapters, save only the adapter weights instead of the
+  # full model state dict. LoRA-only checkpoints are detected and merged on load.
+  # No effect when the model has no LoRA adapters.
+  save_lora_only: False
+
 # profile the critic model in `update_critic`
 profiler:
 

--- a/verl/trainer/config/sft_trainer_engine.yaml
+++ b/verl/trainer/config/sft_trainer_engine.yaml
@@ -56,6 +56,17 @@ checkpoint:
   # For more flexibility, you can specify the contents to load from the checkpoint.
   load_contents: ${checkpoint.save_contents}
 
+  # Whether to save checkpoints asynchronously. Only effective for Megatron as of now.
+  async_save: False
+
+  # Whether to perform strict validation during weight export
+  strict: True
+
+  # When the model has LoRA adapters, save only the adapter weights instead of the
+  # full model state dict. LoRA-only checkpoints are detected and merged on load.
+  # No effect when the model has no LoRA adapters.
+  save_lora_only: False
+
 trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
   default_hdfs_dir: null


### PR DESCRIPTION
### What does this PR do?

Adds the `CheckpointConfig` fields that exist on the dataclass but are missing from the trainer YAMLs, so they can be set from the command line.

Hydra composes these configs in struct mode, so a key that is not in the backing YAML cannot be set with a plain `a.b.c=value` override, even though the dataclass declares it and the docs describe it. `docs/advance/checkpoint.rst` and `docs/examples/config.rst` both tell users to set `checkpoint.save_lora_only`, and that override is currently rejected.

Closes #7387. That issue reports the actor case; #7388 by @yuxuan-z19 fixes `actor/actor.yaml`. The same drift is also present in `critic/critic.yaml` (missing `strict` and `save_lora_only`) and `sft_trainer_engine.yaml` (missing `async_save`, `strict` and `save_lora_only`), and the checked-in `_generated_*_trainer.yaml` artifacts need regenerating either way, so this covers all three files plus a test that keeps them in sync. Happy to close this in favour of #7388 if the maintainers would rather land the actor fix on its own and take the rest separately.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+save_lora_only — found #7388, referenced above.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Before, on `main`:

```
$ python -c "
from hydra import compose, initialize_config_dir
with initialize_config_dir(config_dir='verl/trainer/config', version_base=None):
    compose('ppo_trainer', overrides=['critic.checkpoint.strict=False'])"
hydra.errors.ConfigCompositionException: Could not override 'critic.checkpoint.strict'.
To append to your config use +critic.checkpoint.strict=False
```

After, the same override composes, and `critic.checkpoint.strict` is `False` in the resolved config.

New test `tests/special_sanity/test_checkpoint_config_parity.py` walks the composed `ppo_trainer`, `ppo_megatron_trainer` and `sft_trainer_engine` configs, finds every node whose `_target_` is `CheckpointConfig` or a subclass, and asserts the node exposes every field the dataclass declares. It discovers the checkpoint blocks by target rather than by hardcoded path, so a new checkpoint block or a new dataclass field is covered without touching the test. It fails on all three configs before this change and passes after. `tests/special_sanity` runs in the `sanity` workflow on `**/*.py` changes, which is the change that introduces this kind of drift in the first place.

Ran locally on CPU: `tests/special_sanity` 20 passed, `tests/utils/test_config_on_cpu.py` and `tests/workers/config/` unchanged, `scripts/generate_trainer_config.sh` reports `All good`, pre-commit `ruff` and `check_license` clean.

The instantiated config objects are unchanged. The YAML defaults match the dataclass defaults, so `omega_conf_to_dataclass` produces byte-identical `CheckpointConfig` objects for every checkpoint node before and after. Only the set of accepted Hydra overrides grows.

### API and Usage Example

These now work instead of raising `ConfigCompositionException`:

```bash
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.actor.checkpoint.save_lora_only=True \
    critic.checkpoint.strict=False \
    critic.checkpoint.save_lora_only=True
```

```bash
python3 -m verl.trainer.main_ppo --config-name=sft_trainer_engine \
    checkpoint.async_save=True \
    checkpoint.strict=False \
    checkpoint.save_lora_only=True
```

### Design & Code Changes

- `verl/trainer/config/actor/actor.yaml`: add `save_lora_only`.
- `verl/trainer/config/critic/critic.yaml`: add `strict`, `save_lora_only`.
- `verl/trainer/config/sft_trainer_engine.yaml`: add `async_save`, `strict`, `save_lora_only`.
- `verl/trainer/config/_generated_{ppo,ppo_megatron,ppo_veomni,ppo_torchtitan}_trainer.yaml`: regenerated with `scripts/generate_trainer_config.sh`. Three lines each, no other churn.
- `tests/special_sanity/test_checkpoint_config_parity.py`: new.

All added values equal the dataclass defaults, so no existing run changes behaviour.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [x] Documentation: `docs/advance/checkpoint.rst` and `docs/examples/config.rst` already document these flags. No docs change needed; this makes the existing docs accurate.
- [x] Add unit or end-to-end test(s) to the CI workflow: `tests/special_sanity/test_checkpoint_config_parity.py`, picked up by the existing `sanity` workflow.
- [ ] Send a message in the `ci-request` channel.
- [x] Not related to the `recipe` submodule.
