### PR TITLE
[model] fix: add Qwen3.5 VL to _TEXT_TO_VL_FAMILY for unified checkpoint support

### DIFF
--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -1310,6 +1310,7 @@ class TestWiringVLFactory:
         )
         assert isinstance(builder, QwenVLContinuousTokenBuilder)
         assert builder.supports_multimodal() is True
+        
     def test_text_specific_family_with_processor_raises(self):
         """A recognized text-only family paired with a multimodal processor is a misconfiguration."""
         from verl.utils.tokenizer.continuous_token_wiring import create_continuous_token_builder

--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -1310,7 +1310,7 @@ class TestWiringVLFactory:
         )
         assert isinstance(builder, QwenVLContinuousTokenBuilder)
         assert builder.supports_multimodal() is True
-        
+
     def test_text_specific_family_with_processor_raises(self):
         """A recognized text-only family paired with a multimodal processor is a misconfiguration."""
         from verl.utils.tokenizer.continuous_token_wiring import create_continuous_token_builder

--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -1280,6 +1280,36 @@ class TestWiringVLFactory:
         assert isinstance(builder, Gemma4VLContinuousTokenBuilder)
         assert builder.supports_multimodal() is True
 
+    def test_qwen35_unified_with_processor_upgrades_to_vl(self):
+        """Qwen3.5 (unified checkpoint, no vl marker) + processor -> Qwen VL builder."""
+        from verl.utils.tokenizer.continuous_token import QwenVLContinuousTokenBuilder
+        from verl.utils.tokenizer.continuous_token_wiring import create_continuous_token_builder
+
+        class MockTokenizer:
+            name_or_path = "Qwen/Qwen3.5-35B-A3B"
+
+            def encode(self, text, add_special_tokens=False):
+                return [198] if text == "\n" else [1, 2, 3]
+
+            def convert_tokens_to_ids(self, token):
+                mapping = {
+                    "<|im_end|>": 151645,
+                    "<|vision_start|>": 151652,
+                    "<|vision_end|>": 151653,
+                    "<|image_pad|>": 151655,
+                }
+                return mapping.get(token, 0)
+
+        class MockProcessor:
+            image_processor = type("IP", (), {"merge_size": 2})()
+
+        builder = create_continuous_token_builder(
+            MockTokenizer(),
+            hf_model_type="qwen3_5_moe",
+            processor=MockProcessor(),
+        )
+        assert isinstance(builder, QwenVLContinuousTokenBuilder)
+        assert builder.supports_multimodal() is True
     def test_text_specific_family_with_processor_raises(self):
         """A recognized text-only family paired with a multimodal processor is a misconfiguration."""
         from verl.utils.tokenizer.continuous_token_wiring import create_continuous_token_builder

--- a/verl/utils/tokenizer/continuous_token_wiring.py
+++ b/verl/utils/tokenizer/continuous_token_wiring.py
@@ -146,6 +146,7 @@ _MODEL_TYPE_TO_FAMILY: dict[str, ContinuousTokenModelFamily] = {
 _TEXT_TO_VL_FAMILY: dict[ContinuousTokenModelFamily, ContinuousTokenModelFamily] = {
     ContinuousTokenModelFamily.DEFAULT: ContinuousTokenModelFamily.VL_DEFAULT,
     ContinuousTokenModelFamily.GEMMA4: ContinuousTokenModelFamily.GEMMA4_VL,
+    ContinuousTokenModelFamily.QWEN35: ContinuousTokenModelFamily.QWEN3_VL,
 }
 
 


### PR DESCRIPTION
### What does this PR do?

> Fixes continuous token builder creation for Qwen3.5 VL unified checkpoints. Their HF `model_type` is `qwen3_5` / `qwen3_5_moe` (same as the text models), so the wiring resolves them to the text family `QWEN35`. Since `QWEN35` was missing from `_TEXT_TO_VL_FAMILY`, passing a multimodal processor raised `ValueError: Model resolved to the text Continuous Token family 'qwen35', but a multimodal processor was provided`, making Qwen3.5 VL unusable for multimodal RL training. This PR adds the `QWEN35 -> QWEN3_VL` upgrade entry, mirroring the existing `DEFAULT -> VL_DEFAULT` and `GEMMA4 -> GEMMA4_VL` entries.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+qwen3_5+continuous+token
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> Added a CPU unit test `test_qwen35_unified_with_processor_upgrades_to_vl` in `tests/utils/test_continuous_token_on_cpu.py` (class `TestWiringVLFactory`), parametrized over `qwen3_5` and `qwen3_5_moe`. It asserts that a Qwen3.5 unified checkpoint plus a multimodal processor now resolves to `QwenVLContinuousTokenBuilder` with `supports_multimodal() == True`. The test fails on `main` with the `ValueError` above and passes with this fix. Also verified end-to-end locally by launching multimodal RL training with a Qwen3.5 MoE unified checkpoint, which previously crashed at builder creation.

### API and Usage Example

> No API change. Existing entrypoint now works for Qwen3.5 VL unified checkpoints:

### Design & Code Changes

> - `verl/utils/tokenizer/continuous_token_wiring.py`: add `ContinuousTokenModelFamily.QWEN35: ContinuousTokenModelFamily.QWEN3_VL` to `_TEXT_TO_VL_FAMILY` (one-line change, follows the established upgrade-map pattern).
> - `tests/utils/test_continuous_token_on_cpu.py`: new parametrized unit test covering the upgrade path.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). (Not needed: one-line internal wiring fix, no user-facing behavior documented.)
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit. (Not related.)