### PR TITLE
[ci] test: reintegrate stable FSDP2 rmpad test

### DIFF
--- a/.github/workflows/model.yml
+++ b/.github/workflows/model.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Running FSDP rmpad model tests on 8 L20 GPUs + latest flash_attn
         run: |
           STRATEGY=fsdp torchrun --nproc_per_node=8 tests/special_distributed/test_fsdp_ckpt.py
+      - name: Running FSDP2 rmpad model tests on 8 L20 GPUs + latest flash_attn
+        run: |
+          STRATEGY=fsdp2 torchrun --nproc_per_node=8 tests/special_distributed/test_fsdp_ckpt.py
       - name: Running transformers ulysses tests on 8 L20 GPUs + latest transformers
         run: |
           torchrun --nproc_per_node=8 -m pytest tests/models/test_transformers_ulysses.py
@@ -127,32 +130,6 @@ jobs:
       - name: Clean up and recover transformers
         run: |
           pip3 install --upgrade "transformers==5.5.3"
-
-  # TODO: Move this back to model_rmpad once FSDP2 is stable.
-  # NOTE: List as an independent job to make rerun easier.
-  model_rmpad_fsdp2_unstable:
-    needs: setup
-    runs-on: ["${{ needs.setup.outputs.runner-label || 'L20x8' }}"]
-    timeout-minutes: 20 # Increase this timeout value as needed
-    env:
-      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
-      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
-      HF_ENDPOINT: "https://hf-mirror.com"
-      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Install the current repository and upgrade to latest transformers/flash_attn
-        run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-      - name: Check final pip list
-        run: |
-          pip3 list
-      - name: Running FSDP2 rmpad model tests on 8 L20 GPUs + latest flash_attn
-        run: |
-          STRATEGY=fsdp2 torchrun --nproc_per_node=8 tests/special_distributed/test_fsdp_ckpt.py
 
   model_engine:
     needs: setup
@@ -187,7 +164,7 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-latest
-    needs: [setup, model_rmpad, model_rmpad_fsdp2_unstable, model_engine]
+    needs: [setup, model_rmpad, model_engine]
     if: always()
     steps:
       - id: destroy-runner


### PR DESCRIPTION
### What does this PR do?

Reintegrate the stable FSDP2 remove-padding checkpoint test into the existing `model_rmpad` job.

- Run `STRATEGY=fsdp2 torchrun --nproc_per_node=8 tests/special_distributed/test_fsdp_ckpt.py` in `model_rmpad`.
- Remove the dedicated `model_rmpad_fsdp2_unstable` job.
- Remove that deleted job from `cleanup.needs`.

This resolves the TODO introduced when the test was isolated in #1389. The test path was later stabilized by #2874 and #3616, and the isolated job has completed successfully in 95/95 audited `main` workflow runs from July 22 through August 14, 2026.

Closes #1388.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [issue #1388](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+1388+in%3Abody), [job name](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+model_rmpad_fsdp2_unstable). No open duplicate was found.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

- `pre-commit run --all-files --show-diff-on-failure --color=always`: all hooks passed.
- Parsed `.github/workflows/model.yml` with PyYAML: passed.
- Structural assertions: exactly one FSDP2 checkpoint command, no remaining `model_rmpad_fsdp2_unstable` job, and `cleanup.needs` contains only `setup`, `model_rmpad`, and `model_engine`.
- `git diff --check origin/main...HEAD`: passed.
- Independent code review: approved with no remaining findings.

The 8-GPU test was not rerun locally. In the latest audited successful run ([31793101191](https://github.com/verl-project/verl/actions/runs/31793101191)), `model_rmpad` took 2.71 minutes and the isolated FSDP2 job took 0.61 minutes. Their combined estimated runtime is about 3.32 minutes, well below the existing 20-minute timeout. The upstream GPU CI should validate the integrated execution.

### API and Usage Example

No API or user-facing usage changes.

### Design & Code Changes

The FSDP2 command is placed immediately after the existing FSDP checkpoint step, while the environment still uses the latest Transformers and FlashAttention versions. The later compatibility downgrade and cleanup steps remain unchanged.

This removes a redundant runner allocation and restores the intended test grouping without changing the test implementation.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [x] Add / Update documentation. Not applicable: this is an internal CI-only change with no user-facing behavior.
- [x] Add unit or end-to-end tests to the CI workflow. This PR reintegrates the existing FSDP2 checkpoint test into the stable model workflow.
- [ ] Request CI in the `ci-request` channel once this draft is marked ready for review.
- [x] Update the `recipe` submodule reference. Not applicable.

### AI assistance disclosure

OpenAI Codex assisted with repository analysis, the one-file workflow edit, validation, and PR drafting. The human submitter reviewed the complete diff and is responsible for the contribution.