### PR TITLE
[trainer, cfg] fix: wire critic batching keys into TrainingWorkerConfig

### DIFF
--- a/tests/workers/config/test_critic_engine_batching_on_cpu.py
+++ b/tests/workers/config/test_critic_engine_batching_on_cpu.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl.workers.config.critic import CriticConfig
+from verl.workers.config.engine import EngineConfig
+from verl.workers.config.optimizer import OptimizerConfig
+
+
+def _make_critic(**kwargs) -> CriticConfig:
+    defaults = dict(
+        strategy="fsdp2",
+        use_dynamic_bsz=True,
+        ppo_micro_batch_size_per_gpu=2,
+        optim=OptimizerConfig(lr=1e-5),
+    )
+    defaults.update(kwargs)
+    return CriticConfig(**defaults)
+
+
+def test_apply_engine_batching_copies_static_and_dynamic_knobs():
+    critic = _make_critic(
+        use_dynamic_bsz=False,
+        ppo_micro_batch_size_per_gpu=4,
+        ppo_infer_micro_batch_size_per_gpu=2,
+        ppo_max_token_len_per_gpu=4096,
+        ppo_infer_max_token_len_per_gpu=2048,
+        forward_max_token_len_per_gpu=1024,
+    )
+    engine = EngineConfig()
+    critic.apply_engine_batching(engine)
+
+    assert engine.use_dynamic_bsz is False
+    assert engine.micro_batch_size_per_gpu == 4
+    assert engine.infer_micro_batch_size_per_gpu == 2
+    assert engine.max_token_len_per_gpu == 4096
+    assert engine.infer_max_token_len_per_gpu == 2048
+
+
+def test_apply_engine_batching_falls_back_infer_micro_batch_to_training():
+    critic = _make_critic(
+        use_dynamic_bsz=False,
+        ppo_micro_batch_size_per_gpu=8,
+        ppo_infer_micro_batch_size_per_gpu=None,
+    )
+    engine = EngineConfig()
+    critic.apply_engine_batching(engine)
+    assert engine.infer_micro_batch_size_per_gpu == 8
+
+
+def test_v1_train_budget_is_not_overwritten_by_infer_budget():
+    """V1 previously assigned max_token_len_per_gpu = ppo_infer_max_token_len_per_gpu."""
+    critic = _make_critic(
+        ppo_max_token_len_per_gpu=8192,
+        ppo_infer_max_token_len_per_gpu=1024,
+    )
+    engine = EngineConfig()
+    critic.apply_engine_batching(engine)
+    assert engine.max_token_len_per_gpu == 8192
+    assert engine.infer_max_token_len_per_gpu == 1024

--- a/tests/workers/config/test_critic_engine_batching_on_cpu.py
+++ b/tests/workers/config/test_critic_engine_batching_on_cpu.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from verl.workers.config.critic import CriticConfig
 from verl.workers.config.engine import EngineConfig
 from verl.workers.config.optimizer import OptimizerConfig
@@ -68,3 +70,34 @@ def test_v1_train_budget_is_not_overwritten_by_infer_budget():
     critic.apply_engine_batching(engine)
     assert engine.max_token_len_per_gpu == 8192
     assert engine.infer_max_token_len_per_gpu == 1024
