### PR TITLE
[fsdp] fix: make deferred gradient sync configurable

### DIFF
--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -198,10 +198,9 @@ Reduce FSDP gradient synchronization during gradient accumulation
 
 When a PPO mini-batch is split into multiple micro-batches, the optimizer only
 steps after the final micro-batch, so gradients only need to be synchronized
-once per mini-batch. The FSDP engine automatically defers gradient
-synchronization on the non-final micro-batches and synchronizes only before the
-final backward. This applies to both the actor and the critic, and requires no
-configuration.
+once per mini-batch. By default, the FSDP engine defers gradient synchronization
+on the non-final micro-batches and synchronizes only before the final backward.
+This applies to both the actor and the critic.
 
 With :math:`M` micro-batches per mini-batch, this reduces gradient
 synchronization from :math:`M` rounds to one round. It does not remove parameter
@@ -211,9 +210,12 @@ numerically identical to synchronizing every micro-batch.
 
 .. note::
     Deferring synchronization retains unsharded gradients until the final
-    micro-batch, which slightly increases peak device memory during gradient
-    accumulation. Forward-only passes are unaffected and always keep the default
-    behavior.
+    micro-batch, which can substantially increase peak device memory during
+    gradient accumulation for large models or long packed sequences. Set
+    ``actor_rollout_ref.actor.fsdp_config.use_no_sync_for_gradient_accumulation=False``
+    (or the corresponding critic FSDP setting) to synchronize and reshard after
+    every micro-batch when memory headroom is limited. Forward-only passes are
+    unaffected.
 
 Migrating to FSDP2
 ----------------------

--- a/tests/workers/config/test_engine_config_on_cpu.py
+++ b/tests/workers/config/test_engine_config_on_cpu.py
@@ -51,6 +51,11 @@ class TestFSDPEngineConfigCPU:
         assert config.param_offload is False
         assert config.optimizer_offload is False
         assert config.fsdp_size == -1
