### PR TITLE
[misc] fix: guard tracking logger finish errors

### DIFF
--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -30,6 +30,34 @@ def test_tracking_finish_finalizes_wandb_once():
     tracking.logger["wandb"].finish.assert_called_once_with(exit_code=1)
 
 
+def test_tracking_finish_logs_backend_finish_errors(caplog):
+    tracking = Tracking.__new__(Tracking)
+    broken_wandb = MagicMock()
+    broken_wandb.finish.side_effect = ConnectionResetError("Connection lost")
+    tensorboard = MagicMock()
+    tracking.logger = {"wandb": broken_wandb, "tensorboard": tensorboard}
+    tracking._finished = False
+
+    tracking.finish(exit_code=0)
+
+    broken_wandb.finish.assert_called_once_with(exit_code=0)
+    tensorboard.finish.assert_called_once_with()
+    assert "Failed to finish wandb logger cleanly." in caplog.text
+
+
+def test_tracking_del_suppresses_backend_finish_errors(caplog):
+    tracking = Tracking.__new__(Tracking)
+    broken_wandb = MagicMock()
+    broken_wandb.finish.side_effect = ConnectionResetError("Connection lost")
+    tracking.logger = {"wandb": broken_wandb}
+    tracking._finished = False
+
+    tracking.__del__()
+
+    broken_wandb.finish.assert_called_once_with(exit_code=0)
+    assert "Failed to finish wandb logger cleanly." in caplog.text
+
+
 def test_dapo_filtered_reward_table_logs_incremental_rows():
     mock_wandb = MagicMock()
     mock_wandb.run = object()

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -199,22 +199,23 @@ class Tracking:
         self._finished = True
         loggers = getattr(self, "logger", {})
 
-        if "wandb" in loggers:
-            loggers["wandb"].finish(exit_code=exit_code)
-        if "swanlab" in loggers:
-            loggers["swanlab"].finish()
-        if "vemlp_wandb" in loggers:
-            loggers["vemlp_wandb"].finish(exit_code=exit_code)
-        if "tensorboard" in loggers:
-            loggers["tensorboard"].finish()
-        if "clearml" in loggers:
-            loggers["clearml"].finish()
-        if "trackio" in loggers:
-            loggers["trackio"].finish()
-        if "file" in loggers:
-            loggers["file"].finish()
-        if "rl_insight" in loggers:
-            loggers["rl_insight"].finish()
+        finish_calls = {
+            "wandb": lambda logger_instance: logger_instance.finish(exit_code=exit_code),
+            "swanlab": lambda logger_instance: logger_instance.finish(),
+            "vemlp_wandb": lambda logger_instance: logger_instance.finish(exit_code=exit_code),
+            "tensorboard": lambda logger_instance: logger_instance.finish(),
+            "clearml": lambda logger_instance: logger_instance.finish(),
+            "trackio": lambda logger_instance: logger_instance.finish(),
+            "file": lambda logger_instance: logger_instance.finish(),
+            "rl_insight": lambda logger_instance: logger_instance.finish(),
+        }
+        for backend, finish_call in finish_calls.items():
+            if backend not in loggers:
+                continue
+            try:
+                finish_call(loggers[backend])
+            except Exception:
+                logger.warning("Failed to finish %s logger cleanly.", backend, exc_info=True)
 
     def __del__(self):
         self.finish()


### PR DESCRIPTION
### What does this PR do?

This PR makes `Tracking.finish()` robust to backend logger teardown failures.

Currently, if a backend such as W&B raises during `finish()` from `Tracking.__del__`, Python prints an unraisable exception traceback like `Exception ignored in: <function Tracking.__del__ ...>`. This can happen during process shutdown when the W&B service connection has already been closed.

The change catches exceptions from individual logger backends, logs a warning with traceback, and continues finalizing the remaining backends. The existing `_finished` guard is preserved, so repeated `finish()` calls still finalize at most once.