+
+
+def test_apply_engine_batching_copies_dynamic_bsz_true():
+    """The True direction was untested; only the False direction was asserted."""
+    critic = _make_critic(use_dynamic_bsz=True, ppo_max_token_len_per_gpu=8192)
+    engine = EngineConfig(use_dynamic_bsz=False)
+    critic.apply_engine_batching(engine)
+    assert engine.use_dynamic_bsz is True
+    assert engine.max_token_len_per_gpu == 8192
+
+
+def test_static_path_rejects_missing_micro_batch_size_per_gpu():
+    """Guard the engine's `total_data_size % (group * mbs)`: a None there is a TypeError
+    deep inside prepare_micro_batches. The deprecated global ppo_micro_batch_size is not
+    normalized into the per-GPU field, so it cannot stand in for it."""
+    critic = _make_critic(
+        use_dynamic_bsz=False,
+        ppo_mini_batch_size=8,
+        ppo_micro_batch_size=8,
+        ppo_micro_batch_size_per_gpu=None,
+    )
+    engine = EngineConfig()
+    with pytest.raises(ValueError, match="ppo_micro_batch_size_per_gpu"):
+        critic.apply_engine_batching(engine)
+
+
+def test_dynamic_path_rejects_missing_token_budget():
+    critic = _make_critic(use_dynamic_bsz=True, ppo_max_token_len_per_gpu=None)
+    engine = EngineConfig()
+    with pytest.raises(ValueError, match="ppo_max_token_len_per_gpu"):
+        critic.apply_engine_batching(engine)

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -155,8 +155,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
             self.orig_critic_cfg = critic_cfg
             if self.orig_critic_cfg.strategy == "fsdp":
                 engine_config: FSDPEngineConfig = self.orig_critic_cfg.model.fsdp_config
-                engine_config.infer_max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
-                engine_config.max_token_len_per_gpu = critic_cfg.ppo_max_token_len_per_gpu
+                self.orig_critic_cfg.apply_engine_batching(engine_config)
             else:
                 raise NotImplementedError(f"Unknown strategy {self.orig_critic_cfg.strategy=}")
 

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -649,9 +649,7 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
-
   ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
-
   ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -649,6 +649,10 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
+
+  ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
+
+  ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}
   data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -546,6 +546,10 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
+
+  ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
+
+  ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}
   data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -546,9 +546,7 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
-
   ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
-
   ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -611,6 +611,10 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
+
+  ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
+
+  ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}
   data_loader_seed: 42

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -611,10 +611,8 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
-
   ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
-
-  ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
+  ppo_infer_micro_batch_size_per_gpu: ${.forward_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}
   data_loader_seed: 42

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -586,6 +586,10 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
+
+  ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
+
+  ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}
   data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -586,9 +586,7 @@ critic:
   use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
   ppo_max_token_len_per_gpu: 32768
   forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
-
   ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
-
   ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
   ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
   shuffle: ${oc.select:actor_rollout_ref.actor.shuffle,false}

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -48,6 +48,12 @@ ppo_max_token_len_per_gpu: 32768
 # Max token length per GPU in forward pass
 forward_max_token_len_per_gpu: ${.ppo_max_token_len_per_gpu}
 
+# Infer-time max tokens per GPU. Defaults to the documented forward budget.
+ppo_infer_max_token_len_per_gpu: ${.forward_max_token_len_per_gpu}
+
+# Infer-time local per-GPU micro batch size. Defaults to the training micro-batch.
+ppo_infer_micro_batch_size_per_gpu: ${.ppo_micro_batch_size_per_gpu}
+
 # Number of PPO epochs per batch
 ppo_epochs: ${oc.select:actor_rollout_ref.actor.ppo_epochs,1}
 

--- a/verl/trainer/config/critic/dp_critic.yaml
+++ b/verl/trainer/config/critic/dp_critic.yaml
@@ -31,6 +31,9 @@ forward_micro_batch_size: ${oc.select:.ppo_micro_batch_size,null}
 # Forward-only batch size during inference (per GPU)
 forward_micro_batch_size_per_gpu: ${oc.select:.ppo_micro_batch_size_per_gpu,null}
 
+# Infer-time local per-GPU micro batch size. Prefer the forward-only knob.
+ppo_infer_micro_batch_size_per_gpu: ${.forward_micro_batch_size_per_gpu}
+
 # Sequence parallelism size for Ulysses-style model parallelism
 # [DEPRECATED] use fsdp_config.ulysses_sequence_parallel_size instead
 ulysses_sequence_parallel_size: 1

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -807,8 +807,7 @@ class RayPPOTrainer:
 
             orig_critic_cfg = critic_cfg
             engine_config: EngineConfig = orig_critic_cfg.engine
