### PR TITLE
[rollout, fully_async] fix: sync LoRA adapters to disaggregated rollout engines

### DIFF
--- a/tests/checkpoint_engine/test_disaggregated_lora_sync_on_cpu.py
+++ b/tests/checkpoint_engine/test_disaggregated_lora_sync_on_cpu.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression: disaggregated weight sync must deliver LoRA adapters, not the base.
+
+With LoRA and `checkpoint_engine.backend != "naive"`, the disaggregated branch of
+ActorRolloutRefWorker.update_weights used to call get_per_tensor_param() with its
+defaults, pinning base_sync_done=False. That collects the frozen base and skips
+every `lora_` tensor, so the adapter never reached the rollout engine: the rollout
+policy silently stayed at the initial checkpoint for the whole run.
+
+These tests pin the two halves of the fix without a GPU or Ray:
+  - the trainer runs the two-phase protocol (base once, adapters afterwards; with a
+    real load_format the very first push is already adapter-only),
+  - the rollout worker recognises an adapter push from the payload itself and
+    forwards peft_config / base_sync_done, while base pushes stay untouched and
+    every tensor is forwarded in order.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import torch
+
+from verl.checkpoint_engine.base import CheckpointEngineWorker
+from verl.workers.engine_workers import ActorRolloutRefWorker
+
+
+def _unwrap(method):
+    """verl decorates worker methods with @register; tests call the raw coroutine."""
+    return getattr(method, "__wrapped__", method)
+
+
+class _RolloutConfig:
+    """Minimal stand-in for the rollout config the worker reads."""
+
+    def __init__(self, load_format="safetensors", backend="nccl"):
+        self.load_format = load_format
+        self.checkpoint_engine = SimpleNamespace(backend=backend)
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+def _make_rollout_worker(tensor_names, wire_format="named_tensors", lora_rank=32):
+    """Build a stub `self` for CheckpointEngineWorker.update_weights."""
+
+    async def receive_weights(global_steps=None):
+        for name in tensor_names:
+            yield name, torch.zeros(1)
+
+    captured = {}
+
+    class _ServerAdapter:
+        async def update_weights(self, weights, global_steps=None, **kwargs):
+            captured["kwargs"] = kwargs
+            captured["names"] = [name async for name, _ in weights]
+
+    # A real instance without __init__ (which would need Ray): helper methods then
+    # resolve through the class, so this test exercises the shipped code rather than
+    # a hand-wired copy of it.
+    worker = object.__new__(CheckpointEngineWorker)
+    worker.checkpoint_engine = SimpleNamespace(receive_weights=receive_weights, wire_format=wire_format)
+    worker.server_adapter = _ServerAdapter()
+    worker.model_config = SimpleNamespace(
+        lora_rank=lora_rank,
+        lora_alpha=2 * lora_rank,
+        target_modules=["q_proj", "v_proj"],
+        exclude_modules=None,
+    )
+    worker.update_weights = _unwrap(CheckpointEngineWorker.update_weights).__get__(worker)
+    return worker, captured
+
+
+class TestRolloutSideAdapterDetection:
+    """CheckpointEngineWorker.update_weights annotates adapter pushes."""
+
+    def test_adapter_push_is_annotated(self):
+        names = [
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight",
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight",
+        ]
+        worker, captured = _make_rollout_worker(names)
+        asyncio.run(worker.update_weights(global_steps=1))
+
+        assert captured["names"] == names, "the peek must forward every tensor, in order"
+        assert captured["kwargs"].get("base_sync_done") is True
+        peft_config = captured["kwargs"].get("peft_config")
+        assert peft_config is not None
+        assert peft_config["r"] == 32
+        assert peft_config["lora_alpha"] == 64
+        assert peft_config["target_modules"] == ["q_proj", "v_proj"]
+
+    def test_base_push_is_untouched(self):
+        names = [
+            "model.embed_tokens.weight",
+            "model.layers.0.self_attn.q_proj.base_layer.weight",
+        ]
+        worker, captured = _make_rollout_worker(names)
+        asyncio.run(worker.update_weights(global_steps=1))
+
+        assert captured["names"] == names
+        assert "peft_config" not in captured["kwargs"], "base pushes must keep the previous behavior"
+        assert "base_sync_done" not in captured["kwargs"]
+
+    def test_full_finetuning_push_is_untouched(self):
+        """No LoRA configured: the payload carries no `lora_` tensor either way."""
+        names = ["model.layers.0.self_attn.q_proj.weight"]
+        worker, captured = _make_rollout_worker(names, lora_rank=0)
+        asyncio.run(worker.update_weights(global_steps=1))
+
+        assert captured["names"] == names
+        assert captured["kwargs"] == {"wire_format": "named_tensors"}
+
+    def test_delta_wire_format_is_not_inspected(self):
+        """Delta engines drive their own sync state machine; leave them alone."""
+        names = ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"]
+        worker, captured = _make_rollout_worker(names, wire_format="sharded_delta")
+        asyncio.run(worker.update_weights(global_steps=1))
+
+        assert captured["names"] == names
+        assert "peft_config" not in captured["kwargs"]
+
+
+class TestTrainerSideTwoPhaseProtocol:
+    """The disaggregated branch must drive base_sync_done like the colocated one."""
+
+    @staticmethod
+    def _make_trainer_worker(load_format="safetensors", peft_config=None):
+        calls = []
+
+        def get_per_tensor_param(layered_summon=False, base_sync_done=False):
+            calls.append(base_sync_done)
+            return iter(()), peft_config
+
+        async def send_weights(per_tensor_param, global_steps=None):
+            return {}
+
+        worker = SimpleNamespace(
+            config=SimpleNamespace(rollout=_RolloutConfig(load_format=load_format)),
+            actor=SimpleNamespace(engine=SimpleNamespace(get_per_tensor_param=get_per_tensor_param)),
+            checkpoint_engine=SimpleNamespace(send_weights=send_weights),
+        )
+        bound = _unwrap(ActorRolloutRefWorker.update_weights).__get__(worker)
+        return bound, calls
+
+    def test_real_load_format_pushes_adapters_from_the_first_sync(self):
+        update_weights, calls = self._make_trainer_worker(peft_config={"r": 32})
+        asyncio.run(update_weights(global_steps=1, mode="nccl"))
+        asyncio.run(update_weights(global_steps=2, mode="nccl"))
+
+        # The rollout engine already holds real base weights, so no base push is needed.
+        assert calls == [True, True]
+
+    def test_dummy_load_format_pushes_base_first(self):
+        update_weights, calls = self._make_trainer_worker(load_format="dummy", peft_config={"r": 32})
+        asyncio.run(update_weights(global_steps=1, mode="nccl"))
+        asyncio.run(update_weights(global_steps=2, mode="nccl"))
+
+        # Base first (weights are placeholders), adapters from then on.
+        assert calls == [False, True]
+
+    def test_full_finetuning_never_flips_the_flag(self):
+        update_weights, calls = self._make_trainer_worker(load_format="dummy", peft_config=None)
+        asyncio.run(update_weights(global_steps=1, mode="nccl"))
+        asyncio.run(update_weights(global_steps=2, mode="nccl"))
+
+        # Without a peft_config there are no adapters to switch to.
+        assert calls == [False, False]

