### PR TITLE
[misc] chore: add HollowMan6 to CODEOWNERS and repair stale paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,10 @@
 /docs @eric-haibin-lin @zhaochenyang20 @hongpeng-guo
 /docs/amd_tutorial @yushengsu-thu
-/docs/slang_multiturn @zhaochenyang20 @SwordFaith
+/docs/sglang_multiturn @zhaochenyang20 @SwordFaith
 /docs/ascend_tutorial @wucong25
 /docs/advance/ppo_lora.rst @HollowMan6
 
-/third_party/sglang @zhaochenyang20 @SwordFaith
-/third_party/vllm @PeterSH6 @wuxibin89
+/verl/third_party/vllm @PeterSH6 @wuxibin89
 
 /examples/grpo_trainer @vermouth1992 @PeterSH6 @tardis-key @wucong25 @ji-huazhong
 
@@ -14,7 +13,7 @@
 /verl/models/mcore @ISEEKYAN @vermouth1992 @HollowMan6
 /verl/models/transformers @vermouth1992 @PeterSH6 @tardis-key @wucong25 @ji-huazhong
 /verl/workers/engine @eric-haibin-lin @vermouth1992 @ZihengJiang @ArronHZG
-/verl/workers/roles @eric-haibin-lin @vermouth1992 @ZihengJiang
+/verl/workers/utils @eric-haibin-lin @vermouth1992 @ZihengJiang
 /verl/workers/engine/fsdp @eric-haibin-lin @vermouth1992 @ZihengJiang
 /verl/workers/engine/veomni @wuxibin89 @Luosuu @FoolPlayer
 /verl/workers/rollout/vllm_rollout @wuxibin89 @PeterSH6 @chenhaiq @ArronHZG @HollowMan6
@@ -24,9 +23,9 @@
 
 /verl/utils/megatron @ISEEKYAN @HollowMan6
 /verl/utils/megatron_peft_utils.py @HollowMan6
-/verl/utils/vllm/utils.py @wuxibin89 @HollowMan6
+/verl/utils/vllm @wuxibin89 @HollowMan6
 
 /tests/single_controller @zw0610 @wuxibin89
 /tests/trainer @eric-haibin-lin @vermouth1992 @tongyx361 @PeterSH6
 /tests/utils/test_vllm_weight_name_normalization_on_cpu.py @HollowMan6
-/tests/workers/rollout/vllm_rollout @wuxibin89 @PeterSH6 @chenhaiq
+/tests/workers/rollout/rollout_vllm @wuxibin89 @PeterSH6 @chenhaiq

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 /docs/amd_tutorial @yushengsu-thu
 /docs/slang_multiturn @zhaochenyang20 @SwordFaith
 /docs/ascend_tutorial @wucong25
+/docs/advance/ppo_lora.rst @HollowMan6
 
 /third_party/sglang @zhaochenyang20 @SwordFaith
 /third_party/vllm @PeterSH6 @wuxibin89
@@ -10,17 +11,22 @@
 
 /verl/single_controller @zw0610 @wuxibin89 @hongpeng-guo
 /verl/trainer @eric-haibin-lin @vermouth1992 @tongyx361 @PeterSH6
-/verl/models/mcore @ISEEKYAN @vermouth1992
+/verl/models/mcore @ISEEKYAN @vermouth1992 @HollowMan6
 /verl/models/transformers @vermouth1992 @PeterSH6 @tardis-key @wucong25 @ji-huazhong
 /verl/workers/engine @eric-haibin-lin @vermouth1992 @ZihengJiang @ArronHZG
 /verl/workers/roles @eric-haibin-lin @vermouth1992 @ZihengJiang
 /verl/workers/engine/fsdp @eric-haibin-lin @vermouth1992 @ZihengJiang
 /verl/workers/engine/veomni @wuxibin89 @Luosuu @FoolPlayer
-/verl/workers/rollout/vllm_rollout @wuxibin89 @PeterSH6 @chenhaiq @ArronHZG
+/verl/workers/rollout/vllm_rollout @wuxibin89 @PeterSH6 @chenhaiq @ArronHZG @HollowMan6
 /verl/workers/rollout/sglang_rollout @zhaochenyang20 @SwordFaith @chenhaiq @ArronHZG
-/verl/workers/engine/megatron @ISEEKYAN @vermouth1992
+/verl/workers/engine/megatron @ISEEKYAN @vermouth1992 @HollowMan6
 /verl/experimental @wuxibin89 @ArronHZG
+
+/verl/utils/megatron @ISEEKYAN @HollowMan6
+/verl/utils/megatron_peft_utils.py @HollowMan6
+/verl/utils/vllm/utils.py @wuxibin89 @HollowMan6
 
 /tests/single_controller @zw0610 @wuxibin89
 /tests/trainer @eric-haibin-lin @vermouth1992 @tongyx361 @PeterSH6
+/tests/utils/test_vllm_weight_name_normalization_on_cpu.py @HollowMan6
 /tests/workers/rollout/vllm_rollout @wuxibin89 @PeterSH6 @chenhaiq


### PR DESCRIPTION
### What does this PR do?

This PR does two related things to `.github/CODEOWNERS`:

1. **Adds `@HollowMan6` as a code owner** for the Megatron LoRA/PEFT, router-replay, mcore and vLLM weight-sync areas, based on commit history in those paths.
2. **Repairs five entries that had gone stale** and were silently matching zero files, so the maintainers listed on them had stopped being auto-requested for review.

The second part is the more important fix. CODEOWNERS performs no validation of its own: a pattern that matches nothing is not a syntax error and produces no warning, it just quietly stops routing reviews. Four of these entries were broken by past renames and refactors rather than by intentional removal, so restoring them returns review routing to maintainers who had lost it without any signal.