-            engine_config.infer_max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
-            engine_config.max_token_len_per_gpu = critic_cfg.ppo_max_token_len_per_gpu
+            orig_critic_cfg.apply_engine_batching(engine_config)
 
             # Build the critic profiler config via the hydra path (same as the actor / ref / SFT),
             # so its tool_config entries are real dataclass instances the torch/nsys/npu backends can

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -259,8 +259,7 @@ class PPOTrainer(ABC):
         # 2. define critic class
         if self.use_critic:
             critic_cfg: CriticConfig = omega_conf_to_dataclass(self.config.critic)
-            critic_cfg.engine.infer_max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
-            critic_cfg.engine.max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
+            critic_cfg.apply_engine_batching(critic_cfg.engine)
 
             # Wire the critic profiler config via the hydra path (real dataclass tool_config), so the
             # standalone critic TrainingWorker gets a working DistProfiler instead of a silent no-op.

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -128,6 +128,26 @@ class CriticConfig(BaseConfig):
                     f"critic.ppo_mini_batch_size ({self.ppo_mini_batch_size})"
                 )
 
+    def apply_engine_batching(self, engine_config):
+        """Copy critic-level batching knobs onto the engine TrainingWorker reads.
+
+        Actor/ref already assign these fields in ``engine_workers.py``. The critic
+        worker is a bare ``TrainingWorker``, so trainers must do the same here.
+        """
+        engine_config.use_dynamic_bsz = self.use_dynamic_bsz
+        engine_config.micro_batch_size_per_gpu = self.ppo_micro_batch_size_per_gpu
+        infer_mbs = self.ppo_infer_micro_batch_size_per_gpu
+        if infer_mbs is None:
+            infer_mbs = getattr(self, "forward_micro_batch_size_per_gpu", None)
+        if infer_mbs is None:
+            infer_mbs = self.ppo_micro_batch_size_per_gpu
+        engine_config.infer_micro_batch_size_per_gpu = infer_mbs
+        engine_config.max_token_len_per_gpu = self.ppo_max_token_len_per_gpu
+        infer_tokens = self.ppo_infer_max_token_len_per_gpu
+        forward_tokens = getattr(self, "forward_max_token_len_per_gpu", None)
+        engine_config.infer_max_token_len_per_gpu = infer_tokens if infer_tokens is not None else forward_tokens
+        return engine_config
+
     @staticmethod
     def _check_mutually_exclusive(mbs, mbs_per_gpu, name: str):
         """Validate mutually exclusive micro batch size configuration options.

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -146,6 +146,24 @@ class CriticConfig(BaseConfig):
         infer_tokens = self.ppo_infer_max_token_len_per_gpu
         forward_tokens = getattr(self, "forward_max_token_len_per_gpu", None)
         engine_config.infer_max_token_len_per_gpu = infer_tokens if infer_tokens is not None else forward_tokens
+
+        # Mirror the actor's guard in engine_workers.py: the engine reads whichever pair
+        # `use_dynamic_bsz` selects, and a None there fails deep inside
+        # `prepare_micro_batches` instead of here. The deprecated global
+        # `critic.ppo_micro_batch_size` is not normalized into the per-GPU field, so it
+        # cannot stand in for it.
+        if engine_config.use_dynamic_bsz:
+            if engine_config.max_token_len_per_gpu is None or engine_config.infer_max_token_len_per_gpu is None:
+                raise ValueError(
+                    "critic.use_dynamic_bsz=True requires critic.ppo_max_token_len_per_gpu and "
+                    "critic.ppo_infer_max_token_len_per_gpu (or critic.forward_max_token_len_per_gpu)."
+                )
+        elif engine_config.micro_batch_size_per_gpu is None or engine_config.infer_micro_batch_size_per_gpu is None:
+            raise ValueError(
+                "critic.use_dynamic_bsz=False requires critic.ppo_micro_batch_size_per_gpu and "
+                "critic.ppo_infer_micro_batch_size_per_gpu (or critic.forward_micro_batch_size_per_gpu). "
+                "The deprecated critic.ppo_micro_batch_size is not a substitute."
+            )
         return engine_config
 
     @staticmethod


### PR DESCRIPTION
### What does this PR do?

`critic.ppo_micro_batch_size_per_gpu`, `critic.ppo_infer_micro_batch_size_per_gpu`,
`critic.ppo_max_token_len_per_gpu` and `critic.ppo_infer_max_token_len_per_gpu` are public,
documented config keys, but the engine config that `TrainingWorker` actually reads never
received them. Setting them changed nothing; the critic silently used the engine defaults.

The v1 trainer did copy two of them by hand, and assigned the **inference** budget to both
fields (`verl/trainer/ppo/v1/trainer_base.py`, before this PR):

```python
critic_cfg.engine.infer_max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
critic_cfg.engine.max_token_len_per_gpu = critic_cfg.ppo_infer_max_token_len_per_gpu
```

So `critic.ppo_max_token_len_per_gpu` was discarded and critic **training** ran on the
inference token budget. Inference budgets are normally set higher than training ones, so this
raises the per-GPU token count during the critic update — the opposite of what the user asked
for, with no warning.

This is the path `trainer.v1.trainer_mode=separate_async` uses.

Fixes #7462

### Design & Code Changes

- `CriticConfig.apply_engine_batching(engine_config)` — one place that copies the batching
  knobs onto an engine config, called from the v0 trainer and the v1 trainer.
- It validates the combination up front instead of letting a `None` reach the engine and fail
  later: `use_dynamic_bsz=True` requires both token budgets, `use_dynamic_bsz=False` requires
  both micro batch sizes.
- `ppo_infer_micro_batch_size_per_gpu` defaults to `forward_micro_batch_size_per_gpu` in
  `dp_critic.yaml`, so the generated reference YAMLs are regenerated with
  `scripts/generate_trainer_config.sh`, not edited by hand.

### Scope change in the latest push

An earlier revision of this PR also fixed the critic construction in
`verl/experimental/separation/ray_trainer.py`, which reads `critic.model.fsdp_config` — an
attribute `HFModelConfig` does not have (reported as #7822).

That is now **removed from this PR**. A maintainer has since stated that
`verl/experimental/separation` is deprecated and moving to verl-recipe, and closed #7822 on
that basis. This PR no longer touches that module; the remaining changes are in the v0 and v1
trainers and in the shared critic config.

### Test

```
$ python -m pytest tests/workers/config/test_critic_engine_batching_on_cpu.py -q
6 passed in 4.05s
```

New file `tests/workers/config/test_critic_engine_batching_on_cpu.py`, 6 CPU cases:
static and dynamic knob copying, the `forward_micro_batch_size_per_gpu` fallback, the two
validation rejections, and `test_v1_train_budget_is_not_overwritten_by_infer_budget`, which
fails on `main` and passes here.

Generated-config consistency was verified by regeneration, not by diff:

```
$ bash scripts/generate_trainer_config.sh
All good
```

Lint: `ruff 0.12.2` (the version pinned in `.pre-commit-config.yaml`) — `All checks passed!`,
files already formatted.

Rebased onto `23a341e3`.

### Not duplicating existing work

Checked before opening and again on this push:

- `gh pr list --repo verl-project/verl --state open --search "7462 in:body"` — only this PR.
- `gh pr list --repo verl-project/verl --state all --search "critic ppo_max_token_len_per_gpu"`
- `gh pr list --repo verl-project/verl --state all --search "apply_engine_batching"`

No other PR wires these keys into the engine config.

### AI assistance

AI assistance was used in investigating and preparing this change. I have reviewed every
changed line, ran the tests and the config regeneration shown above, and can defend the change.

### Checklist

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (ruff pinned at 0.12.2).
- [x] Add unit tests to cover the change.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel. **Not yet done
      — this PR has never had a CI run.**
