### PR TITLE
[ckpt] feat: add NCCL M2N Reshard layout primitives

### DIFF
--- a/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
+++ b/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
@@ -50,7 +50,7 @@ def test_local_shape_rejects_tensor_ranks_unsupported_by_m2n(shape):
         local_shape(shape, shard_dim=None, shard_size=1)
 
 
-def test_shard_api_maps_raw_fsdp_to_rollout_tp():
+def test_shard_api_maps_sharded_source_to_sharded_destination():
     exported = (
         "model.layers.0.mlp.down_proj.weight",
         torch.empty(16, device="meta"),
@@ -59,7 +59,11 @@ def test_shard_api_maps_raw_fsdp_to_rollout_tp():
 
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
     source, destination = build_reshard_layouts(
-        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+        weight,
+        source_replica_size=2,
+        source_shard_size=16,
+        destination_replica_size=8,
+        destination_shard_size=4,
     )
 
     assert weight.tensor.shape == (2, 8)
@@ -79,7 +83,11 @@ def test_shard_api_preserves_replicated_layouts():
 
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=None)
     source, destination = build_reshard_layouts(
-        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+        weight,
+        source_replica_size=2,
+        source_shard_size=16,
+        destination_replica_size=8,
+        destination_shard_size=4,
     )
 
     assert weight.source_shard_dim is None
@@ -98,7 +106,11 @@ def test_shard_api_accepts_one_dimensional_source_mesh():
 
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
     source, _ = build_reshard_layouts(
-        weight, source_dp=1, source_shard_size=16, destination_dp=8, destination_tp_size=4
+        weight,
+        source_replica_size=1,
+        source_shard_size=16,
+        destination_replica_size=8,
+        destination_shard_size=4,
     )
 
     assert weight.source_mesh_dims == (1, 16)
@@ -177,10 +189,10 @@ def test_layout_builder_rejects_source_shard_size_mismatch():
     with pytest.raises(ValueError, match="source mesh shard size 16 does not match configured 8"):
         build_reshard_layouts(
             weight,
-            source_dp=2,
+            source_replica_size=2,
             source_shard_size=8,
-            destination_dp=8,
-            destination_tp_size=4,
+            destination_replica_size=8,
+            destination_shard_size=4,
         )
 
 
@@ -192,11 +204,11 @@ def test_layout_builder_rejects_source_replica_size_mismatch():
     )
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
 
-    with pytest.raises(ValueError, match="source replica size 2 does not match configured source_dp 4"):
+    with pytest.raises(ValueError, match="source replica size 2 does not match configured source replica size 4"):
         build_reshard_layouts(
             weight,
-            source_dp=4,
+            source_replica_size=4,
             source_shard_size=16,
-            destination_dp=8,
-            destination_tp_size=4,
+            destination_replica_size=8,
+            destination_shard_size=4,
         )

