### PR TITLE
[training_utils, env, doc] feat: use Liger fused linear PPO kernel

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -749,4 +749,4 @@ Most parameters for Model are similar to Reward Model.
   default to ``all-linear``. See `peft docs <https://huggingface.co/docs/peft/v0.15.0/en/package_reference/lora#peft.LoraConfig.target_modules>`_ for detail.
 
 - ``use_liger``: Whether to enable Liger kernel, default to False. If True,
-  we apply Liger kernel to the model (depends on `liger-kernel`).
+  we apply Liger kernel to the model (depends on ``liger-kernel>=0.8.2``).

--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -174,16 +174,16 @@ LigerKernel for training performance
 
 LigerKernel provides fused Triton kernels (RMSNorm, SwiGLU, RoPE) that can improve training throughput. It works with both SFT and RL (PPO/GRPO) training, including vision-language models.
 
-1. Install liger-kernel via ``pip3 install liger-kernel``. Set ``use_liger`` in your configuration:
+1. Install Liger Kernel 0.8.2 or newer via ``pip3 install "liger-kernel>=0.8.2"``. Set ``use_liger`` in your configuration:
 
    .. code-block:: yaml
 
       model:
         use_liger: True  # Enable LigerKernel
 
-2. The default value is ``False``. When enabled, verl applies Liger's fused RMSNorm, SwiGLU, and RoPE kernels to the model. The ``fused_linear_cross_entropy`` optimization is disabled because verl computes log-probabilities via its own path.
+2. The default value is ``False``. When enabled, verl applies Liger's fused RMSNorm, SwiGLU, and RoPE kernels to the model. The model-level ``fused_linear_cross_entropy`` patch remains disabled because verl computes log-probabilities through its output-head path. With ``use_fused_kernels`` and the ``torch`` backend, that path uses Liger's fused scaled linear cross entropy from v0.8.2 or newer and falls back to verl's existing chunked ``FusedLinearForPPOFunction`` when Liger is not installed.
 
