### PR TITLE
[misc] fix: validate DataProtoItem consistency

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -23,6 +23,7 @@ from tensordict import TensorDict
 
 from verl import DataProto
 from verl.protocol import (
+    DataProtoItem,
     deserialize_single_tensor,
     deserialize_tensordict,
     serialize_single_tensor,
@@ -150,6 +151,39 @@ def test_tensor_dict_constructor():
 
     with pytest.raises(AssertionError):
         data = DataProto.from_dict(tensors={"obs": obs, "act": act}, num_batch_dims=3)
+
+
+def test_dataproto_item_consistency():
+    data = DataProto.from_dict(
+        tensors={"obs": torch.randn(2, 3)},
+        non_tensors={"label": ["a", "b"]},
+        meta_info={"split": "train"},
+    )
+
+    item = data[0]
+
+    assert item.batch.batch_size == torch.Size([])
+    assert item.non_tensor_batch == {"label": "a"}
+    assert item.meta_info == {"split": "train"}
+
+
+def test_dataproto_item_rejects_batched_tensordict():
+    batch = TensorDict({"obs": torch.randn(1, 3)}, batch_size=[1])
+
+    with pytest.raises(AssertionError, match="must represent a single item"):
+        DataProtoItem(batch=batch)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"non_tensor_batch": []}, "non_tensor_batch must be a dict"),
+        ({"meta_info": []}, "meta_info must be a dict"),
+    ],
+)
+def test_dataproto_item_rejects_non_dict_metadata(kwargs, message):
+    with pytest.raises(AssertionError, match=message):
+        DataProtoItem(**kwargs)
 
 
 def test_tensor_dict_make_iterator():

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -308,10 +308,25 @@ def collate_fn(x: list["DataProtoItem"]):
 
 @dataclass
 class DataProtoItem:
-    # TODO(zhangchi.usc1992) add consistency check
     batch: TensorDict = None
     non_tensor_batch: dict = field(default_factory=dict)
     meta_info: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.check_consistency()
+
+    def check_consistency(self):
+        """Validate the unbatched item contract used by ``DataProto.__getitem__``."""
+
+        if self.batch is not None:
+            assert len(self.batch.batch_size) == 0, (
+                "DataProtoItem.batch must represent a single item with num_batch_dims=0, "
+                f"got batch_size={self.batch.batch_size}"
+            )
+        assert isinstance(self.non_tensor_batch, dict), (
+            f"DataProtoItem.non_tensor_batch must be a dict, got {type(self.non_tensor_batch)}"
+        )
+        assert isinstance(self.meta_info, dict), f"DataProtoItem.meta_info must be a dict, got {type(self.meta_info)}"
 
 
 @dataclass


### PR DESCRIPTION
### What does this PR do?

Validate `DataProtoItem` invariants at construction time and expose the same validation through `check_consistency()`. A `DataProtoItem` now requires an unbatched `TensorDict` (`num_batch_dims == 0`) plus dictionary-valued `non_tensor_batch` and `meta_info` fields.

This resolves the existing consistency-check TODO with a narrow correctness change and targeted CPU tests. Invalid items now fail at their construction boundary instead of propagating into later protocol operations.

This PR was prepared with AI assistance. The human submitter reviewed every changed line, understands the implementation and tests, and can defend the change end to end.

Duplicate-work check: searches for [`DataProtoItem consistency`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+DataProtoItem+consistency) and [`protocol consistency`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+protocol+consistency) found no matching open PR. The only protocol-related result, #4030, addresses `DataProto.concat` timing metadata and is unrelated.

### Checklist Before Starting

- [x] Searched for similar PRs using the query links above; no duplicate implementation was found.
- [x] Formatted the PR title as `[{modules}] {type}: {description}`.

### Test

- `uvx --with hydra-core pre-commit run --files verl/protocol.py tests/test_protocol_on_cpu.py`
  - All hooks passed, including Ruff, Ruff format, Mypy, generated-config verification, license, device/API checks, test structure, and Python compilation.
- `python -m pytest -q tests/test_protocol_on_cpu.py`
  - 41 passed, with one upstream PyTorch nested-tensor warning.

### API and Usage Example

No new API is introduced. Construction now fails early for inconsistent values instead of allowing an invalid `DataProtoItem` to propagate. Existing valid construction remains unchanged.

```python
item = DataProtoItem(batch=batch[0], non_tensor_batch={}, meta_info={})
item.check_consistency()
```

### Design & Code Changes

- Add `DataProtoItem.__post_init__()` so validation always runs after dataclass construction.
- Add public `check_consistency()` for explicit revalidation after mutation.
- Cover a valid indexed item plus batched-`TensorDict` and non-dictionary metadata failures.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md) and `AGENTS.md`.
- [x] Applied [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting) to every changed file.
- [x] Documentation changes are not applicable because this is an internal invariant check with no new user-facing API.
- [x] Added targeted CPU unit tests covering the new behavior.
- [ ] Upstream CI request has not been posted to Slack or Feishu; it can be requested after maintainer triage.
- [x] Recipe submodule update is not applicable.
