### PR TITLE
[rollout] fix: preserve default AgentLoop extra fields

### DIFF
--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -122,6 +122,49 @@ class _FakeTokenizer:
         return "<decoded>"
 
 
+def _make_agent_loop_output() -> AgentLoopOutput:
+    return AgentLoopOutput(
+        prompt_ids=[101, 102],
+        response_ids=[11, 12],
+        response_mask=[1, 1],
+        metrics=AgentLoopMetrics(),
+    )
+
+
+def test_agent_loop_output_as_dict_handles_default_extra_fields():
+    fields = _make_agent_loop_output().as_dict()
+
+    assert fields["extra_fields"] == {}
+
+
+def test_agent_loop_output_as_dict_preserves_mutated_default_extra_fields():
+    output = _make_agent_loop_output()
+    output.extra_fields["raw_prompt"] = [{"role": "user", "content": "hello"}]
+
+    fields = output.as_dict()
+
+    assert fields["extra_fields"] == {"raw_prompt": [{"role": "user", "content": "hello"}]}
+
+
+def test_agent_loop_output_as_dict_promotes_teacher_fields_without_mutating_model():
+    output = _make_agent_loop_output()
+    output.extra_fields.update(
+        {
+            "raw_prompt": [{"role": "user", "content": "hello"}],
+            "teacher_ids": [201, 202],
+            "teacher_logprobs": [-0.1, -0.2],
+        }
+    )
+
+    fields = output.as_dict()
+
+    assert fields["teacher_ids"] == [201, 202]
+    assert fields["teacher_logprobs"] == [-0.1, -0.2]
+    assert fields["extra_fields"] == {"raw_prompt": [{"role": "user", "content": "hello"}]}
+    assert output.extra_fields["teacher_ids"] == [201, 202]
+    assert output.extra_fields["teacher_logprobs"] == [-0.1, -0.2]
+
+
 @pytest.mark.asyncio
 async def test_agent_loop_worker_passes_only_hf_model_type_through_hydra(monkeypatch):
     captured_kwargs: dict[str, Any] = {}

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -144,9 +144,12 @@ class AgentLoopOutput(BaseModel):
             rm_scores[-1] = reward_score
             output["rm_scores"] = rm_scores
 
+        # Mutating a default dict does not add the field to Pydantic's fields-set,
+        # so model_dump(exclude_unset=True) can omit populated extra fields.
+        extra_fields = output.setdefault("extra_fields", self.extra_fields.copy())
         teacher_ids, teacher_logprobs = (
-            output["extra_fields"].pop("teacher_ids", None),
-            output["extra_fields"].pop("teacher_logprobs", None),
+            extra_fields.pop("teacher_ids", None),
+            extra_fields.pop("teacher_logprobs", None),
         )
         if teacher_ids is not None:
             output["teacher_ids"] = teacher_ids


### PR DESCRIPTION
### What does this PR do?

Fixes #7486. `AgentLoopOutput.as_dict()` uses `model_dump(exclude_unset=True)`, which omits `extra_fields` when callers rely on the declared default. Mutating that default mapping after construction does not add the field to Pydantic's fields-set, so the existing teacher-field promotion raises `KeyError` and dynamic fields are lost.

The fix restores a shallow copy of `self.extra_fields` only when the serialized output omitted the field, then performs the existing teacher-field promotion on that output mapping. Explicitly supplied `extra_fields` continue to use Pydantic's serialized mapping, and serialization does not mutate the model.

This is not a duplicate. No open PR is linked to #7486 or matched the `AgentLoopOutput extra_fields exclude_unset` search. #7151 handles sparse reward metadata across samples, and #7019 handles an `output` argument-name collision; neither changes default-field serialization. [Issue search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7486+in%3Abody) · [Keyword search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+AgentLoopOutput+extra_fields+exclude_unset)

AI assistance disclosure: OpenAI Codex was used to inspect the issue, implement the change, run checks, and draft this PR. The PR remains a draft pending human review of every changed line.

### Checklist Before Starting

- [x] Search for similar PRs. Queries and related-PR distinctions are documented above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

- `pre-commit run --all-files --show-diff-on-failure --color=always`: all 13 hooks passed, including Ruff, Ruff format, mypy, generated-config verification, sanity checks, and compileall.
- Prior Model Factory CPU agent-loop regression suite containing the mutated-default case: 8 tests passed.
- Model Factory Qwen3-4B LangGraph GRPO `val_only` run on 2 H20 GPUs: platform phase 5, container exit code 0, MATH `acc/mean@1=0.996`, and no `KeyError: 'extra_fields'` or Python traceback in the full job log.
- The exact three-case test file is automatically collected by the existing `cpu_unit_tests.yml` `*_on_cpu.py` pattern; its PR check is expected to run on this branch.

### API and Usage Example

No public API or configuration changes. Valid `AgentLoopOutput` instances that omit `extra_fields` now serialize successfully, and fields added after construction are retained.

### Design & Code Changes

- Use `output.setdefault("extra_fields", self.extra_fields.copy())` so only an omitted default is restored.
- Preserve the existing promotion of `teacher_ids` and `teacher_logprobs` without mutating `self.extra_fields`.
- Add CPU regression coverage for an untouched default, a dynamically populated default, and teacher-field promotion with model-state preservation.

### Checklist Before Submitting

- [x] Read the contribution guide and current `AGENTS.md`.
- [x] Apply the complete pre-commit suite.
- [ ] Add / Update documentation. Not needed because there is no user-facing API or configuration change.
- [x] Add CPU regression tests covered by the existing CPU CI workflow.
- [ ] Request project CI in Slack or Feishu after human review if the automatic checks require maintainer approval.
- [ ] Update the recipe submodule reference. Not applicable because this PR does not modify the recipe submodule.
