### PR TITLE
[trainer, data] fix: do not drop_last SFT validation batches

### DIFF
--- a/tests/trainer/test_sft_val_batch_on_cpu.py
+++ b/tests/trainer/test_sft_val_batch_on_cpu.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl.trainer.sft_val_utils import resolve_sft_val_batch_size
+
+
+def test_resolve_prefers_explicit_val_batch_size():
+    assert resolve_sft_val_batch_size({"val_batch_size": 16, "micro_batch_size_per_gpu": 4}, 256, 200) == 16
+
+
+def test_resolve_falls_back_to_micro_batch_not_train_batch():
+    assert resolve_sft_val_batch_size({"micro_batch_size_per_gpu": 4}, 256, 200) == 4
+
+
+def test_resolve_uses_val_len_when_no_micro_batch():
+    assert resolve_sft_val_batch_size({}, 256, 200) == 200
+
+
+def test_small_val_set_is_not_empty_with_resolved_batch():
+    train_bs = 256
+    n = 200
+    assert n // train_bs == 0  # old train-batch + drop_last path
+    batch = resolve_sft_val_batch_size({"micro_batch_size_per_gpu": 4}, train_bs, n)
+    assert (n + batch - 1) // batch > 0

--- a/tests/trainer/test_sft_val_batch_on_cpu.py
+++ b/tests/trainer/test_sft_val_batch_on_cpu.py
@@ -12,24 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from verl.trainer.sft_val_utils import resolve_sft_val_batch_size
+from torch.utils.data import DataLoader, Dataset, DistributedSampler
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from verl.trainer.sft_val_utils import reduce_sft_val_loss, resolve_sft_val_batch_size
+
+
+class _Toy(Dataset):
+    def __len__(self):
+        return 200
+
+    def __getitem__(self, i):
+        return i
 
 
 def test_resolve_prefers_explicit_val_batch_size():
-    assert resolve_sft_val_batch_size({"val_batch_size": 16, "micro_batch_size_per_gpu": 4}, 256, 200) == 16
+    assert resolve_sft_val_batch_size({"val_batch_size": 16}, 200) == 16
 
 
-def test_resolve_falls_back_to_micro_batch_not_train_batch():
-    assert resolve_sft_val_batch_size({"micro_batch_size_per_gpu": 4}, 256, 200) == 4
+def test_resolve_defaults_to_full_val_set():
+    assert resolve_sft_val_batch_size({}, 200) == 200
+    assert resolve_sft_val_batch_size({"micro_batch_size_per_gpu": 4}, 200) == 200
 
 
-def test_resolve_uses_val_len_when_no_micro_batch():
-    assert resolve_sft_val_batch_size({}, 256, 200) == 200
+def test_reduce_sft_val_loss_is_sample_weighted():
+    # Batches of 4, 4, 4, 1 must not treat the tail as 25% of the mean.
+    assert reduce_sft_val_loss([(1.0, 4), (1.0, 4), (1.0, 4), (13.0, 1)]) == (3 * 4 * 1.0 + 13.0) / 13
+    assert reduce_sft_val_loss([]) is None
 
 
-def test_small_val_set_is_not_empty_with_resolved_batch():
-    train_bs = 256
-    n = 200
-    assert n // train_bs == 0  # old train-batch + drop_last path
-    batch = resolve_sft_val_batch_size({"micro_batch_size_per_gpu": 4}, train_bs, n)
-    assert (n + batch - 1) // batch > 0
+def _make_val_loader(*, drop_last: bool) -> DataLoader:
+    dataset = _Toy()
+    return StatefulDataLoader(
+        dataset,
+        batch_size=256,
+        sampler=DistributedSampler(dataset, num_replicas=1, rank=0, shuffle=False, drop_last=drop_last),
+        drop_last=drop_last,
+    )
+
+
+def test_drop_last_true_with_train_batch_is_empty():
+    assert len(_make_val_loader(drop_last=True)) == 0
+
+
+def test_drop_last_false_keeps_short_val_set():
+    """Regression test for #7464: 200 samples, train-sized batch 256 must still yield a batch."""
+    loader = _make_val_loader(drop_last=False)
+    assert len(loader) >= 1
+    seen = sum(len(batch) for batch in loader)
+    assert seen == 200

--- a/tests/trainer/test_sft_val_batch_on_cpu.py
+++ b/tests/trainer/test_sft_val_batch_on_cpu.py
@@ -12,18 +12,82 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from torch.utils.data import DataLoader, Dataset, DistributedSampler
+import pytest
+import torch
+from torch.utils.data import Dataset, DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 
-from verl.trainer.sft_val_utils import reduce_sft_val_loss, resolve_sft_val_batch_size
+from verl.trainer.sft_val_utils import (
+    build_sft_val_dataloader,
+    pad_sft_val_batch,
+    reduce_sft_val_loss,
+    resolve_sft_val_batch_size,
+    sft_val_batch_divisor,
+    sft_val_num_tokens,
+)
+from verl.utils import tensordict_utils as tu
+from verl.utils.dataset.dataset_utils import DatasetPadMode, SFTTensorCollator
+
+# gsm8k test.parquet: the val set the reported validation crash was hit with.
+GSM8K_VAL_ROWS = 1319
 
 
 class _Toy(Dataset):
+    """Val dataset whose row ``i`` carries exactly ``i + 1`` loss-mask tokens."""
+
+    def __init__(self, num_rows: int = 200):
+        self.num_rows = num_rows
+
     def __len__(self):
-        return 200
+        return self.num_rows
 
     def __getitem__(self, i):
-        return i
+        n = i + 1
+        return {
+            "input_ids": torch.arange(n),
+            "attention_mask": torch.ones(n, dtype=torch.long),
+            "position_ids": torch.arange(n),
+            "loss_mask": torch.ones(n, dtype=torch.long),
+        }
+
+    def total_tokens(self) -> int:
+        return sum(i + 1 for i in range(self.num_rows))
+
+
+def _batch(token_counts: list[int]):
+    """A collated no-padding SFT batch whose rows carry the given loss-mask token counts."""
+    return tu.get_tensordict(
+        tensor_dict={
+            "input_ids": torch.nested.as_nested_tensor([torch.arange(t) for t in token_counts], layout=torch.jagged),
+            "loss_mask": torch.nested.as_nested_tensor(
+                [torch.ones(t, dtype=torch.long) for t in token_counts], layout=torch.jagged
+            ),
+        },
+        non_tensor_dict={"use_dynamic_bsz": True},
+    )
+
+
+def _num_rows(collated_batch) -> int:
+    """Row count of a batch as the collator hands it out (a plain dict of tensors)."""
+    return int(collated_batch["input_ids"].shape[0])
+
+
+def _make_val_loader(*, num_replicas: int, rank: int = 0, dataset=None, data_config=None):
+    """Mirror of the validation dataloader both SFT trainers build."""
+    return build_sft_val_dataloader(
+        dataset=dataset if dataset is not None else _Toy(),
+        data_config=data_config if data_config is not None else {},
+        dp_rank=rank,
+        dp_size=num_replicas,
+        collate_fn=SFTTensorCollator(DatasetPadMode.NO_PADDING),
+        num_workers=0,
+        device_name="cpu",
+    )
+
+
+# ----------------------------------------------------------------------------------
+# validation batch size resolution
+# ----------------------------------------------------------------------------------
 
 
 def test_resolve_prefers_explicit_val_batch_size():
