### PR TITLE
[fsdp] fix: prevent FSDP2 backward failure with fused untied LM heads

### DIFF
--- a/tests/utils/test_fsdp2_peft_wrapping.py
+++ b/tests/utils/test_fsdp2_peft_wrapping.py
@@ -69,9 +69,9 @@ class MockCausalLM(nn.Module):
 class TestFSDP2PeftWrapping(unittest.TestCase):
     """Test module selection in apply_fsdp2 for vanilla and peft-wrapped models."""
 
-    def _get_wrapped_names(self, model, cls_names):
+    def _get_wrapped_names(self, model, cls_names, *, use_fused_kernels=False):
         """Return names of modules selected for wrapping."""
-        selected = _select_fsdp2_wrap_targets(model, cls_names)
+        selected = _select_fsdp2_wrap_targets(model, cls_names, use_fused_kernels=use_fused_kernels)
         # _select_fsdp2_wrap_targets returns module objects; map back to names
         module_to_name = {id(m): n for n, m in model.named_modules()}
         return [module_to_name[id(m)] for m in selected]
@@ -96,6 +96,14 @@ class TestFSDP2PeftWrapping(unittest.TestCase):
 
         self.assertIn("model.embed_tokens", names)
         self.assertIn("lm_head", names)
+        self.assertTrue(any("layers.0" in n for n in names))
+
+    def test_fused_model_keeps_untied_lm_head_in_root(self):
+        model = MockCausalLM(tie_word_embeddings=False)
+        names = self._get_wrapped_names(model, ["MockDecoderLayer"], use_fused_kernels=True)
+
+        self.assertIn("model.embed_tokens", names)
+        self.assertNotIn("lm_head", names)
         self.assertTrue(any("layers.0" in n for n in names))
 
     def test_tied_embeddings_skips_name_based_wrapping(self):

--- a/tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
+++ b/tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -20,9 +21,11 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 from tensordict import TensorDict
 from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.fsdp import FSDPModule, MixedPrecisionPolicy, ShardingStrategy, fully_shard
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp import ShardingStrategy, fully_shard
+from torch.distributed.tensor import DTensor
 
+from verl.utils.fsdp_utils import apply_fsdp2
 from verl.workers.engine.fsdp import transformer_impl
 from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
 
