### PR TITLE
[algo, trainer, doc] feat: add CoDaPO

### DIFF
--- a/docs/algo/codapo.md
+++ b/docs/algo/codapo.md
@@ -1,0 +1,136 @@
+# CoDaPO
+
+Last updated: 08/20/2026.
+
+[![ArXiv](https://img.shields.io/badge/arXiv-2606.07950-b31b1b?style=flat-square&logo=arxiv&logoColor=white)](https://arxiv.org/abs/2606.07950)
+[![ICML 2026](https://img.shields.io/badge/ICML-2026-4b44ce?style=flat-square)](https://icml.cc/virtual/2026/poster/62741)
+[![GitHub](https://img.shields.io/badge/GitHub-CoDaPO-181717?style=flat-square&logo=github)](https://github.com/tmlr-group/CoDaPO)
+
+Confidence and Difficulty-Adaptive Policy Optimization (CoDaPO) extends
+[GRPO](grpo.md) with question-level compute allocation. It gives each question a
+CoDaValue, uses that value to scale its policy update, and spends a second
+rollout-and-update step on the highest-value questions in the batch.
+The method calls these three parts CoDaWeighting, CoDaSampling, and CoDaLearning.
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tmlr-group/CoDaPO/main/assets/codapo.png" width="90%" alt="Comparison of the GRPO and CoDaPO training pipelines">
+</p>
+
+## CoDaWeighting
+
+For a question $q$, CoDaWeighting first computes its CoDaValue. Sample $G$ responses
+from the rollout policy, let $T_i$ be the length of response $o_i$, and let
+$y_i \in \{0,1\}$ indicate whether it is correct. Confidence and difficulty are
+
+$$
+c_q = \exp\left(
+  \frac{1}{G}\sum_{i=1}^{G}\frac{1}{T_i}
+  \sum_{t=1}^{T_i}\log \pi_{\mathrm{rollout}}(o_{i,t}\mid q,o_{i,<t})
+\right),
+\qquad
+d_q = 1 - \frac{1}{G}\sum_{i=1}^{G} y_i.
+$$
+
+The CoDaValue is
+
+$$
+v_q = c_q\left[1 - 4\left(d_q-\frac{1}{2}\right)^2\right].
+$$
+
+It is small for nearly solved questions ($d_q \approx 0$) and discovery-limited
+questions ($d_q \approx 1$), and largest in the learnable middle. Confidence further
+down-weights questions whose sampled reasoning is uncertain.
+
+CoDaWeighting computes the usual GRPO advantage and scales it by the question value:
+
+$$
+\widehat{A}^{\mathrm{CoDaPO}}_i = (v_q + \delta)\widehat{A}^{\mathrm{GRPO}}_i.
+$$
+
+The additive weight floor $\delta$ is configured by `codapo_weight_offset`.
+
+In verl, correctness and optimization reward are separate inputs. The binary $y_i$
+comes from the reward extra-info key selected by `codapo_accuracy_key`; a value of `1`
+is correct and any other value is incorrect. The underlying GRPO advantage continues
+to use the aggregate reward, so format or other reward components do not change the
+difficulty estimate.
+
+## CoDaSampling
+
+After the original batch has been scored, CoDaSampling retains the exact top-K
+questions by CoDaValue. verl repeats those prompts round-robin until the focused prompt
+batch has the same size as the original batch and assigns every repeat a fresh group
+ID. The focused phase therefore generates new grouped rollouts instead of reusing the
+original trajectories.
+
+## CoDaLearning
+
+CoDaLearning applies CoDaWeighting in two consecutive phases:
+
+1. **Original phase (O):** generate grouped rollouts for a normal prompt batch, compute
+   CoDaValues, and apply the weighted update.
+2. **Focused phase (F):** use the batch produced by CoDaSampling, generate fresh
+   rollouts, recompute CoDaValues, and apply the weighted update again.
+
+The V1 synchronous trainer generates the focused rollouts after the original update and
+weight synchronization. Both phases count toward `trainer.total_training_steps`, so one
+CoDaPO cycle is two optimizer steps.
+
+## Configuration
+
+| Option | Default | Meaning |
+| --- | ---: | --- |
+| `algorithm.codapo_top_k` | `4` | Questions retained for the focused phase |
+| `algorithm.codapo_weight_offset` | `0.1` | Advantage-weight floor $\delta$ |
+| `algorithm.codapo_accuracy_key` | `acc` | Reward extra-info key containing correctness |
+
+A minimal configuration is:
+
+```yaml
+algorithm:
+  adv_estimator: codapo
+  use_kl_in_reward: false
+  codapo_top_k: 4
+  codapo_weight_offset: 0.1
+  codapo_accuracy_key: acc
+
+actor_rollout_ref:
+  actor:
+    loss_agg_mode: token-mean
+    use_kl_loss: false
+  rollout:
+    do_sample: true
+    n: 8
+
+trainer:
+  use_v1: true
+  v1:
+    trainer_mode: sync
+```
+
+CoDaPO requires synchronous V1 training with `parameter_sync_step=1`, grouped
+stochastic rollouts, and `1 <= codapo_top_k <= data.train_batch_size`. It cannot be
+combined with `algorithm.filter_groups`, because filtering would change the prompt set
+between value estimation and focused sampling.
+
+## Example
+
+The included recipe trains Qwen2.5-Math-1.5B on MATH with prompt batch size 16,
+rollout group size 8, and top-K 4:
+
+```bash
+python3 examples/data_preprocess/math_dataset.py
+bash examples/codapo_trainer/run_qwen2_5_math_1_5b_fsdp.sh
+```
+
+The MATH recipe uses the standard `dapo` reward manager to expose its scalar accuracy
+score as reward extra-info key `acc`.
+
+## Metrics
+
+- `codapo/is_focused_step`: `0` for the original phase and `1` for the focused phase.
+- `codapo/value/mean`: mean CoDaValue across original-batch questions.
+- `codapo/selected_value/mean`: mean CoDaValue of the top-K selected questions.
+
+The two value metrics are emitted on original phases, when the next focused batch is
+selected.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ verl is fast with:
 
    algo/ppo.md
    algo/grpo.md
+   algo/codapo.md
    algo/dapo.md
    algo/spin.md
    algo/sppo.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -110,6 +110,7 @@ under `recipe/` instead.
 | `remax_trainer/`                   | ReMax                          | `adv_estimator=remax`                               |
 | `reinforce_plus_plus_trainer/`     | REINFORCE++ / baseline         | `adv_estimator=reinforce_plus_plus[_baseline]`      |
 | `cispo_trainer/`                   | CISPO                          | `loss_mode=cispo`                                   |
+| `codapo_trainer/`                  | CoDaPO                         | `adv_estimator=codapo`                              |
 | `dppo_trainer/`                    | DPPO (TV / KL variants)        | `loss_mode=dppo_tv \| dppo_kl`                      |
 | `gdpo_trainer/`                    | GDPO                           | `adv_estimator=gdpo`                                |
 | `gmpo_trainer/`                    | GMPO                           | `loss_mode=geo_mean`                                |

--- a/examples/codapo_trainer/README.md
+++ b/examples/codapo_trainer/README.md
@@ -1,0 +1,29 @@
+# CoDaPO
+
+[Paper: The Easy, the Hard, and the Learnable: Confidence and Difficulty-Adaptive
+Policy Optimization for LLM Reasoning](https://arxiv.org/abs/2606.07950)
+
+This directory contains a CoDaPO recipe for Qwen2.5-Math-1.5B on MATH. It uses
+verl's standard dataset, reward, rollout, and V1 synchronous trainer;
+the only algorithm-specific behavior is CoDaWeighting, CoDaSampling, and the paired
+CoDaLearning updates.
+
+Prepare data and run:
+
+```bash
+python3 examples/data_preprocess/math_dataset.py
+bash examples/codapo_trainer/run_qwen2_5_math_1_5b_fsdp.sh
+```
+
+The recipe uses prompt batch size 16, rollout group size 8, and top-K 4. One CoDaPO
+cycle contains an original-batch update followed by a focused-batch update; both count
+toward `TOTAL_TRAINING_STEPS`.
+
+For MATH, the recipe selects the standard `dapo` reward manager so that its scalar
+accuracy score is also exposed through reward extra-info key `acc`, which CoDaPO reads
+by default. If a custom score is an aggregate reward, `compute_score` must return a
+separate accuracy component and `ACCURACY_KEY` must name it; the aggregate optimization
+reward is not used to infer correctness.
+
+See [the CoDaPO algorithm documentation](../../docs/algo/codapo.md) for the formula,
+constraints, and configuration details.

--- a/examples/codapo_trainer/run_qwen2_5_math_1_5b_fsdp.sh
+++ b/examples/codapo_trainer/run_qwen2_5_math_1_5b_fsdp.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# CoDaPO | Qwen2.5-Math-1.5B | MATH | vLLM + FSDP
+
+set -xeuo pipefail
+
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen2.5-Math-1.5B}
+TRAIN_FILE=${TRAIN_FILE:-$HOME/data/math/train.parquet}
+TEST_FILE=${TEST_FILE:-$HOME/data/math/test.parquet}
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-2}
+
+TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-16}
+PPO_MINI_BATCH_SIZE=${PPO_MINI_BATCH_SIZE:-16}
+MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-1024}
+MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-3072}
+ROLLOUT_N=${ROLLOUT_N:-8}
+TOP_K=${TOP_K:-4}
+WEIGHT_OFFSET=${WEIGHT_OFFSET:-0.1}
+ACCURACY_KEY=${ACCURACY_KEY:-acc}
+
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-1000}
+SAVE_FREQ=${SAVE_FREQ:-100}
+TEST_FREQ=${TEST_FREQ:-100}
+PROJECT_NAME=${PROJECT_NAME:-verl_codapo_math}
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-qwen2_5_math_1_5b}
+
+DATA=(
+    data.train_files=${TRAIN_FILE}
+    data.val_files=${TEST_FILE}
+    data.train_batch_size=${TRAIN_BATCH_SIZE}
+    data.max_prompt_length=${MAX_PROMPT_LENGTH}
+    data.max_response_length=${MAX_RESPONSE_LENGTH}
+    data.filter_overlong_prompts=True
+    data.truncation=error
+)
+
+MODEL=(
+    actor_rollout_ref.model.path=${MODEL_PATH}
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.model.enable_gradient_checkpointing=True
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.optim.lr=1e-6
+    actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE}
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=16384
+    actor_rollout_ref.actor.loss_agg_mode=token-mean
+    actor_rollout_ref.actor.use_kl_loss=False
+    actor_rollout_ref.actor.entropy_coeff=0
+    actor_rollout_ref.actor.fsdp_config.param_offload=False
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6
+    actor_rollout_ref.rollout.temperature=1.0
+    actor_rollout_ref.rollout.do_sample=True
+    actor_rollout_ref.rollout.n=${ROLLOUT_N}
+)
+
+ALGORITHM=(
+    algorithm.adv_estimator=codapo
+    algorithm.use_kl_in_reward=False
+    +algorithm.codapo_top_k=${TOP_K}
+    +algorithm.codapo_weight_offset=${WEIGHT_OFFSET}
+    +algorithm.codapo_accuracy_key=${ACCURACY_KEY}
+)
+
+REWARD=(
+    reward.reward_manager.name=dapo
+)
+
+TRAINER=(
+    trainer.use_v1=True
+    trainer.v1.trainer_mode=sync
+    trainer.critic_warmup=0
+    trainer.logger='["console","wandb"]'
+    trainer.project_name=${PROJECT_NAME}
+    trainer.experiment_name=${EXPERIMENT_NAME}
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.total_epochs=10
+    trainer.total_training_steps=${TOTAL_TRAINING_STEPS}
+    trainer.save_freq=${SAVE_FREQ}
+    trainer.test_freq=${TEST_FREQ}
+)
+
+python3 -m verl.trainer.main_ppo \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${ROLLOUT[@]}" \
+    "${ALGORITHM[@]}" \
+    "${REWARD[@]}" \
+    "${TRAINER[@]}" \
+    "$@"