@@ -35,29 +99,224 @@ def test_resolve_defaults_to_full_val_set():
     assert resolve_sft_val_batch_size({"micro_batch_size_per_gpu": 4}, 200) == 200
 
 
-def test_reduce_sft_val_loss_is_sample_weighted():
-    # Batches of 4, 4, 4, 1 must not treat the tail as 25% of the mean.
-    assert reduce_sft_val_loss([(1.0, 4), (1.0, 4), (1.0, 4), (13.0, 1)]) == (3 * 4 * 1.0 + 13.0) / 13
-    assert reduce_sft_val_loss([]) is None
+def test_resolve_treats_non_positive_as_full_val_set():
+    """``-1`` means "use the full dataset" everywhere else in the SFT data config."""
+    assert resolve_sft_val_batch_size({"val_batch_size": -1}, GSM8K_VAL_ROWS) == GSM8K_VAL_ROWS
+    assert resolve_sft_val_batch_size({"val_batch_size": 0}, GSM8K_VAL_ROWS) == GSM8K_VAL_ROWS
+    assert resolve_sft_val_batch_size({"val_batch_size": None}, GSM8K_VAL_ROWS) == GSM8K_VAL_ROWS
 
 
-def _make_val_loader(*, drop_last: bool) -> DataLoader:
-    dataset = _Toy()
-    return StatefulDataLoader(
-        dataset,
-        batch_size=256,
-        sampler=DistributedSampler(dataset, num_replicas=1, rank=0, shuffle=False, drop_last=drop_last),
-        drop_last=drop_last,
+# ----------------------------------------------------------------------------------
+# batch divisibility: dispatch chunking (DP) and static micro-batch splitting
+# ----------------------------------------------------------------------------------
+
+
+def test_divisor_tracks_dp_size_and_micro_batch_size():
+    dynamic = {"use_dynamic_bsz": True, "micro_batch_size_per_gpu": 4}
+    assert sft_val_batch_divisor(dynamic, dp_size=1) == 1
+    assert sft_val_batch_divisor(dynamic, dp_size=2) == 2
+
+    static = {"use_dynamic_bsz": False, "micro_batch_size_per_gpu": 4}
+    assert sft_val_batch_divisor(static, dp_size=1) == 4
+    assert sft_val_batch_divisor(static, dp_size=2) == 8
+
+
+def test_full_val_batch_is_chunkable_after_padding():
+    """A single-batch val set must survive the DP chunk the worker group performs.
+
+    ``chunk_tensordict`` asserts ``len(td) % chunks == 0``, and 1319 gsm8k rows over DP=2
+    does not divide.
+    """
+    with pytest.raises(AssertionError, match="divisible by chunks"):
+        tu.chunk_tensordict(_batch([5] * GSM8K_VAL_ROWS), 2)
+
+    padded, pad_size = pad_sft_val_batch(_batch([5] * GSM8K_VAL_ROWS), sft_val_batch_divisor({}, dp_size=2))
+    assert pad_size == 1
+    assert len(padded) == GSM8K_VAL_ROWS + 1
+    assert [len(chunk) for chunk in tu.chunk_tensordict(padded, 2)] == [660, 660]
+
+
+def test_full_val_batch_is_micro_batchable_after_padding():
+    """The ``use_dynamic_bsz=False`` path additionally asserts divisibility by
+    ``micro_batch_size_per_gpu``."""
+    from verl.workers.engine.utils import prepare_micro_batches
+
+    static = {"use_dynamic_bsz": False, "micro_batch_size_per_gpu": 4}
+    batch = _batch([5] * GSM8K_VAL_ROWS)
+    tu.assign_non_tensor(batch, use_dynamic_bsz=False, micro_batch_size_per_gpu=4)
+    with pytest.raises(AssertionError, match="micro_batch_size_per_gpu"):
+        prepare_micro_batches(batch, dp_group=None)
+
+    padded, pad_size = pad_sft_val_batch(batch, sft_val_batch_divisor(static, dp_size=1))
+    assert pad_size == 1
+    micro_batches, _ = prepare_micro_batches(padded, dp_group=None)
+    assert sum(len(mb) for mb in micro_batches) == GSM8K_VAL_ROWS + 1
+    assert all(len(mb) % 4 == 0 for mb in micro_batches)
+
+
+def test_padding_rows_carry_no_tokens_and_no_loss():
+    """Padding must not move the loss: pad rows are loss-masked out, so they contribute
+    neither to ``masked_sum(log_prob, loss_mask)`` nor to the ``batch_num_tokens`` divisor.
+    """
+    batch = _batch([3, 4, 5])
+    padded, pad_size = pad_sft_val_batch(batch, 4)
+    assert pad_size == 1
+    assert sft_val_num_tokens(padded) == sft_val_num_tokens(batch) == 12
+    rows = list(padded["loss_mask"].unbind(0))
+    assert int(rows[-1].sum()) == 0
+    assert all(int(row.sum()) > 0 for row in rows[:-1])
+
+
+def test_padding_is_a_noop_when_already_divisible():
+    batch = _batch([3, 4, 5, 6])
+    padded, pad_size = pad_sft_val_batch(batch, 4)
+    assert pad_size == 0
+    assert padded is batch
+    assert pad_sft_val_batch(batch, 1)[1] == 0
+
+
+# ----------------------------------------------------------------------------------
+# val loss aggregation
+# ----------------------------------------------------------------------------------
+
+
+def test_reduce_sft_val_loss_is_token_weighted():
+    """``sft_loss`` divides by the all-reduced ``loss_mask.sum()``, so a batch's reported
+    loss is already that batch's global per-token NLL. Aggregating across batches is
+    therefore ``sum(loss_b * T_b) / sum(T_b)`` and not a per-sample mean.
+
+    Worked example: token counts ``[10, 10, 10, 10, 1000]`` with a per-token NLL of 2.0 for
+    the four short rows and 1.0 for the long one, at ``val_batch_size=2``. Weighting by
+    sample count instead reports 1.8 (+73%).
+    """
+    batches = [_batch([10, 10]), _batch([10, 10]), _batch([1000])]
+    per_token_nll = [2.0, 2.0, 1.0]
+
+    token_weighted = reduce_sft_val_loss(
+        [(nll, sft_val_num_tokens(batch)) for nll, batch in zip(per_token_nll, batches, strict=True)]
     )
+    assert token_weighted == pytest.approx(1080 / 1040)
+
+    sample_weighted = reduce_sft_val_loss(
+        [(nll, len(batch)) for nll, batch in zip(per_token_nll, batches, strict=True)]
+    )
+    assert sample_weighted == pytest.approx(1.8)
+    assert token_weighted != pytest.approx(sample_weighted)
+
+
+def test_reduce_sft_val_loss_without_tokens_is_none():
+    assert reduce_sft_val_loss([]) is None
+    assert reduce_sft_val_loss([(1.0, 0)]) is None
+
+
+def test_num_tokens_counts_loss_mask_not_sequences():
+    batch = _batch([3, 4, 5])
+    assert len(batch) == 3
+    assert sft_val_num_tokens(batch) == 12
+
+
+# ----------------------------------------------------------------------------------
+# dataloader construction
+# ----------------------------------------------------------------------------------
 
 
 def test_drop_last_true_with_train_batch_is_empty():
-    assert len(_make_val_loader(drop_last=True)) == 0
+    """The #7464 bug itself: a train-sized batch with ``drop_last=True`` yields no batch."""
+    dataset = _Toy()
+    loader = StatefulDataLoader(
+        dataset,
+        batch_size=256,
+        sampler=DistributedSampler(dataset, num_replicas=1, rank=0, shuffle=False, drop_last=True),
+        drop_last=True,
+    )
+    assert len(loader) == 0
 
 
 def test_drop_last_false_keeps_short_val_set():
-    """Regression test for #7464: 200 samples, train-sized batch 256 must still yield a batch."""
-    loader = _make_val_loader(drop_last=False)
-    assert len(loader) >= 1
-    seen = sum(len(batch) for batch in loader)
-    assert seen == 200
+    """Regression test for #7464: a val set smaller than one batch must still yield a batch."""
+    loader = _make_val_loader(num_replicas=1, data_config={"val_batch_size": 256})
+    assert len(loader) == 1
+    assert sum(_num_rows(batch) for batch in loader) == 200
+
+
+def test_val_loader_evaluates_every_sample_exactly_once():
+    """``DistributedSampler(drop_last=False)`` repeats real samples so every rank gets
+    ``ceil(N / D)`` indices, which evaluates and counts those rows twice. The rows that
+    even out the shards must be loss-masked out instead, so ``val/loss`` stays a mean over
+    distinct samples.
+    """
+    dataset = _Toy(num_rows=10)
+    dp_size = 4
+
+    batch_counts, tokens = [], 0
+    for rank in range(dp_size):
+        loader = _make_val_loader(num_replicas=dp_size, rank=rank, dataset=dataset)
+        batch_counts.append(len(loader))
+        for batch in loader:
+            tokens += sft_val_num_tokens(batch)
+
+    # every rank must run the same number of batches, or the engine's collectives deadlock
+    assert len(set(batch_counts)) == 1
+    assert tokens == dataset.total_tokens() == 55
+
+
+def test_val_loader_shards_a_prime_val_set_without_dropping_rows():
+    dataset = _Toy(num_rows=GSM8K_VAL_ROWS)
+    dp_size = 8
+    tokens = 0
+    for rank in range(dp_size):
+        loader = _make_val_loader(num_replicas=dp_size, rank=rank, dataset=dataset)
+        for batch in loader:
+            tokens += sft_val_num_tokens(batch)
+    assert tokens == dataset.total_tokens()
+
+
+def _per_token_nll(collated_batch) -> float:
+    """Stand-in for what the engine reports back per batch.
+
+    ``sft_loss`` returns ``-masked_sum(log_prob, loss_mask) / batch_num_tokens * dp_size``,
+    which after the DP average in ``_postprocess_output`` is the batch's global per-token
+    NLL. Here every token of a row of length ``n`` is given a log prob of ``-n``, so the
+    exact answer over a set of rows is ``sum(n^2) / sum(n)``.
+    """
+    rows = collated_batch["input_ids"].unbind(0)
+    masks = collated_batch["loss_mask"].unbind(0)
+    weighted = sum(float(row.shape[0]) * int(mask.sum()) for row, mask in zip(rows, masks, strict=True))
+    tokens = sum(int(mask.sum()) for mask in masks)
+    return weighted / tokens if tokens else 0.0
+
+
+def test_reported_val_loss_is_the_exact_per_token_nll_of_the_val_set():
+    """End-to-end check of the validation math the SPMD trainer runs.
+
+    Shards a val set over DP, pads every batch to what the engine needs, reports each batch's
+    global per-token NLL, and weights by DP-local token counts the way the trainer's
+    ``all_reduce(SUM)`` pair does. The result has to be the per-token NLL over the distinct
+    val rows -- no dropped rows, no double-counted rows, no per-sample skew.
+    """
+    dataset = _Toy(num_rows=10)
+    dp_size, divisor = 4, sft_val_batch_divisor({"use_dynamic_bsz": False, "micro_batch_size_per_gpu": 2})
+    data_config = {"val_batch_size": 2, "use_dynamic_bsz": False, "micro_batch_size_per_gpu": 2}
+
+    per_rank_batches = []
+    for rank in range(dp_size):
+        loader = _make_val_loader(num_replicas=dp_size, rank=rank, dataset=dataset, data_config=data_config)
+        batches = []
+        for batch in loader:
+            padded, _ = pad_sft_val_batch(tu.get_tensordict(tensor_dict=batch), divisor)
+            assert len(padded) % divisor == 0
+            batches.append(padded)
+        per_rank_batches.append(batches)
+
+    numerator, denominator = 0.0, 0
+    for batches in zip(*per_rank_batches, strict=True):
+        # one validation step: the loss the engine reports is global over the DP group
+        global_tokens = sum(sft_val_num_tokens(b) for b in batches)
+        global_nll = sum(_per_token_nll(b) * sft_val_num_tokens(b) for b in batches) / global_tokens
+        for batch in batches:
+            numerator += global_nll * sft_val_num_tokens(batch)
+            denominator += sft_val_num_tokens(batch)
+
+    expected = sum((i + 1) ** 2 for i in range(len(dataset))) / dataset.total_tokens()
+    assert numerator / denominator == pytest.approx(expected)
+    assert denominator == dataset.total_tokens()

--- a/verl/trainer/config/sft_trainer_engine.yaml
+++ b/verl/trainer/config/sft_trainer_engine.yaml
@@ -17,7 +17,7 @@ data:
   train_batch_size: 256 # global batch size
   micro_batch_size_per_gpu: 4
 
-  # Validation batch size per DP rank. Null uses micro_batch_size_per_gpu.
+  # Validation dataloader batch size. Null sends the full val set in one batch (same as PPO).
   val_batch_size: null
 
   max_token_len_per_gpu: 8192

--- a/verl/trainer/config/sft_trainer_engine.yaml
+++ b/verl/trainer/config/sft_trainer_engine.yaml
@@ -15,7 +15,11 @@ defaults:
 
 data:
   train_batch_size: 256 # global batch size
-  micro_batch_size_per_gpu: 4  # this is also val batch size
+  micro_batch_size_per_gpu: 4
+
+  # Validation batch size per DP rank. Null uses micro_batch_size_per_gpu.
+  val_batch_size: null
+
   max_token_len_per_gpu: 8192
   use_dynamic_bsz: True
   train_files: ~/data/gsm8k/train.parquet

--- a/verl/trainer/config/sft_trainer_engine.yaml
+++ b/verl/trainer/config/sft_trainer_engine.yaml
@@ -17,7 +17,10 @@ data:
   train_batch_size: 256 # global batch size
   micro_batch_size_per_gpu: 4
 
-  # Validation dataloader batch size. Null sends the full val set in one batch (same as PPO).
+  # Rows per validation dataloader batch (per DP rank where the loader is sharded).
+  # null, 0 or -1 all mean the full val set in one batch. Validation never drops a
+  # partial batch: batches are padded with loss-masked-out rows where the engine needs
+  # a divisible row count, so every val row is scored exactly once.
   val_batch_size: null
 
   max_token_len_per_gpu: 8192

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -31,6 +31,7 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
+from verl.trainer.sft_val_utils import resolve_sft_val_batch_size
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -253,17 +254,20 @@ class SFTTrainer:
         )
 
         if self.val_dataset:
+            val_batch_size = resolve_sft_val_batch_size(
+                config.data, self.train_batch_size_per_dp, len(self.val_dataset)
+            )
             self.val_sampler = DistributedSampler(
-                self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=True
+                self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=False
             )
             self.val_dataloader = StatefulDataLoader(
                 dataset=self.val_dataset,
-                batch_size=self.train_batch_size_per_dp,
+                batch_size=val_batch_size,
                 sampler=self.val_sampler,
                 collate_fn=self.collate_fn,
                 num_workers=self.config.data.num_workers,
                 pin_memory=False,
-                drop_last=True,
+                drop_last=False,
                 pin_memory_device=device_name,
             )
         else:
@@ -426,16 +430,26 @@ class SFTTrainer:
                             val_losses.append(metrics["loss"])
 
                     if self.engine.is_mp_src_rank_with_outputs():
-                        val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
-                        # average over data parallel group
+                        n_val = torch.tensor(float(len(val_losses)), device=self.device_name)
+                        sum_val = torch.tensor(
+                            float(sum(val_losses)) if val_losses else 0.0, device=self.device_name
+                        )
                         dp_group = self.engine.get_data_parallel_group()
                         if dp_group is not None:
-                            torch.distributed.all_reduce(val_loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
-
-                    if is_logging:
-                        metric = {"val/loss": val_loss.detach().item()}
-                        tracking.log(data=metric, step=global_step)
-                        last_valid_metric = metric
+                            torch.distributed.all_reduce(n_val, op=torch.distributed.ReduceOp.SUM, group=dp_group)
+                            torch.distributed.all_reduce(sum_val, op=torch.distributed.ReduceOp.SUM, group=dp_group)
+                        if n_val.item() <= 0:
+                            log_with_rank(
+                                "Validation produced no batches; skip val/loss rather than logging NaN.",
+                                logger=logger,
+                                rank=self.rank,
+                                level=logging.WARNING,
+                                log_only_rank_0=True,
+                            )
+                        elif is_logging:
+                            metric = {"val/loss": (sum_val / n_val).detach().item()}
+                            tracking.log(data=metric, step=global_step)
+                            last_valid_metric = metric
                     torch.distributed.barrier()
 
                 if is_last_step or (self.save_freq > 0 and is_save_step):

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -31,7 +31,12 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
-from verl.trainer.sft_val_utils import resolve_sft_val_batch_size, sft_val_num_samples
+from verl.trainer.sft_val_utils import (
+    build_sft_val_dataloader,
+    pad_sft_val_batch,
+    sft_val_batch_divisor,
+    sft_val_num_tokens,
+)
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -254,23 +259,21 @@ class SFTTrainer:
         )
 
         if self.val_dataset:
-            val_batch_size = resolve_sft_val_batch_size(config.data, len(self.val_dataset))
-            self.val_sampler = DistributedSampler(
-                self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=False
-            )
-            self.val_dataloader = StatefulDataLoader(
+            self.val_dataloader = build_sft_val_dataloader(
                 dataset=self.val_dataset,
-                batch_size=val_batch_size,
-                sampler=self.val_sampler,
+                data_config=config.data,
+                dp_rank=dp_rank,
+                dp_size=dp_size,
                 collate_fn=self.collate_fn,
                 num_workers=self.config.data.num_workers,
-                pin_memory=False,
-                drop_last=False,
-                pin_memory_device=device_name,
+                device_name=device_name,
             )
-            assert len(self.val_dataloader) >= 1, "Validation dataloader is empty!"
+            self.val_sampler = self.val_dataloader.sampler
+            # the dataloader is already sharded per DP rank here, so no dispatch-time chunk
+            self.val_batch_divisor = sft_val_batch_divisor(config.data, dp_size=1)
         else:
             self.val_dataloader = None
+            self.val_batch_divisor = 1
 
     def _get_batch_seqlens(self, data):
         # mean over dp group
@@ -419,20 +422,23 @@ class SFTTrainer:
                 # early exit or validation step
                 if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
                     # Perform validation
-                    val_losses_and_counts = []
+                    val_losses_and_tokens = []
                     for val_data in self.val_dataloader:
                         val_data = tu.get_tensordict(tensor_dict=val_data, non_tensor_dict=meta_info)
-                        n_samples = sft_val_num_samples(val_data)
+                        val_data, _ = pad_sft_val_batch(val_data, self.val_batch_divisor)
+                        num_tokens = sft_val_num_tokens(val_data)
                         output = self.training_client.infer_batch(val_data)
 
                         if self.engine.is_mp_src_rank_with_outputs():
                             metrics = tu.get(output, "metrics")
-                            val_losses_and_counts.append((metrics["loss"], n_samples))
+                            val_losses_and_tokens.append((metrics["loss"], num_tokens))
 
                     if self.engine.is_mp_src_rank_with_outputs():
-                        n_val = torch.tensor(float(sum(n for _, n in val_losses_and_counts)), device=self.device_name)
+                        # each reported loss is already the global per-token NLL of its batch, so
+                        # the DP-local token counts sum straight into the token-weighted mean.
+                        n_val = torch.tensor(float(sum(t for _, t in val_losses_and_tokens)), device=self.device_name)
                         sum_val = torch.tensor(
-                            float(sum(float(loss) * n for loss, n in val_losses_and_counts)),
+                            float(sum(float(loss) * t for loss, t in val_losses_and_tokens)),
                             device=self.device_name,
                         )
                         dp_group = self.engine.get_data_parallel_group()

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -31,7 +31,7 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
-from verl.trainer.sft_val_utils import resolve_sft_val_batch_size
+from verl.trainer.sft_val_utils import resolve_sft_val_batch_size, sft_val_num_samples
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -254,9 +254,7 @@ class SFTTrainer:
         )
 
         if self.val_dataset:
-            val_batch_size = resolve_sft_val_batch_size(
-                config.data, self.train_batch_size_per_dp, len(self.val_dataset)
-            )
+            val_batch_size = resolve_sft_val_batch_size(config.data, len(self.val_dataset))
             self.val_sampler = DistributedSampler(
                 self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=False
             )
@@ -270,6 +268,7 @@ class SFTTrainer:
                 drop_last=False,
                 pin_memory_device=device_name,
             )