-3. ``use_liger`` is compatible with ``use_fused_kernels`` — they operate at different levels (Liger optimizes model internals, fused kernels optimize the output head). Using both together gives the best speed-memory tradeoff.
+3. ``use_liger`` is compatible with ``use_fused_kernels``. The former controls model-internal kernels, while the latter controls the output head and can use Liger's scaled cross entropy independently when ``liger-kernel>=0.8.2`` is installed.
 
 Forward prefetch in FSDP training backend
 ----------------------

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -405,7 +405,7 @@ Find the docker for AMD ROCm: `docker/Dockerfile.rocm <https://github.com/verl-p
         datasets \
         dill \
         hydra-core \
-        liger-kernel \
+        "liger-kernel>=0.8.2" \
         numpy \
         pandas \
         datasets \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ fsdp = [
     "torch==2.11.0",
     "torchvision==0.26.0",
     "torchaudio==2.11.0",
-    "liger-kernel",
+    "liger-kernel>=0.8.2",
     "trl==0.27.0",
     # transformers NOT pinned here: trainers inherit the synced engine's version
     # (vllm 5.5.3 / sglang 5.3.0). See override-dependencies below.
@@ -162,7 +162,7 @@ megatron = [
     "onnxscript",
     "trl==0.27.0",
     "matplotlib",
-    "liger-kernel",
+    "liger-kernel>=0.8.2",
     # Two Megatron<->HF connectors: mbridge (legacy) and megatron-bridge (NVIDIA,
     # imported as megatron.bridge; the migration target, installed deps-free — see
     # [[tool.uv.dependency-metadata]] below). 0.5.2 is the wheelhouse build of the

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ codetiming
 datasets
 dill
 hydra-core
-liger-kernel
+liger-kernel>=0.8.2
 numpy>=2.0.0
 pandas
 peft

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ TEST_REQUIRES = ["pytest", "pre-commit", "py-spy", "pytest-asyncio", "pytest-rer
 # Empty since PRIME code scoring dropped `pyext`; kept so `verl[prime]` stays installable.
 PRIME_REQUIRES = []
 GEO_REQUIRES = ["mathruler", "torchvision", "qwen_vl_utils"]
-GPU_REQUIRES = ["liger-kernel", "flash-attn"]
+GPU_REQUIRES = ["liger-kernel>=0.8.2", "flash-attn"]
 MATH_REQUIRES = ["math-verify"]  # Add math-verify as an optional dependency
 VLLM_REQUIRES = ["tensordict>=0.8.0,<=0.10.0,!=0.9.0", "vllm>=0.18.0"]
 TRTLLM_REQUIRES = ["tensorrt-llm>=1.2.0rc6"]

--- a/tests/utils/test_experimental_torch_functional_on_cpu.py
+++ b/tests/utils/test_experimental_torch_functional_on_cpu.py
@@ -1,0 +1,117 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "verl" / "utils" / "experimental" / "torch_functional.py"
+_SPEC = importlib.util.spec_from_file_location("_experimental_torch_functional", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+experimental_F = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(experimental_F)
+
+
+@pytest.mark.parametrize("hidden_shape", [(7, 5), (2, 7, 5)])
+def test_fused_linear_for_ppo_chunked_fallback_matches_torch(monkeypatch, hidden_shape):
+    monkeypatch.setattr(experimental_F, "_LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY", None)
+    monkeypatch.setattr(experimental_F, "_FLASH_ATTN_CROSS_ENTROPY_AVAILABLE", False)
+    torch.manual_seed(42)
+
+    temperature = 0.7
+    vocab_size = 11
+    hidden = torch.randn(hidden_shape, requires_grad=True)
+    weight = torch.randn(vocab_size, hidden_shape[-1], requires_grad=True)
+    labels = torch.randint(vocab_size, hidden_shape[:-1], dtype=torch.int32)
+    grad_log_probs = torch.randn(hidden_shape[:-1])
+    grad_entropy = torch.randn(hidden_shape[:-1])
+
+    log_probs, entropy = experimental_F.FusedLinearForPPO()(hidden, weight, labels, temperature)
+    torch.autograd.backward((log_probs, entropy), (grad_log_probs, grad_entropy))
+
+    expected_hidden = hidden.detach().clone().requires_grad_(True)
+    expected_weight = weight.detach().clone().requires_grad_(True)
+    logits = ((expected_hidden @ expected_weight.t()) / temperature).float()
+    expected_log_probs = logits.log_softmax(dim=-1).gather(-1, labels.long().unsqueeze(-1)).squeeze(-1)
+    probs = logits.softmax(dim=-1)
+    expected_entropy = torch.logsumexp(logits, dim=-1) - torch.sum(probs * logits, dim=-1)
+    torch.autograd.backward(
+        (expected_log_probs, expected_entropy),
+        (grad_log_probs, grad_entropy),
+    )
+
+    torch.testing.assert_close(log_probs, expected_log_probs)
+    torch.testing.assert_close(entropy, expected_entropy)
+    torch.testing.assert_close(hidden.grad, expected_hidden.grad)
+    torch.testing.assert_close(weight.grad, expected_weight.grad)
+
+
+def test_fused_linear_for_ppo_dispatches_to_liger(monkeypatch):
+    calls = []
+
+    class FakeLigerFusedLinearScaledCrossEntropyFunction:
+        @staticmethod
+        def apply(*args):
+            calls.append(args)
+            hidden_states = args[0]
+            token_count = hidden_states.shape[0]
+            nll = torch.arange(token_count, dtype=torch.float32)
+            entropy = torch.arange(token_count, dtype=hidden_states.dtype) + 10
+            return nll, entropy
+
+    monkeypatch.setattr(
+        experimental_F,
+        "_LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY",
+        FakeLigerFusedLinearScaledCrossEntropyFunction,
+    )
+    hidden = torch.randn(2, 3, 5)
+    weight = torch.randn(7, 5)
+    labels = torch.randint(7, (2, 3), dtype=torch.int32)
+
+    log_probs, entropy = experimental_F.FusedLinearForPPO()(hidden, weight, labels, temperature=0.8)
+
+    assert len(calls) == 1
+    liger_hidden, liger_weight, liger_labels, temperature, ignore_index, m_tiles, return_entropy = calls[0]
+    assert liger_hidden.shape == (6, 5)
+    assert liger_weight is weight
+    assert liger_labels.shape == (6,)
+    assert liger_labels.dtype == torch.int64
+    assert temperature == 0.8
+    assert ignore_index == -100
+    assert m_tiles == 1
+    assert return_entropy is True
+    torch.testing.assert_close(log_probs, -torch.arange(6, dtype=torch.float32).reshape(2, 3))
+    torch.testing.assert_close(entropy, (torch.arange(6, dtype=hidden.dtype) + 10).reshape(2, 3))
+
+
+def test_fused_linear_for_ppo_fallback_preserves_chunking(monkeypatch):
+    monkeypatch.setattr(experimental_F, "_LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY", None)
+    monkeypatch.setattr(experimental_F, "_FLASH_ATTN_CROSS_ENTROPY_AVAILABLE", False)
+    original_forward = experimental_F._fused_linear_for_ppo_fwd
+    chunk_sizes = []
+
+    def record_chunk_size(hidden_states, *args, **kwargs):
+        chunk_sizes.append(hidden_states.shape[0])
+        return original_forward(hidden_states, *args, **kwargs)
+
+    monkeypatch.setattr(experimental_F, "_fused_linear_for_ppo_fwd", record_chunk_size)
+    hidden = torch.randn(1, 7, 5)
+    weight = torch.randn(11, 5)
+    labels = torch.randint(11, (1, 7))
+
+    experimental_F.FusedLinearForPPO(chunk_size=3)(hidden, weight, labels)
+
+    assert chunk_sizes == [3, 3, 1]

--- a/uv.lock
+++ b/uv.lock
@@ -1529,15 +1529,15 @@ wheels = [
 
 [[package]]
 name = "liger-kernel"
-version = "0.8.0"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.12' and extra == 'extra-4-verl-sglang' and extra == 'extra-4-verl-vllm') or (platform_machine != 'x86_64' and extra == 'extra-4-verl-sglang' and extra == 'extra-4-verl-vllm') or (sys_platform != 'linux' and extra == 'extra-4-verl-sglang' and extra == 'extra-4-verl-vllm')" },
     { name = "triton", marker = "(python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.12' and extra == 'extra-4-verl-sglang' and extra == 'extra-4-verl-vllm') or (platform_machine != 'x86_64' and extra == 'extra-4-verl-sglang' and extra == 'extra-4-verl-vllm') or (sys_platform != 'linux' and extra == 'extra-4-verl-sglang' and extra == 'extra-4-verl-vllm')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/d6/85f032b40fc30c969e817f9f3527f987b508171b46d9958befd0868855fd/liger_kernel-0.8.0.tar.gz", hash = "sha256:f98b94faf018814a0757e7b72bb8ebaaf12a78782cd09b157732acca2791e72c", size = 3989670, upload-time = "2026-04-30T23:02:15.183Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/a5/27575f85fd91cb92a0d72b4c37daa79021334926b5c4624f7ce9fa15e6ae/liger_kernel-0.8.2.tar.gz", hash = "sha256:387673ed6bf64fc8150cc8315fed578d2fc717ec3450f53489f480880223c1b8", size = 6136426, upload-time = "2026-08-18T20:54:30.62Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/6b/eb29b56f128a819e2cded552e293212c57daa949481206b82490b207deac/liger_kernel-0.8.0-py3-none-any.whl", hash = "sha256:e1f03eeb4ba6a6a413d585dacf92c4c15d164bab5844fa4ead2fede6bcac469c", size = 403120, upload-time = "2026-04-30T23:02:13.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b3/a66f1d9143697784ad2c2abf665b02c47aa17857232ed72224588186103c/liger_kernel-0.8.2-py3-none-any.whl", hash = "sha256:84c0a7bc9bf4d4cf8ea5ba89ff84d28686afc94215b220851d9f57dc87852741", size = 644266, upload-time = "2026-08-18T20:54:28.728Z" },
 ]
 
 [[package]]
@@ -4733,8 +4733,8 @@ requires-dist = [
     { name = "hf-transfer", marker = "extra == 'ci'" },
     { name = "hydra-core" },
     { name = "hydra-core", marker = "extra == 'verl-core'" },
-    { name = "liger-kernel", marker = "extra == 'fsdp'" },
-    { name = "liger-kernel", marker = "extra == 'megatron'" },
+    { name = "liger-kernel", marker = "extra == 'fsdp'", specifier = ">=0.8.2" },
+    { name = "liger-kernel", marker = "extra == 'megatron'", specifier = ">=0.8.2" },
     { name = "math-verify", marker = "extra == 'math'" },
     { name = "mathruler", marker = "extra == 'verl-core'" },
     { name = "matplotlib", marker = "extra == 'megatron'" },

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -17,6 +17,15 @@ from typing import Optional
 import torch
 
 try:
+    from liger_kernel.ops import (
+        LigerFusedLinearScaledCrossEntropyFunction as _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "liger_kernel":
+        raise
+    _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY = None
+
+try:
     from flash_attn.ops.triton.cross_entropy import cross_entropy_loss
 
     _FLASH_ATTN_CROSS_ENTROPY_AVAILABLE = True
@@ -222,10 +231,36 @@ class FusedLinearForPPO(torch.nn.Module):
         temperature: float = 1.0,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
         input_ids = input_ids.to(torch.int64)
-        return FusedLinearForPPOFunction.apply(
+        if _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY is None:
+            return FusedLinearForPPOFunction.apply(
+                hidden_states,
+                vocab_weights,
+                input_ids,
+                temperature,
+                self.chunk_size,
+            )
+
+        if hidden_states.ndim not in (2, 3):
+            raise ValueError(f"hidden_states must be 2D or 3D, got shape {tuple(hidden_states.shape)}")
+        if input_ids.shape != hidden_states.shape[:-1]:
+            raise ValueError(
+                f"input_ids shape {tuple(input_ids.shape)} must match hidden_states shape "
+                f"{tuple(hidden_states.shape[:-1])}"
+            )
+
+        output_shape = input_ids.shape
+        hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+        input_ids = input_ids.reshape(-1)
+
+        nll, entropy = _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY.apply(
             hidden_states,
             vocab_weights,
             input_ids,
             temperature,
-            self.chunk_size,
+            -100,
+            1,
+            True,
         )
+        log_probs = -nll
+
+        return log_probs.reshape(output_shape), entropy.reshape(output_shape)


### PR DESCRIPTION
### What does this PR do?

Closes #7424.

Replaces verl's experimental fused linear PPO output-head implementation with Liger Kernel v0.8.2's `LigerFusedLinearScaledCrossEntropyFunction` when Liger is installed. The wrapper preserves log-probability sign, entropy output, 2D/3D shapes, and gradients; without Liger it keeps the existing chunked `FusedLinearForPPOFunction` unchanged.

### Highlights

- **13.53% faster actor updates:** Mean actor update time fell from 0.02803 to 0.02424 ms/token across four H100 seeds, with an improvement on every seed and a paired 95% CI of [-0.00434, -0.00325] ms/token.
- **Lower GPU memory:** Actor max allocated memory dropped from 35.68 to 33.70 GiB (**5.56% / 1.98 GiB lower**), while mean per-GPU physical peak memory fell from 39.63 to 37.80 GiB (**4.64% / 1.83 GiB lower**).
- **Drop-in acceleration with a safe fallback:** Existing fused-kernel configurations require no changes; `liger-kernel>=0.8.2` uses the optimized Liger path, while environments without Liger retain verl's current chunked implementation.
- **Training behavior preserved:** The wrapper maintains log-probability and entropy semantics, supported shapes, and gradients. The four-seed reward comparison found no statistically resolved regression (the paired 95% CI crosses zero).

This does not duplicate an existing PR: searches for issue-linked and fused-linear-PPO work found no open implementation PR.

AI assistance: GitHub Copilot CLI assisted with implementation, testing, benchmark automation, and PR drafting. The human submitter reviewed every changed line and supervised all validation.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [#7424 in open PR bodies](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7424+in%3Abody) and [fused linear PPO Liger](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22fused+linear+PPO+Liger%22).
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

- `python -m pytest -q tests/utils/test_experimental_torch_functional_on_cpu.py` — 4 passed.
- `python -m pre_commit run --all-files --show-diff-on-failure --color=always` — all hooks passed.
- `uv lock --check --python 3.12` — 337 packages resolved; lock is current.
- H100 training benchmark — Qwen3-0.6B on GSM8K, GRPO/FSDP, 4 GPUs per run, 4 seeds per method (42, 101, 303, 404), 100 steps each, BF16 compute, dynamic batching and remove-padding packing, 48 trajectories/GPU (approximately 13–16K packed tokens/GPU), 32K token cap, and steps 11–100 used for timing statistics.

#### Four-seed actor update performance

| Method | Seeds | Mean ms/token ± SD | Paired Liger-minus-Verl 95% CI | Liger reduction |
|---|---:|---:|---:|---:|
| Existing verl chunked fused PPO | 4 | 0.02803 ± 0.00268 | — | — |
| Liger CuTe DSL | 4 | **0.02424 ± 0.00294** | **[-0.00434, -0.00325]** | **13.53%** |

Liger reduced actor update time/token on every seed.

#### Four-seed peak memory

| Method | Actor max allocated (GiB) ± SD | Mean per-GPU peak used (GiB) ± SD |
|---|---:|---:|
| Existing verl chunked fused PPO | 35.68 ± 0.06 | 39.63 ± 0.21 |
| Liger CuTe DSL | **33.70 ± 0.10** | **37.80 ± 0.11** |

Liger reduced actor allocated memory by 5.56% and physical peak memory by 4.64% versus the existing verl fused baseline.

#### Four-seed reward behavior

| Method | Final-10-step reward mean ± SD |
|---|---:|
| Existing verl chunked fused PPO | 0.652 ± 0.014 |
| Liger CuTe DSL | 0.638 ± 0.022 |

The paired Liger-minus-Verl final-reward difference was -0.0141 with a 95% CI of [-0.0494, 0.0213]. The interval crosses zero, so these four seeds do not resolve a reward regression; both methods converge to the same reward range.

### Benchmark Figures

Figures are attached below and are intentionally not committed to the repository.

#### Actor update time/token across seeds

![Verl fused versus Liger CuTe DSL actor update across four seeds](https://github.com/user-attachments/assets/7caf1069-4124-4ad4-a41b-7d2f7abf4b82)

#### GSM8K reward across seeds

![Verl fused versus Liger CuTe DSL GSM8K reward mean and confidence interval](https://github.com/user-attachments/assets/d51728ed-c96d-4523-9953-47bf12c5afcd)

#### Peak GPU memory across seeds

![Verl fused versus Liger CuTe DSL peak GPU memory across four seeds](https://github.com/user-attachments/assets/737d78da-bee4-4aa4-a463-969ac9ab1c50)

### API and Usage Example

No configuration change is required for existing fused-kernel users:

```yaml
actor_rollout_ref:
  model:
    use_fused_kernels: true
    fused_kernel_options:
      impl_backend: torch
```

With `liger-kernel>=0.8.2`, the torch backend uses Liger fused scaled linear cross entropy. If Liger is absent, it uses verl's existing chunked fallback.

### Design & Code Changes

- Import Liger's public fused scaled linear cross-entropy operator optionally and surface broken/incompatible Liger installations instead of silently masking import failures.
- Flatten supported 3D hidden states and labels for Liger's 2D operator, negate NLL back to log-probabilities, and restore the original output shape.
- Preserve the original chunked custom autograd implementation and `chunk_size` behavior as the no-Liger fallback.
- Require `liger-kernel>=0.8.2` in setup, development, FSDP, and Megatron dependency manifests; regenerate `uv.lock`.
- Add CPU tests for forward/backward parity, Liger dispatch arguments, shape restoration, label casting, and fallback chunking.
- Update installation, configuration, and performance documentation.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to the CI workflow to cover all the code. The new `tests/utils/test_experimental_torch_functional_on_cpu.py` follows the CPU CI naming convention.
- [ ] Once the PR is ready for CI, send a message in the `ci-request` channel in the verl Slack workspace.
- [x] If the PR is related to the `recipe` submodule, update its reference. Not applicable; this PR does not change `recipe`.










