### PR TITLE
[fsdp] fix: skip no-op unit temperature scaling

### DIFF
--- a/tests/workers/test_fsdp_temperature_scaling_on_cpu.py
+++ b/tests/workers/test_fsdp_temperature_scaling_on_cpu.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from verl.workers.engine.fsdp.transformer_impl import (
+    _is_scalar_unit_temperature,
+    _scale_logits_by_temperature,
+)
+
+
+@pytest.mark.parametrize("temperature", [1, 1.0])
+def test_scalar_unit_temperature_is_detected(temperature):
+    assert _is_scalar_unit_temperature(temperature) is True
+
+
+@pytest.mark.parametrize("temperature", [0.7, 2.0, torch.tensor(1.0)])
+def test_non_unit_or_tensor_temperature_uses_general_path(temperature):
+    assert _is_scalar_unit_temperature(temperature) is False
+
+
+def test_unit_temperature_preserves_logits_storage_and_gradient():
+    base = torch.randn(1, 4, 8, requires_grad=True)
+    logits_view = base.squeeze(0)
+
+    scaled = _scale_logits_by_temperature(
+        logits_view,
+        torch.ones(4, 1),
+        is_unit_temperature=True,
+    )
+
+    assert scaled is logits_view
+    scaled.sum().backward()
+    torch.testing.assert_close(base.grad, torch.ones_like(base))
+
+
+def test_non_unit_temperature_is_out_of_place_and_has_correct_gradient():
+    logits = torch.randn(4, 8, requires_grad=True)
+    temperature = torch.full((4, 1), 0.5)
+
+    scaled = _scale_logits_by_temperature(
+        logits,
+        temperature,
+        is_unit_temperature=False,
+    )
+
+    assert scaled is not logits
+    torch.testing.assert_close(scaled, logits * 2)
+    scaled.sum().backward()
+    torch.testing.assert_close(logits.grad, torch.full_like(logits, 2))

--- a/tests/workers/test_fsdp_temperature_scaling_on_cpu.py
+++ b/tests/workers/test_fsdp_temperature_scaling_on_cpu.py
@@ -1,6 +1,6 @@
 # Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0(the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -84,6 +84,20 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 device_name = get_device_name()
 
 
