### PR TITLE
[trainer] feat: pass non_tensor_batch to advantage estimators that can accept it

### DIFF
--- a/tests/trainer/ppo/test_adv_estimator_kwargs_on_cpu.py
+++ b/tests/trainer/ppo/test_adv_estimator_kwargs_on_cpu.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A registered advantage estimator can read the per-sample non-tensor fields."""
+
+import numpy as np
+import torch
+
+from verl.protocol import DataProto
+from verl.trainer.ppo import core_algos
+from verl.trainer.ppo.ray_trainer import _accepts_kwarg, compute_advantage
+
+
+def _batch() -> DataProto:
+    tensors = {
+        "token_level_rewards": torch.tensor([[0.0, 1.0], [0.0, 0.0]]),
+        "response_mask": torch.ones(2, 2, dtype=torch.int64),
+    }
+    non_tensors = {
+        "uid": np.array(["g", "g"], dtype=object),
+        "sample_is_valid": np.array([True, False], dtype=object),
+    }
+    return DataProto.from_dict(tensors=tensors, non_tensors=non_tensors)
+
+
+def test_accepts_kwarg_detects_declared_and_catch_all_parameters():
+    def declared(token_level_rewards, response_mask, non_tensor_batch=None):
+        return None
+
+    def catch_all(token_level_rewards, response_mask, **kwargs):
+        return None
+
+    def fixed(token_level_rewards, response_mask, index=None):
+        return None
+
+    assert _accepts_kwarg(declared, "non_tensor_batch")
+    assert _accepts_kwarg(catch_all, "non_tensor_batch")
+    assert not _accepts_kwarg(fixed, "non_tensor_batch")
+
+
+def test_custom_estimator_receives_non_tensor_batch():
+    seen = {}
+
+    @core_algos.register_adv_est("test_non_tensor_aware")
+    def _estimator(token_level_rewards, response_mask, index=None, config=None, **kwargs):
+        seen["non_tensor_batch"] = kwargs.get("non_tensor_batch")
+        advantages = token_level_rewards * response_mask
+        return advantages, advantages
+
+    data = compute_advantage(_batch(), adv_estimator="test_non_tensor_aware")
+
+    assert seen["non_tensor_batch"] is not None
+    assert list(seen["non_tensor_batch"]["sample_is_valid"]) == [True, False]
+    assert "advantages" in data.batch
+
+
+def test_estimator_with_a_fixed_signature_is_unaffected():
+    """An estimator that cannot accept the extra keys must still be callable."""
+    calls = {"n": 0}
+
+    @core_algos.register_adv_est("test_fixed_signature")
+    def _estimator(token_level_rewards, response_mask, index=None, config=None):
+        calls["n"] += 1
+        advantages = token_level_rewards * response_mask
+        return advantages, advantages
+
+    compute_advantage(_batch(), adv_estimator="test_fixed_signature")
+
+    assert calls["n"] == 1

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -18,13 +18,14 @@ PPO Trainer with Ray-based single controller.
 This trainer supports model-agonistic model initialization with huggingface
 """
 
+import inspect
 import json
 import os
 import uuid
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pprint import pprint
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 import torch
@@ -184,6 +185,17 @@ def compute_spec_decode_metrics(
     }
 
 