+            assert len(self.val_dataloader) >= 1, "Validation dataloader is empty!"
         else:
             self.val_dataloader = None
 
@@ -420,19 +419,21 @@ class SFTTrainer:
                 # early exit or validation step
                 if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
                     # Perform validation
-                    val_losses = []
+                    val_losses_and_counts = []
                     for val_data in self.val_dataloader:
                         val_data = tu.get_tensordict(tensor_dict=val_data, non_tensor_dict=meta_info)
+                        n_samples = sft_val_num_samples(val_data)
                         output = self.training_client.infer_batch(val_data)
 
                         if self.engine.is_mp_src_rank_with_outputs():
                             metrics = tu.get(output, "metrics")
-                            val_losses.append(metrics["loss"])
+                            val_losses_and_counts.append((metrics["loss"], n_samples))
 
                     if self.engine.is_mp_src_rank_with_outputs():
-                        n_val = torch.tensor(float(len(val_losses)), device=self.device_name)
+                        n_val = torch.tensor(float(sum(n for _, n in val_losses_and_counts)), device=self.device_name)
                         sum_val = torch.tensor(
-                            float(sum(val_losses)) if val_losses else 0.0, device=self.device_name
+                            float(sum(float(loss) * n for loss, n in val_losses_and_counts)),
+                            device=self.device_name,
                         )
                         dp_group = self.engine.get_data_parallel_group()
                         if dp_group is not None:

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -32,6 +32,7 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
+from verl.trainer.sft_val_utils import resolve_sft_val_batch_size
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler, OrchestrationMode
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -201,17 +202,20 @@ class SFTTrainer:
         )
 
         if self.val_dataset:
+            val_batch_size = resolve_sft_val_batch_size(
+                config.data, self.train_batch_size_per_dp, len(self.val_dataset)
+            )
             self.val_sampler = DistributedSampler(
-                self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=True
+                self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=False
             )
             self.val_dataloader = StatefulDataLoader(
                 dataset=self.val_dataset,
-                batch_size=self.train_batch_size_per_dp,
+                batch_size=val_batch_size,
                 sampler=self.val_sampler,
                 collate_fn=self.collate_fn,
                 num_workers=8,
                 pin_memory=False,
-                drop_last=True,
+                drop_last=False,
                 pin_memory_device=device_name,
             )
         else:
@@ -364,11 +368,19 @@ class SFTTrainer:
                         metrics = tu.get(output, "metrics")
                         val_losses.append(metrics["loss"])
 
-                    val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
-
-                    metric = {"val/loss": val_loss.detach().item()}
-                    tracking.log(data=metric, step=global_step)
-                    last_valid_metric = metric
+                    if not val_losses:
+                        log_with_rank(
+                            "Validation produced no batches; skip val/loss rather than logging NaN.",
+                            logger=logger,
+                            rank=0,
+                            level=logging.WARNING,
+                            log_only_rank_0=True,
+                        )
+                    else:
+                        val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
+                        metric = {"val/loss": val_loss.detach().item()}
+                        tracking.log(data=metric, step=global_step)
+                        last_valid_metric = metric
 
                 if is_last_step or (self.save_freq > 0 and is_save_step):
                     self.ckpt_handler.save_checkpoint(step=global_step)

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -32,7 +32,7 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
-from verl.trainer.sft_val_utils import resolve_sft_val_batch_size
+from verl.trainer.sft_val_utils import reduce_sft_val_loss, resolve_sft_val_batch_size, sft_val_num_samples
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler, OrchestrationMode
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -202,9 +202,7 @@ class SFTTrainer:
         )
 
         if self.val_dataset:
-            val_batch_size = resolve_sft_val_batch_size(
-                config.data, self.train_batch_size_per_dp, len(self.val_dataset)
-            )
+            val_batch_size = resolve_sft_val_batch_size(config.data, len(self.val_dataset))
             self.val_sampler = DistributedSampler(
                 self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=False
             )
@@ -218,6 +216,7 @@ class SFTTrainer:
                 drop_last=False,
                 pin_memory_device=device_name,
             )
+            assert len(self.val_dataloader) >= 1, "Validation dataloader is empty!"
         else:
             self.val_dataloader = None
 
@@ -360,15 +359,17 @@ class SFTTrainer:
                 # early exit or validation step
                 if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
                     # Perform validation
-                    val_losses = []
+                    val_losses_and_counts = []
                     for val_data in self.val_dataloader:
                         val_data = tu.get_tensordict(tensor_dict=val_data, non_tensor_dict=meta_info)
+                        n_samples = sft_val_num_samples(val_data)
                         output = self.training_client.infer_batch(val_data)
                         output = output.get()
                         metrics = tu.get(output, "metrics")
-                        val_losses.append(metrics["loss"])
+                        val_losses_and_counts.append((metrics["loss"], n_samples))
 
-                    if not val_losses:
+                    val_loss = reduce_sft_val_loss(val_losses_and_counts)
+                    if val_loss is None:
                         log_with_rank(
                             "Validation produced no batches; skip val/loss rather than logging NaN.",
                             logger=logger,
@@ -377,8 +378,7 @@ class SFTTrainer:
                             log_only_rank_0=True,
                         )
                     else:
-                        val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
-                        metric = {"val/loss": val_loss.detach().item()}
+                        metric = {"val/loss": val_loss}
                         tracking.log(data=metric, step=global_step)
                         last_valid_metric = metric
 

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -32,7 +32,13 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
-from verl.trainer.sft_val_utils import reduce_sft_val_loss, resolve_sft_val_batch_size, sft_val_num_samples
+from verl.trainer.sft_val_utils import (
+    build_sft_val_dataloader,
+    pad_sft_val_batch,
+    reduce_sft_val_loss,
+    sft_val_batch_divisor,
+    sft_val_num_tokens,
+)
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler, OrchestrationMode
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -53,6 +59,8 @@ class SFTTrainer:
         config,
     ):
         self.config = config
+
+        self._train_dp_size_cache = None
 
         self._build_config()
         self._build_dataset()
@@ -202,21 +210,18 @@ class SFTTrainer:
         )
 
         if self.val_dataset:
