### PR TITLE
[cfg, megatron, doc] fix: drop unused actor.router_replay in favor of engine config

### DIFF
--- a/docs/ascend_tutorial/dev_guide/model_dev/parameter_and_metrics.md
+++ b/docs/ascend_tutorial/dev_guide/model_dev/parameter_and_metrics.md
@@ -598,7 +598,8 @@ verl 通过层级化的 YAML 配置文件管理所有参数，涉及到的所有
 
 | 参数名 | 默认值 | 说明 |
 |--------|--------|------|
-| `router_replay.mode` | `disabled` | 路由重放模式，可选 disabled、record、replay |
+| `actor.megatron.router_replay.mode` / `actor.veomni.router_replay.mode` | `disabled` | 引擎侧路由重放模式，可选 disabled、R2、R3 |
+| `actor.router_replay.mode` | `disabled` | 文档兼容键。非 disabled 且引擎侧仍为 disabled 时复制到引擎配置 |
 | `router_replay.record_file` | `null` | 路由记录文件路径 |
 | `router_replay.replay_file` | `null` | 路由重放文件路径 |
 

--- a/docs/ascend_tutorial/dev_guide/model_dev/parameter_and_metrics.md
+++ b/docs/ascend_tutorial/dev_guide/model_dev/parameter_and_metrics.md
@@ -599,7 +599,6 @@ verl 通过层级化的 YAML 配置文件管理所有参数，涉及到的所有
 | 参数名 | 默认值 | 说明 |
 |--------|--------|------|
 | `actor.megatron.router_replay.mode` / `actor.veomni.router_replay.mode` | `disabled` | 引擎侧路由重放模式，可选 disabled、R2、R3 |
-| `actor.router_replay.mode` | `disabled` | 文档兼容键。非 disabled 且引擎侧仍为 disabled 时复制到引擎配置 |
 | `router_replay.record_file` | `null` | 路由记录文件路径 |
 | `router_replay.replay_file` | `null` | 路由重放文件路径 |
 

--- a/docs/ascend_tutorial/dev_guide/model_dev/transfer_to_npu_guide.md
+++ b/docs/ascend_tutorial/dev_guide/model_dev/transfer_to_npu_guide.md
@@ -155,7 +155,7 @@ class DSAIndexer(MegatronModule):
 
 为了解决这一通用问题，业界引入了 **Routing Replay（路由回放）** 机制。其核心思想是通过锁定特定阶段的专家路由路径，屏蔽微小扰动对路由决策的干扰，从而保证模型训练的稳定性。目前主流包含R2和R3两种变体：
 
-* **（1）Vanilla Routing Replay (R2)**： (对应`actor_rollout_ref.actor.router_replay.mode="R2"`)
+* **（1）Vanilla Routing Replay (R2)**： (对应`actor_rollout_ref.actor.megatron.router_replay.mode="R2"`，或顶层 `actor_rollout_ref.actor.router_replay.mode="R2"`。顶层键在引擎侧仍为 `disabled` 时会复制到引擎配置)
   
   * **机制**：在梯度更新阶段，复现训练引擎在上一轮采样阶段计算出的专家路径。
   * **作用**：主要缓解**策略陈旧性**对路由的影响。随着策略的更新，当前前向传播计算出的路由可能与生成旧数据时的路由不一致，R2通过回放旧路由来维持优化信号的连贯性。
@@ -169,9 +169,11 @@ class DSAIndexer(MegatronModule):
 因此对于大尺寸 MoE 模型，在实际配置中通常推荐使用对齐更彻底的 R3 模式：
 
 ```
-actor_rollout_ref.actor.router_replay.mode="R3" \
+actor_rollout_ref.actor.megatron.router_replay.mode="R3" \
 actor_rollout_ref.rollout.enable_rollout_routing_replay=True \
 ```
+
+顶层 `actor_rollout_ref.actor.router_replay.mode="R3"` 同样有效：当 `actor.megatron.router_replay.mode`（或 VeOmni 的对应字段）仍为 `disabled` 时，会自动复制到引擎配置。
 
 ## 四、性能优化
 