--- a/tests/checkpoint_engine/test_global_steps_on_cpu.py
+++ b/tests/checkpoint_engine/test_global_steps_on_cpu.py
@@ -19,11 +19,18 @@ from verl.checkpoint_engine.base import CheckpointEngineWorker
 from verl.workers.engine_workers import ActorRolloutRefWorker
 
 
+class _FakeRolloutConfig(SimpleNamespace):
+    """RolloutConfig stand-in: the real one is a dataclass, so it also supports .get()."""
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
 class _FakeTrainerEngine:
     def __init__(self):
         self.weights = [("w", object())]
 
-    def get_per_tensor_param(self):
+    def get_per_tensor_param(self, **kwargs):
         return iter(self.weights), None
 
 
@@ -60,8 +67,9 @@ def test_actor_worker_passes_global_steps_to_checkpoint_engine_send():
     checkpoint_engine = _FakeCheckpointEngine()
     worker = ActorRolloutRefWorker.__new__(ActorRolloutRefWorker)
     worker.config = SimpleNamespace(
-        rollout=SimpleNamespace(
+        rollout=_FakeRolloutConfig(
             checkpoint_engine=SimpleNamespace(backend="modelexpress"),
+            load_format="dummy",
         ),
     )
     worker.actor = SimpleNamespace(engine=_FakeTrainerEngine())

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -351,13 +351,64 @@ class CheckpointEngineWorker(Worker):
         # sglang and trt-llm need device_mesh for internal communication
         initialize_global_process_group_ray(timeout_second=None, backend="cpu:gloo")
 
+    def _infer_lora_peft_config(self):
+        """Rebuild the minimal peft_config a LoRA adapter push needs.
+
+        The trainer engine returns the authoritative config, but it lives in a
+        different process. Both sides are built from the same model_config, and
+        vLLM's PEFTHelper.from_dict only requires r / lora_alpha / target_modules.
+        """
+        from verl.utils.py_functional import convert_to_regular_types
+
+        rank = getattr(self.model_config, "lora_rank", 0) or 0
+        if rank <= 0:
+            return None
+        cfg = {
+            "task_type": "CAUSAL_LM",
+            "peft_type": "LORA",
+            "r": rank,
+            "lora_alpha": getattr(self.model_config, "lora_alpha", 2 * rank),
+            "target_modules": convert_to_regular_types(self.model_config.target_modules),
+            "bias": "none",
+        }
+        exclude = convert_to_regular_types(getattr(self.model_config, "exclude_modules", None))
+        if exclude:
+            cfg["exclude_modules"] = exclude
+        return cfg
+
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
     async def update_weights(self, global_steps: int = None):
         weights = self.checkpoint_engine.receive_weights(global_steps=global_steps)
+        wire_format = getattr(self.checkpoint_engine, "wire_format", "named_tensors")
+        # Adapter pushes are self-describing: they contain only `lora_` tensors,
+        # while base / full / merged pushes contain none. Peek at the first name so
+        # no extra signalling is needed on the wire. Delta engines own their own
+        # layout, so only the named-tensors format is inspected.
+        first = None
+        kwargs = {}
+        if wire_format == "named_tensors":
+            try:
+                first = await weights.__anext__()
+            except StopAsyncIteration:
+                first = None
+            if first is not None and "lora_" in first[0]:
+                peft_config = self._infer_lora_peft_config()
+                if peft_config is not None:
+                    kwargs = {"peft_config": peft_config, "base_sync_done": True}
+        if first is not None:
+            inner = weights
+
+            async def _chained():
+                yield first
+                async for item in inner:
+                    yield item
+
+            weights = _chained()
         await self.server_adapter.update_weights(
             weights,
             global_steps=global_steps,
-            wire_format=getattr(self.checkpoint_engine, "wire_format", "named_tensors"),
+            wire_format=wire_format,
+            **kwargs,
         )
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE, blocking=False)

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -760,8 +760,23 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 # snapshot prime), so it drives the training engine itself.
                 metrics = await self.checkpoint_engine.send_weights(self.actor.engine, global_steps=global_steps)
                 return metrics or {}