@@ -215,6 +218,71 @@ def test_distributed_accumulation_matches_per_micro_batch_sync(tmp_path):
     rendezvous_file = str(tmp_path / "fsdp_rdzv")
     mp.spawn(
         _distributed_equivalence_worker,
+        args=(world_size, rendezvous_file),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+class _DirectWeightCausalLM(torch.nn.Module):
+    """Minimal untied model matching the Torch fused LM-head access pattern."""
+
+    _no_split_modules = ["Qwen3_5DecoderLayer"]
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(tie_word_embeddings=False)
+        self.embed_tokens = torch.nn.Embedding(16, 8)
+        self.lm_head = torch.nn.Linear(8, 16, bias=False)
+
+    def forward(self, input_ids):
+        hidden_states = self.embed_tokens(input_ids)
+        vocab_weights = self.lm_head.weight
+        if isinstance(vocab_weights, DTensor):
+            vocab_weights = vocab_weights.full_tensor()
+        hidden_states = hidden_states.to(vocab_weights.dtype)
+        return hidden_states @ vocab_weights.t()
+
+
+def _direct_weight_deferred_sync_worker(rank, world_size, rendezvous_file):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        mesh = init_device_mesh("cpu", (world_size,))
+        model = _DirectWeightCausalLM()
+        apply_fsdp2(
+            model,
+            {
+                "mesh": mesh,
+                "mp_policy": MixedPrecisionPolicy(
+                    param_dtype=torch.bfloat16,
+                    reduce_dtype=torch.float32,
+                    cast_forward_inputs=True,
+                ),
+                "reshard_after_forward": True,
+            },
+            {"use_fused_kernels": True},
+        )
+        assert not isinstance(model.lm_head, FSDPModule)
+
+        engine = _make_engine(model)
+        for micro_batch_idx in range(2):
+            with engine._gradient_sync_context(is_last_micro_batch=micro_batch_idx == 1):
+                input_ids = torch.tensor([[rank, micro_batch_idx + 1]], dtype=torch.long)
+                model(input_ids).float().square().sum().backward()
+    finally:
+        dist.destroy_process_group()
+
+
+def test_fsdp2_deferred_sync_with_fused_direct_weight_access(tmp_path):
+    world_size = 2
+    rendezvous_file = str(tmp_path / "fsdp_direct_weight_rdzv")
+    mp.spawn(
+        _direct_weight_deferred_sync_worker,
         args=(world_size, rendezvous_file),
         nprocs=world_size,
         join=True,

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -534,17 +534,20 @@ def maybe_patch_fsdp_module(model):
         fully_shard_module.FSDPModule = orig_fsdp_module
 
 
-def _select_fsdp2_wrap_targets(model, fsdp_transformer_layer_cls_to_wrap):
+def _select_fsdp2_wrap_targets(model, fsdp_transformer_layer_cls_to_wrap, *, use_fused_kernels=False):
     """Select modules to wrap individually with fully_shard in FSDP2.
 
     Matches transformer layers by class name, and embed_tokens/lm_head by name
     (with isinstance fallback). Name-based matching is needed because peft wraps
     embed_tokens in ModulesToSaveWrapper, breaking isinstance(module, nn.Embedding).
     When tie_word_embeddings is True, embed_tokens and lm_head share weights and
-    must not be wrapped separately.
+    must not be wrapped separately. Fused forwards access lm_head.weight directly,
+    so an untied lm_head remains in the root FSDP unit that owns its forward lifecycle.
     """
     _tie = getattr(model.config, "tie_word_embeddings", False)
-    _wrap_by_name = set() if _tie else {"embed_tokens", "lm_head"}
+    _wrap_by_name = set() if _tie else {"embed_tokens"}
+    if not _tie and not use_fused_kernels:
+        _wrap_by_name.add("lm_head")
 
     modules = []
     for name, module in model.named_modules():
@@ -574,7 +577,11 @@ def apply_fsdp2(model, fsdp_kwargs, config):
         fsdp_transformer_layer_cls_to_wrap = list(fsdp_transformer_layer_cls_to_wrap)
     assert len(fsdp_transformer_layer_cls_to_wrap) > 0 and fsdp_transformer_layer_cls_to_wrap[0] is not None
 
-    modules = _select_fsdp2_wrap_targets(model, fsdp_transformer_layer_cls_to_wrap)
+    modules = _select_fsdp2_wrap_targets(
+        model,
+        fsdp_transformer_layer_cls_to_wrap,
+        use_fused_kernels=config.get("use_fused_kernels", False),
+    )
 
     for idx, module in enumerate(modules):
         # if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:


### PR DESCRIPTION
`[fsdp] fix: prevent FSDP2 backward failure with fused untied LM heads`

Manage fused untied LM heads as part of the root FSDP2 unit so direct weight access follows a valid FSDP lifecycle during deferred gradient synchronization.

### What does this PR do?

I encountered this while running Qwen3.5-9B with FSDP2, gradient accumulation, and `use_fused_kernels=true` on the Torch backend. Rollout completed, but the first actor backward failed on every rank with:

```text
AttributeError: 'FSDPParam' object has no attribute '_unsharded_param'
```

The failure comes from the interaction of three existing behaviors:

- the fused path reads `lm_head.weight` directly instead of invoking `lm_head.forward()`;
- untied `lm_head` is wrapped as an independent FSDP2 child;
- gradient synchronization is deferred on non-final micro-batches.

Because the fused path bypasses the child module call, the `lm_head` child does not enter its normal FSDP2 forward lifecycle before deferred backward handling expects its unsharded parameter state.

This PR only changes the wrapping decision for fused, untied models: `embed_tokens` remains an independent child, while `lm_head` is managed by the root FSDP2 unit. The fused computation and output contract are unchanged, and no model-specific branch is added.

The relevant behavior was introduced across [#1212](https://github.com/verl-project/verl/pull/1212) and [#462](https://github.com/verl-project/verl/pull/462) (fused direct-weight loss), [#5516](https://github.com/verl-project/verl/pull/5516) (untied-head wrapping), [#5682](https://github.com/verl-project/verl/pull/5682) (the Qwen3.5 adapter), [#6482](https://github.com/verl-project/verl/pull/6482) (DTensor materialization), and [#7095](https://github.com/verl-project/verl/pull/7095) (deferred synchronization).

#### Scope and trade-off

The head remains sharded by FSDP2 as part of the root unit; it is not replicated. Moving it from an independent child to the root can lengthen its unsharded lifetime and may affect peak memory or communication overlap.

For Qwen3.5-9B, the BF16 head has shape `[248320, 4096]` and is approximately 1.9 GiB. The fused Qwen3.5 path already materializes it with `DTensor.full_tensor()`, so this PR changes ownership and lifecycle rather than introducing that materialization. I have not measured full actor peak memory before and after the change and do not claim that it is memory-neutral.

### Checklist Before Starting

- [x] Searched for similar open PRs:
  - [`FSDP2 fused lm_head`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+FSDP2+fused+lm_head)
  - [`_unsharded_param`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+_unsharded_param)
  - No matching open PR was found at the time of writing.
- [x] Formatted the title as `[{modules}] {type}: {description}`.

### Test

```bash
python -m pytest -q \
  tests/utils/test_fsdp2_peft_wrapping.py \
  tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
```

```text
13 passed, 6 warnings in 143.82s
```

The combined suites cover the existing tied, untied, and PEFT wrapping behavior, the new fused + untied ownership case, and a two-rank direct-weight model completing two micro-batches with deferred synchronization. The original workload failed with the `_unsharded_param` error. The committed regression covers the corrected ownership decision and exercises direct-weight access across two micro-batches with deferred synchronization.

Static checks also passed:

```bash
pre-commit run ruff --files \
  verl/utils/fsdp_utils.py \
  tests/utils/test_fsdp2_peft_wrapping.py \
  tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
git diff --check
pre-commit run --all-files --show-diff-on-failure --color=always
```

### API and Usage Example

There is no new public API, configuration option, checkpoint field, or model-specific branch. FSDP1, tied-weight models, and configurations with `use_fused_kernels=false` retain their previous wrapping behavior.

### Design & Code Changes

- Pass the existing `use_fused_kernels` setting to the private FSDP2 wrap-target selector.
- For fused, untied models, leave `lm_head` to the existing root `fully_shard(model)` call.
- Extend existing CPU test files with ownership and deferred-sync regression coverage.

The implementation does not modify model adapters, fused-loss math, gradient-sync logic, PyTorch private state, or downstream PPO outputs.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md) and repository `AGENTS.md`.
- [x] Ran the full pre-commit checks.
- [x] No documentation update is required because there is no public API or configuration change.
- [x] Added coverage to existing CPU test files; no CI workflow change is required.
- [x] Request CI in the [`ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) or the [Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).
- [x] Recipe submodule update is not applicable.

### AI Assistance Disclosure

OpenAI Codex assisted with code analysis, implementation, testing, and drafting. The submitter reviewed the final changes and is responsible for the submission.

Assisted-by: OpenAI Codex
