### PR TITLE
[reward] fix: enforce symbolic equality timeouts

### DIFF
--- a/tests/utils/reward_score/test_prime_math_grader_on_cpu.py
+++ b/tests/utils/reward_score/test_prime_math_grader_on_cpu.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import pytest
+from sympy import Expr, Float
+
+from verl.utils.reward_score.prime_math.grader import symbolic_equal
+
+
+class _SlowExpr(Expr):
+    def _eval_evalf(self, prec):
+        time.sleep(0.2)
+        return Float(1)
+
+
+@pytest.mark.parametrize(
+    ("prediction", "reference"),
+    [
+        ("x + x", "2 * x"),
+        ("1 / 3", "0.3333333333333333"),
+    ],
+)
+def test_symbolic_equal_accepts_equivalent_expressions(prediction, reference):
+    assert symbolic_equal(prediction, reference, tolerance=1e-4, timeout=2.0)
+
+
+def test_symbolic_equal_times_out_numerical_evaluation():
+    assert not symbolic_equal(_SlowExpr(), Float(1), tolerance=1e-4, timeout=0.05)

--- a/verl/utils/reward_score/prime_math/grader.py
+++ b/verl/utils/reward_score/prime_math/grader.py
@@ -321,12 +321,19 @@ def math_equal(
     return symbolic_equal(prediction, reference, tolerance, timeout)
 
 
+def _simplify_equal(a, b):
+    return simplify(a - b) == 0
+
+
+def _numerically_equal(a, b, tolerance):
+    return isclose(N(a), N(b), rel_tol=tolerance)
+
+
 def symbolic_equal(a, b, tolerance, timeout=10.0):
     def _parse(s):
         for f in [parse_expr, parse_latex]:
             try:
-                with timeout_limit(seconds=timeout):
-                    return f(s)
+                return timeout_limit(seconds=timeout)(f)(s)
             except TimeoutError:
                 print(f"Parsing timed out for {s}")
                 continue
@@ -338,9 +345,8 @@ def symbolic_equal(a, b, tolerance, timeout=10.0):
     b = _parse(b)
 
     try:
-        with timeout_limit(seconds=timeout):
-            if simplify(a - b) == 0:
-                return True
+        if timeout_limit(seconds=timeout)(_simplify_equal)(a, b):
+            return True
     except TimeoutError:
         print(f"Simplification timed out for {a} - {b}")
         pass
@@ -348,9 +354,8 @@ def symbolic_equal(a, b, tolerance, timeout=10.0):
         pass
 
     try:
-        with timeout_limit(seconds=timeout):
-            if isclose(N(a), N(b), rel_tol=tolerance):
-                return True
+        if timeout_limit(seconds=timeout)(_numerically_equal)(a, b, tolerance):
+            return True
     except TimeoutError:
         print(f"Numerical evaluation timed out for {a}, {b}")
         pass


### PR DESCRIPTION
### What does this PR do?

`symbolic_equal()` treats `timeout_limit()` as a context manager even though it
is a decorator factory. Each parsing, simplification, and numerical comparison
attempt therefore raises before the guarded function runs; the surrounding
exception handlers silently convert those failures into a `False` result.

This change applies `timeout_limit()` as a decorator for parsing and adds
module-level helpers that keep each complete simplification or numerical
comparison inside the timed child process. Equivalent PRIME math answers can now
reach the intended SymPy checks instead of being silently marked incorrect,
while expensive `simplify()` and `N()` work remains bounded by the configured
timeout.

### Checklist Before Starting

- [x] Searched for similar work:
  https://github.com/verl-project/verl/pulls?q=is%3Apr+timeout_limit+symbolic_equal
  and a full file-level scan of all open PRs returned no matching implementation.
  - Open PR #3389 also changes `grader.py`, but only in `handle_pi()` and matrix
    prefix/suffix parsing; it does not touch `symbolic_equal()` or timeout usage.
  - Open PR #5600 touches `py_functional.py` only in metric aggregation code.
  - Closed PRs #7211 and #7267 concern timeout-process lifecycle, while #7254
    concerns PRIME code worker cleanup; none changes `symbolic_equal()`.
  - Issue #5331 concerns unsafe `eval()` calls in the same grader file, not the
    timeout decorator misuse fixed here.
- [x] Formatted the title as `[{modules}] {type}: {description}` and verified it
  with `tests/special_sanity/check_pr_title.py`.

### Test

On the unmodified implementation, both fast equivalence cases failed because
`symbolic_equal()` returned `False`. An additional timeout-scope regression then
failed on the initial decorator-only patch because `N()` still ran in the parent
process:

```text
PYTHONDONTWRITEBYTECODE=1 python /tmp/verl_w8_test_runner.py
1 failed, 2 passed in 0.78s
```

After moving the complete operations into module-level timed helpers:

```text
PYTHONDONTWRITEBYTECODE=1 python /tmp/verl_w8_test_runner.py
3 passed in 0.22s
```

The lightweight local pytest harness loads the real `grader.py` and
`py_functional.py` while stubbing only import-time verl dependencies. A separate
behavior probe confirmed that both public `math_equal()` cases return `True`,
covering symbolic simplification and numerical `isclose()` fallback. The timeout
regression uses a slow SymPy numerical evaluation and verifies the existing
`False` fallback without a tight wall-clock assertion.

```text
PYTHONDONTWRITEBYTECODE=1 python -m compileall -q \
  verl/utils/reward_score/prime_math/grader.py \
  tests/utils/reward_score/test_prime_math_grader_on_cpu.py
Passed
```

```text
uvx --with hydra-core pre-commit run --all-files --show-diff-on-failure --color=never
All 13 hooks passed
```

The full dependency test environment and remote CI were not run locally.

### API and Usage Example

No public API or configuration changes. Existing PRIME math scoring calls keep
the same signatures and timeout values.

### Design & Code Changes

- Call `timeout_limit(seconds=timeout)(function)(...)` for parsing.
- Use module-level, multiprocessing-pickleable helpers so `simplify(a - b)` and
  `isclose(N(a), N(b), rel_tol=tolerance)` execute entirely inside the timeout
  child.
- Preserve the existing timeout messages, exception fallbacks, tolerance, and
  parser order.
- Add CPU tests collected by `cpu_unit_tests.yml` for exact symbolic
  equivalence, approximate numerical equivalence, and numerical-evaluation
  timeout fallback.

### AI Assistance

OpenAI Codex was used for repository exploration, implementation assistance,
test orchestration, and review. I reviewed every changed line and verified the
behavior and test evidence end-to-end.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md)
  and `AGENTS.md`.
- [x] Applied the full-repository pre-commit checks; all hooks passed.
- [x] Documentation is not required because this fixes internal scoring
  behavior without changing a public interface or configuration.
- [x] Added a CPU regression test collected by the existing CPU unit-test
  workflow.
- [ ] Request project CI in Slack or Feishu after the PR is available.
- [x] The `recipe` submodule is not involved.
