### PR TITLE
[model] fix: resolve Qwen3.5 delta-net kernels and block type on current transformers

### DIFF
--- a/tests/models/test_qwen3_5_kernel_resolution_on_cpu.py
+++ b/tests/models/test_qwen3_5_kernel_resolution_on_cpu.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Where the Qwen3.5 patch looks for the delta-net kernels and the block type.
+
+Both moved in transformers: the kernels from GatedDeltaNet attributes to module
+scope, and the decoder layer's `layer_type` to `block_type`. These pin the
+resolution so a rename upstream fails loudly here instead of at the first step.
+"""
+
+import inspect
+
+import pytest
+
+from verl.models.transformers.qwen3_5 import _delta_net_kernel, qwen3_5_decoder_layer_forward
+
+KERNELS = [
+    "chunk_gated_delta_rule",
+    "recurrent_gated_delta_rule",
+    "causal_conv1d_fn",
+    "causal_conv1d_update",
+]
+
+
+class _Bare:
+    """A module that carries none of the kernels, like current transformers."""
+
+
+@pytest.mark.parametrize("name", KERNELS)
+def test_a_kernel_absent_from_the_instance_is_found_anyway(name):
+    assert callable(_delta_net_kernel(_Bare(), name))
+
+
+def test_an_attribute_on_the_instance_still_wins():
+    sentinel = object()
+
+    class WithAttr:
+        chunk_gated_delta_rule = sentinel
+
+    assert _delta_net_kernel(WithAttr(), "chunk_gated_delta_rule") is sentinel
+
+
+def test_the_chunk_rule_keeps_the_kwargs_this_file_introspects():
+    # _packed_chunk_gated_delta_rule asks the resolved function whether it accepts
+    # cu_seqlens and cp_context. transformers' decorated wrapper re-exports the torch
+    # fallback's signature and hides both, which silently disables the packed fast
+    # path and makes ulysses SP raise NotImplementedError.
+    fla = pytest.importorskip("fla.ops.gated_delta_rule")
+    params = inspect.signature(_delta_net_kernel(_Bare(), "chunk_gated_delta_rule")).parameters
+    assert "cu_seqlens" in params
+    assert "cp_context" in params
+    assert _delta_net_kernel(_Bare(), "chunk_gated_delta_rule") is fla.chunk_gated_delta_rule
+
+
+def test_an_unknown_kernel_name_is_refused():
+    with pytest.raises(AttributeError, match="delta-net kernels live"):
+        _delta_net_kernel(_Bare(), "no_such_kernel")
+
+
+def test_a_decoder_layer_with_no_recognisable_block_type_refuses_to_run():
+    # Without this the if/elif fell through and the layer returned its input, i.e.
+    # training proceeded with no attention at all and no error.
+    class Layer:
+        block_type = "something_else"
+
+        def input_layernorm(self, x):
+            return x
+
+    with pytest.raises(ValueError, match="skip attention"):
+        qwen3_5_decoder_layer_forward(Layer(), hidden_states=None, position_embeddings=None)

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -155,6 +155,46 @@ def _packed_causal_conv1d_fallback(
     return torch.cat(outputs, dim=-1)
 
 
+def _delta_net_kernel(module, name):
+    """Resolve a gated-delta-net kernel however the installed stack exposes it.
+
+    Older transformers releases bound these on the GatedDeltaNet instance. Current
+    ones define them at module scope, the two rules behind a `torch_` prefix and a
+    decorator that dispatches to FLA when it is installed.
+
+    FLA's own function is preferred over that decorated wrapper on purpose. The
+    wrapper does call FLA, but it re-exports the torch fallback's signature, and
+    this file decides what it may pass by inspecting the signature: through the
+    wrapper `cu_seqlens` and `cp_context` look unsupported, which silently costs
+    the packed-sequence fast path and makes ulysses sequence parallelism raise
+    NotImplementedError on a stack that in fact supports it.
+    """
+    fn = getattr(module, name, None)
+    if fn is not None:
+        return fn
+
+    if name in ("chunk_gated_delta_rule", "recurrent_gated_delta_rule"):
+        try:
+            import fla.ops.gated_delta_rule as fla_ops
+
+            fla_fn = getattr(fla_ops, name, None)
+            if fla_fn is not None:
+                return fla_fn
+        except ImportError:
+            pass
+
+    from transformers.models.qwen3_5 import modeling_qwen3_5 as hf_qwen3_5
+
+    fn = getattr(hf_qwen3_5, name, None) or getattr(hf_qwen3_5, f"torch_{name}", None)
+    if fn is None:
+        raise AttributeError(
+            f"{type(module).__name__} has no {name}, and transformers exposes neither "
+            f"{name} nor torch_{name} at module scope. This file and the installed "
+            "transformers disagree about where the delta-net kernels live."
+        )
+    return fn
+
+
 def _packed_chunk_gated_delta_rule(self, query, key, value, g, beta, cu_seqlens, cu_seqlens_cpu, cp_context=None):
     kwargs = {
         "g": g,
@@ -164,19 +204,19 @@ def _packed_chunk_gated_delta_rule(self, query, key, value, g, beta, cu_seqlens,
         "use_qk_l2norm_in_kernel": True,
     }
     if cu_seqlens is None:
-        return self.chunk_gated_delta_rule(query, key, value, **kwargs)
+        return _delta_net_kernel(self, "chunk_gated_delta_rule")(query, key, value, **kwargs)
 
     if cp_context is not None:
-        if not _call_accepts_kwarg(self.chunk_gated_delta_rule, "cp_context"):
+        if not _call_accepts_kwarg(_delta_net_kernel(self, "chunk_gated_delta_rule"), "cp_context"):
             raise NotImplementedError("Qwen3.5 Ulysses SP requires FLA chunk_gated_delta_rule cp_context support.")
         kwargs["cp_context"] = cp_context
-        return self.chunk_gated_delta_rule(query, key, value, **kwargs)
+        return _delta_net_kernel(self, "chunk_gated_delta_rule")(query, key, value, **kwargs)
 
-    if _call_accepts_kwarg(self.chunk_gated_delta_rule, "cu_seqlens"):
+    if _call_accepts_kwarg(_delta_net_kernel(self, "chunk_gated_delta_rule"), "cu_seqlens"):
         kwargs["cu_seqlens"] = cu_seqlens
-        if _call_accepts_kwarg(self.chunk_gated_delta_rule, "cu_seqlens_cpu"):
+        if _call_accepts_kwarg(_delta_net_kernel(self, "chunk_gated_delta_rule"), "cu_seqlens_cpu"):
             kwargs["cu_seqlens_cpu"] = cu_seqlens_cpu
-        return self.chunk_gated_delta_rule(query, key, value, **kwargs)
+        return _delta_net_kernel(self, "chunk_gated_delta_rule")(query, key, value, **kwargs)
 
     outputs = []
     for q_i, k_i, v_i, g_i, beta_i in _split_packed_args(
@@ -185,7 +225,7 @@ def _packed_chunk_gated_delta_rule(self, query, key, value, g, beta, cu_seqlens,
         split_kwargs = dict(kwargs)
         split_kwargs["g"] = g_i
         split_kwargs["beta"] = beta_i
-        out_i, _ = self.chunk_gated_delta_rule(q_i, k_i, v_i, **split_kwargs)
+        out_i, _ = _delta_net_kernel(self, "chunk_gated_delta_rule")(q_i, k_i, v_i, **split_kwargs)
         outputs.append(out_i)
     return torch.cat(outputs, dim=1), None
 
@@ -239,7 +279,7 @@ def qwen3_5_gated_delta_net_forward(
     a = self.in_proj_a(hidden_states)
 
     if use_precomputed_states:
-        mixed_qkv = self.causal_conv1d_update(
+        mixed_qkv = _delta_net_kernel(self, "causal_conv1d_update")(
             mixed_qkv,
             conv_state,
             self.conv1d.weight.squeeze(1),
@@ -250,7 +290,7 @@ def qwen3_5_gated_delta_net_forward(
         if cache_params is not None:
             conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
             cache_params.conv_states[self.layer_idx] = conv_state
-        if self.causal_conv1d_fn is not None:
+        if _delta_net_kernel(self, "causal_conv1d_fn") is not None:
             conv_prefix_len = 0
             conv_input = mixed_qkv
             if cp_context is not None:
@@ -262,7 +302,7 @@ def qwen3_5_gated_delta_net_forward(
                 if model_cu_seqlens is not None
                 else None
             )
-            conv_output = self.causal_conv1d_fn(
+            conv_output = _delta_net_kernel(self, "causal_conv1d_fn")(
                 x=conv_input,
                 weight=self.conv1d.weight.squeeze(1),
                 bias=self.conv1d.bias,
@@ -312,7 +352,7 @@ def qwen3_5_gated_delta_net_forward(
             self, query, key, value, g, beta, model_cu_seqlens, model_cu_seqlens_cpu, cp_context
         )
     else:
-        core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
+        core_attn_out, last_recurrent_state = _delta_net_kernel(self, "recurrent_gated_delta_rule")(
             query,
             key,
             value,
@@ -350,7 +390,21 @@ def qwen3_5_decoder_layer_forward(
 
     hidden_states = self.input_layernorm(hidden_states)
 
-    if self.layer_type == "linear_attention":
+    # transformers names this `block_type` on Qwen3_5DecoderLayer; older releases
+    # called it `layer_type`. Accept either, and refuse an unknown value rather than
+    # falling through: with neither branch taken the layer would return its input
+    # unchanged, i.e. train silently with no attention at all.
+    block_type = getattr(self, "block_type", None)
+    if block_type is None:
+        block_type = getattr(self, "layer_type", None)
+    if block_type not in ("linear_attention", "full_attention"):
+        raise ValueError(
+            f"{type(self).__name__} exposes neither block_type nor layer_type with a "
+            f"known value (got {block_type!r}); refusing to run a decoder layer that "
+            "would skip attention entirely."
+        )
+
+    if block_type == "linear_attention":
         hidden_states = self.linear_attn(
             hidden_states=hidden_states,
             cache_params=past_key_values,
@@ -358,7 +412,7 @@ def qwen3_5_decoder_layer_forward(
             cu_seqlens=cu_seqlens,
             cu_seqlens_cpu=cu_seqlens_cpu,
         )
-    elif self.layer_type == "full_attention":
+    elif block_type == "full_attention":
         hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,


### PR DESCRIPTION
### What breaks

`verl/models/transformers/qwen3_5.py` reads four gated-delta-net kernels off the
`Qwen3_5GatedDeltaNet` instance, and reads `layer_type` off the decoder layer.
Current transformers exposes neither. The kernels are module-scope functions (the
two rules behind a `torch_` prefix, with a decorator that dispatches to FLA), and
the decoder layer names the attribute `block_type`.

On that stack a 27B SFT run dies before its first step:

```
AttributeError: 'FSDPQwen3_5DecoderLayer' object has no attribute 'layer_type'
  qwen3_5.py:353 in qwen3_5_decoder_layer_forward

AttributeError: 'Qwen3_5GatedDeltaNet' object has no attribute 'causal_conv1d_fn'
  qwen3_5.py:253 in qwen3_5_gated_delta_net_forward
```

Checked against a real instance rather than by reading: of everything this file
touches, only `causal_conv1d_fn`, `causal_conv1d_update` and
`recurrent_gated_delta_rule` are missing. `A_log`, `dt_bias`, `in_proj_*`,
`conv1d`, `norm` and the rest are all present, and the maths matches line for
line, so this is a naming and location drift, not a change in the model.

### The fix

`_delta_net_kernel(module, name)` accepts either layout: instance attribute
first, then FLA, then the transformers module (with and without the `torch_`
prefix), raising if none of them has it.

**FLA is preferred over the transformers wrapper deliberately.** The wrapper does
dispatch to FLA at call time, but it re-exports the torch fallback's signature,
and this file decides what it may pass by inspecting that signature
(`_call_accepts_kwarg`). Measured on transformers 5.15.0 with FLA 0.5.0:

| resolved to | `cu_seqlens` | `cp_context` |
|---|---|---|
| `transformers...torch_chunk_gated_delta_rule` | no | no |
| `fla.ops.gated_delta_rule.chunk_gated_delta_rule` | **yes** | **yes** |

Through the wrapper, packed sequences silently fall back to the per-document
split path, and ulysses sequence parallelism raises

```
NotImplementedError: Qwen3.5 Ulysses SP requires FLA chunk_gated_delta_rule cp_context support.
```

on a stack whose FLA supports it.

**The block-type check now raises instead of falling through.** Previously, if
neither `"linear_attention"` nor `"full_attention"` matched, the `if/elif` simply
ended and the layer returned its input unchanged. A future rename would therefore
not crash: it would train with no attention at all, at a loss that still goes
down. That silent mode seems worse than the `AttributeError` this patch replaces,
so an unrecognised value is now a `ValueError`.

### Tests

`tests/models/test_qwen3_5_kernel_resolution_on_cpu.py`, CPU only, no weights:

* each of the four kernels resolves when the instance does not carry it;
* an instance attribute still wins, so an older transformers is unaffected;
* the chunk rule keeps the two kwargs this file introspects, and is FLA's
  function rather than the wrapper;
* an unknown kernel name raises rather than returning `None`;
* a decoder layer whose block type is unrecognised refuses to run.

8 passed locally. Without the change the module fails to import at collection,
which is the point of the first four.

`ruff check` and `ruff format --check` are clean on the changed file (the file was
format-clean before, so the reformat is only of the added lines).

### Not covered here

`verl/utils/activation_offload.py:295` asserts the saved activation is not a
tuple, and the Qwen3.5 gated-delta-net layers save a tuple (their recurrent
state), so `model.enable_activation_offload=True` raises `AssertionError` on this
model. That needs its own change and is filed separately.
