### PR TITLE
[fsdp] fix: keep FSDP2 training alive on torch releases that mis-read _unsharded_param

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -15,6 +15,7 @@
 The concrete Engine implementation using PyTorch FullyShardedDataParallel (FSDP)
 """
 
+import functools
 import gc
 import logging
 import os
@@ -82,6 +83,48 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 device_name = get_device_name()
+
+
+def _guard_fsdp2_accumulated_grad() -> None:
+    """Work around an AttributeError in torch's FSDP2 gradient accumulation.
+
+    `FSDPParam.to_accumulated_grad_if_needed` reads `self._unsharded_param`
+    without checking that it exists. That attribute is created by
+    `init_unsharded_param` (which guards its own access with `hasattr`) and
+    dropped by `free_unsharded_param`, so a parameter that never took part in the
+    forward pass does not have it, and training dies with
+
+        AttributeError: 'FSDPParam' object has no attribute '_unsharded_param'
+
+    Seen on a Qwen3.5 VL model under text-only batches, where the vision tower is
+    never gathered. Such a parameter has no unsharded gradient to upcast, which is
+    the case the method already returns early for, so returning is what it means
+    to do.
+
+    Fixed upstream in pytorch/pytorch#194058. This shim keeps verl working on the
+    torch releases that carry the bug and becomes a no-op once the fix lands: it
+    only inserts an early return for the case that would otherwise raise.
+    """
+    try:
+        from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam
+    except ImportError:
+        return
+
+    original = getattr(FSDPParam, "to_accumulated_grad_if_needed", None)
+    if original is None or getattr(original, "_verl_guarded", False):
+        return
+
+    @functools.wraps(original)
+    def to_accumulated_grad_if_needed(self):
+        if getattr(self, "_unsharded_param", None) is None:
+            return
+        return original(self)
+
+    to_accumulated_grad_if_needed._verl_guarded = True
+    FSDPParam.to_accumulated_grad_if_needed = to_accumulated_grad_if_needed
+
+
+_guard_fsdp2_accumulated_grad()
 
 
 class FSDPEngine(BaseEngine):


### PR DESCRIPTION
### What breaks

FSDP2 training dies during gradient accumulation:

```
File "torch/distributed/fsdp/_fully_shard/_fsdp_param.py", line 733,
     in to_accumulated_grad_if_needed
    or self._unsharded_param.grad is None
AttributeError: 'FSDPParam' object has no attribute '_unsharded_param'
```

`_unsharded_param` is created by `init_unsharded_param` and dropped by
`free_unsharded_param`, so it is not always present. torch guards its own read of
it inside `init_unsharded_param` with `hasattr`; this call site does not.

Reproduced here on Qwen3.5 VL fine-tuning with text-only batches, where the
vision tower never takes part in the forward and so is never all-gathered. It
happens with optimizer offload enabled and disabled, and with
`engine.reshard_after_forward=False` — that last one rules out "gathered then
freed" and shows the attribute is simply never created for those parameters.

### Why a shim here

The bug is torch's, not verl's, and the real fix is
pytorch/pytorch#194058. But every FSDP2 user on an affected release hits it as
soon as a parameter sits out the forward pass, which for VL models under
text-only data is routine, so verl is currently unusable there.

The shim inserts exactly the early return the method already intends: a parameter
that was never gathered has no unsharded gradient to upcast. It is idempotent, it
is a no-op if the method is absent or already fixed upstream, and it can be
deleted once the minimum supported torch carries the fix.

If maintainers would rather not carry a workaround for an upstream bug, that is a
reasonable call — the upstream PR is the real fix, and this can be closed in
favour of a version pin or a note in the docs.

### Validation

Two full fine-tunes, identical code, data and configuration, one of which failed
at this line every time:

| model | before | after |
|---|---|---|
| 4.66B | trains (never reached the path) | unchanged: step 35, loss 0.209, grad-norm 0.68 |
| 9.65B | AttributeError at step 1, three separate runs | trains: step 2, loss 0.234, grad-norm 7.24 |

The 9.65B loss and grad-norm sit in the same range as the 4.66B run that was
never affected, so the guard is not hiding a gradient that should have been
upcast.

`ruff check` and `ruff format --check` are clean on the changed file.