In a real training run on an older/local checkout, the job had already completed and saved checkpoints, but W&B teardown still produced noisy traceback output. The local file path and exact line number below are intentionally elided because they do not correspond to current master; the relevant call is `Tracking.__del__ -> finish() -> wandb.finish()`:

```text
[Rank 0] Saved model to .../checkpoints/global_step_20/actor/model_world_size_1_rank_0.pt
[Rank 0] Saved model to .../checkpoints/global_step_20/critic/model_world_size_1_rank_0.pt
Training Progress: 100%|██████████| 20/20 [05:59<00:00, 17.98s/it]

Traceback (most recent call last):
  File ".../ray/_private/workers/default_worker.py", line 323, in <module>
    worker.main_loop()
  File ".../ray/_private/worker.py", line 1066, in main_loop
    self.core_worker.run_task_loop()
  File ".../torch/utils/data/_utils/signal_handling.py", line 73, in handler
    _error_if_any_worker_fails()
RuntimeError: DataLoader worker (pid 10607) is killed by signal: Killed.

Exception ignored in: <function Tracking.__del__ at 0x75767c767640>
Traceback (most recent call last):
  File "<verl_repo>/verl/utils/tracking.py", line ..., in __del__
    self.finish()
  File "<verl_repo>/verl/utils/tracking.py", line ..., in finish
    loggers["wandb"].finish(exit_code=exit_code)
  File ".../wandb/sdk/wandb_run.py", line 4243, in finish
    wandb.run.finish(exit_code=exit_code, quiet=quiet)
  ...
  File ".../wandb/sdk/lib/service/service_client.py", line 84, in _send_server_request
    await self._drain_writer()
  File ".../wandb/sdk/lib/service/service_client.py", line 92, in _drain_writer
    await self._writer.drain()
  File ".../asyncio/streams.py", line 167, in _drain_helper
    raise ConnectionResetError('Connection lost')
ConnectionResetError: Connection lost

Exception ignored in atexit callback: <function _start_and_connect_service.<locals>.teardown_atexit ...>
Traceback (most recent call last):
  File ".../wandb/sdk/lib/service/service_connection.py", line 74, in teardown_atexit
    conn.teardown(hooks.exit_code)
  ...
ConnectionResetError: Connection lost

step:20 - ... training/global_step:20.000 ...
'Final validation metrics: None'
```

The checkpoint and final step metrics were already written, so the traceback came from logger shutdown rather than the training step itself.

Similar PR search:
https://github.com/verl-project/verl/pulls?q=is%3Apr+Tracking+finish+wandb+ConnectionResetError

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+Tracking+finish+wandb+ConnectionResetError
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```text
python -m pytest tests/utils/test_tracking_on_cpu.py -q -k "tracking_finish"

2 passed, 4 deselected in 1.49s
```

Also checked:

```text
git diff --check
py_compile verl/utils/tracking.py tests/utils/test_tracking_on_cpu.py
```

As a negative control, keeping the tests but reverting `verl/utils/tracking.py` to upstream master fails with:

```text
FAILED tests/utils/test_tracking_on_cpu.py::test_tracking_finish_logs_backend_finish_errors
E   ConnectionResetError: Connection lost

1 failed, 1 passed, 4 deselected in 1.55s
```

### API and Usage Example

No API changes.

### Design & Code Changes

- Replace repeated backend-specific `if` blocks in `Tracking.finish()` with a small backend-to-finish-call mapping.
- Catch and log exceptions from each backend `finish()` call.
- Continue finalizing other backends if one backend fails.
- Add regression tests for W&B-like finish failures and destructor cleanup behavior.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks: `pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update documentation. Not needed; no user-facing API or behavior change besides safer teardown.
- [x] Add unit test(s) to cover the code.
- [x] Request CI in the verl Slack/Feishu channel if needed.
- [x] Not related to the `recipe` submodule.
