### PR TITLE
[megatron] fix: align DDP gradient dtype with optimizer precision

### DIFF
--- a/tests/workers/test_megatron_ddp_config_on_cpu.py
+++ b/tests/workers/test_megatron_ddp_config_on_cpu.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from verl.workers.engine.megatron.transformer_impl import MegatronEngine
+
+
+class _Config(SimpleNamespace):
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+def _resolve_ddp_config(
+    *,
+    use_precision_aware_optimizer=False,
+    main_grads_dtype="fp32",
+    override_ddp_config=None,
+    with_optimizer=True,
+):
+    engine = object.__new__(MegatronEngine)
+    engine.engine_config = _Config(override_ddp_config=override_ddp_config or {})
+    engine.optimizer_config = (
+        _Config(
+            optimizer="adam",
+            use_precision_aware_optimizer=use_precision_aware_optimizer,
+            main_grads_dtype=main_grads_dtype,
+        )
+        if with_optimizer
+        else None
+    )
+    return engine._resolve_override_ddp_config()
+
+
+@pytest.mark.parametrize(
+    ("use_precision_aware_optimizer", "main_grads_dtype", "expected"),
+    [
+        (False, "fp32", True),
+        (False, "bf16", True),
+        (True, "fp32", True),
+        (True, "bf16", False),
+    ],
+)
+def test_ddp_grad_dtype_follows_effective_main_grad_dtype(use_precision_aware_optimizer, main_grads_dtype, expected):
+    resolved = _resolve_ddp_config(
+        use_precision_aware_optimizer=use_precision_aware_optimizer,
+        main_grads_dtype=main_grads_dtype,
+    )
+
+    assert resolved["grad_reduce_in_fp32"] is expected
+
+
+@pytest.mark.parametrize("explicit_value", [False, True])
+def test_explicit_ddp_grad_dtype_override_wins(explicit_value):
+    resolved = _resolve_ddp_config(
+        use_precision_aware_optimizer=True,
+        main_grads_dtype="bf16",
+        override_ddp_config={"grad_reduce_in_fp32": explicit_value},
+    )
+
+    assert resolved["grad_reduce_in_fp32"] is explicit_value
+
+
+def test_optimizerless_engine_does_not_inject_grad_dtype():
+    assert _resolve_ddp_config(with_optimizer=False) == {}

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -440,11 +440,10 @@ class MegatronEngine(BaseEngine):
     def _resolve_override_ddp_config(self):
         """Keep the DDP grad-bucket dtype consistent with the optimizer's grad buffer.
 
-        When the precision-aware optimizer is opted into with a sub-fp32
-        ``main_grads_dtype``, the DDP grad bucket must reduce grads in the same
-        dtype, so inject ``grad_reduce_in_fp32=False`` unless the user set it
-        explicitly via ``override_ddp_config``. Default (opt-out) leaves the fp32
-        grad bucket untouched, preserving prior behavior.
+        Default to FP32 gradient reduction for the conventional optimizer. When
+        the precision-aware optimizer is opted into with a sub-FP32
+        ``main_grads_dtype``, reduce gradients in that lower precision instead.
+        An explicit ``override_ddp_config`` value always wins.
 
         For Muon + LayerWise, also enable ``use_layer_wise_param_layout`` on the
         DDP config so master weights live in the param buffer (not fp32 clones).
@@ -454,13 +453,12 @@ class MegatronEngine(BaseEngine):
 
         override_ddp_config = dict(self.engine_config.override_ddp_config or {})
         opt_cfg = self.optimizer_config
-        if (
-            opt_cfg is not None
-            and getattr(opt_cfg, "use_precision_aware_optimizer", False)
-            and PrecisionType.to_dtype(getattr(opt_cfg, "main_grads_dtype", "fp32")) != torch.float32
-            and "grad_reduce_in_fp32" not in override_ddp_config
-        ):
-            override_ddp_config["grad_reduce_in_fp32"] = False
+        if opt_cfg is not None and "grad_reduce_in_fp32" not in override_ddp_config:
+            use_low_precision_main_grads = (
+                getattr(opt_cfg, "use_precision_aware_optimizer", False)
+                and PrecisionType.to_dtype(getattr(opt_cfg, "main_grads_dtype", "fp32")) != torch.float32
+            )
+            override_ddp_config["grad_reduce_in_fp32"] = not use_low_precision_main_grads
         if opt_cfg is not None and is_muon_layer_wise_config(opt_cfg):
             override_ddp_config.setdefault("use_layer_wise_param_layout", True)
         return override_ddp_config


### PR DESCRIPTION
### What does this PR do?

 Fix the Megatron-Bridge DDP configuration so its gradient-buffer dtype matches the optimizer’s effective main-gradient precision.

The conventional optimizer expects FP32 gradients, but the Bridge path omitted `grad_reduce_in_fp32` and inherited Megatron-Core’s `False` default. For BF16 models, this kept a full BF16 gradient buffer (large blue block) and allocated FP32 gradient shards (the right peak in the profiling result) during the optimizer step. 

<img width="1372" height="519" alt="image" src="https://github.com/user-attachments/assets/e845a20c-e8ae-46b2-8738-580fde157412" />

 
 This PR:
 - Defaults DDP gradient reduction to FP32 for the conventional optimizer.
 - Uses lower-precision DDP gradients only when the precision-aware optimizer explicitly requests sub-FP32 `main_grads_dtype`.
 - Preserves explicit `override_ddp_config.grad_reduce_in_fp32` values.
 - Adds CPU unit tests for FP32 defaults, BF16 opt-in, explicit overrides, and optimizer-less engines.
 
 This follows the FP32-by-default behavior agreed on in #6526.


> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/issues?q=is%3Apr+precision-aware+optimizer
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
Added CPU-only tests:
```bash
 pytest tests/workers/test_megatron_ddp_config_on_cpu.py
```

Profile after fix:
<img width="1490" height="519" alt="image" src="https://github.com/user-attachments/assets/90b1d273-8d30-49ae-b372-75ec5cdd91ff" />


### API and Usage Example
No API or configuration schema change

### Design & Code Changes
 - Update  MegatronEngine._resolve_override_ddp_config()  to derive the DDP gradient dtype from the active optimizer mode.
 - Add focused CPU tests in  tests/workers/test_megatron_ddp_config_on_cpu.py .

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
