### PR TITLE
[rollout] fix: add missing RolloutConfig keys to rollout.yaml

### DIFF
--- a/tests/special_sanity/test_rollout_config_parity.py
+++ b/tests/special_sanity/test_rollout_config_parity.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Every RolloutConfig field must have a key in rollout.yaml.
+
+Hydra runs in struct mode, so a dataclass field with no YAML counterpart cannot be
+set with a plain ``a.b.c=value`` override -- the run aborts with
+ConfigCompositionException. Fields listed in KNOWN_UNMAPPED have no YAML key yet;
+anything else that drifts fails here instead of at a user's first training run.
+"""
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+from hydra import compose, initialize_config_dir
+
+from verl.workers.config import RolloutConfig
+
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "verl" / "trainer" / "config"
+
+# Fields that are deliberately not exposed in rollout.yaml.
+KNOWN_UNMAPPED = {
+    # Mandatory (???) in the YAML, so OmegaConf reports it as absent.
+    "name",
+    # Nested ServerConfig block; read by the trtllm rollout only.
+    "server",
+    # No reader in the tree.
+    "custom",
+    "layer_name_map",
+    "sglang_engine_mode",
+}
+
+
+def _rollout_node(config_name):
+    with initialize_config_dir(config_dir=str(CONFIG_DIR), version_base=None):
+        return compose(config_name=config_name).actor_rollout_ref.rollout
+
+
+@pytest.mark.parametrize("config_name", ["ppo_trainer", "ppo_megatron_trainer"])
+def test_every_field_is_reachable(config_name):
+    node = _rollout_node(config_name)
+    missing = sorted(f.name for f in fields(RolloutConfig) if f.name not in node and f.name not in KNOWN_UNMAPPED)
+    assert not missing, (
+        f"{config_name}: RolloutConfig fields {missing} have no key in rollout.yaml, so "
+        f"actor_rollout_ref.rollout.<field>=... is rejected by Hydra. Add each one to "
+        f"verl/trainer/config/rollout/rollout.yaml, or to KNOWN_UNMAPPED if it is not "
+        f"meant to be set from the command line."
+    )
+
+
+@pytest.mark.parametrize("config_name", ["ppo_trainer", "ppo_megatron_trainer"])
+def test_known_unmapped_is_not_stale(config_name):
+    node = _rollout_node(config_name)
+    mapped = sorted(name for name in KNOWN_UNMAPPED if name in node)
+    assert not mapped, f"{config_name}: {mapped} are in rollout.yaml now; drop them from KNOWN_UNMAPPED"

--- a/tests/special_sanity/test_rollout_config_parity.py
+++ b/tests/special_sanity/test_rollout_config_parity.py
@@ -34,8 +34,6 @@ CONFIG_DIR = Path(__file__).resolve().parents[2] / "verl" / "trainer" / "config"
 KNOWN_UNMAPPED = {
     # Mandatory (???) in the YAML, so OmegaConf reports it as absent.
     "name",
-    # Nested ServerConfig block; read by the trtllm rollout only.
-    "server",
     # No reader in the tree.
     "custom",
     "layer_name_map",

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -310,20 +310,24 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    repetition_penalty: 1.0
     full_determinism: false
     seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
     gpu_memory_utilization: 0.5
+    standalone_gpu_memory_utilization: null
     ignore_eos: false
     enforce_eager: false
     cudagraph_capture_sizes: null
     free_cache_engine: true
+    enable_sleep_mode: true
     tensor_model_parallel_size: 2
     data_parallel_size: 1
     expert_parallel_size: 1
     pipeline_model_parallel_size: 1
+    moe_tensor_parallel_size: 1
     max_num_batched_tokens: 8192
     max_model_len: null
     max_num_seqs: 256
@@ -342,6 +346,7 @@ actor_rollout_ref:
     'n': 1
     over_sample_rate: 0
     multi_stage_wake_up: false
+    limit_images: null
     engine_kwargs:
       vllm: {}
       sglang: {}
@@ -377,6 +382,7 @@ actor_rollout_ref:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null
         name: null
+    checkpoint_manager_class: null
     checkpoint_engine:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -431,6 +431,13 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
           strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
+    server:
+      _target_: verl.workers.config.ServerConfig
+      timeout: 60.0
+      max_attempts: 3
+      retry_delay: 2.0
+      max_connections: 1000
+      max_start_wait_time: 300.0
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -254,20 +254,24 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    repetition_penalty: 1.0
     full_determinism: false
     seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
     gpu_memory_utilization: 0.5
+    standalone_gpu_memory_utilization: null
     ignore_eos: false
     enforce_eager: false
     cudagraph_capture_sizes: null
     free_cache_engine: true
+    enable_sleep_mode: true
     tensor_model_parallel_size: 2
     data_parallel_size: 1
     expert_parallel_size: 1
     pipeline_model_parallel_size: 1
+    moe_tensor_parallel_size: 1
     max_num_batched_tokens: 8192
     max_model_len: null
     max_num_seqs: 256
@@ -286,6 +290,7 @@ actor_rollout_ref:
     'n': 1
     over_sample_rate: 0
     multi_stage_wake_up: false
+    limit_images: null
     engine_kwargs:
       vllm: {}
       sglang: {}
@@ -321,6 +326,7 @@ actor_rollout_ref:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null
         name: null
+    checkpoint_manager_class: null
     checkpoint_engine:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -375,6 +375,13 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
           strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
+    server:
+      _target_: verl.workers.config.ServerConfig
+      timeout: 60.0
+      max_attempts: 3
+      retry_delay: 2.0
+      max_connections: 1000
+      max_start_wait_time: 300.0
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -295,20 +295,24 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    repetition_penalty: 1.0
     full_determinism: false
     seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
     gpu_memory_utilization: 0.5
+    standalone_gpu_memory_utilization: null
     ignore_eos: false
     enforce_eager: false
     cudagraph_capture_sizes: null
     free_cache_engine: true
+    enable_sleep_mode: true
     tensor_model_parallel_size: 2
     data_parallel_size: 1
     expert_parallel_size: 1
     pipeline_model_parallel_size: 1
+    moe_tensor_parallel_size: 1
     max_num_batched_tokens: 8192
     max_model_len: null
     max_num_seqs: 256
@@ -327,6 +331,7 @@ actor_rollout_ref:
     'n': 1
     over_sample_rate: 0
     multi_stage_wake_up: false
+    limit_images: null
     engine_kwargs:
       vllm: {}
       sglang: {}
@@ -362,6 +367,7 @@ actor_rollout_ref:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null
         name: null
+    checkpoint_manager_class: null
     checkpoint_engine:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -416,6 +416,13 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
           strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
+    server:
+      _target_: verl.workers.config.ServerConfig
+      timeout: 60.0
+      max_attempts: 3
+      retry_delay: 2.0
+      max_connections: 1000
+      max_start_wait_time: 300.0
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -272,20 +272,24 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    repetition_penalty: 1.0
     full_determinism: false
     seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
     gpu_memory_utilization: 0.5
+    standalone_gpu_memory_utilization: null
     ignore_eos: false
     enforce_eager: false
     cudagraph_capture_sizes: null
     free_cache_engine: true
+    enable_sleep_mode: true
     tensor_model_parallel_size: 2
     data_parallel_size: 1
     expert_parallel_size: 1
     pipeline_model_parallel_size: 1
+    moe_tensor_parallel_size: 1
     max_num_batched_tokens: 8192
     max_model_len: null
     max_num_seqs: 256
@@ -304,6 +308,7 @@ actor_rollout_ref:
     'n': 1
     over_sample_rate: 0
     multi_stage_wake_up: false
+    limit_images: null
     engine_kwargs:
       vllm: {}
       sglang: {}
@@ -339,6 +344,7 @@ actor_rollout_ref:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null
         name: null
+    checkpoint_manager_class: null
     checkpoint_engine:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -393,6 +393,13 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
           strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
+    server:
+      _target_: verl.workers.config.ServerConfig
+      timeout: 60.0
+      max_attempts: 3
+      retry_delay: 2.0
+      max_connections: 1000
+      max_start_wait_time: 300.0
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -473,6 +473,27 @@ profiler:
       # Whether to fail on unknown stage or missing msprobe
       strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
 
+# HTTP client settings used to reach a rollout server, read by the trtllm rollout
+server:
+
+  # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+  _target_: verl.workers.config.ServerConfig
+
+  # Per-request timeout in seconds
+  timeout: 60.0
+
+  # Number of attempts per request before giving up
+  max_attempts: 3
+
+  # Seconds to wait between attempts
+  retry_delay: 2.0
+
+  # Maximum number of concurrent connections to the server
+  max_connections: 1000
+
+  # Seconds to wait for the server to come up before failing
+  max_start_wait_time: 300.0
+
 # prometheus configuration for vllm/sglang server mode
 prometheus:
 

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -22,6 +22,11 @@ top_k: -1
 # Top-p sampling parameter. Default 1.0.
 top_p: 1
 
+# Penalty applied to tokens already present in the generated text. Values above 1.0
+# discourage repetition, below 1.0 encourage it. Used as the default for the
+# repetition_penalty sampling parameter.
+repetition_penalty: 1.0
+
 # Whether to enable full determinism for reproducibility in rollout.
 # See https://pytorch.org/docs/stable/notes/randomness.html for details.
 full_determinism: false
@@ -45,6 +50,11 @@ dtype: bfloat16
 # Fraction of GPU memory used by vLLM/SGLang/TRTLLM for KV cache.
 gpu_memory_utilization: 0.5
 
+# Fraction of GPU memory used by the rollout engine when it runs on its own resource
+# pool, as in one-step-off/fully async training. Falls back to gpu_memory_utilization
+# when null.
+standalone_gpu_memory_utilization: null
+
 # Whether to ignore EOS and continue generating after EOS is hit.
 ignore_eos: False
 
@@ -60,6 +70,10 @@ cudagraph_capture_sizes: null
 # Whether to free engine KVCache after generation.
 free_cache_engine: True
 
+# Whether the inference engine may sleep (offload its weights and KV cache) while the
+# trainer holds the GPU. Set to False when the engine owns a separate resource pool.
+enable_sleep_mode: True
+
 # TP size for rollout. Not effective for hf
 tensor_model_parallel_size: 2
 
@@ -73,6 +87,10 @@ expert_parallel_size: 1
 
 # PP size for rollout.
 pipeline_model_parallel_size: 1
+
+# MoE TP size for rollout. Only supported by the trtllm engine, where it must satisfy
+# moe_tensor_parallel_size * expert_parallel_size == tensor_model_parallel_size.
+moe_tensor_parallel_size: 1
 
 # max number of tokens in a batch
 max_num_batched_tokens: 8192
@@ -134,6 +152,10 @@ over_sample_rate: 0
 # to reduce peak memory during training-rollout transition.
 # This is only effective for SGLang rollout.
 multi_stage_wake_up: false
+
+# Maximum number of images per prompt, passed to the engine as limit_mm_per_prompt.
+# Required for multi-image data; null leaves the engine default in place.
+limit_images: null
 
 # Extra inference engine arguments (vllm, sglang, trtllm), please refer vllm/sglang/trtllm official doc for detail
 engine_kwargs:
@@ -267,6 +289,10 @@ agent:
 
     # Class name of the custom async server class (e.g. AsyncvLLMServer)
     name: null
+
+# Fully qualified class name for a custom CheckpointEngineManager. When set, the trainer
+# loads this class instead of the built-in CheckpointEngineManager.
+checkpoint_manager_class: null
 
 # Checkpoint Engine config for update weights from trainer to rollout
 checkpoint_engine:


### PR DESCRIPTION
### What does this PR do?

Seven `RolloutConfig` entries have no key in `verl/trainer/config/rollout/rollout.yaml`. Hydra composes the trainer config in struct mode, so a plain `actor_rollout_ref.rollout.<field>=...` override is rejected before training starts, even though every one of them is read at runtime:

| entry | read at |
| --- | --- |
| `limit_images` | `vllm_async_server.py` — sets `limit_mm_per_prompt` for multi-image data |
| `repetition_penalty` | `vllm_async_server.py` — default for the sampling parameter |
| `enable_sleep_mode` | `vllm_async_server.py`, `trtllm_async_server.py` |
| `standalone_gpu_memory_utilization` | `fully_async_rollouter.py` |
| `moe_tensor_parallel_size` | `trtllm_async_server.py` |
| `checkpoint_manager_class` | `ray_trainer.py`, `separation/ray_trainer.py` |
| `server` (`ServerConfig`) | `trtllm_rollout.py` — `timeout`, `max_attempts`, `retry_delay`, `max_connections` |

On `main`, each of them aborts the run:

```
$ python3 -m verl.trainer.main_ppo actor_rollout_ref.rollout.limit_images=4 ...
Could not override 'actor_rollout_ref.rollout.limit_images'.
To append to your config use +actor_rollout_ref.rollout.limit_images=4
```

`limit_images` shows the inconsistency most directly: `reward/reward.yaml` carries an inline rollout block with the same `_target_: verl.workers.config.RolloutConfig`, and it *does* list `limit_images: null`. So the same override works on the reward-model rollout and fails on the actor rollout, which is where multi-image training data needs it.

`enable_sleep_mode` defaults to `True` and gates `if not self.config.enable_sleep_mode:` in the vLLM async server, so there is currently no way to turn it off from the command line. `server` has no block at all, so the trtllm rollout's HTTP timeout and retry settings are pinned to their dataclass defaults for every run.

Same class as #7387 / #7426 (checkpoint config), on the rollout config.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [`is:pr is:open limit_images`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+limit_images), [`is:pr is:open repetition_penalty`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+repetition_penalty), [`is:pr is:open rollout.yaml`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+rollout.yaml). #5138 also touches `rollout.yaml` but adds a new custom-sampling-parameter mechanism rather than restoring parity for existing fields; happy to rebase around it.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

`tests/special_sanity/test_rollout_config_parity.py` compares `fields(RolloutConfig)` against the composed `actor_rollout_ref.rollout` node for both `ppo_trainer` and `ppo_megatron_trainer`. It fails on `main`:

```
AssertionError: ppo_trainer: RolloutConfig fields ['checkpoint_manager_class',
'enable_sleep_mode', 'limit_images', 'moe_tensor_parallel_size',
'repetition_penalty', 'server', 'standalone_gpu_memory_utilization'] have no key
in rollout.yaml, so actor_rollout_ref.rollout.<field>=... is rejected by Hydra.
```

and passes with this change. A second test asserts `KNOWN_UNMAPPED` does not go stale.

```
$ pytest tests/special_sanity/ -q
21 passed
$ bash scripts/generate_trainer_config.sh
All good
```

### API and Usage Example

All seven become settable; composed defaults are unchanged because each key is added with its dataclass default.

```bash
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.rollout.limit_images=4 \
    actor_rollout_ref.rollout.repetition_penalty=1.05 \
    actor_rollout_ref.rollout.enable_sleep_mode=False \
    actor_rollout_ref.rollout.standalone_gpu_memory_utilization=0.9 \
    actor_rollout_ref.rollout.checkpoint_manager_class=my.pkg.MyManager \
    actor_rollout_ref.rollout.server.timeout=120 \
    actor_rollout_ref.rollout.server.max_attempts=5 \
    ...
```

Composing with no overrides gives `limit_images=None`, `repetition_penalty=1.0`, `enable_sleep_mode=True`, `standalone_gpu_memory_utilization=None`, `moe_tensor_parallel_size=1`, `checkpoint_manager_class=None`, and `server` at `timeout=60.0, max_attempts=3, retry_delay=2.0, max_connections=1000, max_start_wait_time=300.0` — the dataclass defaults.

### Design & Code Changes

- `verl/trainer/config/rollout/rollout.yaml`: six scalar keys added next to their related settings, plus a `server:` block shaped like the neighbouring `prometheus:` block (with `_target_`). Every value is the dataclass default.
- `verl/trainer/config/_generated_*_trainer.yaml`: regenerated via `scripts/generate_trainer_config.sh` (+13 lines each, additive).
- `tests/special_sanity/test_rollout_config_parity.py`: new.

Left out, and why: `custom`, `layer_name_map` and `sglang_engine_mode` have no reader in the tree. All three are listed in `KNOWN_UNMAPPED` in the test so the exclusion is explicit rather than silent, and the second test fails if one of them later gains a YAML key.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation. — the YAML comments are the documentation for these keys; no separate doc page lists them.
- [x] Add unit or end-to-end test(s) to the CI workflow. `tests/special_sanity/` already runs in CI.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [ ] `recipe` submodule — not touched.
