### PR TITLE
[vllm] fix: vllm always need to resume weights before weight sync

### DIFF
--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -762,9 +762,15 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         log_gpu_memory_usage("Before resume weights", logger=logger)
 
         # 1. resume rollout memory (weights were released during sleep)
-        # sleep_level=1 (adapter mode) never released weights, so do not resume them.
-        # Backends other than sglang carry no sleep_level, hence the default.
-        if self.config.rollout.free_cache_engine and getattr(self.rollout, "sleep_level", 2) != 1:
+        # sleep_level=1 (adapter mode) in SGLang never released weights, so do not resume them.
+        # vLLM is different: its level-1 sleep goes through CuMemAllocator.sleep(offload_tags=("weights",))
+        is_sglang = self.config.rollout.get("name", "") == "sglang"
+        if is_sglang:
+            resume_weights = self.config.rollout.free_cache_engine and getattr(self.rollout, "sleep_level", 2) != 1
+        else:
+            # vLLM: level-1 sleep still unmaps weights → must resume.
+            resume_weights = self.config.rollout.free_cache_engine
+        if resume_weights:
             await self.rollout.resume(tags=["weights"])
         log_gpu_memory_usage("After resume weights", logger=logger)
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/verl-project/verl/pull/7413 introduced a regression for vLLM.

The sleep_level==1 skip is SGLang-specific and must NOT be applied to vLLM. SGLang's sleep_level=1 release() only frees kv_cache and keeps base weights mapped, so resuming weights is a no-op and can be skipped. vLLM is different: its level-1 sleep goes through
CuMemAllocator.sleep(offload_tags=("weights",)), which backs up AND unmap_and_release()'s every weights-tagged allocation — including the LoRA lora_a_stacked/lora_b_stacked buffers (allocated under use_memory_pool("weights") at load time). After generate->sleep(level=1) those buffers' GPU VA is unmapped; if we skip resume(weights) here, the adapter sync's add_lora->set_lora copy_() targets an unmapped VA and raises cudaErrorInvalidValue. So for vLLM we always resume weights before the sync (cumem wake_up restores the CPU backup).

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