-            val_batch_size = resolve_sft_val_batch_size(config.data, len(self.val_dataset))
-            self.val_sampler = DistributedSampler(
-                self.val_dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=False
-            )
-            self.val_dataloader = StatefulDataLoader(
+            # the driver holds whole batches here (dp_size == 1 above); the worker group
+            # chunks them across the real DP mesh, which `_train_dp_size` reports.
+            self.val_dataloader = build_sft_val_dataloader(
                 dataset=self.val_dataset,
-                batch_size=val_batch_size,
-                sampler=self.val_sampler,
+                data_config=config.data,
+                dp_rank=dp_rank,
+                dp_size=dp_size,
                 collate_fn=self.collate_fn,
                 num_workers=8,
-                pin_memory=False,
-                drop_last=False,
-                pin_memory_device=device_name,
+                device_name=device_name,
             )
-            assert len(self.val_dataloader) >= 1, "Validation dataloader is empty!"
+            self.val_sampler = self.val_dataloader.sampler
         else:
             self.val_dataloader = None
 
@@ -237,6 +242,18 @@ class SFTTrainer:
         self.test_freq = self.config.trainer.test_freq
         if self.test_freq == "after_each_epoch":
             self.test_freq = self.steps_per_epoch
+
+    def _train_dp_size(self) -> int:
+        """Number of chunks the worker group splits a dispatched batch into.
+
+        The driver builds its dataloaders with ``dp_size = 1`` -- it holds whole batches and
+        the worker group shards them on dispatch. This is the same
+        ``max(dp_rank_mapping) + 1`` that ``dispatch_lazy_compute_data_proto`` uses, so a
+        batch sized to a multiple of it is guaranteed to chunk evenly.
+        """
+        if self._train_dp_size_cache is None:
+            self._train_dp_size_cache = max(self.training_client._query_dispatch_info("train")) + 1
+        return self._train_dp_size_cache
 
     def _get_batch_seqlens(self, data):
         # mean over dp group
@@ -314,7 +331,7 @@ class SFTTrainer:
                 if self.config.trainer.balance_batch:
                     global_seqlen_lst = torch.Tensor([item.size()[0] for item in data["input_ids"]])
                     global_seqlen_lst = calculate_workload(global_seqlen_lst)
-                    dp_size = max(self.training_client._query_dispatch_info("train")) + 1
+                    dp_size = self._train_dp_size()
 
                     global_partition_lst = get_seqlen_balanced_partitions(
                         global_seqlen_lst, k_partitions=dp_size, equal_size=True
@@ -359,16 +376,18 @@ class SFTTrainer:
                 # early exit or validation step
                 if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
                     # Perform validation
-                    val_losses_and_counts = []
+                    val_losses_and_tokens = []
+                    val_batch_divisor = sft_val_batch_divisor(self.config.data, dp_size=self._train_dp_size())
                     for val_data in self.val_dataloader:
                         val_data = tu.get_tensordict(tensor_dict=val_data, non_tensor_dict=meta_info)
-                        n_samples = sft_val_num_samples(val_data)
+                        val_data, _ = pad_sft_val_batch(val_data, val_batch_divisor)
+                        num_tokens = sft_val_num_tokens(val_data)
                         output = self.training_client.infer_batch(val_data)
                         output = output.get()
                         metrics = tu.get(output, "metrics")
-                        val_losses_and_counts.append((metrics["loss"], n_samples))
+                        val_losses_and_tokens.append((metrics["loss"], num_tokens))
 
-                    val_loss = reduce_sft_val_loss(val_losses_and_counts)
+                    val_loss = reduce_sft_val_loss(val_losses_and_tokens)
                     if val_loss is None:
                         log_with_rank(
                             "Validation produced no batches; skip val/loss rather than logging NaN.",

--- a/verl/trainer/sft_val_utils.py
+++ b/verl/trainer/sft_val_utils.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def resolve_sft_val_batch_size(data_config, train_batch_size_per_dp: int, val_dataset_len: int) -> int:
+    """Pick a validation batch size that does not swallow small val sets.
+
+    Preference: ``data.val_batch_size`` > ``data.micro_batch_size_per_gpu`` >
+    the full val set. Falls back to the train per-DP batch only if nothing else
+    is available.
+    """
+    val_batch_size = data_config.get("val_batch_size", None)
+    if val_batch_size is None:
+        val_batch_size = data_config.get("micro_batch_size_per_gpu", None)
+    if val_batch_size is None:
+        val_batch_size = val_dataset_len if val_dataset_len > 0 else train_batch_size_per_dp
+    return max(1, int(val_batch_size))

--- a/verl/trainer/sft_val_utils.py
+++ b/verl/trainer/sft_val_utils.py
@@ -12,17 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
 
-def resolve_sft_val_batch_size(data_config, train_batch_size_per_dp: int, val_dataset_len: int) -> int:
-    """Pick a validation batch size that does not swallow small val sets.
 
-    Preference: ``data.val_batch_size`` > ``data.micro_batch_size_per_gpu`` >
-    the full val set. Falls back to the train per-DP batch only if nothing else
-    is available.
+def resolve_sft_val_batch_size(data_config, val_dataset_len: int) -> int:
+    """Pick the SFT validation dataloader batch size.
+
+    Matches PPO: ``data.val_batch_size`` if set, otherwise the full val set.
+    ``micro_batch_size_per_gpu`` is an engine split size, not a dataloader knob.
     """
     val_batch_size = data_config.get("val_batch_size", None)
     if val_batch_size is None:
-        val_batch_size = data_config.get("micro_batch_size_per_gpu", None)
-    if val_batch_size is None:
-        val_batch_size = val_dataset_len if val_dataset_len > 0 else train_batch_size_per_dp
+        val_batch_size = val_dataset_len
     return max(1, int(val_batch_size))
+
+
+def sft_val_num_samples(batch) -> int:
+    """Number of sequences in a collated SFT val batch."""
+    batch_size = getattr(batch, "batch_size", None)
+    if batch_size:
+        return int(batch_size[0])
+    if hasattr(batch, "__contains__") and "input_ids" in batch:
+        return int(batch["input_ids"].shape[0])
+    return 1
+
+
+def reduce_sft_val_loss(losses_and_counts: list[tuple[float, int]]) -> Optional[float]:
+    """Sample-weighted mean of per-batch val losses. None if there were no samples."""
+    total_n = sum(n for _, n in losses_and_counts)
+    if total_n <= 0:
+        return None
+    return sum(float(loss) * n for loss, n in losses_and_counts) / total_n

--- a/verl/trainer/sft_val_utils.py
+++ b/verl/trainer/sft_val_utils.py
@@ -12,34 +12,195 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Helpers shared by the SPMD and Ray SFT trainers for building and reducing validation.
+
+The invariant this module leans on: a row whose loss mask is all zeros is invisible to
+``sft_loss``. It adds nothing to ``masked_sum(log_prob, loss_mask)`` and nothing to
+``batch_num_tokens`` (the all-reduced ``loss_mask.sum()`` that loss is divided by), so such
+rows can be appended freely to even out shard lengths and batch sizes without moving
+``val/loss`` by a single token.
+"""
+
+import math
 from typing import Optional
+
+import torch
+from torch.utils.data import Dataset, DistributedSampler
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from verl.utils import tensordict_utils as tu
+
+# Keys whose zeroing takes a row out of the loss. ``loss_mask`` is the one every backend
+# derives ``batch_num_tokens`` from; ``response_mask`` is what the padded pad modes reduce.
+_LOSS_MASK_KEYS = ("loss_mask", "response_mask")
 
 
 def resolve_sft_val_batch_size(data_config, val_dataset_len: int) -> int:
     """Pick the SFT validation dataloader batch size.
 
-    Matches PPO: ``data.val_batch_size`` if set, otherwise the full val set.
-    ``micro_batch_size_per_gpu`` is an engine split size, not a dataloader knob.
+    ``data.val_batch_size`` when it is set to a positive value, otherwise the full val set.
+    ``null``/``0``/``-1`` all mean "the whole dataset", matching how ``train_max_samples``
+    and ``val_max_samples`` read ``-1`` in the same config. ``micro_batch_size_per_gpu`` is
+    an engine split size, not a dataloader knob.
     """
     val_batch_size = data_config.get("val_batch_size", None)
-    if val_batch_size is None:
-        val_batch_size = val_dataset_len
-    return max(1, int(val_batch_size))
+    if val_batch_size is None or int(val_batch_size) <= 0:
+        return max(1, int(val_dataset_len))
+    return int(val_batch_size)
 
 
-def sft_val_num_samples(batch) -> int:
-    """Number of sequences in a collated SFT val batch."""
-    batch_size = getattr(batch, "batch_size", None)
-    if batch_size:
-        return int(batch_size[0])
-    if hasattr(batch, "__contains__") and "input_ids" in batch:
-        return int(batch["input_ids"].shape[0])
-    return 1
+def sft_val_batch_divisor(data_config, dp_size: int = 1) -> int:
+    """Row count a validation batch has to be a multiple of before it reaches the engine.
+
+    Two asserts stand between a val batch and its forward pass:
+
+    * ``chunk_tensordict`` requires ``len(batch) % dp_size == 0`` wherever a worker group
+      splits a dispatched batch across the DP mesh. Pass ``dp_size=1`` where the dataloader
+      is already sharded per rank (the SPMD trainer) and the real DP size where the driver
+      hands a whole batch to the worker group (the Ray trainer).
+    * with ``use_dynamic_bsz=False``, ``prepare_micro_batches`` requires the per-rank rows
+      to be a multiple of ``micro_batch_size_per_gpu``. The dynamic path packs micro-batches
+      by token budget and has no such constraint.
+
+    ``force_group_size`` is left out on purpose: it is a reward-model knob that the SFT
+    trainers never set, so it stays at its default of 1.
+    """
+    dp_size = max(1, int(dp_size))
+    if data_config.get("use_dynamic_bsz", True):
+        return dp_size
+    micro_batch_size_per_gpu = data_config.get("micro_batch_size_per_gpu", 1) or 1
+    return dp_size * max(1, int(micro_batch_size_per_gpu))
 
 
-def reduce_sft_val_loss(losses_and_counts: list[tuple[float, int]]) -> Optional[float]:
-    """Sample-weighted mean of per-batch val losses. None if there were no samples."""
-    total_n = sum(n for _, n in losses_and_counts)
-    if total_n <= 0:
+def pad_sft_val_batch(batch, divisor: int):
+    """Pad a collated validation batch up to a multiple of ``divisor``.
+
+    The padding rows are copies of the first row with their loss mask zeroed, so the loss
+    and the token count of the padded batch are exactly those of ``batch``. That keeps every
+    real val row evaluated exactly once, which rounding the batch size down (or bringing
+    ``drop_last=True`` back) would not.
+
+    Returns ``(batch, pad_size)``; ``batch`` is handed back untouched when it already fits.
+    """
+    num_rows = len(batch)
+    if divisor <= 1 or num_rows % divisor == 0:
+        return batch, 0
+
+    pad_size = divisor - num_rows % divisor
+    padded = tu.index_select_tensor_dict(batch, list(range(num_rows)) + [0] * pad_size)
+    for key in _LOSS_MASK_KEYS:
+        if key not in padded.keys():
+            continue
+        mask = padded[key]
+        if mask.is_nested:
+            rows = list(mask.unbind(0))
+            for i in range(num_rows, num_rows + pad_size):
+                rows[i] = torch.zeros_like(rows[i])
+            padded[key] = tu.nested_tensor_from_tensor_list(
+                rows, ragged_idx=getattr(mask, "_ragged_idx", mask.dim() - 1)
+            )
+        else:
+            mask = mask.clone()
+            mask[num_rows:] = 0
+            padded[key] = mask
+    return padded, pad_size
+
+
+def sft_val_num_tokens(batch) -> int:
+    """Loss-mask token count of a collated SFT validation batch.
+
+    This is this rank's share of the ``batch_num_tokens`` the engine divides the loss by, so
+    it is the weight to aggregate per-batch validation losses with.
+    """
+    loss_mask = batch["loss_mask"]
+    return int(loss_mask.values().sum() if loss_mask.is_nested else loss_mask.sum())
+
+
+def reduce_sft_val_loss(losses_and_token_counts: list[tuple[float, int]]) -> Optional[float]:
+    """Token-weighted mean of per-batch validation losses. ``None`` if there were no tokens.
+
+    ``sft_loss`` normalizes by ``batch_num_tokens``, an all-reduced ``loss_mask.sum()`` over
+    the DP group, so each per-batch loss reported back is already the global per-token NLL
+    of that batch. Combining batches is therefore ``sum(loss_b * T_b) / sum(T_b)``; a
+    per-sample or per-batch mean over-weights the batches made of short sequences.
+    """
+    total_tokens = sum(num_tokens for _, num_tokens in losses_and_token_counts)
+    if total_tokens <= 0:
         return None
-    return sum(float(loss) * n for loss, n in losses_and_counts) / total_n
+    return sum(float(loss) * num_tokens for loss, num_tokens in losses_and_token_counts) / total_tokens
+
+
+class LossMaskedPaddedDataset(Dataset):
+    """A val dataset grown to ``target_len`` rows with loss-masked-out copies of real rows.
+
+    ``DistributedSampler(drop_last=False)`` pads its index list by repeating from the head so
+    every rank receives ``ceil(N / D)`` indices. Those repeats are real samples: they get
+    evaluated twice and counted twice, and because ``shuffle=False`` and the val sampler
+    never sees ``set_epoch``, it is the same rows at every validation step -- a stable bias
+    towards whatever sits at the front of the val set, worst for exactly the small val sets
+    #7464 is about. Rounding the dataset itself up to a multiple of the DP size keeps the
+    per-rank index counts equal -- which the engine's collectives need -- while the extra
+    rows carry no tokens and no loss.
+    """
+
+    def __init__(self, dataset, target_len: int):
+        assert len(dataset) > 0, "cannot pad an empty val dataset"
+        assert target_len >= len(dataset), f"target_len {target_len} is below len(dataset) {len(dataset)}"
+        self.dataset = dataset
+        self.target_len = int(target_len)
+
+    def __len__(self):
+        return self.target_len
+
+    def __getitem__(self, index):
+        real_len = len(self.dataset)
+        if index < real_len:
+            return self.dataset[index]
+        item = dict(self.dataset[index % real_len])
+        for key in _LOSS_MASK_KEYS:
+            if key in item:
+                item[key] = torch.zeros_like(item[key])
+        return item
+
+
+def pad_val_dataset_for_dp(dataset, dp_size: int):
+    """Round a val dataset up to a multiple of ``dp_size`` with loss-masked-out rows."""
+    dp_size = max(1, int(dp_size))
+    target_len = math.ceil(len(dataset) / dp_size) * dp_size
+    if target_len == len(dataset):
+        return dataset
+    return LossMaskedPaddedDataset(dataset, target_len)
+
+
+def build_sft_val_dataloader(
+    *,
+    dataset,
+    data_config,
+    dp_rank: int,
+    dp_size: int,
+    collate_fn,
+    num_workers: int,
+    device_name: str,
+) -> StatefulDataLoader:
+    """Build the SFT validation dataloader.
+
+    ``drop_last=False`` on both the sampler and the loader, so a val set smaller than one
+    batch still yields a batch instead of an empty loader and ``val/loss=NaN`` (#7464). The
+    dataset is padded to a multiple of ``dp_size`` first, so that ``drop_last=False`` does
+    not make the sampler repeat -- and the metric double-count -- real samples.
+    """
+    dataset = pad_val_dataset_for_dp(dataset, dp_size)
+    val_batch_size = resolve_sft_val_batch_size(data_config, len(dataset))
+    sampler = DistributedSampler(dataset, shuffle=False, num_replicas=dp_size, rank=dp_rank, drop_last=False)
+    dataloader = StatefulDataLoader(
+        dataset=dataset,
+        batch_size=val_batch_size,
+        sampler=sampler,
+        collate_fn=collate_fn,
+        num_workers=num_workers,
+        pin_memory=False,
+        drop_last=False,
+        pin_memory_device=device_name,
+    )
+    assert len(dataloader) >= 1, "Validation dataloader is empty!"
+    return dataloader


### PR DESCRIPTION
### What does this PR do?

> **Update (third commit, `87dc0d00`) — @UgaTheDev this changes things you already reviewed, sorry.** A follow-up audit found that the first two commits introduced three new failure paths and got the `val/loss` weight wrong. All five are fixed in `87dc0d00`; the "Design & Code Changes" section below describes the current state, and the details are in "What the third commit fixes". Worth a re-read rather than trusting the earlier LGTM.


Fixes #7464.

Both SFT trainers built the validation loader with `train_batch_size` and `drop_last=True`. A val set smaller than that batch (default 256 on Ray SFT) produced **zero** val batches. The trainer then did `torch.mean(torch.tensor([]))` and logged `val/loss = NaN` with exit code 0.

The actual NaN fix is `drop_last=False`. Review feedback also asked to stop using `micro_batch_size_per_gpu` as the dataloader batch: that field is the engine's micro-batch split, not a loader knob. Using it (default 4) would make validation much slower and defeat `use_dynamic_bsz`.

This PR now:

- Uses `drop_last=False` on the val sampler and dataloader (the #7464 fix).
- Resolves val batch size the same way as PPO: `data.val_batch_size` if set, otherwise `len(val_dataset)`.
- Weights `val/loss` by sample count so a short tail batch is not over-weighted.
- Asserts `len(val_dataloader) >= 1` at build time, matching PPO.
- Adds a `StatefulDataLoader` + `DistributedSampler` regression test that fails if `drop_last=True` is restored.

Not a duplicate of #7401 (epoch-boundary resume) or #467 / #6319 (train-loss NaN).

`data.val_batch_size` is still warned as deprecated on the PPO `validate_config` path, because vLLM/SGLang schedule a whole val set themselves. SFT uses a local dataloader, so the same name is the explicit OOM escape hatch, matching PPO's API. Left that naming call as-is.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+SFT+drop_last+validation
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

```bash
pytest tests/trainer/test_sft_val_batch_on_cpu.py -q
```

Helpers were also executed via a direct module load. Ruff passed on the touched files.

### API and Usage Example

```bash
# default: one dataloader batch of the full val set (same as PPO)
data.val_files=/path/to/val.parquet

# optional smaller loader batch if a huge val set OOMs
data.val_batch_size=64
```

A 200-sample val set with `train_batch_size=256` now runs validation instead of logging NaN.

### Design & Code Changes

`resolve_sft_val_batch_size()` / `reduce_sft_val_loss()` live in `verl/trainer/sft_val_utils.py` so the SPMD and Ray trainers share one rule. `micro_batch_size_per_gpu` stays on the engine path only.

### What the third commit fixes

1. **Ray SFT val batch was not divisible by the worker DP size** — a hard `AssertionError: expecting td with length divisible by chunks, but got 1319 and 2`. The driver builds the val loader with `dp_rank=0, dp_size=1` hardcoded, so after commit 2 it yielded one batch of `len(val_dataset)` rows, which `chunk_tensordict` then split by the *real* DP size. CI never saw it: the only ray SFT e2e case runs TP2/PP2/CP2 on 8 GPUs, i.e. DP=1.
2. **`use_dynamic_bsz=False` micro-batch divisibility** — `prepare_micro_batches` requires the per-rank rows to be a multiple of `micro_batch_size_per_gpu`; 1319 rows with the shipped default 4 raised.
3. **`val/loss` was weighted by sample count, but `sft_loss` normalizes by `batch_num_tokens`** — so each reported per-batch loss is already a *per-token* NLL and the aggregate has to be token-weighted. On the review's own example (token counts `[10,10,10,10,1000]`, per-token NLL 2.0/2.0/2.0/2.0/1.0, `val_batch_size=2`) sample weighting gave 1.800 against the correct 1.038, **+73%**. Invisible with the default single batch, which is why it slipped through; it bites exactly the users who set `val_batch_size`.
4. **`DistributedSampler(drop_last=False)` double-counted rows** — torch pads the index list by repeating from the head, so `total_size - N` rows were evaluated *and weighted* twice, the same rows every validation step (`shuffle=False`, `set_epoch` never called on the val sampler). N=10 / DP=4 over-counted 3 of 55 tokens.
5. **`val_batch_size=-1` meant batch size 1** — `max(1, int(...))` — while the same YAML block documents `-1` as "use full dataset" for `train_max_samples` / `val_max_samples`. `null`, `0` and `-1` now all mean the full val set.

Fixes 1, 2 and 4 share one mechanism: pad to what the engine needs with **loss-masked-out** rows rather than rounding the batch size or restoring `drop_last=True`. Because `masked_sum(log_prob, loss_mask)` and `batch_num_tokens = loss_mask.sum()` both ignore a zeroed mask, the padded batch's loss is *exactly* the unpadded batch's loss — no real row is dropped, and none is scored twice. `LossMaskedPaddedDataset` grows the val dataset to a multiple of the DP size so the sampler has nothing left to pad, and `pad_sft_val_batch` tops up a collated batch to `sft_val_batch_divisor(...)`.

Two alternatives were tried and rejected: resolving the real DP size at loader-build time cannot work (`_build_dataloader()` runs before `_build_engine()`, and 1319 is odd so no batch size makes every batch a multiple of 2), and the auto-padding dispatch variant asserts on `DataProto`, splits by `world_size` rather than the DP mesh, and pads by repeating real rows — reintroducing defect 4.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/blob/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU tests cover the helper, sample-weighted reduce, and the empty-loader regression (`drop_last=True` is empty; `False` yields the 200-sample set).
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

AI assistance was used to locate the bug and apply the review. A human author should review every changed line.

