### PR TITLE
[vllm] fix: restage shuffled AITER FP8 weights

### DIFF
--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -198,7 +198,16 @@ def _record_pristine_fp8_layout(layer, params):
 def _layer_needs_fp8_staging(layer, pristine) -> bool:
     for name, (shape, dtype) in pristine.items():
         param = getattr(layer, name, None)
-        if isinstance(param, torch.nn.Parameter) and (tuple(param.shape) != shape or param.dtype != dtype):
+        if not isinstance(param, torch.nn.Parameter):
+            continue
+        if tuple(param.shape) != shape or param.dtype != dtype:
+            return True
+        # ROCm's AITER MoE backend permutes the expert weights into its MFMA
+        # layout while leaving shape and dtype untouched, so the comparison
+        # above cannot see it. ``is_shuffled``, which that backend sets on the
+        # repacked parameter, is the only signal that the live buffer is no
+        # longer in checkpoint layout.
+        if getattr(param, "is_shuffled", False):
             return True
     return False
 


### PR DESCRIPTION
### What does this PR do?

Fix FP8 weight refits for the ROCm AITER MoE backend.

AITER shuffles expert weights into an MFMA runtime layout without changing their shape or dtype. The existing staging check therefore treated those parameters as still being in checkpoint layout and skipped post-load reprocessing. Detect `is_shuffled` parameters so refits stage the layer and reapply the AITER shuffle before inference.

This does not duplicate an existing PR. Searches for [AITER FP8 refit](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+AITER+FP8+refit), [`is_shuffled` FP8](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+is_shuffled+FP8), and [ROCm FP8 staging](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ROCm+FP8+staging) found no open PR addressing this fix.

### Checklist Before Starting

- [x] Searched for similar PRs using the links above.
- [x] Formatted the PR title as `[vllm] fix: ...`.

### Test

- `uvx --with hydra-core pre-commit run --all-files --show-diff-on-failure --color=never` — all hooks passed.
- `python3 -m py_compile verl/utils/vllm/vllm_fp8_utils.py` — passed.
- Inline CPU smoke test for `_layer_needs_fp8_staging` — passed, covering unchanged parameters, shape mismatch, non-parameter values, and the new `is_shuffled=True` path.

A full ROCm AITER MoE refit was not run in this environment.

### API and Usage Example

No API or configuration changes. FP8 refits automatically restage AITER-shuffled MoE weights.

### Design & Code Changes

- Keep the existing shape and dtype staging checks.
- Also stage a layer when a live FP8 parameter is marked `is_shuffled`, since AITER's MFMA permutation preserves shape and dtype.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied the full pre-commit checks.
- [ ] Documentation was not updated because this is an internal correctness fix with no user-facing API or configuration change.
- [ ] No CI test was added because the end-to-end failure requires the ROCm AITER MoE backend. The new predicate path was covered by an isolated CPU smoke test.
- [ ] CI will be requested in the verl community channel when the PR is ready for maintainer review.
- [x] Recipe submodule update is not applicable.

### AI assistance

OpenAI Codex was used to review the human-authored change, run checks, prepare the commit and PR text, and submit the PR. The human submitter authored and reviewed every changed line and owns the change end-to-end.

Signed-off-by: PeterYang12 <yuhanya@amd.com>
