### PR TITLE
[vllm] fix: preserve ROCm attention cache for CUDA graphs

### DIFF
--- a/verl/utils/vllm/vllm_quant_utils.py
+++ b/verl/utils/vllm/vllm_quant_utils.py
@@ -260,22 +260,42 @@ def apply_mxfp8_transformation_after_loading(model):
                 module.quant_method.process_weights_after_loading(module)
 
 
-def clear_rocm_attention_weight_caches(model):
-    """Drop the bf16 ``wo_a`` copy vLLM derives from the loaded weight.
+def refresh_rocm_attention_weight_caches(model):
+    """Rebuild the bf16 ``wo_a`` copy vLLM derives from the loaded weight.
 
     ``rocm_aiter_mla_sparse._get_cached_wo_a_bf16`` caches a dequantized ``wo_a``
     on the module, assuming the weight is static. A refit updates the weight but
-    not the cache, so attention would keep using the previous step's copy. The
-    rebuild is lazy, so dropping the cache here is enough.
+    not the cache, so attention would keep using the previous step's copy.
+
+    Dropping the cache and letting the lazy rebuild handle it is only correct in
+    eager mode. ``_o_proj`` runs during graph capture, so a captured graph holds
+    the buffer's address and replays the einsum without re-entering the builder:
+    a fresh allocation would leave it reading freed memory. Rebuild into the
+    original storage instead.
+
+    Must run after the live FP8 parameters have been reinstated, otherwise the
+    dequantization reads the staging buffers.
 
     Only ROCm DeepSeek-V4 builds this cache, hence the guard below.
     """
     if torch.version.hip is None or not is_deepseek_v4_model(model):
         return
 
-    for module in model.modules():
-        if hasattr(module, "_dsv4_wo_a_bf16"):
+    from vllm.v1.attention.ops.rocm_aiter_mla_sparse import _get_cached_wo_a_bf16
+
+    # The cache was built inside the forward pass, so it is an inference tensor
+    # and PyTorch refuses to mutate it outside InferenceMode.
+    with torch.inference_mode():
+        for module in model.modules():
+            live = getattr(module, "_dsv4_wo_a_bf16", None)
+            if live is None:
+                continue
+            n_local_groups, o_lora_rank, hidden_dim = live.shape
             del module._dsv4_wo_a_bf16
+            rebuilt = _get_cached_wo_a_bf16(module, n_local_groups, o_lora_rank, hidden_dim)
+            if rebuilt.data_ptr() != live.data_ptr():
+                live.copy_(rebuilt)
+            module._dsv4_wo_a_bf16 = live
 
 
 def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
@@ -355,11 +375,13 @@ def prepare_quanted_weights_for_loading(model):
 
 def process_quanted_weights_after_loading(model, reload_state):
     """Re-apply the inference layout undone by ``prepare_quanted_weights_for_loading``."""
-    clear_rocm_attention_weight_caches(model)
     apply_mxfp8_transformation_after_loading(model)
     reload_state = reload_state or {}
     process_fp8_weights_after_loading(reload_state.get("fp8_layers") or [])
     process_mxfp4_moe_weights_after_loading(reload_state.get("mxfp4_moe_modules") or [])
+    # Last: the rebuild reads ``wo_a``, which is only back in its inference
+    # layout once the staged FP8 params above have been reinstated.
+    refresh_rocm_attention_weight_caches(model)
 
 
 def load_quanted_weights(weights, model_runner, is_drafter=False):


### PR DESCRIPTION
### What does this PR do?

Fixes ROCm DeepSeek-V4 vLLM weight refits when CUDA/HIP graph replay is enabled.

The captured attention graph keeps the address of the cached bf16 `wo_a` tensor. Deleting that cache after a weight refit and rebuilding it lazily allocates new storage, leaving the captured graph pointing at stale storage. This change rebuilds the cache after the live FP8 weights are restored, copies the refreshed value into the original tensor, and reattaches that tensor so its address remains stable.

This is a follow-up to #7050.

### Checklist Before Starting

- [x] Searched for similar open PRs and found no duplicate:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ROCm+CUDA+graph+attention+cache
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22_dsv4_wo_a_bf16%22
- [x] Formatted the PR title as `[vllm] fix: ...`.

### Test

- `uvx --with hydra-core pre-commit run --all-files --show-diff-on-failure --color=never` — passed.
- `python -m pytest -q tests/utils/test_vllm_quant_utils_moe_on_cpu.py` in an uv-managed Python 3.10 environment — 4 passed.
- `python3 -m py_compile verl/utils/vllm/vllm_quant_utils.py` — passed.
- Inline CPU regression smoke covering stable cache `data_ptr()` and refresh ordering — passed.

A full captured-graph replay requires a ROCm DeepSeek-V4 environment and was not run in the PR preparation environment.

### API and Usage Example

No API or configuration change. The cache refresh remains automatic during quantized vLLM weight updates.

### Design & Code Changes

- Replace cache deletion with an in-place refresh that preserves the original tensor storage.
- Run the refresh under inference mode because the cached tensor is created during inference.
- Refresh only after FP8/MXFP4 weights have returned to their inference layout.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied the full pre-commit checks.
- [x] Documentation is not required because there is no user-facing API or configuration change.
- [ ] No CI test was added: the failure requires the ROCm-only DeepSeek-V4 attention implementation under captured graph replay. A CPU smoke check covers storage preservation and call ordering.
- [ ] CI request will be sent after maintainer review/readiness.
- [x] Not related to the `recipe` submodule.

### AI assistance

OpenAI Codex was used to review the human-authored change, run checks, prepare the commit and PR text, and submit the PR. The submitter reviewed and owns the code change.