--- a/docs/ascend_tutorial/dev_guide/model_dev/transfer_to_npu_guide.md
+++ b/docs/ascend_tutorial/dev_guide/model_dev/transfer_to_npu_guide.md
@@ -155,7 +155,7 @@ class DSAIndexer(MegatronModule):
 
 为了解决这一通用问题，业界引入了 **Routing Replay（路由回放）** 机制。其核心思想是通过锁定特定阶段的专家路由路径，屏蔽微小扰动对路由决策的干扰，从而保证模型训练的稳定性。目前主流包含R2和R3两种变体：
 
-* **（1）Vanilla Routing Replay (R2)**： (对应`actor_rollout_ref.actor.megatron.router_replay.mode="R2"`，或顶层 `actor_rollout_ref.actor.router_replay.mode="R2"`。顶层键在引擎侧仍为 `disabled` 时会复制到引擎配置)
+* **（1）Vanilla Routing Replay (R2)**： (对应`actor_rollout_ref.actor.megatron.router_replay.mode="R2"`，VeOmni 则为 `actor_rollout_ref.actor.veomni.router_replay.mode="R2"`)
   
   * **机制**：在梯度更新阶段，复现训练引擎在上一轮采样阶段计算出的专家路径。
   * **作用**：主要缓解**策略陈旧性**对路由的影响。随着策略的更新，当前前向传播计算出的路由可能与生成旧数据时的路由不一致，R2通过回放旧路由来维持优化信号的连贯性。
