### PR TITLE
[fsdp] fix: fsdp_size=1 silently disables gradient synchronization

### DIFF
--- a/tests/special_distributed/run_all.sh
+++ b/tests/special_distributed/run_all.sh
@@ -25,3 +25,7 @@ torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_cp
 # Regression for colocated FSDP2 full-parameter model transfers. It locks in
 # PyTorch's implicit pinned allocation for non-blocking D2H Module.to().
 torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_pinned_model_transfer.py
+# Regression: fsdp_size=1 builds a degenerate (world_size, 1) mesh; selecting a
+# hybrid strategy for it silently stops cross-rank gradient synchronization.
+# Two ranks are enough to observe it.
+torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp_degenerate_mesh_grad_sync.py

--- a/tests/special_distributed/test_fsdp_degenerate_mesh_grad_sync.py
+++ b/tests/special_distributed/test_fsdp_degenerate_mesh_grad_sync.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression: fsdp_size=1 on multiple GPUs must still synchronize gradients.
+
+create_device_mesh(world_size, fsdp_size=1) builds a (world_size, 1) mesh, whose
+shard dim is degenerate. Selecting HYBRID_SHARD for it makes FSDP1 clamp to
+NO_SHARD (the shard group holds a single rank) while still reducing gradients
+over that size-1 shard group, so every rank trains its own copy of the model --
+with no error, no warning beyond FSDP's strategy-switch notice, and plausible
+metrics. See pytorch/pytorch#154888 (acknowledged upstream, closed as
+not_planned because FSDP1 is in maintenance mode).
+
+get_sharding_strategy therefore returns NO_SHARD for a degenerate shard dim,
+which routes FSDP's non-hybrid path to mesh_dim=0 -- the replicate dim.
+
+This test feeds each rank different data and asserts that post-backward
+gradients are identical across ranks (all-reduce averages them). Pre-fix the
+gradients differ; post-fix they match bitwise.
+
+Launch:
+    torchrun --nproc-per-node=2 --standalone \\
+        tests/special_distributed/test_fsdp_degenerate_mesh_grad_sync.py
+"""
+
+import torch
+import torch.distributed
+import torch.nn as nn
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import ShardingStrategy
+
+from verl.utils.device import get_device_name
+from verl.workers.engine.fsdp.utils import create_device_mesh, get_sharding_strategy
+
+
+def main():
+    torch.distributed.init_process_group()
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    assert world_size >= 2, "this regression needs at least 2 ranks"
+    device_name = get_device_name()
+    torch.get_device_module(device_name).set_device(rank)
+
+    device_mesh = create_device_mesh(world_size=world_size, fsdp_size=1)
+    assert device_mesh.ndim == 2, f"fsdp_size=1 is expected to build a 2D mesh, got {device_mesh.shape}"
+    assert device_mesh.size(1) == 1, f"shard dim should be degenerate, got {device_mesh.size(1)}"
+
+    sharding_strategy = get_sharding_strategy(device_mesh)
+
+    torch.manual_seed(0)
+    module = nn.Linear(64, 64, bias=False).to(device_name)
+    model = FSDP(
+        module,
+        device_mesh=device_mesh,
+        sharding_strategy=sharding_strategy,
+        use_orig_params=True,
+        sync_module_states=True,
+        device_id=rank,
+    )
+
+    # Different data per rank: without gradient synchronization the resulting
+    # gradients differ, which is exactly the failure this test guards against.
+    inputs = torch.randn(4, 64, device=device_name) * (rank + 1)
+    model(inputs).square().mean().backward()
+
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert grads, "no gradients were produced"
+    local_norm = torch.stack([g.detach().float().norm() for g in grads]).norm()
+
+    gathered = [torch.zeros_like(local_norm) for _ in range(world_size)]
+    torch.distributed.all_gather(gathered, local_norm)
+    gathered = torch.stack(gathered)
+    assert torch.equal(gathered, gathered[0].expand_as(gathered)), (
+        f"gradients are not synchronized across ranks: {gathered.tolist()} (sharding_strategy={sharding_strategy})"
+    )
+
+    # Pin the mechanism as well, so a future strategy change that happens to
+    # keep gradients in sync still surfaces here rather than silently drifting.
+    assert sharding_strategy == ShardingStrategy.NO_SHARD, (
+        f"a degenerate shard dim must not select a hybrid strategy, got {sharding_strategy}"
+    )
+
+    if rank == 0:
+        print(f"[fsdp_size=1] gradient norms across {world_size} ranks: {gathered.tolist()} -- synchronized")
+    torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/verl/workers/engine/fsdp/utils.py
+++ b/verl/workers/engine/fsdp/utils.py
@@ -80,8 +80,17 @@ def get_sharding_strategy(device_mesh, zero3_enable=True):
         sharding_strategy = ShardingStrategy.FULL_SHARD
         sharding_strategy = fsdp_strategy
     elif device_mesh.ndim == 2:
-        sharding_strategy = ShardingStrategy.HYBRID_SHARD
-        sharding_strategy = hsdp_strategy
+        if device_mesh.size(1) == 1:
+            # fsdp_size=1 degenerates the shard dim to size 1. FSDP1 clamps
+            # HYBRID_SHARD to NO_SHARD but keeps reducing gradients over the
+            # size-1 shard group, so ranks on the replicate dim never
+            # synchronize -- silently (pytorch/pytorch#154888, closed as
+            # not_planned). Selecting NO_SHARD explicitly makes FSDP's
+            # non-hybrid path reduce over mesh_dim=0, the replicate dim.
+            sharding_strategy = ShardingStrategy.NO_SHARD
+        else:
+            sharding_strategy = ShardingStrategy.HYBRID_SHARD
+            sharding_strategy = hsdp_strategy
     else:
         raise NotImplementedError(f"Get device mesh ndim={device_mesh.ndim}, but only support 1 or 2")
     return sharding_strategy


### PR DESCRIPTION
### What does this PR do?

Fixes #7493.

`create_device_mesh(world_size, fsdp_size=1)` builds a `(world_size, 1)` mesh whose shard dim is degenerate. `get_sharding_strategy` selected `HYBRID_SHARD` for it, which FSDP1 clamps to `NO_SHARD` (the shard group holds a single rank) **while still reducing gradients over that size-1 shard group**. The replicate-dim ranks therefore never synchronize: every rank trains its own copy of the model, with no error and plausible metrics. PyTorch acknowledged this FSDP1 behavior as a bug and closed it as `not_planned` (FSDP1 is in maintenance mode): [pytorch/pytorch#154888](https://github.com/pytorch/pytorch/issues/154888).

This PR selects `NO_SHARD` explicitly when the shard dim is degenerate. The mesh is untouched; FSDP's non-hybrid path then reduces gradients over `mesh_dim=0` — the replicate dim, which is exactly the intended "data parallel, no sharding" semantics.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [`is:pr fsdp_size`](https://github.com/verl-project/verl/pulls?q=is%3Apr+fsdp_size) (34 hits, none about degenerate-mesh gradient sync), [`is:pr HYBRID_SHARD`](https://github.com/verl-project/verl/pulls?q=is%3Apr+HYBRID_SHARD) (0 hits). Closest existing issue is #2478 — same FSDP warning, different and benign cause (world size genuinely 1).
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Adds `tests/special_distributed/test_fsdp_degenerate_mesh_grad_sync.py` (2 ranks, registered in `tests/special_distributed/run_all.sh`, which `model.yml` already runs). It builds the mesh through `create_device_mesh(world_size, fsdp_size=1)`, feeds each rank different data, and asserts post-backward gradients are identical across ranks; it also pins the selected strategy.

```
before this PR:  AssertionError: gradients are not synchronized across ranks:
                 [0.3134024441242218, 1.2536097764968872] (sharding_strategy=ShardingStrategy.HYBRID_SHARD)
after this PR:   [fsdp_size=1] gradient norms across 2 ranks:
                 [1.5670123100280762, 1.5670123100280762] -- synchronized
```

Additionally validated outside CI:

- Seeded 3-GPU script (pure PyTorch, in the issue): the broken config yields per-rank gradients `['0.18393682', '0.73574728', '1.65543127']` (each rank's own data only, scaled by its input); with this fix all ranks report `2.57511520`, matching both a plain-DDP control and FSDP2 `fully_shard` on the same `(3,1)` mesh bit-for-bit — i.e. this is specific to FSDP1's clamp path, not to the mesh.
- Real RL training (Qwen3-4B + LoRA r32, 3 trainer ranks, fully_async) with only this diff applied: the three saved rank checkpoints are bit-identical for all 504/504 trainable tensors, optimizer state included. Without the fix, cross-rank relative difference converges to ~sqrt(2) (statistically unrelated).

### API and Usage Example

No API, config or checkpoint-format change. `fsdp_size=1` keeps its meaning ("do not shard") and now actually synchronizes gradients:

```bash
# unchanged usage; previously a silent 1/world_size data loss per update
actor_rollout_ref.actor.fsdp_config.fsdp_size=1 trainer.n_gpus_per_node=3
```

Checkpoint format is unchanged: probing `state_dict()` under `SHARDED_STATE_DICT` before and after this PR returns the same thing (`n_entries=1`, `value_types=['Tensor']`, identical shapes), because the current config is already clamped to `NO_SHARD` internally and `NO_SHARD` short-circuits sharded state dicts to full tensors. Resume compatibility is unaffected.

### Design & Code Changes

- `verl/workers/engine/fsdp/utils.py::get_sharding_strategy`: return `NO_SHARD` when `device_mesh.size(1) == 1`; all other cases unchanged.
  - Single call site (`workers/engine/fsdp/transformer_impl.py`), no signature change.
  - Mesh shape and `mesh_dim_names` unchanged, so `model_merger`'s `assert mesh_dim_names in (("fsdp",), ("ddp", "fsdp"))` and existing checkpoints are unaffected.
  - Non-degenerate configs (`fsdp_size>1`, 1-D meshes) take the exact same path as before. The only behavioral change is the gradient reduction group: size-1 shard group -> N-rank replicate group.
- `tests/special_distributed/test_fsdp_degenerate_mesh_grad_sync.py`: new regression test.
- `tests/special_distributed/run_all.sh`: register it.

Note: FSDP1's `NO_SHARD` emits a deprecation `FutureWarning` pointing to DDP; within FSDP1 it is nevertheless the only correct strategy for this topology. The `fsdp2` backend is unaffected (verified: same `(N,1)` mesh under `fully_shard` synchronizes correctly).

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks — `pre-commit run` on the changed files: all 14 hooks pass (ruff, ruff-format, mypy, autogen-trainer-cfg, license, docstrings, naming, test-structure, device-API, DataProto, compile-all).
- [ ] Add / Update the documentation — not needed: `fsdp_size` appears in `docs/examples/config.rst` only as a config listing (`fsdp_size: -1`) with no prose contradicting this fix, and `docs/advance/ppo_lora.rst` uses `fsdp_size=8`, which is unaffected. This PR makes the runtime behavior match the documented meaning of `fsdp_size=1`.
- [x] Add unit or end-to-end test(s) to the CI workflow.
- [x] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] Not related to the `recipe` submodule.