--- a/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
+++ b/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for NCCL M2N Reshard layout construction."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.distributed.tensor import Replicate, Shard
+
+from verl.checkpoint_engine.reshard_layout import (
+    build_reshard_layouts,
+    local_shape,
+    local_weight_desc_from_shard_api,
+)
+from verl.workers.engine.spec import ShardSpec
+
+
+class _Mesh:
+    ndim = 2
+
+    @staticmethod
+    def size(mesh_dim=None):
+        return 32 if mesh_dim is None else (2, 16)[mesh_dim]
+
+
+class _OneDimensionalMesh:
+    ndim = 1
+
+    @staticmethod
+    def size(mesh_dim=None):
+        return 16
+
+
+@pytest.mark.parametrize("shape", [(), (2, 2, 2, 2)])
+def test_local_shape_rejects_tensor_ranks_unsupported_by_m2n(shape):
+    with pytest.raises(ValueError, match="supports tensor ranks 1 through 3"):
+        local_shape(shape, shard_dim=None, shard_size=1)
+
+
+def test_shard_api_maps_raw_fsdp_to_rollout_tp():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+    source, destination = build_reshard_layouts(
+        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+    )
+
+    assert weight.tensor.shape == (2, 8)
+    assert weight.source_shard_size == 16
+    assert weight.source_mesh_dims == (2, 16)
+    assert (source.mesh_dims, source.placements) == ((2, 16), (None, 0))
+    assert (destination.mesh_dims, destination.placements) == ((8, 4), (None, 1))
+    assert destination.local_shape == (32, 2)
+
+
+def test_shard_api_preserves_replicated_layouts():
+    exported = (
+        "model.layers.0.input_layernorm.weight",
+        torch.empty(32, device="meta"),
+        ShardSpec(full_shape=(32,), mesh=_Mesh(), placements=(Replicate(), Replicate())),
+    )
+
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=None)
+    source, destination = build_reshard_layouts(
+        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+    )
+
+    assert weight.source_shard_dim is None
+    assert weight.source_mesh_dims == (2, 16)
+    assert source.mesh_dims == destination.mesh_dims == (32, 1)
+    assert source.placements == destination.placements == (None, None)
+    assert source.local_shape == destination.local_shape == (32,)
+
+
+def test_shard_api_accepts_one_dimensional_source_mesh():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_OneDimensionalMesh(), placements=(Shard(0),)),
+    )
+
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+    source, _ = build_reshard_layouts(
+        weight, source_dp=1, source_shard_size=16, destination_dp=8, destination_tp_size=4
+    )
+
+    assert weight.source_mesh_dims == (1, 16)
+    assert (source.mesh_dims, source.placements) == ((1, 16), (None, 0))
+
+
+def test_shard_api_rejects_deferred_hf_conversion():
+    exported = (
+        "decoder.layers.0.self_attention.linear_qkv.weight",
+        torch.empty(1, device="meta"),
+        ShardSpec(
+            full_shape=(16,),
+            mesh=_Mesh(),
+            placements=(Replicate(), Shard(0)),
+            to_hf_chunk=lambda start, tensor: [],
+            hf_slots=[("model.layers.0.self_attn.q_proj.weight", (16,))],
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="converter metadata"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_explicit_placement_metadata():
+    exported = (
+        "decoder.layers.0.self_attention.linear_qkv.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(16,), place=0, gather_group=object()),
+    )
+
+    with pytest.raises(NotImplementedError, match="explicit ShardSpec placement metadata"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_multiple_sharded_mesh_dimensions():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(8, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Shard(0), Shard(1))),
+    )
+
+    with pytest.raises(NotImplementedError, match="one source Shard placement"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_outer_sharded_mesh_dimension():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(128, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Shard(0), Replicate())),
+    )
+
+    with pytest.raises(NotImplementedError, match="sharded source mesh dimension to be innermost"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_wrong_local_tensor_size():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(15, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+
+    with pytest.raises(ValueError, match="has 15 elements, expected 16"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_layout_builder_rejects_source_shard_size_mismatch():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+
+    with pytest.raises(ValueError, match="source mesh shard size 16 does not match configured 8"):
+        build_reshard_layouts(
+            weight,
+            source_dp=2,
+            source_shard_size=8,
+            destination_dp=8,
+            destination_tp_size=4,
+        )
+
+
+def test_layout_builder_rejects_source_replica_size_mismatch():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+
+    with pytest.raises(ValueError, match="source replica size 2 does not match configured source_dp 4"):
+        build_reshard_layouts(
+            weight,
+            source_dp=4,
+            source_shard_size=16,
+            destination_dp=8,
+            destination_tp_size=4,
+        )

--- a/verl/checkpoint_engine/reshard_layout.py
+++ b/verl/checkpoint_engine/reshard_layout.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Layout helpers shared by NCCL M2N Reshard checkpoint backends."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import torch
+
+from verl.workers.engine.spec import ShardSpec
+
+__all__ = [
+    "LocalWeightDesc",
+    "ReshardLayout",
+    "build_reshard_layouts",
+    "local_shape",
+    "local_weight_desc_from_shard_api",
+]
+
+
+@dataclass(frozen=True)
+class LocalWeightDesc:
+    """Describe one rank-local tensor and how it is partitioned.
+
+    "source_shard_dim" and "destination_shard_dim" are tensor dimensions,
+    not device-mesh dimensions. "None" means that the tensor is replicated on
+    that side of the transfer.
+
+    For a sharded source, "source_shard_size" is the size of the device-mesh
+    dimension that shards the tensor. It is ignored for a replicated source.
+    "source_mesh_dims" records the source mesh as the logical
+    ``(replica_size, shard_size)`` expected by M2N. It is ``None`` when the
+    shard export has no mesh and therefore cannot describe its replica count.
+    """
+
+    # The producer has already converted this to the consumer's parameter name.
+    name: str
+    tensor: torch.Tensor
+    # Shape before either the source or destination partition is applied.
+    global_shape: torch.Size
+    destination_shard_dim: int | None
+    source_shard_dim: int | None
+    source_shard_size: int
+    source_mesh_dims: tuple[int, int] | None = None
+
+
+@dataclass(frozen=True)
+class ReshardLayout:
+    """Describe one side of a transfer as a logical two-dimensional mesh.
+
+    "mesh_dims" gives the number of ranks along each mesh dimension.
+    "placements" has one entry for each mesh dimension: an integer means that
+    mesh dimension shards the corresponding tensor dimension, while "None"
+    means replication. For example, placements=(None, 0) replicates the tensor
+    along mesh dimension 0 and shards tensor dimension 0 along mesh dimension 1.
+
+    "start_rank" is the first rank occupied by this mesh in the dedicated M2N
+    communicator, not a rank in the trainer's global process group. The backend
+    maps participating processes into contiguous M2N source and destination
+    ranges before building this layout. "local_shape" is the tensor shape held
+    by one rank after applying the placements.
+    """
+
+    mesh_dims: tuple[int, int]
+    start_rank: int
+    placements: tuple[int | None, int | None]
+    local_shape: torch.Size
+
+
+def local_shape(global_shape: Sequence[int], shard_dim: int | None, shard_size: int) -> torch.Size:
+    """Return one rank's shape after an even partition on "shard_dim".
+
+    A "None" shard dimension represents replication, so it leaves the global
+    shape unchanged.
+    """
+
+    if shard_size <= 0:
+        raise ValueError(f"shard_size must be positive, got {shard_size}")
+    shape = list(global_shape)
+    if not 1 <= len(shape) <= 3:
+        raise ValueError(f"NCCL M2N supports tensor ranks 1 through 3, got {len(shape)} for shape {tuple(shape)}")
+    if shard_dim is not None:
+        if not 0 <= shard_dim < len(shape) or shape[shard_dim] % shard_size:
+            raise ValueError(f"shape {tuple(shape)} cannot be sharded on dim {shard_dim} by {shard_size}")
+        shape[shard_dim] //= shard_size
+    return torch.Size(shape)
+
+
+def local_weight_desc_from_shard_api(
+    exported: tuple[str, torch.Tensor, ShardSpec],
+    *,
+    destination_shard_dim: int | None | Literal["source"] = "source",
+) -> LocalWeightDesc:
+    """Convert one engine shard export into a transport-independent descriptor.
+
+    "ShardSpec.placements" describes the trainer tensor over its device mesh.
+    Destination placement is supplied by the producer because it is a
+    model/consumer policy, not a property of the generic layout library. Passing
+    "source" preserves the source tensor placement.
+    """
+
+    if not isinstance(exported, tuple) or len(exported) != 3:
+        raise TypeError("get_per_tensor_param_shard() must yield (name, tensor, ShardSpec)")
+    name, tensor, spec = exported
+    if not isinstance(name, str) or not isinstance(tensor, torch.Tensor) or not isinstance(spec, ShardSpec):
+        raise TypeError("invalid get_per_tensor_param_shard() item")
+    if spec.to_hf_chunk is not None or spec.hf_slots is not None:
+        # A deferred format conversion may need multiple source shards. The
+        # no-gather path requires conversion before constructing this descriptor.
+        raise NotImplementedError(
+            f"Reshard requires {name!r} in final HF-local form; ShardSpec converter metadata is unsupported"
+        )
+    if spec.place is not None or spec.gather_group is not None or not spec.contributes:
+        # These fields describe sharding that is not necessarily represented by
+        # mesh/placements. Treating mesh=None as replication would silently send
+        # an incomplete tensor for Megatron and veomni explicit-placement exports.
+        raise NotImplementedError(f"Reshard does not support explicit ShardSpec placement metadata for {name!r}")
+    if spec.mesh is None and spec.placements is not None:
+        raise ValueError(f"source placements for {name!r} require a source mesh")
+
+    source_dim, source_size, source_mesh_dims = None, 1, None
+    if spec.mesh is not None:
+        mesh_ndim = int(spec.mesh.ndim)
+        if mesh_ndim not in (1, 2):
+            raise NotImplementedError(f"Reshard supports one- or two-dimensional source meshes for {name!r}")
+        if not isinstance(spec.placements, tuple) or len(spec.placements) != mesh_ndim:
+            raise ValueError(f"invalid source placements for {name!r}")
+
+        mesh_shape = tuple(int(spec.mesh.size(mesh_dim=axis)) for axis in range(mesh_ndim))
+        source_mesh_dims = (1, mesh_shape[0]) if mesh_ndim == 1 else mesh_shape
+
+        # Each placement belongs to a device-mesh dimension; Shard.dim is the
+        # tensor dimension split along that mesh dimension. For example,
+        # (Replicate(), Shard(0)) on a (DP, FSDP) mesh splits tensor dimension 0
+        # across FSDP while DP replicas hold identical shards. The current M2N
+        # descriptor supports at most one such sharded mesh dimension.
+        sharded = []
+        unsupported = []
+        for axis, placement in enumerate(spec.placements):
+            if placement.is_shard():
+                sharded.append((axis, placement))
+            elif not placement.is_replicate():
+                unsupported.append(placement)
+        if unsupported or len(sharded) > 1:
+            raise NotImplementedError(f"Reshard supports one source Shard placement for {name!r}")
+        if sharded:
+            mesh_dim, placement = sharded[0]
+            if mesh_dim != mesh_ndim - 1:
+                raise NotImplementedError(
+                    f"Reshard requires the sharded source mesh dimension to be innermost for {name!r}"
+                )
+            source_dim = int(placement.dim)
+            source_size = source_mesh_dims[1]
+        else:
+            source_size = source_mesh_dims[1]
+
+    full_shape = torch.Size(spec.full_shape)
+    destination_dim = source_dim if destination_shard_dim == "source" else destination_shard_dim
+    expected = local_shape(full_shape, source_dim, source_size)
+    if tensor.numel() != math.prod(expected):
+        raise ValueError(f"local shard for {name!r} has {tensor.numel()} elements, expected {math.prod(expected)}")
+
+    # FSDP may expose a flattened local shard. The element-count check above
+    # makes this reshape safe and restores the expected rank-local tensor shape.
+    return LocalWeightDesc(
+        name=name,
+        tensor=tensor.reshape(expected),
+        global_shape=full_shape,
+        destination_shard_dim=destination_dim,
+        source_shard_dim=source_dim,
+        source_shard_size=source_size,
+        source_mesh_dims=source_mesh_dims,
+    )
+
+
+def build_reshard_layouts(
+    weight: LocalWeightDesc,
+    *,
+    source_dp: int,
+    source_shard_size: int,
+    destination_dp: int,
+    destination_tp_size: int,
+) -> tuple[ReshardLayout, ReshardLayout]:
+    """Build source and destination layouts in one combined communicator.
+
+    A sharded source is modeled as (source_dp, source_shard_size), and a
+    sharded destination as (destination_dp, destination_tp_size). For a
+    replicated weight, all ranks are flattened onto the first mesh dimension
+    and the second dimension is one. This lets every weight use the same
+    two-placement representation.
+
+    Source ranks occupy the first contiguous communicator range. Destination
+    ranks immediately follow them, so the destination "start_rank" equals the
+    source world size. Selecting participants, including any pipeline-stage
+    filtering, is the caller's responsibility and happens before this function.
+    """
+
+    if min(source_dp, source_shard_size, destination_dp, destination_tp_size) <= 0:
+        raise ValueError("Reshard topology sizes must be positive")
+    if weight.source_mesh_dims is not None:
+        source_replica_size, exported_shard_size = weight.source_mesh_dims
+        if source_replica_size != source_dp:
+            raise ValueError(
+                f"source replica size {source_replica_size} does not match configured source_dp {source_dp}"
+            )
+        if exported_shard_size != source_shard_size:
+            raise ValueError(
+                f"source mesh shard size {exported_shard_size} does not match configured {source_shard_size}"
+            )
+    if weight.source_shard_dim is not None and weight.source_shard_size != source_shard_size:
+        raise ValueError(f"source shard size {weight.source_shard_size} does not match configured {source_shard_size}")
+
+    # With no tensor shard dimension, placements=(None, None) replicates the
+    # full tensor across the flattened rank dimension and a singleton dimension.
+    source_world_size = source_dp * source_shard_size
+    source_dims = (source_dp, source_shard_size) if weight.source_shard_dim is not None else (source_world_size, 1)
+    destination_dims = (
+        (destination_dp, destination_tp_size)
+        if weight.destination_shard_dim is not None
+        else (destination_dp * destination_tp_size, 1)
+    )
+    return (
+        ReshardLayout(
+            mesh_dims=source_dims,
+            start_rank=0,
+            placements=(None, weight.source_shard_dim),
+            local_shape=local_shape(weight.global_shape, weight.source_shard_dim, weight.source_shard_size),
+        ),
+        ReshardLayout(
+            mesh_dims=destination_dims,
+            start_rank=source_world_size,
+            placements=(None, weight.destination_shard_dim),
+            local_shape=local_shape(weight.global_shape, weight.destination_shard_dim, destination_tp_size),
+        ),
+    )

--- a/verl/checkpoint_engine/reshard_layout.py
+++ b/verl/checkpoint_engine/reshard_layout.py
@@ -191,18 +191,17 @@ def local_weight_desc_from_shard_api(
 def build_reshard_layouts(
     weight: LocalWeightDesc,
     *,
-    source_dp: int,
+    source_replica_size: int,
     source_shard_size: int,
-    destination_dp: int,
-    destination_tp_size: int,
+    destination_replica_size: int,
+    destination_shard_size: int,
 ) -> tuple[ReshardLayout, ReshardLayout]:
     """Build source and destination layouts in one combined communicator.
 
-    A sharded source is modeled as (source_dp, source_shard_size), and a
-    sharded destination as (destination_dp, destination_tp_size). For a
-    replicated weight, all ranks are flattened onto the first mesh dimension
-    and the second dimension is one. This lets every weight use the same
-    two-placement representation.
+    A sharded side is modeled as (replica_size, shard_size). For a replicated
+    weight, all ranks are flattened onto the first mesh dimension and the
+    second dimension is one. This lets every weight use the same two-placement
+    representation without assigning parallelism roles to the mesh dimensions.
 
     Source ranks occupy the first contiguous communicator range. Destination
     ranks immediately follow them, so the destination "start_rank" equals the
@@ -210,13 +209,14 @@ def build_reshard_layouts(
     filtering, is the caller's responsibility and happens before this function.
     """
 
-    if min(source_dp, source_shard_size, destination_dp, destination_tp_size) <= 0:
+    if min(source_replica_size, source_shard_size, destination_replica_size, destination_shard_size) <= 0:
         raise ValueError("Reshard topology sizes must be positive")
     if weight.source_mesh_dims is not None:
-        source_replica_size, exported_shard_size = weight.source_mesh_dims
-        if source_replica_size != source_dp:
+        exported_replica_size, exported_shard_size = weight.source_mesh_dims
+        if exported_replica_size != source_replica_size:
             raise ValueError(
-                f"source replica size {source_replica_size} does not match configured source_dp {source_dp}"
+                f"source replica size {exported_replica_size} does not match configured source replica size "
+                f"{source_replica_size}"
             )
         if exported_shard_size != source_shard_size:
             raise ValueError(
@@ -227,12 +227,14 @@ def build_reshard_layouts(
 
     # With no tensor shard dimension, placements=(None, None) replicates the
     # full tensor across the flattened rank dimension and a singleton dimension.
-    source_world_size = source_dp * source_shard_size
-    source_dims = (source_dp, source_shard_size) if weight.source_shard_dim is not None else (source_world_size, 1)
+    source_world_size = source_replica_size * source_shard_size
+    source_dims = (
+        (source_replica_size, source_shard_size) if weight.source_shard_dim is not None else (source_world_size, 1)
+    )
     destination_dims = (
-        (destination_dp, destination_tp_size)
+        (destination_replica_size, destination_shard_size)
         if weight.destination_shard_dim is not None
-        else (destination_dp * destination_tp_size, 1)
+        else (destination_replica_size * destination_shard_size, 1)
     )
     return (
         ReshardLayout(
@@ -245,6 +247,6 @@ def build_reshard_layouts(
             mesh_dims=destination_dims,
             start_rank=source_world_size,
             placements=(None, weight.destination_shard_dim),
-            local_shape=local_shape(weight.global_shape, weight.destination_shard_dim, destination_tp_size),
+            local_shape=local_shape(weight.global_shape, weight.destination_shard_dim, destination_shard_size),
         ),
     )


### PR DESCRIPTION
### What does this PR do?

Adds transport-independent tensor-layout primitives for the staged NCCL M2N Reshard checkpoint path.

veRL engine producers export rank-local parameters as `(name, tensor, ShardSpec)`, while M2N requires explicit source and destination mesh dimensions, placements, local shapes, and communicator rank ranges. This PR introduces:

- `LocalWeightDesc` for normalized rank-local exports;
- `ReshardLayout` for one side of an M2N transfer;
- `local_weight_desc_from_shard_api()` for validated `ShardSpec` conversion; and
- `build_reshard_layouts()` for constructing matching source and destination layouts.

The reusable API uses replica/shard terminology rather than assigning DP or TP roles to its mesh axes.

This is the foundational PR in a staged integration. It intentionally contains no NCCL calls, checkpoint-backend registration, configuration, or rollout changes; those will be added in follow-up PRs.

This does not duplicate an existing PR. Searches for [NCCL M2N](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22NCCL+M2N%22) and [reshard layout](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22reshard+layout%22) found no matching implementation. The closest related work—#4876, #7263, #7108, and #7227—implements different consumers, transports, or wire formats rather than this layout-conversion layer.

Related to #400 and #1063.

### Checklist Before Starting

- [x] Searched for similar PRs and documented the results above.
- [x] Formatted the title as `[{modules}] {type}: {description}`.

### Test

```bash
pytest -q tests/checkpoint_engine/test_reshard_layout_on_cpu.py
# 12 passed

pre-commit run --all-files --show-diff-on-failure --color=always
# All 13 hooks passed
```

The CPU tests cover sharded and replicated layouts, one- and two-dimensional source meshes, topology mismatches, invalid local tensor sizes, unsupported placements, and deferred Hugging Face conversion metadata.

No GPU test is needed for this PR because it does not initialize NCCL or invoke M2N.

### API and Usage Example

This adds an internal checkpoint-engine API and does not change user-facing configuration.

```python
weight = local_weight_desc_from_shard_api(
    exported,
    destination_shard_dim=1,
)

source_layout, destination_layout = build_reshard_layouts(
    weight,
    source_replica_size=2,
    source_shard_size=16,
    destination_replica_size=8,
    destination_shard_size=4,
)
```

### Design & Code Changes

- Convert the current engine `ShardSpec` contract into a transport-independent descriptor.
- Support replicated tensors and one sharded axis over a one- or two-dimensional source mesh.
- Validate source replica/shard sizes and rank-local tensor element counts.
- Fail closed on deferred conversion, explicit placement metadata, multiple sharded axes, and non-innermost source sharding.
- Represent replicated tensors as `(world_size, 1)` so all weights share the same two-axis representation.
- Place source and destination ranges contiguously in the dedicated M2N communicator.

### Acknowledgements

This layout layer is adapted from the original NCCL M2N Reshard prototype and RFC by Alexandre Chidiac (@achidiac). Thanks to Ke Wen (@kwen2501) and Pouya Kousha (@pkousha) for design and code-review feedback.

### AI assistance disclosure

OpenAI Codex was used for code exploration, implementation assistance, test orchestration, and preparation of this PR.

The human submitter must review every changed line and understand and be able to defend the change before requesting upstream review.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied the complete pre-commit suite; all 13 hooks passed.
- [ ] Add / update documentation. Not needed for this internal helper. Its API and scope are documented with docstrings and CPU tests.
- [x] Added unit tests discoverable by the CPU CI workflow.
- [ ] Request upstream CI in the veRL community channel when ready.
- [ ] Recipe submodule update. Not applicable.