@@ -173,7 +173,7 @@ actor_rollout_ref.actor.megatron.router_replay.mode="R3" \
 actor_rollout_ref.rollout.enable_rollout_routing_replay=True \
 ```
 
-顶层 `actor_rollout_ref.actor.router_replay.mode="R3"` 同样有效：当 `actor.megatron.router_replay.mode`（或 VeOmni 的对应字段）仍为 `disabled` 时，会自动复制到引擎配置。
+VeOmni 后端请改用 `actor_rollout_ref.actor.veomni.router_replay.mode="R3"`。顶层 `actor.router_replay` 已移除，不会再生效。
 
 ## 四、性能优化
 

--- a/tests/workers/config/test_actor_router_replay_sync_on_cpu.py
+++ b/tests/workers/config/test_actor_router_replay_sync_on_cpu.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.workers.config.actor import McoreActorConfig, RouterReplayConfig, VeOmniActorConfig
+from verl.workers.config.engine import EngineRouterReplayConfig, McoreEngineConfig, VeOmniEngineConfig
+from verl.workers.config.optimizer import OptimizerConfig
+
+
+def test_mcore_copies_actor_router_replay_onto_disabled_engine():
+    cfg = McoreActorConfig(
+        rollout_n=1,
+        ppo_micro_batch_size_per_gpu=1,
+        router_replay=RouterReplayConfig(mode="R3", record_file="rec.json"),
+        megatron=McoreEngineConfig(router_replay=EngineRouterReplayConfig(mode="disabled")),
+        optim=OptimizerConfig(lr=1e-6),
+    )
+    assert cfg.megatron.router_replay.mode == "R3"
+    assert cfg.megatron.router_replay.record_file == "rec.json"
+
+
+def test_veomni_copies_actor_router_replay_onto_disabled_engine():
+    cfg = VeOmniActorConfig(
+        rollout_n=1,
+        ppo_micro_batch_size_per_gpu=1,
+        use_remove_padding=True,
+        router_replay=RouterReplayConfig(mode="R2"),
+        veomni=VeOmniEngineConfig(router_replay=EngineRouterReplayConfig(mode="disabled")),
+        optim=OptimizerConfig(lr=1e-6),
+    )
+    assert cfg.veomni.router_replay.mode == "R2"
+
+
+def test_conflicting_router_replay_modes_raise():
+    with pytest.raises(ValueError, match="Conflicting router_replay modes"):
+        McoreActorConfig(
+            rollout_n=1,
+            ppo_micro_batch_size_per_gpu=1,
+            router_replay=RouterReplayConfig(mode="R2"),
+            megatron=McoreEngineConfig(router_replay=EngineRouterReplayConfig(mode="R3")),
+            optim=OptimizerConfig(lr=1e-6),
+        )
+
+
+def test_engine_mode_kept_when_actor_is_disabled():
+    cfg = McoreActorConfig(
+        rollout_n=1,
+        ppo_micro_batch_size_per_gpu=1,
+        router_replay=RouterReplayConfig(mode="disabled"),
+        megatron=McoreEngineConfig(router_replay=EngineRouterReplayConfig(mode="R3")),
+        optim=OptimizerConfig(lr=1e-6),
+    )
+    assert cfg.megatron.router_replay.mode == "R3"

--- a/tests/workers/config/test_actor_router_replay_sync_on_cpu.py
+++ b/tests/workers/config/test_actor_router_replay_sync_on_cpu.py
@@ -12,54 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+from dataclasses import fields
 
-from verl.workers.config.actor import McoreActorConfig, RouterReplayConfig, VeOmniActorConfig
+from verl.workers.config.actor import ActorConfig, McoreActorConfig, VeOmniActorConfig
 from verl.workers.config.engine import EngineRouterReplayConfig, McoreEngineConfig, VeOmniEngineConfig
 from verl.workers.config.optimizer import OptimizerConfig
 
 
-def test_mcore_copies_actor_router_replay_onto_disabled_engine():
+def test_actor_config_has_no_top_level_router_replay():
+    assert "router_replay" not in {f.name for f in fields(ActorConfig)}
+
+
+def test_mcore_router_replay_lives_on_engine():
     cfg = McoreActorConfig(
         rollout_n=1,
         ppo_micro_batch_size_per_gpu=1,
-        router_replay=RouterReplayConfig(mode="R3", record_file="rec.json"),
-        megatron=McoreEngineConfig(router_replay=EngineRouterReplayConfig(mode="disabled")),
+        megatron=McoreEngineConfig(router_replay=EngineRouterReplayConfig(mode="R3")),
         optim=OptimizerConfig(lr=1e-6),
     )
+    assert not hasattr(cfg, "router_replay")
     assert cfg.megatron.router_replay.mode == "R3"
-    assert cfg.megatron.router_replay.record_file == "rec.json"
 
 
-def test_veomni_copies_actor_router_replay_onto_disabled_engine():
+def test_veomni_router_replay_lives_on_engine():
     cfg = VeOmniActorConfig(
         rollout_n=1,
         ppo_micro_batch_size_per_gpu=1,
         use_remove_padding=True,
-        router_replay=RouterReplayConfig(mode="R2"),
-        veomni=VeOmniEngineConfig(router_replay=EngineRouterReplayConfig(mode="disabled")),
+        veomni=VeOmniEngineConfig(router_replay=EngineRouterReplayConfig(mode="R2")),
         optim=OptimizerConfig(lr=1e-6),
     )
+    assert not hasattr(cfg, "router_replay")
     assert cfg.veomni.router_replay.mode == "R2"
-
-
-def test_conflicting_router_replay_modes_raise():
-    with pytest.raises(ValueError, match="Conflicting router_replay modes"):
-        McoreActorConfig(
-            rollout_n=1,
-            ppo_micro_batch_size_per_gpu=1,
-            router_replay=RouterReplayConfig(mode="R2"),
-            megatron=McoreEngineConfig(router_replay=EngineRouterReplayConfig(mode="R3")),
-            optim=OptimizerConfig(lr=1e-6),
-        )
-
-
-def test_engine_mode_kept_when_actor_is_disabled():
-    cfg = McoreActorConfig(
-        rollout_n=1,
-        ppo_micro_batch_size_per_gpu=1,
-        router_replay=RouterReplayConfig(mode="disabled"),
-        megatron=McoreEngineConfig(router_replay=EngineRouterReplayConfig(mode="R3")),
-        optim=OptimizerConfig(lr=1e-6),
-    )
-    assert cfg.megatron.router_replay.mode == "R3"

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -535,7 +535,16 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                 metrics.update(old_log_prob_metrics)
                 old_log_prob.batch.pop("entropys")
                 if "routed_experts" in batch.batch and "routed_experts" in old_log_prob.batch:
-                    router_mode = getattr(self.config.actor_rollout_ref.actor.router_replay, "mode", "disabled")
+                    actor_cfg = self.config.actor_rollout_ref.actor
+                    if getattr(actor_cfg, "strategy", None) == "megatron":
+                        engine_rr = getattr(actor_cfg, "megatron", None)
+                    elif getattr(actor_cfg, "strategy", None) == "veomni":
+                        engine_rr = getattr(actor_cfg, "veomni", None)
+                    else:
+                        engine_rr = None
+                    engine_mode = getattr(getattr(engine_rr, "router_replay", None), "mode", None)
+                    actor_mode = getattr(getattr(actor_cfg, "router_replay", None), "mode", "disabled")
+                    router_mode = engine_mode if engine_mode and engine_mode != "disabled" else actor_mode
                     if router_mode == "R2":
                         batch.batch.pop("routed_experts")
                     else:

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -537,14 +537,12 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                 if "routed_experts" in batch.batch and "routed_experts" in old_log_prob.batch:
                     actor_cfg = self.config.actor_rollout_ref.actor
                     if getattr(actor_cfg, "strategy", None) == "megatron":
-                        engine_rr = getattr(actor_cfg, "megatron", None)
+                        engine_cfg = getattr(actor_cfg, "megatron", None)
                     elif getattr(actor_cfg, "strategy", None) == "veomni":
-                        engine_rr = getattr(actor_cfg, "veomni", None)
+                        engine_cfg = getattr(actor_cfg, "veomni", None)
                     else:
-                        engine_rr = None
-                    engine_mode = getattr(getattr(engine_rr, "router_replay", None), "mode", None)
-                    actor_mode = getattr(getattr(actor_cfg, "router_replay", None), "mode", "disabled")
-                    router_mode = engine_mode if engine_mode and engine_mode != "disabled" else actor_mode
+                        engine_cfg = None
+                    router_mode = getattr(getattr(engine_cfg, "router_replay", None), "mode", "disabled")
                     if router_mode == "R2":
                         batch.batch.pop("routed_experts")
                     else:

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -184,11 +184,6 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
           strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
-    router_replay:
-      _target_: verl.workers.config.RouterReplayConfig
-      mode: disabled
-      record_file: null
-      replay_file: null
     qat:
       enable: false
       mode: w4a16

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -135,11 +135,6 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
           strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
-    router_replay:
-      _target_: verl.workers.config.RouterReplayConfig
-      mode: disabled
-      record_file: null
-      replay_file: null
     qat:
       enable: false
       mode: w4a16

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -158,11 +158,6 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
           strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
-    router_replay:
-      _target_: verl.workers.config.RouterReplayConfig
-      mode: disabled
-      record_file: null
-      replay_file: null
     qat:
       enable: false
       mode: w4a16

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -150,11 +150,6 @@ actor_rollout_ref:
           steps: null
           stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
           strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
-    router_replay:
-      _target_: verl.workers.config.RouterReplayConfig
-      mode: disabled
-      record_file: null
-      replay_file: null
     qat:
       enable: false
       mode: w4a16

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -286,7 +286,9 @@ profiler:
       # Whether to fail on unknown stage or missing msprobe
       strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
 
-# Router replay configuration for MoE models
+# Router replay configuration for MoE models.
+# The Megatron/VeOmni workers read actor.{megatron,veomni}.router_replay.
+# A non-disabled value here is copied onto that engine field when the engine is still disabled.
 router_replay:
 
   # Target dataclass for this configuration

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -286,27 +286,6 @@ profiler:
       # Whether to fail on unknown stage or missing msprobe
       strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
 
-# Router replay configuration for MoE models.
-# The Megatron/VeOmni workers read actor.{megatron,veomni}.router_replay.
-# A non-disabled value here is copied onto that engine field when the engine is still disabled.
-router_replay:
-
-  # Target dataclass for this configuration
-  _target_: verl.workers.config.RouterReplayConfig
-
-  # Router replay mode: disabled, R2, R3
-  # - R2: Use R2 routing strategy (record mode)
-  # - R3: Use R3 routing strategy (record mode)
-  mode: disabled
-
-  # File path to save recorded routing decisions
-  # Required when mode is 'record', 'R2', or 'R3'
-  record_file: null
-
-  # File path to load recorded routing decisions for replay
-  # Required when mode is 'replay'
-  replay_file: null
-
 # QAT (Quantization-Aware Training) configuration
 # When enabled:
 #   - QAT is automatically applied to actor model during training

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -136,7 +136,6 @@ class ActorConfig(BaseConfig):
         optim (OptimizerConfig): Configuration for optimizer.
         use_fused_kernels (bool): Whether to use custom fused kernels (e.g., FlashAttention, fused MLP).
         data_loader_seed (int): Seed for data loader. If None, uses global seed.
-        router_replay (RouterReplayConfig): Configuration for router replay in MoE models.
     """
 
     _mutable_fields = BaseConfig._mutable_fields | {
@@ -185,7 +184,6 @@ class ActorConfig(BaseConfig):
     engine: BaseConfig = field(default_factory=BaseConfig)
     rollout_n: int = MISSING  # must be override by sampling config
     model_config: HFModelConfig = field(default_factory=BaseConfig)
-    router_replay: RouterReplayConfig = field(default_factory=RouterReplayConfig)
 
     # Store global batch info for loss aggregation:
     # dp_size: data parallel size
@@ -220,31 +218,6 @@ class ActorConfig(BaseConfig):
         ]
         if self.loss_agg_mode not in valid_loss_agg_modes:
             raise ValueError(f"Invalid loss_agg_mode: {self.loss_agg_mode}")
-
-    def sync_router_replay_to_engine(self, engine) -> None:
-        """Forward ``actor.router_replay`` onto the engine config the worker reads.
-
-        The documented key is ``actor_rollout_ref.actor.router_replay``. The
-        Megatron/VeOmni workers read ``actor.{megatron,veomni}.router_replay``.
-        Copy the actor-level setting when the engine is still disabled, and
-        fail if both are set to different non-disabled modes.
-        """
-        actor_rr = getattr(self, "router_replay", None)
-        engine_rr = getattr(engine, "router_replay", None)
-        if actor_rr is None or engine_rr is None:
-            return
-        actor_mode = getattr(actor_rr, "mode", "disabled")
-        engine_mode = getattr(engine_rr, "mode", "disabled")
-        if actor_mode != "disabled" and engine_mode != "disabled" and actor_mode != engine_mode:
-            raise ValueError(
-                "Conflicting router_replay modes: "
-                f"actor.router_replay.mode={actor_mode!r} vs engine.router_replay.mode={engine_mode!r}. "
-                "Set only one, or make them match."
-            )
-        if actor_mode != "disabled" and engine_mode == "disabled":
-            object.__setattr__(engine_rr, "mode", actor_mode)
-            object.__setattr__(engine_rr, "record_file", getattr(actor_rr, "record_file", None))
-            object.__setattr__(engine_rr, "replay_file", getattr(actor_rr, "replay_file", None))
 
     def validate(self, n_gpus: int, train_batch_size: int, model_config: dict = None):
         """Validate actor configuration with runtime parameters."""
@@ -310,7 +283,6 @@ class McoreActorConfig(ActorConfig):
         """Validate FSDP actor configuration parameters."""
         super().__post_init__()
         self.engine = self.megatron
-        self.sync_router_replay_to_engine(self.megatron)
 
 
 @dataclass
@@ -393,7 +365,6 @@ class VeOmniActorConfig(ActorConfig):
         """Validate VeOmni actor configuration parameters."""
         super().__post_init__()
         self.engine = self.veomni
-        self.sync_router_replay_to_engine(self.veomni)
         if self.veomni.router_replay.mode != "disabled" and not self.use_remove_padding:
             raise RuntimeError(
                 "router_replay requires use_remove_padding=True. In VeOmni engine, "

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -221,6 +221,31 @@ class ActorConfig(BaseConfig):
         if self.loss_agg_mode not in valid_loss_agg_modes:
             raise ValueError(f"Invalid loss_agg_mode: {self.loss_agg_mode}")
 
+    def sync_router_replay_to_engine(self, engine) -> None:
+        """Forward ``actor.router_replay`` onto the engine config the worker reads.
+
+        The documented key is ``actor_rollout_ref.actor.router_replay``. The
+        Megatron/VeOmni workers read ``actor.{megatron,veomni}.router_replay``.
+        Copy the actor-level setting when the engine is still disabled, and
+        fail if both are set to different non-disabled modes.
+        """
+        actor_rr = getattr(self, "router_replay", None)
+        engine_rr = getattr(engine, "router_replay", None)
+        if actor_rr is None or engine_rr is None:
+            return
+        actor_mode = getattr(actor_rr, "mode", "disabled")
+        engine_mode = getattr(engine_rr, "mode", "disabled")
+        if actor_mode != "disabled" and engine_mode != "disabled" and actor_mode != engine_mode:
+            raise ValueError(
+                "Conflicting router_replay modes: "
+                f"actor.router_replay.mode={actor_mode!r} vs engine.router_replay.mode={engine_mode!r}. "
+                "Set only one, or make them match."
+            )
+        if actor_mode != "disabled" and engine_mode == "disabled":
+            object.__setattr__(engine_rr, "mode", actor_mode)
+            object.__setattr__(engine_rr, "record_file", getattr(actor_rr, "record_file", None))
+            object.__setattr__(engine_rr, "replay_file", getattr(actor_rr, "replay_file", None))
+
     def validate(self, n_gpus: int, train_batch_size: int, model_config: dict = None):
         """Validate actor configuration with runtime parameters."""
         if not self.use_dynamic_bsz:
@@ -285,6 +310,7 @@ class McoreActorConfig(ActorConfig):
         """Validate FSDP actor configuration parameters."""
         super().__post_init__()
         self.engine = self.megatron
+        self.sync_router_replay_to_engine(self.megatron)
 
 
 @dataclass
@@ -367,6 +393,7 @@ class VeOmniActorConfig(ActorConfig):
         """Validate VeOmni actor configuration parameters."""
         super().__post_init__()
         self.engine = self.veomni
+        self.sync_router_replay_to_engine(self.veomni)
         if self.veomni.router_replay.mode != "disabled" and not self.use_remove_padding:
             raise RuntimeError(
                 "router_replay requires use_remove_padding=True. In VeOmni engine, "


### PR DESCRIPTION
### What does this PR do?

Fixes #7463.

`actor.yaml` exposed `actor_rollout_ref.actor.router_replay`, but Megatron/VeOmni workers only read `actor.{megatron,veomni}.router_replay`. The documented top-level key was a silent no-op.

Per review, this PR **drops** the unused top-level key instead of aliasing it:

- Remove `router_replay` from `actor.yaml` and from `ActorConfig`.
- Keep the live engine field on `actor.megatron.router_replay` / `actor.veomni.router_replay`.
- Point the Ascend NPU guide and parameter table at those engine keys only.
- Read the engine copy in `experimental/separation` when deciding R2 vs R3.

`actor_rollout_ref.actor.router_replay.mode=...` now fails in Hydra struct mode. The supported override is `actor_rollout_ref.actor.megatron.router_replay.mode=R3` (or `veomni`).

Closed #3762 asked whether routing replay would be supported (it is). This issue is the leftover dead key.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+router_replay+actor.router_replay
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

```bash
pytest tests/workers/config/test_actor_router_replay_sync_on_cpu.py -q
```

Ruff passed on the touched Python files. Please run the CPU test in CI.

### API and Usage Example

```bash
# Megatron
actor_rollout_ref.actor.megatron.router_replay.mode=R3
actor_rollout_ref.rollout.enable_rollout_routing_replay=True

# VeOmni
actor_rollout_ref.actor.veomni.router_replay.mode=R3
```

### Design & Code Changes

The worker already selected `self.config.actor.megatron.router_replay` / `self.config.actor.veomni.router_replay`. Removing the unused actor-level schema avoids a second source of truth.

`ref.router_replay` in `ref.yaml` is unchanged; this review only asked to drop the actor-level key.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/blob/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU unit tests assert `ActorConfig` no longer has a top-level `router_replay` field and that the engine field still works.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

AI assistance was used to locate the bug and apply the review. A human author should review every changed line.