+def _is_scalar_unit_temperature(temperature) -> bool:
+    """Return whether a host scalar temperature makes scaling a no-op."""
+
+    return not isinstance(temperature, torch.Tensor) and float(temperature) == 1.0
+
+
+def _scale_logits_by_temperature(logits, temperature, *, is_unit_temperature: bool):
+    """Scale logits without copying the full vocabulary tensor for temperature 1."""
+
+    if is_unit_temperature:
+        return logits
+    return logits / temperature.clamp(min=1e-8).to(logits.dtype)
+
+
 class FSDPEngine(BaseEngine):
     """
     Concrete Engine implementation using PyTorch FullyShardedDataParallel (FSDP).
@@ -1130,6 +1144,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
         temperature = micro_batch["temperature"]
         temperature_item = temperature
+        temperature_is_one = _is_scalar_unit_temperature(temperature)
         if use_fused_kernels:
             assert not isinstance(temperature, torch.Tensor), (
                 "use_fused_kernels does not support per sample temperature yet"
@@ -1148,7 +1163,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
         assert temperature.shape[0] == input_ids.shape[0]
 
         # args used to get outputs
-        output_args = {}
+        output_args = {"temperature_is_one": temperature_is_one}
 
         if use_remove_padding:
             # support per sample temperature
@@ -1349,7 +1364,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 # With TP, logits are DTensors sharded on vocab dim; gather for log_softmax.
                 if isinstance(logits_rmpad, DTensor):
                     logits_rmpad = logits_rmpad.full_tensor()
-                logits_rmpad = logits_rmpad / temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype)
+                logits_rmpad = _scale_logits_by_temperature(
+                    logits_rmpad,
+                    temperature_rmpad.unsqueeze(-1),
+                    is_unit_temperature=output_args["temperature_is_one"],
+                )
 
                 log_probs = None
 
@@ -1442,7 +1461,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 # With TP, logits are DTensors sharded on vocab dim; gather for log_softmax.
                 if isinstance(logits, DTensor):
                     logits = logits.full_tensor()
-                logits = logits / temperature.clamp(min=1e-8).to(logits.dtype)
+                logits = _scale_logits_by_temperature(
+                    logits,
+                    temperature,
+                    is_unit_temperature=output_args["temperature_is_one"],
+                )
 
                 if calculate_entropy:
                     if not self.engine_config.entropy_checkpointing:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1334,6 +1334,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
         model_output = {}
 
+        # Some internal callers construct output_args directly instead of going
+        # through prepare_model_inputs. Without the optimization metadata, fall
+        # back to the original out-of-place scaling path.
+        temperature_is_one = output_args.get("temperature_is_one", False)
+
         input_ids = micro_batch["input_ids"]
 
         if use_remove_padding:
@@ -1367,7 +1372,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 logits_rmpad = _scale_logits_by_temperature(
                     logits_rmpad,
                     temperature_rmpad.unsqueeze(-1),
-                    is_unit_temperature=output_args["temperature_is_one"],
+                    is_unit_temperature=temperature_is_one,
                 )
 
                 log_probs = None
@@ -1464,7 +1469,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 logits = _scale_logits_by_temperature(
                     logits,
                     temperature,
-                    is_unit_temperature=output_args["temperature_is_one"],
+                    is_unit_temperature=temperature_is_one,
                 )
 
                 if calculate_entropy:


### PR DESCRIPTION
Preserve the original logits tensor when a host scalar temperature is exactly one, avoiding a full-vocabulary allocation while retaining the safe out-of-place path for non-unit and per-sample temperatures.

### What does this PR do?

This PR avoids an unnecessary full-vocabulary logits allocation in the FSDP eager log-probability path when the configured temperature is a host scalar equal to `1`.

[#6935](https://github.com/verl-project/verl/pull/6935) changed temperature scaling from an in-place operation to a safe out-of-place operation because `output.logits.squeeze(0)` may return a view backed by a custom autograd function. However, the out-of-place division still allocates a logits-sized tensor when `temperature == 1`, even though the operation is mathematically a no-op.

This change:

- Detects host scalar temperatures equal to `1` before temperature tensors are expanded.
- Reuses the original logits tensor for unit temperature.
- Preserves the existing safe out-of-place scaling for non-unit temperatures.
- Preserves the existing behavior for tensor and per-sample temperatures.
- Applies consistently to both remove-padding and padded FSDP eager paths.

Related PRs:

- [#6935: FSDP logits temperature scaling for view tensors](https://github.com/verl-project/verl/pull/6935)
- [#6945: FSDP logits temperature scaling for view tensors](https://github.com/verl-project/verl/pull/6945)

### Checklist Before Starting

- [x] Search for similar PRs. Query: [FSDP temperature scaling PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr+FSDP+temperature+scaling)
- [x] Format the PR title as `[{modules}] {type}: {description}`.
  - PR title: `[fsdp] fix: skip no-op unit temperature scaling`
  - This change does not introduce a breaking API or configuration change.

### Test

Added `tests/workers/test_fsdp_temperature_scaling_on_cpu.py` covering:

- Detection of Python scalar temperatures `1` and `1.0`.
- Rejection of non-unit scalar temperatures from the fast path.
- Rejection of tensor temperatures from the host-scalar fast path.
- Preservation of the original logits storage for unit temperature.
- Correct gradient propagation for unit temperature.
- Preservation of out-of-place behavior for non-unit temperatures.
- Correct values and gradients for non-unit temperature scaling.

Test command:

```bash
python -m pytest tests/workers/test_fsdp_temperature_scaling_on_cpu.py -q
```

Local execution status:

```text
Not executed in the current local environment because pytest is not installed.
The test file is included and should be executed by CI or in a development
environment with the VERL test dependencies installed.
```

Accelerator end-to-end validation is still recommended because the motivating peak-memory behavior occurs in the FSDP accelerator path with large vocabulary logits.

### API and Usage Example

This PR does not change any public API or configuration.

Existing configurations continue to work without modification:

```yaml
actor_rollout_ref:
  rollout:
    temperature: 1
```

The behavior is internally selected as follows:

```python
if temperature_is_host_scalar_one:
    scaled_logits = logits
else:
    scaled_logits = logits / temperature.clamp(min=1e-8).to(logits.dtype)
```

Tensor and per-sample temperatures continue to use the general out-of-place path.

### Design & Code Changes

The implementation introduces two focused helpers:

```python
_is_scalar_unit_temperature(temperature)
_scale_logits_by_temperature(
    logits,
    temperature,
    is_unit_temperature=...,
)
```

`_is_scalar_unit_temperature()` only recognizes non-tensor host scalars equal to `1`. Tensor temperatures deliberately remain on the general path to avoid device synchronization and to preserve per-sample temperature semantics.

The unit-temperature decision is made before the temperature is converted or expanded for individual samples. The resulting flag is passed through `output_args` and consumed in both FSDP eager logits branches:

- The remove-padding path operating on `logits_rmpad`.
- The padded path operating on batched `logits`.

For unit temperature, the helper returns the original logits object without performing an in-place mutation. This avoids the full-vocabulary allocation while retaining the autograd safety introduced by #6935.

For non-unit and per-sample temperatures, the existing out-of-place division remains unchanged.

This is a narrowly scoped peak-memory optimization. It does not change or attempt to address other memory contributors such as FSDP gradient accumulation, deferred gradient synchronization, rollout engine allocations, or speculative decoding workers.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#pre-commit): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Documentation update is not required because this PR does not change any public API, configuration, or user-facing behavior.
- [x] Add unit tests under the existing test suite. No CI workflow modification is required because the test is placed under the existing `tests/workers/` pytest discovery path.
- [ ] Run the focused unit tests in an environment with the VERL test dependencies installed.
- [ ] Run accelerator/FSDP validation to confirm the expected peak-memory reduction.
- [ ] Once the PR is ready for CI, send a message in the [`ci-request` channel](https://verl-workspace.slack.com/archives/C091TCESWB1) in the [`verl` Slack workspace](https://join.slack.com/t/verl-workspace/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). If Slack is not accessible, use the [Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).
- [x] Recipe submodule update is not applicable to this change.