+        assert config.use_no_sync_for_gradient_accumulation is True
+
+    def test_gradient_accumulation_sync_can_be_restored_per_micro_batch(self):
+        config = FSDPEngineConfig(use_no_sync_for_gradient_accumulation=False)
+        assert config.use_no_sync_for_gradient_accumulation is False
 
     @pytest.mark.parametrize(
         "offload_params",

--- a/tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
+++ b/tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -48,9 +49,12 @@ class _FSDP2Module:
         self.events.append(enabled)
 
 
-def _make_engine(module):
+def _make_engine(module, *, use_no_sync_for_gradient_accumulation=True):
     engine = object.__new__(FSDPEngine)
     engine.module = module
+    engine.engine_config = SimpleNamespace(
+        use_no_sync_for_gradient_accumulation=use_no_sync_for_gradient_accumulation,
+    )
     return engine
 
 
@@ -88,6 +92,36 @@ def test_gradient_sync_context_keeps_sync_for_final_micro_batch(monkeypatch):
         module.events.append("backward")
 
     assert module.events == ["backward"]
+
+
+@pytest.mark.parametrize("version,module_cls", [(1, _FSDP1Module), (2, _FSDP2Module)])
+def test_gradient_sync_context_keeps_sync_when_disabled(monkeypatch, version, module_cls):
+    module = module_cls()
+    engine = _make_engine(module, use_no_sync_for_gradient_accumulation=False)
+    monkeypatch.setattr(transformer_impl, "fsdp_version", lambda _: version)
+
+    with engine._gradient_sync_context(is_last_micro_batch=False):
+        module.events.append("backward")
+
+    assert module.events == ["backward"]
+
+
+@pytest.mark.parametrize("version,module_cls", [(1, _FSDP1Module), (2, _FSDP2Module)])
+def test_gradient_sync_context_defaults_to_deferred_sync_for_legacy_config(
+    monkeypatch,
+    version,
+    module_cls,
+):
+    module = module_cls()
+    engine = _make_engine(module)
+    engine.engine_config = SimpleNamespace()
+    monkeypatch.setattr(transformer_impl, "fsdp_version", lambda _: version)
+
+    with engine._gradient_sync_context(is_last_micro_batch=False):
+        module.events.append("backward")
+
+    expected = ["enter", "backward", "exit"] if version == 1 else [False, "backward", True]
+    assert module.events == expected
 
 
 def test_forward_backward_batch_syncs_only_final_micro_batch(monkeypatch):

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -43,7 +43,7 @@ actor_rollout_ref:
       entropy_from_logits_chunk_size: ${oc.select:actor_rollout_ref.actor.entropy_from_logits_chunk_size,2048}
       use_torch_compile: true
       entropy_checkpointing: ${oc.select:actor_rollout_ref.actor.entropy_checkpointing,False}
-      use_no_sync_for_gradient_accumulation: true
+      use_no_sync_for_gradient_accumulation: false
       pad_to_length: ${oc.select:actor_rollout_ref.actor.pad_to_length,False}
       pad_to_length_bucket: 1024
       forward_only: false
@@ -251,7 +251,7 @@ actor_rollout_ref:
       entropy_from_logits_chunk_size: ${oc.select:actor_rollout_ref.ref.entropy_from_logits_chunk_size,2048}
       use_torch_compile: true
       entropy_checkpointing: ${oc.select:actor_rollout_ref.ref.entropy_checkpointing,False}
-      use_no_sync_for_gradient_accumulation: true
+      use_no_sync_for_gradient_accumulation: false
       pad_to_length: ${oc.select:actor_rollout_ref.ref.pad_to_length,False}
       pad_to_length_bucket: ${oc.select:actor_rollout_ref.actor.fsdp_config.pad_to_length_bucket,1024}
       forward_only: true
@@ -565,7 +565,7 @@ critic:
     entropy_from_logits_chunk_size: 2048
     use_torch_compile: true
     entropy_checkpointing: false
-    use_no_sync_for_gradient_accumulation: true
+    use_no_sync_for_gradient_accumulation: false
     pad_to_length: false
     pad_to_length_bucket: 1024
     forward_only: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -43,6 +43,7 @@ actor_rollout_ref:
       entropy_from_logits_chunk_size: ${oc.select:actor_rollout_ref.actor.entropy_from_logits_chunk_size,2048}
       use_torch_compile: true
       entropy_checkpointing: ${oc.select:actor_rollout_ref.actor.entropy_checkpointing,False}
+      use_no_sync_for_gradient_accumulation: true
       pad_to_length: ${oc.select:actor_rollout_ref.actor.pad_to_length,False}
       pad_to_length_bucket: 1024
       forward_only: false
@@ -250,6 +251,7 @@ actor_rollout_ref:
       entropy_from_logits_chunk_size: ${oc.select:actor_rollout_ref.ref.entropy_from_logits_chunk_size,2048}
       use_torch_compile: true
       entropy_checkpointing: ${oc.select:actor_rollout_ref.ref.entropy_checkpointing,False}
+      use_no_sync_for_gradient_accumulation: true
       pad_to_length: ${oc.select:actor_rollout_ref.ref.pad_to_length,False}
       pad_to_length_bucket: ${oc.select:actor_rollout_ref.actor.fsdp_config.pad_to_length_bucket,1024}
       forward_only: true
@@ -563,6 +565,7 @@ critic:
     entropy_from_logits_chunk_size: 2048
     use_torch_compile: true
     entropy_checkpointing: false
+    use_no_sync_for_gradient_accumulation: true
     pad_to_length: false
     pad_to_length_bucket: 1024
     forward_only: false

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -3,6 +3,7 @@ _target_: verl.workers.config.FSDPEngineConfig
 
 # policy for wrapping the model
 wrap_policy:
+
   # Minimum number of parameters to trigger wrapping a layer with FSDP
   min_num_params: 0
 
@@ -82,6 +83,7 @@ dtype: bfloat16 # ["bfloat16", "float16"]
 
 # QAT (Quantization-Aware Training) configuration
 qat:
+
   # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
   _target_: verl.workers.config.QATEngineConfig
 
@@ -96,6 +98,7 @@ qat:
 
   # Patterns to ignore (e.g., lm_head, embed_tokens)
   ignore_patterns:
+
     - "lm_head"
     - "embed_tokens"
     - "re:.*mlp.gate$"

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -56,6 +56,10 @@ use_torch_compile: true
 # Whether to use entropy checkpointing in fsdp.
 entropy_checkpointing: false
 
+# Whether to defer gradient synchronization until the final micro-batch. Disable this when the extra peak memory
+# from retaining unsharded gradients outweighs the communication savings.
+use_no_sync_for_gradient_accumulation: true
+
 # Round every packed micro-batch up to a multiple of `pad_to_length_bucket` tokens, so the packed
 # shape only takes a few distinct values instead of a new one per micro-batch (avoids kernel
 # recompilation / re-autotuning). Requires use_remove_padding=True. Pad tokens are stripped before

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -3,7 +3,6 @@ _target_: verl.workers.config.FSDPEngineConfig
 
 # policy for wrapping the model
 wrap_policy:
-
   # Minimum number of parameters to trigger wrapping a layer with FSDP
   min_num_params: 0
 
@@ -58,7 +57,7 @@ entropy_checkpointing: false
 
 # Whether to defer gradient synchronization until the final micro-batch. Disable this when the extra peak memory
 # from retaining unsharded gradients outweighs the communication savings.
-use_no_sync_for_gradient_accumulation: true
+use_no_sync_for_gradient_accumulation: false
 
 # Round every packed micro-batch up to a multiple of `pad_to_length_bucket` tokens, so the packed
 # shape only takes a few distinct values instead of a new one per micro-batch (avoids kernel
@@ -83,7 +82,6 @@ dtype: bfloat16 # ["bfloat16", "float16"]
 
 # QAT (Quantization-Aware Training) configuration
 qat:
-
   # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
   _target_: verl.workers.config.QATEngineConfig
 
@@ -98,7 +96,6 @@ qat:
 
   # Patterns to ignore (e.g., lm_head, embed_tokens)
   ignore_patterns:
-
     - "lm_head"
     - "embed_tokens"
     - "re:.*mlp.gate$"

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -260,6 +260,9 @@ class FSDPEngineConfig(EngineConfig):
             debugging.
         mixed_precision (Optional[dict[str, Any]]): Mixed precision configuration for FSDP, default None
         dtype (str): Mixed precision training param dtype, default "bfloat16"
+        use_no_sync_for_gradient_accumulation (bool): Whether to defer FSDP gradient synchronization until the
+            final micro-batch. Disabling this reduces peak memory by synchronizing and resharding gradients after
+            every micro-batch. default True
         pad_to_length (bool): Round every packed micro-batch up to a multiple of
             ``pad_to_length_bucket`` tokens, so the packed shape only takes a handful of distinct
             values instead of a new one per micro-batch, which avoids repeated kernel
@@ -293,6 +296,7 @@ class FSDPEngineConfig(EngineConfig):
     entropy_from_logits_chunk_size: int = 2048
     use_torch_compile: bool = True
     entropy_checkpointing: bool = False
+    use_no_sync_for_gradient_accumulation: bool = True
     strategy: str = "fsdp"
     pad_to_length: bool = False
     pad_to_length_bucket: int = 1024

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -680,7 +680,12 @@ class FSDPEngine(BaseEngine):
         micro-batch to a single round, at the cost of temporarily retaining
         unsharded gradients until the final backward.
         """
-        if is_last_micro_batch:
+        defer_sync = getattr(
+            self.engine_config,
+            "use_no_sync_for_gradient_accumulation",
+            True,
+        )
+        if is_last_micro_batch or not defer_sync:
             yield
             return
 


### PR DESCRIPTION
<!-- Suggested PR title: [fsdp] fix: make deferred gradient sync configurable -->

### What does this PR do?

Complete the configuration contract for deferred FSDP gradient synchronization introduced by [#7095](https://github.com/verl-project/verl/pull/7095).

The merged implementation currently defers synchronization on every non-final micro-batch, but it does not expose the documented `use_no_sync_for_gradient_accumulation` setting. This PR adds the missing FSDP engine option and keeps its default `true` to preserve the current runtime behavior. Memory-constrained jobs can explicitly set it to `false` to synchronize and reshard gradients after every micro-batch.

<img width="1466" height="98" alt="image" src="https://github.com/user-attachments/assets/64a24680-68a9-4781-b624-2d32c3cf3104" />


The change supports both FSDP1 and FSDP2, preserves forward-only behavior, and retains the current deferred-sync behavior for legacy engine config objects that do not define the new field.

Related: [#7095](https://github.com/verl-project/verl/pull/7095), [#6010](https://github.com/verl-project/verl/issues/6010).

### Checklist Before Starting

- [x] Searched for similar open PRs: [use_no_sync_for_gradient_accumulation](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+use_no_sync_for_gradient_accumulation), [FSDP no_sync](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+FSDP+no_sync), and [gradient sync accumulation](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+gradient+sync+accumulation). No open duplicate was found at the time of submission preparation.
- [x] Formatted the PR title as `[fsdp] fix: make deferred gradient sync configurable`.
- [x] Verified that the latest `main` still has the unconditional deferred-sync path and does not define `use_no_sync_for_gradient_accumulation`.

### Test

Focused CPU tests that do not depend on the local two-rank Gloo backend:

```bash
python -m pytest -q \
  tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py \
  tests/workers/config/test_engine_config_on_cpu.py \
  -k "not distributed_accumulation_matches_per_micro_batch_sync"
```

Result:

```text
21 passed, 1 deselected
```

Additional validation completed:

- Ruff lint passed for all changed Python files.
- Ruff format check passed for all changed Python files.
- Mypy passed for the changed-file pre-commit run.
- Hydra composition verified `true` for the actor, reference model, and critic defaults.
- A Hydra actor override was verified to resolve to `false`.
- Generated trainer configuration verification passed.
- Documentation, license, device API, DataProto, naming, and compileall hooks passed.
- `git diff --check` passed.

The real two-rank Gloo equivalence test was attempted on Windows, but the local PyTorch backend failed during `init_process_group()` with `makeDeviceForHostname(): unsupported gloo device`, before entering the FSDP code under test. It remains enabled for Linux CI.

The complete pre-commit suite is not marked as passed locally because the current upstream tree contains root-level `tests/test_*` files rejected by the repository's `validate-structure` hook. This PR does not add or modify those files.

### API and Usage Example

No existing CLI or Python API is removed. The new FSDP engine option defaults to `true`, matching the current merged runtime behavior.

```bash
# Default: defer gradient synchronization until the final micro-batch.
actor_rollout_ref.actor.fsdp_config.use_no_sync_for_gradient_accumulation=True

# Memory-constrained actor training: synchronize and reshard after every micro-batch.
actor_rollout_ref.actor.fsdp_config.use_no_sync_for_gradient_accumulation=False

# Apply the same memory-oriented behavior to critic training when needed.
critic.fsdp.use_no_sync_for_gradient_accumulation=False
```

With `M` micro-batches, `true` reduces gradient synchronization from `M` rounds to one, but temporarily retains unsharded gradients and can increase peak device memory. Setting the option to `false` trades additional gradient communication for lower peak memory. When there is only one micro-batch, both settings follow the normal synchronized backward path.

### Design & Code Changes

- Add `use_no_sync_for_gradient_accumulation: bool = True` to `FSDPEngineConfig`.
- Add the option to the FSDP Hydra YAML and regenerate the flattened PPO reference configuration.
- Gate the existing FSDP1 `no_sync()` and FSDP2 `set_requires_gradient_sync(False)` paths on the new option.
- Use a `getattr(..., True)` compatibility fallback so legacy or subclass-specific engine config objects preserve the current deferred-sync behavior.
- Keep the final micro-batch and all forward-only execution synchronized exactly as before.
- Add CPU coverage for the default, explicit opt-out, FSDP1, FSDP2, final-micro-batch, exception restoration, and legacy-config behavior.
- Document the communication-versus-memory trade-off and the actor/critic override paths.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply the complete [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`. Relevant changed-file hooks passed locally; see the test limitation above.
- [x] Updated the FSDP performance-tuning documentation.
- [x] Added CPU unit tests covering the configuration and both FSDP synchronization paths. The existing Linux two-rank test remains enabled for CI.
- [ ] Once the PR is ready for CI, request CI in the `ci-request` channel in the `verl` Slack workspace or the linked Feishu group.
- [x] The `recipe` submodule is not affected.
- [x] AI assistance was used for repository inspection, implementation review, test execution, and drafting this description. The human submitter must review every changed line and be able to explain the synchronization and memory trade-off before requesting review.