+def _accepts_kwarg(fn: Callable, name: str) -> bool:
+    """True when ``fn`` declares ``name`` or accepts a ``**kwargs`` catch-all."""
+    try:
+        parameters = inspect.signature(fn).parameters
+    except (TypeError, ValueError):  # builtins / C callables
+        return False
+    if name in parameters:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+
+
 def compute_advantage(
     data: DataProto,
     adv_estimator: AdvantageEstimator,
@@ -257,10 +269,14 @@ def compute_advantage(
             adv_kwargs["index"] = data.non_tensor_batch["uid"]
         if "reward_baselines" in data.batch:  # optional
             adv_kwargs["reward_baselines"] = data.batch["reward_baselines"]
-        # GDPO: pass raw data for per-dimension reward extraction
-        if adv_estimator in (AdvantageEstimator.GDPO, "gdpo"):
-            adv_kwargs["non_tensor_batch"] = data.non_tensor_batch
-            adv_kwargs["batch"] = data.batch
+        # Per-sample non-tensor fields are the only place an estimator can see what the
+        # rollout attached to a sample (validity flags, task metadata, ids). GDPO needed
+        # this first and got a special case; pass it to any estimator that can accept it,
+        # so a custom estimator does not have to be named here to be usable.
+        # Estimators with a fixed signature (e.g. grpo_vectorized) are unaffected.
+        for key, value in (("non_tensor_batch", data.non_tensor_batch), ("batch", data.batch)):
+            if _accepts_kwarg(adv_estimator_fn, key):
+                adv_kwargs[key] = value
         # Add sum_pi_squared for Optimal Token Baseline
         if adv_estimator in (AdvantageEstimator.OPTIMAL_TOKEN_BASELINE, AdvantageEstimator.TIR_OPTIMAL_TOKEN_BASELINE):
             # Check if sum_pi_squared is available


### PR DESCRIPTION
## Problem

`compute_advantage()` hands a registered advantage estimator tensors plus `index`. Everything a rollout attached per sample — a validity flag, a task id, benchmark metadata — lives in `DataProto.non_tensor_batch` and never reaches the estimator, so a custom estimator cannot use it.

The data is already there. `AgentLoopOutput.extra_fields` is promoted into `non_tensor_batch` by the agent loop (`verl/experimental/agent_loop/agent_loop.py`), so a rollout can attach anything it wants per sample. It just is not forwarded one function further.

GDPO hit this first and got a named special case in `verl/trainer/ppo/ray_trainer.py`:

```python
# GDPO: pass raw data for per-dimension reward extraction
if adv_estimator in (AdvantageEstimator.GDPO, "gdpo"):
    adv_kwargs["non_tensor_batch"] = data.non_tensor_batch
    adv_kwargs["batch"] = data.batch
```

That works, but it means an estimator has to be named in `ray_trainer.py` to see its own data — a custom estimator registered through `register_adv_est` cannot.

## Change

Pass both keys to any estimator whose signature can accept them (a declared parameter, or `**kwargs`), which subsumes the GDPO case:

```python
for key, value in (("non_tensor_batch", data.non_tensor_batch), ("batch", data.batch)):
    if _accepts_kwarg(adv_estimator_fn, key):
        adv_kwargs[key] = value
```

## Why this is safe for every estimator registered today

I audited all twelve `@register_adv_est` functions in `core_algos.py`:

| Estimator | Signature | Effect |
| --- | --- | --- |
| `gdpo` | declares `non_tensor_batch`, has `**kwargs` | identical to the special case it replaces |
| `grpo_passk`, `reinforce_plus_plus_baseline`, `rloo`, `opo`, `reinforce_plus_plus`, `remax`, `gpg`, `optimal_token_baseline`, `multi_turn_optimal_token_baseline` | `**kwargs` | receive two more keys and ignore them, as they already do for other optional keys |
| `grpo_vectorized` | fixed signature, no `**kwargs` | **receives exactly what it did before** — this is why the check exists rather than passing unconditionally |
| `gae`, `grpo` | never reach this branch (own branches above) | unchanged |

Passing unconditionally would raise `TypeError` on `grpo_vectorized`, which is the failure mode the signature check avoids.

## Motivation

A rollout that fails for infrastructure reasons — a lost environment session, an unreachable judge, an OOM-killed container — scores `reward=0`, which is indistinguishable from a policy that genuinely scored zero. In GRPO that zero does not merely contribute no gradient: it lowers the group baseline and inflates the advantage of whatever survived, so the batch trains away from correct behaviour.

We hit this training a browser agent: at 64-way rollout concurrency, orphaned environment sessions caused 1172 of 1280 rollouts across 20 steps (91.6%) to fail before the policy ever acted, and mean reward fell from 15.45% to 0.39%. Excluding those samples from the group statistics needs a per-sample flag *inside* the estimator, which is what this change makes possible.

Upstream context, for what produces such a flag: NeMo Gym is adding `mask_sample` to its verify contract so an environment can report an infrastructure failure rather than an implicit zero (NVIDIA-NeMo/Gym#2608, NVIDIA-NeMo/Gym#2611). With this change a recipe can consume it with a plain `@register_adv_est` estimator; without it, the only options are monkey-patching `compute_advantage` or vendoring `core_algos.py`.

## Tests

`tests/trainer/ppo/test_adv_estimator_kwargs_on_cpu.py`:

- `_accepts_kwarg` recognises a declared parameter and a `**kwargs` catch-all, and rejects a fixed signature.
- A registered estimator receives `non_tensor_batch` and can read a per-sample field from it.
- An estimator with a fixed signature is still called successfully.

## Note on the V1 trainer

`verl/trainer/ppo/v1/trainer_base.py::_compute_advantage` selects a fixed field list from the TransferQueue (`uid`, `response_mask`, `rm_scores`, `rollout_log_probs`, `old_log_probs`, `ref_log_prob`, `values`) before building the `DataProto`, so under V1 a custom non-tensor field still does not reach the estimator even with this change. I left that out to keep this PR to one idea, but I am happy to follow up with a way to opt extra fields into that selection if you think that is the right direction.
