### PR TITLE
[data] fix: keep mm_token_type_ids in MultiTurnSFTDataset

### DIFF
--- a/tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
@@ -532,3 +532,58 @@ def test_multiturn_sft_vlm_dataloader_on_cpu(model_path, vlm_data_file):
             f"pixel_values: {pixel_values.shape} should have shape "
             f"({num_patches}, 3 * {temporal_patch_size} * {patch_size} * {patch_size})"
         )
+
+        # 4. verify mm_token_type_ids: one row per sample, padded to the longest sequence
+        mm_token_type_ids = multi_modal_inputs["mm_token_type_ids"]
+        assert mm_token_type_ids.shape == (batch_size, max(len(ids) for ids in input_ids)), (
+            f"mm_token_type_ids: {mm_token_type_ids.shape} should have shape "
+            f"({batch_size}, {max(len(ids) for ids in input_ids)})"
+        )
+        # padding is tagged 0 ("text"), so tagging neither loses nor invents image tokens
+        assert (mm_token_type_ids == 1).sum() == (input_ids.values() == processor.image_token_id).sum(), (
+            "number of image-tagged positions should equal the number of image tokens in the batch"
+        )
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        f"{custom_model_prefix}/Qwen/Qwen3-VL-2B-Instruct",
+    ],
+)
+@pytest.mark.parametrize(
+    "pad_mode, truncation",
+    [
+        ("right", "left"),
+        ("right", "right"),
+        ("no_padding", "right"),
+    ],
+)
+def test_multiturn_sft_vlm_mm_token_type_ids_on_cpu(model_path, pad_mode, truncation, vlm_data_file):
+    """Test that mm_token_type_ids is kept and stays one entry per token of input_ids.
+
+    Multimodal models read it to tell image tokens from text ones, so it has to come out of every
+    branch that changes the sequence length still indexing input_ids position for position.
+    max_length is below the longest row, so both padding and truncation run.
+    """
+    tokenizer = hf_tokenizer(model_path)
+    processor = hf_processor(model_path)
+    config = {"max_length": 64, "pad_mode": pad_mode, "truncation": truncation, "messages_key": "messages"}
+    dataset = MultiTurnSFTDataset(parquet_files=vlm_data_file, tokenizer=tokenizer, processor=processor, config=config)
+
+    for i in range(len(dataset)):
+        item = dataset[i]
+        input_ids = item["input_ids"]
+        mm_token_type_ids = item.get("multi_modal_inputs", {}).get("mm_token_type_ids")
+
+        # 1. verify mm_token_type_ids is kept with one entry per token
+        assert mm_token_type_ids is not None, f"row {i}: mm_token_type_ids must not be dropped"
+        assert mm_token_type_ids.shape == (1, input_ids.shape[0]), (
+            f"row {i}: mm_token_type_ids {tuple(mm_token_type_ids.shape)} should be (1, {input_ids.shape[0]})"
+        )
+
+        # 2. verify image tokens are tagged 1 and everything else, padding included, 0
+        expected = (input_ids == processor.image_token_id).to(mm_token_type_ids.dtype)
+        assert torch.equal(mm_token_type_ids.reshape(-1), expected), (
+            f"row {i}: mm_token_type_ids should tag the image tokens of input_ids 1 and text or padding 0"
+        )

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -230,6 +230,9 @@ class MultiTurnSFTDataset(Dataset):
         if index != 0 and message["role"] != "system":
             input_ids = input_ids[len(self.system_prompt) :]
             attention_mask = attention_mask[len(self.system_prompt) :]
+            # mm_token_type_ids is one entry per token, remove the same leading tokens
+            if "mm_token_type_ids" in inputs:
+                inputs["mm_token_type_ids"] = inputs["mm_token_type_ids"][..., len(self.system_prompt) :]
 
         if message["role"] == "assistant":
             loss_mask = torch.ones_like(attention_mask)
@@ -324,12 +327,13 @@ class MultiTurnSFTDataset(Dataset):
         print_assembled_message(self.tokenizer, messages, input_ids, loss_mask, attention_mask, tools)
         self.sanity_check(input_ids, messages, tools, enable_thinking)
 
+        # mm_token_type_ids is (1, turn_len) per turn with one entry per token, so turns join on dim 1,
+        # not dim 0: exempt it from the filtering and stacking below, then pad and truncate it like input_ids
+        mm_token_type_ids = multi_modal_inputs.pop("mm_token_type_ids", None)
+
         # Since the tokenizer may return user-customized results, we need to filter out inconsistent tensor shapes
         keys_to_remove = []
         for k, v in multi_modal_inputs.items():
-            if k == "mm_token_type_ids":
-                keys_to_remove.append(k)
-                continue
             if len(v) > 0 and v[0] is not None and isinstance(v[0], torch.Tensor):
                 # Check if all tensors in the list have the same shape
                 first_shape = v[0].shape[1:]