-            per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
+            # LoRA (merge=False) needs the same two-phase protocol as the colocated
+            # path below: push the base once, then push adapters. Calling
+            # get_per_tensor_param() with defaults pins base_sync_done=False, which
+            # collects the frozen base and skips every `lora_` tensor, so the adapter
+            # never reaches the rollout engine and the rollout policy silently stays
+            # at the initial checkpoint.
+            if not hasattr(self, "ckpt_base_sync_done"):
+                # Mirror the colocated init: a "dummy" load_format is the only case
+                # where the rollout engine lacks real base weights.
+                self.ckpt_base_sync_done = "dummy" not in self.config.rollout.load_format
+            per_tensor_param, peft_config = self.actor.engine.get_per_tensor_param(
+                layered_summon=self.config.rollout.get("layered_summon", False),
+                base_sync_done=self.ckpt_base_sync_done,
+            )
             metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
+            if peft_config is not None:
+                self.ckpt_base_sync_done = True
             return metrics or {}
 
         set_expandable_segments(False)


### PR DESCRIPTION
### What does this PR do?

Fixes #7495 .

This is the default path for async LoRA RL: `model.lora.merge=False` is the default and every disaggregated recipe uses a non-`naive` checkpoint-engine backend. In that configuration, every weight sync pushed the unmodified frozen base model and never transferred the adapter — the rollout engine kept sampling from the initial policy for the whole run, silently (evidence and impact in the issue).