#### 1. Ownership additions

Each entry below is backed by commit counts in that path (`mine / total`, from `git log`):

| Path | Commits | Share | Area |
| --- | --- | --- | --- |
| `/verl/utils/vllm/utils.py` | 5 / 6 | 83% | vLLM weight-name normalization for LoRA sync |
| `/tests/utils/test_vllm_weight_name_normalization_on_cpu.py` | 3 / 4 | 75% | test for the above (authored in #5599) |
| `/verl/utils/megatron_peft_utils.py` | 6 / 8 | 75% | Megatron PEFT helpers |
| `/docs/advance/ppo_lora.rst` | 7 / 15 | 47% | LoRA documentation |
| `/verl/workers/engine/megatron` | 15 / 94 | 16% | Megatron engine |
| `/verl/models/mcore` | 16 / 136 | 12% | mcore patches, MTP, fused kernels |
| `/verl/utils/megatron` | 7 / 60 | 12% | router replay |
| `/verl/workers/rollout/vllm_rollout` | 13 / 257 | 5% | vLLM rollout, `TensorLoRARequest` |

Related work in these areas includes #4063, #4632, #4673, #5462, #5575, #5599, #6335, #6951, #7327 and #7376.

Paths where my history was too diluted to justify a review gate were deliberately left alone, including `/verl/trainer` (3.0%), `/docs` (3.5%), `/verl/experimental` (2.9%) and `/tests/trainer` (7.3%). Existing owners are preserved everywhere; `@ISEEKYAN` and `@wuxibin89` are added alongside on `/verl/utils/megatron` and `/verl/utils/vllm/utils.py` so those paths are not solely owned.

#### 2. Stale path repairs

| Before | After | Why |
| --- | --- | --- |
| `/docs/slang_multiturn` | `/docs/sglang_multiturn` | Typo: missing `g`. The real directory has always existed under the correct name. |
| `/third_party/vllm` | `/verl/third_party/vllm` | Wrong prefix; a root-level `third_party/` has never existed in this repo. |
| `/tests/workers/rollout/vllm_rollout` | `/tests/workers/rollout/rollout_vllm` | Directory was renamed (path components swapped). |
| `/verl/workers/roles` | `/verl/workers/utils` | `verl/workers/roles/utils/` was renamed to `verl/workers/utils/` at 100% similarity by #4352. |
| `/third_party/sglang` | *(removed)* | Genuinely dead: `verl/third_party/sglang` was deleted from the repo and has no successor. |

> [!NOTE]
> **Reviewers, please sanity-check the `/verl/workers/roles` → `/verl/workers/utils` remap.** It is the one change here based on intent rather than a clean rename. #4352 moved `roles/utils/{losses,padding}.py` to `workers/utils/` at `R100`, but deleted `actor.py`, `critic.py` and `hybrid_engine.py` outright. So `workers/utils` is the surviving fragment of `roles`, not a true successor. It is currently unowned, so the remap keeps `@eric-haibin-lin`, `@vermouth1992` and `@ZihengJiang` on the code that survived. If you would rather they did not inherit it, this line should be deleted instead.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+CODEOWNERS — no open PR touches `.github/CODEOWNERS`. The most recent standalone precedent is #6260 (`[doc] feat: add code reviewer`); other CODEOWNERS edits (#6067, #6612) were bundled into substantive PRs.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

CODEOWNERS is GitHub-side configuration with no runtime behavior, so there is no unit or e2e test to add. It was instead validated mechanically against the tree.

Every pattern was matched against `git ls-files` using CODEOWNERS glob semantics — notably that `*` does not cross `/`, and that a wildcard matching a directory does **not** recurse into it, unlike `.gitignore`. Result: **all 26 entries match at least one tracked file; 0 dead entries.** Before this PR, 5 entries matched nothing.

```
$ pre-commit run --files .github/CODEOWNERS
ruff (legacy alias).........................................(no files to check)Skipped
ruff format.................................................(no files to check)Skipped
mypy........................................................(no files to check)Skipped
Generate and verify verl/trainer/config/_generated_*.yaml.......................Failed
Check docs Last updated info....................................................Passed
Check doc string coverage.......................................................Passed
Check license...................................................................Passed
Check device API usage..........................................................Passed
Check DataProto usage...........................................................Passed
Validate test structure.........................................................Passed
Check naming conventions........................................................Passed
Check example script naming convention..........................................Passed
Compile all python files........................................................Passed
```

The single `Failed` hook is a pre-existing local environment issue, not caused by this change: it raises `ModuleNotFoundError: No module named 'hydra'`, and it fails identically on an unmodified `main` checkout. This PR touches no Python and no config.

One caveat worth stating explicitly: `git check-ignore` and similar `.gitignore` tooling **cannot** be used to validate CODEOWNERS patterns. `.gitignore` recurses into a directory matched by a wildcard and CODEOWNERS does not, so such tooling reports false matches for patterns GitHub silently ignores.

### API and Usage Example

No API change. This PR only affects GitHub review-request routing.

### Design & Code Changes

Single file changed: `.github/CODEOWNERS`. Eight lines add or extend ownership, five lines repair or remove stale paths. No existing owner is removed from any path they still own.

### Checklist Before Submitting

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` (see Test section above for the pre-existing unrelated failure)
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not applicable: no user-facing behavior changes.
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: CODEOWNERS is GitHub platform configuration and is not executed by CI; it was validated by matching every pattern against `git ls-files` as described above.
- [X] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit. Not applicable.

---

AI assistance (Claude Code) was used to analyze the commit history behind the ownership additions, to diagnose the five stale paths, and to draft this description. All changes have been reviewed line by line by the submitter.