@@ -341,6 +345,12 @@ class MultiTurnSFTDataset(Dataset):
 
         for k, v in multi_modal_inputs.items():
             multi_modal_inputs[k] = torch.concat(v, dim=0)
+
+        if mm_token_type_ids is not None:
+            mm_token_type_ids = torch.cat(mm_token_type_ids, dim=1)
+            assert mm_token_type_ids.shape[-1] == input_ids.shape[0], (
+                f"mm_token_type_ids has {mm_token_type_ids.shape[-1]} entries for {input_ids.shape[0]} tokens"
+            )
 
         # 2. handle position_ids for Qwen-VL series models
         if self.processor is not None and "Qwen2VLImageProcessor" in self.processor.image_processor.__class__.__name__:
@@ -376,17 +386,24 @@ class MultiTurnSFTDataset(Dataset):
                 attention_mask = torch.cat((attention_mask, padded_attention_mask))
                 loss_mask = torch.cat((loss_mask, padded_loss_mask))
                 position_ids = F.pad(position_ids, (0, self.max_length - sequence_length), value=0)
+                if mm_token_type_ids is not None:
+                    # pad with 0 ("text") so the padding adds no image attention
+                    mm_token_type_ids = F.pad(mm_token_type_ids, (0, self.max_length - sequence_length), value=0)
             elif sequence_length > self.max_length:
                 if self.truncation == "left":
                     input_ids = input_ids[-self.max_length :]
                     attention_mask = attention_mask[-self.max_length :]
                     loss_mask = loss_mask[-self.max_length :]
                     position_ids = position_ids[..., -self.max_length :]
+                    if mm_token_type_ids is not None:
+                        mm_token_type_ids = mm_token_type_ids[..., -self.max_length :]
                 elif self.truncation == "right":
                     input_ids = input_ids[: self.max_length]
                     attention_mask = attention_mask[: self.max_length]
                     loss_mask = loss_mask[: self.max_length]
                     position_ids = position_ids[..., : self.max_length]
+                    if mm_token_type_ids is not None:
+                        mm_token_type_ids = mm_token_type_ids[..., : self.max_length]
                 elif self.truncation == "error":
                     raise ValueError(f"{sequence_length=} is larger than {self.max_length=}")
                 else:
@@ -398,6 +415,8 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
+            if mm_token_type_ids is not None:
+                multi_modal_inputs["mm_token_type_ids"] = mm_token_type_ids
             if len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
@@ -409,6 +428,8 @@ class MultiTurnSFTDataset(Dataset):
                 input_ids = input_ids[: self.max_length]
                 loss_mask = loss_mask[: self.max_length]
                 position_ids = position_ids[..., : self.max_length]
+                if mm_token_type_ids is not None:
+                    mm_token_type_ids = mm_token_type_ids[..., : self.max_length]
 
             # return nested tensor with out padding
             res = {
@@ -416,6 +437,8 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
+            if mm_token_type_ids is not None:
+                multi_modal_inputs["mm_token_type_ids"] = mm_token_type_ids
             if len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res


### PR DESCRIPTION
### What does this PR do?

`MultiTurnSFTDataset` deletes `mm_token_type_ids` from the processor output. That array carries one entry per token — 0 text, 1 image, 2 video. Gemma-4 uses it to build a bidirectional attention mask for vision inputs, as the patches of one picture have no left-to-right order. With the key gone such a checkpoint silently falls back to standard causal masking over image tokens.

This PR keeps the array, joins the per-turn pieces along tokens, and carries it through every branch that changes the sequence length.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+mm_token_type_ids — the overlapping PR #6030 was closed; nothing open touches this key. Related: #6715 (same array, RL path), #5909 (where these lines were added).
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Extended `tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py`, which `cpu_unit_tests.yml` already runs.

```bash
pytest tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py    # 9 passed
```

### API and Usage Example

No API, config, or CLI change. A dataset whose processor emits the array now returns it inside `multi_modal_inputs`, shaped `(1, seq_len)`. A text-only row of such a dataset therefore carries `multi_modal_inputs={"mm_token_type_ids": ...}` (all zeros) where it previously had no `multi_modal_inputs` key at all.

### Design & Code Changes

The array is per-**token**, so turns join end to end along tokens — similar to `input_ids`, `loss_mask` and `attention_mask`. The generic `torch.concat(v, dim=0)` treats it as a batch-like key and stacks ragged turns into a rectangle, which is the crash the deletion silenced; joining on `dim=1` is what makes keeping it work.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). — not applicable: no new config knob, API, or user-facing behavior to document.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule... — not applicable.

### AI assistance

AI assistance (Claude Code) was used for this PR. Every line was reviewed by me, and I ran the tests reported above.