The disaggregated branch called `get_per_tensor_param()` with its defaults, pinning `base_sync_done=False`. For a LoRA model that lands in `collect_lora_params(base_sync_done=False)`, which skips every `lora_` tensor and returns the frozen base renamed to `...base_layer.weight` — a payload a LoRA-enabled engine happily accepts, which is why nothing ever failed. The colocated branch already runs both phases (base, then adapters); only the disaggregated one stopped after the first half. Downstream, `CheckpointEngineWorker.update_weights` had no parameter to pass `peft_config` on, even though the server adapters below it already support adapter loads.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [`is:pr base_sync_done`](https://github.com/verl-project/verl/pulls?q=is%3Apr+base_sync_done), [`is:pr collect_lora_params`](https://github.com/verl-project/verl/pulls?q=is%3Apr+collect_lora_params), [`is:pr TensorLoRARequest`](https://github.com/verl-project/verl/pulls?q=is%3Apr+TensorLoRARequest) — recent adapter-sync fixes (#7287, #3907) all target the *colocated* paths; the disaggregated checkpoint-engine path is untouched.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

`tests/checkpoint_engine/test_disaggregated_lora_sync_on_cpu.py` — 7 CPU tests (no GPU, no Ray), picked up automatically by `cpu_unit_tests.yml` (`tests/**/test_*_on_cpu.py`).

```
before this PR:  3 failed, 4 passed
  test_adapter_push_is_annotated                          assert None is True
                                                          (kwargs = {'wire_format': 'named_tensors'};
                                                           the rollout side is never told it is an adapter)
  test_real_load_format_pushes_adapters_from_the_first_sync   assert [False, False] == [True, True]
  test_dummy_load_format_pushes_base_first                    assert [False, False] == [False, True]
                                                          (the trainer never switches to adapters)
after this PR:   7 passed
```

The four that already pass before the change are the no-regression cases (base pushes, full fine-tuning, delta wire format, and the flag staying put without a `peft_config`) — they guard the paths this PR must leave alone. The tests build a real `CheckpointEngineWorker` via `object.__new__` rather than a hand-wired stub, so the failures above land on behavioral assertions rather than on a missing helper.

Additionally validated outside CI, with exactly this diff applied to the source tree (verl 0.8.0, Qwen3-4B + LoRA r32, 3 trainer + 1 rollout GPU, `fully_async`, NCCL backend, 3 syncs):

- payload per sync: 8,414 MiB (frozen base, 0 `lora_` tensors) → **252 MiB, 504/504 `lora_`
tensors**; the base push never occurs at all, since `load_format` is real
- `rollout_corr/kl` at the numerical floor (6.4e-05 / 2.9e-04) instead of climbing (3e-3 and
rising at the same point in training) — i.e. the rollout policy now tracks the trainer policy
- longer runs with the functionally equivalent patch (60 steps + an independent 12-step rerun):
`list_loras()` `[]` → `[<id>]`, end-to-end logprob agreement at the engine floor (~3-6e-4, so scaling / module targeting / tensor contents are verified, not just transfer), `param_sync`
  6.25 s → 0.97 s (6.4x)

### API and Usage Example

No API, config or wire-format change. The same async recipe now actually delivers the adapter:

```bash
# unchanged usage; previously the rollout engine kept the initial policy for the whole run
actor_rollout_ref.model.lora_rank=32 \
actor_rollout_ref.model.lora.merge=False \
actor_rollout_ref.rollout.checkpoint_engine.backend=nccl
```

Behavior is keyed off what the engine actually returns, so full-parameter training, `model.lora.merge=True` and base pushes are byte-for-byte unaffected: their payloads contain no `lora_` tensor, so they take today's exact path.

### Design & Code Changes

- `verl/workers/engine_workers.py` — the disaggregated branch now runs the same two-phase
protocol as the colocated branch below it: `base_sync_done` initialized from `"dummy" not in rollout.load_format` (with real weights loaded, no base push is needed at all — the first sync is already adapter-only), collection called with it, flag flipped once the engine returns a `peft_config`.
- `verl/checkpoint_engine/base.py` — `CheckpointEngineWorker.update_weights` peeks at the first
tensor name (stream re-chained, nothing consumed twice): adapter pushes consist only of `lora_` tensors, so they are self-describing. For an adapter push it rebuilds the minimal `peft_config` dict from its own `model_config` and forwards `peft_config` + `base_sync_done=True` to the server adapter, which already supports them (`update_weights_from_ipc` → `TensorLoRARequest` + `add_lora`).
- `tests/checkpoint_engine/test_disaggregated_lora_sync_on_cpu.py` — new CPU regression tests.

Why this shape:

- **No wire change**: nothing new is serialized, so every backend speaking the named-tensors wire
format is covered (nccl / nixl / mooncake / kimi all go through this worker). The peek is guarded on `wire_format == "named_tensors"`; `delta_sharded` owns its own sync state machine and is untouched.
- `peft_config` is rebuilt worker-side from `model_config` (both processes are constructed from
the same config) rather than serialized across the wire; vLLM's `PEFTHelper.from_dict` requires only `r` / `lora_alpha` / `target_modules`. Field-level equality with the trainer-side config was verified explicitly (r=32 / alpha=64 / scaling=2.0 on both sides).

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks — `pre-commit run` on the changed files: all 14 hooks pass (ruff, ruff-format, mypy, autogen-trainer-cfg, license, docstrings, naming, test-structure, device-API, DataProto, compile-all).
- [ ] Add / Update the documentation — not needed: this restores the documented behavior of an existing option (`model.lora.merge=False` with a disaggregated backend); no config or API surface changes.
- [x] Add unit or end-to-end test(s) to the CI workflow — CPU tests, auto-collected by `cpu_unit_tests.yml`.
- [x] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] Not related to the `recipe` submodule.