--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -14,6 +14,8 @@
 
 import random
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -21,6 +23,7 @@ import torch
 
 import verl.trainer.ppo.core_algos
 from verl.trainer.ppo.core_algos import (
+    compute_codapo_outcome_advantage,
     compute_gae_advantage_return,
     compute_grpo_outcome_advantage,
     compute_grpo_vectorized_outcome_advantage,
@@ -332,6 +335,60 @@ def test_grpo_and_vectorized_equivalence(batch_size: int, seq_len: int, num_grou
     assert ret1.shape == ret2.shape == (batch_size, seq_len)
     assert torch.allclose(adv1, adv2, rtol=1e-5, atol=1e-6)
     assert torch.allclose(ret1, ret2, rtol=1e-5, atol=1e-6)
+
+
+def test_codapo_value_and_weighted_grpo_advantage():
+    token_level_rewards = torch.tensor([[0.7, 0.0], [0.2, 0.0], [0.9, 0.0], [0.8, 0.0]])
+    response_mask = torch.tensor([[1.0, 1.0], [1.0, 0.0], [1.0, 1.0], [1.0, 1.0]])
+    old_log_probs = torch.log(torch.tensor([[0.5, 0.5], [0.25, 1.0], [0.5, 0.5], [0.5, 0.5]]))
+    index = np.array(["learnable", "learnable", "easy", "easy"], dtype=object)
+
+    batch = {}
+    advantages, returns = compute_codapo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        old_log_probs=old_log_probs,
+        index=index,
+        config={"codapo_accuracy_key": "acc", "codapo_weight_offset": 0.1},
+        non_tensor_batch={"acc": np.array([1.0, -0.5, 1.0, 1.0])},
+        batch=batch,
+    )
+    expected_values = torch.tensor([(0.5 * 0.25) ** 0.5] * 2 + [0.0] * 2)
+    grpo_advantages, _ = compute_grpo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+
+    assert torch.allclose(batch["codapo_values"], expected_values)
+    assert torch.allclose(advantages, grpo_advantages * (expected_values + 0.1).unsqueeze(-1))
+    assert torch.equal(returns, advantages)
+
+
+def test_codapo_dispatches_grpo_normalization_setting():
+    from verl.trainer.ppo.ray_trainer import compute_advantage
+
+    data = SimpleNamespace(
+        batch={
+            "token_level_rewards": torch.tensor([[1.0], [0.0]]),
+            "response_mask": torch.ones(2, 1),
+            "old_log_probs": torch.zeros(2, 1),
+        },
+        non_tensor_batch={"uid": np.array(["question"] * 2), "acc": np.array([1.0, 0.0])},
+    )
+
+    with patch(
+        "verl.trainer.ppo.ray_trainer.core_algos.get_adv_estimator_fn",
+        return_value=compute_codapo_outcome_advantage,
+    ):
+        compute_advantage(
+            data,
+            adv_estimator="codapo",
+            norm_adv_by_std_in_grpo=False,
+            config={},
+        )
+
+    assert torch.allclose(data.batch["advantages"], torch.tensor([[0.55], [-0.55]]))
 
 
 @pytest.mark.parametrize(

--- a/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
@@ -14,10 +14,14 @@
 
 from unittest.mock import patch
 
+import numpy as np
+import torch
 from omegaconf import OmegaConf
+from transfer_queue import KVBatchMeta
 
 from verl.trainer.ppo.v1.replay_buffer import ReplayBuffer, ReplayBufferAsync
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+from verl.utils import tensordict_utils as tu
 
 
 class _StubTrainer(PPOTrainer):
@@ -163,3 +167,54 @@ def test_builtin_filter_groups_warns_when_total_generation_limit_is_configured()
         "use max_inflight_gen_batches to bound concurrent Sync DAPO generation.",
         10,
     )
+
+
+def test_codapo_builds_focused_batch_with_fresh_independent_uids():
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    trainer.config = OmegaConf.create({"algorithm": {"codapo_top_k": 2}})
+    prompt_batch = tu.get_tensordict(
+        {
+            "uid": np.array(["q0", "q1", "q2", "q3"], dtype=object),
+            "row": torch.arange(4),
+        }
+    )
+    rollout_data = tu.get_tensordict(
+        {
+            "uid": np.repeat(np.array(["q0", "q1", "q2", "q3"], dtype=object), 2),
+            "codapo_values": torch.tensor([0.1, 0.1, 0.9, 0.9, 0.8, 0.8, 0.2, 0.2]),
+        }
+    )
+    rollout_batch = KVBatchMeta(partition_id="train", keys=[f"key-{row}" for row in range(8)], tags=[{}] * 8)
+    with patch("verl.trainer.ppo.v1.trainer_base.tq.kv_batch_get", return_value=rollout_data):
+        focused_batch = trainer._build_codapo_resampled_batch(prompt_batch, rollout_batch, {})
+
+    focused_uids = [tu.unwrap_non_tensor_data(uid) for uid in focused_batch["uid"]]
+    assert focused_batch["row"].tolist() == [1, 2, 1, 2]
+    assert len(set(focused_uids)) == 4
+    assert set(focused_uids).isdisjoint({"q0", "q1", "q2", "q3"})
+
+
+def test_codapo_step_uses_pending_focused_batch_before_fetching_new_prompts():
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    trainer.config = OmegaConf.create({"data": {"train_batch_size": 2}})
+    trainer.parameter_sync_step = 1
+    trainer._codapo_enabled = True
+    trainer._codapo_resampled_batch = None
+    trainer.global_steps = 8  # Phase is state-driven, not tied to step parity.
+    original_batch = tu.get_tensordict({"uid": np.array(["q0", "q1"], dtype=object)})
+    focused_batch = tu.get_tensordict({"uid": np.array(["f0", "f1"], dtype=object)})
+    rollout_batch = KVBatchMeta(partition_id="train", keys=["k0", "k1"], tags=[{}, {}])
+
+    with (
+        patch.object(trainer, "_next_train_batch", return_value=original_batch) as fetch,
+        patch.object(trainer, "_submit_batch_to_rollout") as submit,
+        patch.object(trainer, "_step_once", return_value=rollout_batch),
+        patch.object(trainer, "_build_codapo_resampled_batch", return_value=focused_batch),
+    ):
+        trainer.step({}, {})
+        trainer.global_steps += 1
+        trainer.step({}, {})
+
+    fetch.assert_called_once_with()
+    assert [call.args[0] for call in submit.call_args_list] == [original_batch, focused_batch]
+    assert trainer._codapo_resampled_batch is None

--- a/verl/trainer/config/algorithm.py
+++ b/verl/trainer/config/algorithm.py
@@ -670,3 +670,7 @@ class AlgoConfig(BaseConfig):
     # gdpo_reward_weights: per-dimension weights for aggregation (default: equal weights).
     gdpo_reward_keys: Optional[list[str]] = None
     gdpo_reward_weights: Optional[list[float]] = None
+    # CoDaPO (Confidence and Difficulty-adaptive Policy Optimization) settings.
+    codapo_top_k: int = 4
+    codapo_weight_offset: float = 0.1
+    codapo_accuracy_key: str = "acc"

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -108,6 +108,7 @@ class AdvantageEstimator(str, Enum):
     OPTIMAL_TOKEN_BASELINE = "optimal_token_baseline"
     TIR_OPTIMAL_TOKEN_BASELINE = "tir_optimal_token_baseline"
     GDPO = "gdpo"
+    CODAPO = "codapo"
 
 
 ADV_ESTIMATOR_REGISTRY: dict[str, Any] = {}
@@ -329,6 +330,87 @@ def compute_grpo_outcome_advantage(
         scores = scores.unsqueeze(-1) * response_mask
 
     return scores, scores
+
+
+@register_adv_est(AdvantageEstimator.CODAPO)
+def compute_codapo_outcome_advantage(
+    token_level_rewards: torch.Tensor,
+    response_mask: torch.Tensor,
+    old_log_probs: torch.Tensor,
+    index: np.ndarray,
+    accuracy_scores: Optional[torch.Tensor] = None,
+    epsilon: float = 1e-6,
+    norm_adv_by_std_in_grpo: bool = True,
+    weight_offset: float = 0.1,
+    config: Optional[AlgoConfig] = None,
+    non_tensor_batch: Optional[dict] = None,
+    batch: Optional[dict] = None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reweight GRPO advantages with CoDaPO confidence and difficulty.
+
+    An accuracy score of one counts as correct for difficulty; all other values
+    count as incorrect. GRPO independently uses ``token_level_rewards``.
+    """
+    with torch.no_grad():
+        scores = token_level_rewards.sum(dim=-1)
+        if accuracy_scores is None:
+            accuracy_key = config.get("codapo_accuracy_key", "acc") if config is not None else "acc"
+            if non_tensor_batch is None or accuracy_key not in non_tensor_batch:
+                raise ValueError(f"CoDaPO accuracy key '{accuracy_key}' was not returned by the reward function")
+            accuracy_scores = torch.as_tensor(
+                np.asarray(non_tensor_batch[accuracy_key], dtype=np.float32),
+                device=scores.device,
+                dtype=scores.dtype,
+            )
+        else:
+            accuracy_scores = accuracy_scores.to(device=scores.device, dtype=scores.dtype)
+        if accuracy_scores.shape != scores.shape:
+            raise ValueError(
+                f"CoDaPO accuracy scores must have shape {tuple(scores.shape)}, got {tuple(accuracy_scores.shape)}"
+            )
+        response_lengths = response_mask.sum(dim=-1)
+        valid = response_lengths > 0
+        valid_accuracy_scores = accuracy_scores[valid]
+        is_correct = torch.isclose(
+            valid_accuracy_scores,
+            torch.ones_like(valid_accuracy_scores),
+            atol=1e-6,
+            rtol=0,
+        )
+
+        group_index = as_torch_index(index, device=scores.device)
+        num_groups = int(group_index.max().item()) + 1 if group_index.numel() else 0
+        counts = torch.zeros(num_groups, dtype=scores.dtype, device=scores.device)
+        counts.index_add_(0, group_index[valid], torch.ones_like(valid_accuracy_scores))
+
+        accuracy = torch.zeros_like(counts)
+        accuracy.index_add_(0, group_index[valid], is_correct.to(scores.dtype))
+        accuracy /= counts.clamp_min(1)
+
+        response_log_probs = (old_log_probs * response_mask).sum(dim=-1) / response_lengths.clamp_min(1)
+        confidence = torch.zeros_like(counts)
+        confidence.index_add_(0, group_index[valid], response_log_probs[valid])
+        confidence = (confidence / counts.clamp_min(1)).exp()
+
+        question_values = (confidence * 4 * accuracy * (1 - accuracy))[group_index]
+
+    if config is not None:
+        weight_offset = config.get("codapo_weight_offset", weight_offset)
+    if not weight_offset >= 0:
+        raise ValueError(f"algorithm.codapo_weight_offset must be non-negative, got {weight_offset}")
+
+    advantages, _ = compute_grpo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+        epsilon=epsilon,
+        norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+    )
+    advantages = advantages * (question_values + weight_offset).unsqueeze(-1)
+    if batch is not None:
+        batch["codapo_values"] = question_values
+    return advantages, advantages
 
 
 @register_adv_est(AdvantageEstimator.GRPO_VECTORIZED)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -261,6 +261,11 @@ def compute_advantage(
         if adv_estimator in (AdvantageEstimator.GDPO, "gdpo"):
             adv_kwargs["non_tensor_batch"] = data.non_tensor_batch
             adv_kwargs["batch"] = data.batch
+        if adv_estimator in (AdvantageEstimator.CODAPO, "codapo"):
+            adv_kwargs["non_tensor_batch"] = data.non_tensor_batch
+            adv_kwargs["batch"] = data.batch
+            adv_kwargs["old_log_probs"] = data.batch["old_log_probs"]
+            adv_kwargs["norm_adv_by_std_in_grpo"] = norm_adv_by_std_in_grpo
         # Add sum_pi_squared for Optimal Token Baseline
         if adv_estimator in (AdvantageEstimator.OPTIMAL_TOKEN_BASELINE, AdvantageEstimator.TIR_OPTIMAL_TOKEN_BASELINE):
             # Check if sum_pi_squared is available
@@ -329,6 +334,8 @@ class RayPPOTrainer:
         self.tokenizer = tokenizer
         self.processor = processor
         self.config = config
+        if config.algorithm.adv_estimator in (AdvantageEstimator.CODAPO, "codapo"):
+            raise ValueError("CoDaPO requires trainer.use_v1=True")
 
         self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
         assert self.hybrid_engine, "Currently, only support hybrid engine"

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -115,6 +115,20 @@ def _tq_supports_checkpoint() -> bool:
     )
 
 
+def _extract_reward_extra_info(extra_fields: Any) -> dict[str, np.ndarray]:
+    """Convert per-sample reward metadata to DataProto non-tensor fields."""
+    if extra_fields is None:
+        return {}
+    reward_extra_infos = [
+        extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
+        for extra_field in extra_fields
+    ]
+    if not reward_extra_infos:
+        return {}
+    common_keys = set.intersection(*(set(info) for info in reward_extra_infos))
+    return {key: np.asarray([info[key] for info in reward_extra_infos]) for key in common_keys}
+
+
 class PPOTrainer(ABC):
     """Base class for PPO trainer.
 
@@ -138,6 +152,14 @@ class PPOTrainer(ABC):
         )
         # track mini-batch index within a parameter_sync_step cycle for Decoupled PPO
         self.local_trigger_step = 0
+        self._codapo_enabled = config.algorithm.adv_estimator in (core_algos.AdvantageEstimator.CODAPO, "codapo")
+        self._codapo_resampled_batch: TensorDict | None = None
+        if self._codapo_enabled:
+            if self.trainer_mode != "sync" or self.parameter_sync_step != 1:
+                raise ValueError("CoDaPO requires the V1 sync trainer with parameter_sync_step=1")
+            filter_groups = config.algorithm.get("filter_groups")
+            if filter_groups is not None and filter_groups.get("enable", False):
+                raise ValueError("CoDaPO cannot be combined with algorithm.filter_groups")
 
     def _build_replay_buffer(self) -> ReplayBuffer:
         """Instantiate the replay buffer (or a user-provided custom sampler).
@@ -514,7 +536,18 @@ class PPOTrainer(ABC):
         )
         sample_batch_size = train_batch_size // self.parameter_sync_step
 
-        self._add_batch_to_generate()
+        codapo_original_batch = None
+        if self._codapo_enabled:
+            if self._codapo_resampled_batch is None:
+                codapo_original_batch = self._next_train_batch()
+                prompt_batch = codapo_original_batch
+            else:
+                prompt_batch = self._codapo_resampled_batch
+                self._codapo_resampled_batch = None
+                tu.assign_non_tensor_data(prompt_batch, "global_steps", self.global_steps)
+            self._submit_batch_to_rollout(prompt_batch)
+        else:
+            self._add_batch_to_generate()
 
         metrics_aggregator = MetricsAggregator()
         combined_keys: list = []
@@ -531,7 +564,54 @@ class PPOTrainer(ABC):
             combined_partition_id = batch.partition_id
 
         metrics.update(metrics_aggregator.get_aggregated_metrics())
+        if self._codapo_enabled:
+            metrics["codapo/is_focused_step"] = float(codapo_original_batch is None)
+            if codapo_original_batch is not None:
+                self._codapo_resampled_batch = self._build_codapo_resampled_batch(
+                    codapo_original_batch,
+                    KVBatchMeta(partition_id=combined_partition_id, keys=combined_keys, tags=combined_tags),
+                    metrics,
+                )
         return KVBatchMeta(partition_id=combined_partition_id, keys=combined_keys, tags=combined_tags)
+
+    def _build_codapo_resampled_batch(
+        self,
+        prompt_batch: TensorDict,
+        rollout_batch: KVBatchMeta,
+        metrics: dict,
+    ) -> TensorDict:
+        """Build CoDaPO's focused prompt batch from the original rollout values."""
+        data = tq.kv_batch_get(
+            keys=rollout_batch.keys,
+            partition_id=rollout_batch.partition_id,
+            select_fields=["uid", "codapo_values"],
+        )
+        value_by_uid = {
+            tu.unwrap_non_tensor_data(uid): value
+            for uid, value in zip(data["uid"], data["codapo_values"].detach().cpu().tolist(), strict=True)
+        }
+        prompt_values = torch.tensor(
+            [value_by_uid[tu.unwrap_non_tensor_data(uid)] for uid in prompt_batch["uid"]], dtype=torch.float32
+        )
+        top_k = self.config.algorithm.get("codapo_top_k", 4)
+        if not 0 < top_k <= len(prompt_batch):
+            raise ValueError(f"algorithm.codapo_top_k must be in [1, {len(prompt_batch)}], got {top_k}")
+        selected_indices = torch.topk(prompt_values, top_k).indices.tolist()
+        resample_indices = [selected_indices[i % top_k] for i in range(len(prompt_batch))]
+        resampled_batch = tu.index_select_tensor_dict(prompt_batch, resample_indices)
+        tu.assign_non_tensor_stack(
+            resampled_batch,
+            "uid",
+            [str(uuid.uuid4()) for _ in range(len(resampled_batch))],
+        )
+
+        metrics.update(
+            {
+                "codapo/value/mean": prompt_values.mean().item(),
+                "codapo/selected_value/mean": prompt_values[selected_indices].mean().item(),
+            }
+        )
+        return resampled_batch
 
     def _step_once(self, metrics: dict, timing_raw: dict, sample_batch_size: int) -> KVBatchMeta:
         """Run a single local update: sample one mini-batch and perform the full PPO pipeline once."""
@@ -708,6 +788,8 @@ class PPOTrainer(ABC):
         )
 
         self.steps_per_epoch = len(self.train_dataset) // self.config.data.train_batch_size
+        if getattr(self, "_codapo_enabled", False):
+            self.steps_per_epoch *= 2
 
         # adjust total_training_steps
         total_training_steps = self.steps_per_epoch * self.config.trainer.total_epochs
@@ -1631,11 +1713,21 @@ class PPOTrainer(ABC):
 
     def _compute_advantage(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Compute the advantage of the batch."""
-        fields = ["uid", "response_mask", "rm_scores", "rollout_log_probs", "old_log_probs", "ref_log_prob", "values"]
+        fields = [
+            "uid",
+            "response_mask",
+            "rm_scores",
+            "rollout_log_probs",
+            "old_log_probs",
+            "ref_log_prob",
+            "values",
+            "extra_fields",
+        ]
         data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
 
         response_mask = data["response_mask"]
-        data = DataProto(batch=data.to_padded_tensor())
+        reward_extra_info = _extract_reward_extra_info(tu.pop(data, "extra_fields"))
+        data = DataProto(batch=data.to_padded_tensor(), non_tensor_batch=reward_extra_info)
         data.batch["token_level_scores"] = data.batch["rm_scores"]
         data.non_tensor_batch["uid"] = np.array(data.batch.pop("uid").tolist(), dtype=object)
 
@@ -1661,6 +1753,7 @@ class PPOTrainer(ABC):
             metrics.update(is_metrics)
 
         # 3. compute advantages
+        advantage_input_fields = set(data.batch.keys())
         data = compute_advantage_for_multi_trajectories(
             data,
             batch_keys=batch.keys,
@@ -1671,6 +1764,7 @@ class PPOTrainer(ABC):
             norm_adv_by_std_in_grpo=self.config.algorithm.get("norm_adv_by_std_in_grpo", True),
             config=self.config.algorithm,
         )
+        advantage_output_fields = set(data.batch.keys()) - advantage_input_fields
 
         # 4. write nested advantages and returns back to TransferQueue
         fields = ["advantages", "returns"]
@@ -1684,6 +1778,13 @@ class PPOTrainer(ABC):
         output = {}
         for field in fields:
             output[field] = response_to_nested(data.batch[field], response_mask)
+        for field in sorted(advantage_output_fields - set(output)):
+            value = data.batch[field]
+            output[field] = (
+                response_to_nested(value, response_mask)
+                if value.ndim == response_mask.ndim and value.shape == response_mask.shape
+                else value
+            )
         output = TensorDict(output, batch_size=len(batch))
 
         batch = tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=output)


### PR DESCRIPTION
### What does this PR do?

Add [Confidence and Difficulty-Adaptive Policy Optimization (CoDaPO)](https://arxiv.org/abs/2606.07950) (ICML 2026) to verl. CoDaPO extends GRPO with CoDaWeighting, top-K CoDaSampling, and paired original/focused CoDaLearning updates.

The implementation registers a CoDaPO advantage estimator, carries an independent correctness signal from reward extra-info, and adds state-driven focused resampling to the V1 synchronous trainer. It also includes four mechanism tests, a Qwen2.5-Math-1.5B MATH recipe, and [algorithm documentation](https://github.com/X1angyuLu/verl/blob/feat/codapo/docs/algo/codapo.md).

This is not duplicate work: searches for [open CoDaPO PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+CoDaPO), [CoDaPO issues](https://github.com/verl-project/verl/issues?q=is%3Aissue+CoDaPO), and related confidence/difficulty-adaptive PRs returned no results on August 20, 2026.

AI assistance disclosure: OpenAI Codex was used to help implement, test, and document this change. The human submitters have reviewed every changed line and confirmed the final PR text before submission.

Official implementation: [tmlr-group/CoDaPO](https://github.com/tmlr-group/CoDaPO)

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+CoDaPO
- [x] Format the title as `[{modules}] {type}: {description}`.

### Test

```bash
uv run --no-sync pytest -q tests/trainer/ppo/test_core_algos_on_cpu.py tests/trainer/ppo/v1/test_trainer_base_on_cpu.py tests/trainer/ppo/v1/test_compute_reward_colocate_on_cpu.py
uv run --no-sync pre-commit run --all-files --show-diff-on-failure --color=never
uv run --no-sync python scripts/print_cfg.py --cfg job algorithm.adv_estimator=codapo +algorithm.codapo_top_k=4 +algorithm.codapo_weight_offset=0.1 +algorithm.codapo_accuracy_key=acc
bash -n examples/codapo_trainer/run_qwen2_5_math_1_5b_fsdp.sh
```

- CPU regression: `45 passed, 6 warnings`.
- Pre-commit: all hooks passed in a clean worktree.
- Hydra and shell checks: the CoDaPO fields composed correctly and the example script parsed successfully.
- Two-GPU vLLM 0.26.0 run: optimizer steps completed, finite losses/gradient norms, and selected CoDaValue means above the batch means on every non-zero original phase.

### API and Usage Example

```yaml
algorithm:
  adv_estimator: codapo
  codapo_top_k: 4
  codapo_weight_offset: 0.1
  codapo_accuracy_key: acc
```

```bash
python3 examples/data_preprocess/math_dataset.py
bash examples/codapo_trainer/run_qwen2_5_math_1_5b_fsdp.sh
```

`codapo_accuracy_key` identifies reward extra-info where `1` denotes a correct response; aggregate reward remains the input to the underlying GRPO advantage.

### Design & Code Changes

- Register CoDaWeighting on top of the existing GRPO advantage calculation.
- Forward reward extra-info through the V1 advantage path for explicit correctness.
- Build same-sized focused batches by round-robin repetition of exact top-K prompts with fresh group IDs.
- Alternate original and focused V1 sync updates and expose CoDaPO phase/value metrics.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add tests covered by the existing CPU workflow.
- [x] Send a message in the `ci-request` channel when ready for CI.
- [x] `recipe` submodule update: not applicable.
