### PR TITLE
fix(mcore): don't crash fused forward when labels is None (#5273)

### DIFF
--- a/tests/models/test_model_forward_fused.py
+++ b/tests/models/test_model_forward_fused.py
@@ -285,6 +285,107 @@ def test_output_processor_preserves_config_logger_payload(monkeypatch):
     assert logged["prefix"] == "input_and_logits"
 
 
+class _LegacyDecoder(torch.nn.Module):
+    def forward(self, *, hidden_states, **_kwargs):
+        return hidden_states
+
+
+def _new_legacy_fused_model(hidden_states, output_layer_weight, gather_output=True, sequence_parallel=False):
+    """Build a minimal object satisfying what `_fused_GPTModel_forward` touches."""
+    model = _new_uninitialized_model()
+    model.config = SimpleNamespace(sequence_parallel=sequence_parallel)
+    model.post_process = True
+    model.output_layer = _OutputLayer()
+    model.output_layer.weight = torch.nn.Parameter(output_layer_weight)
+    model.output_layer.gather_output = gather_output
+    model.decoder = _LegacyDecoder()
+
+    def preprocess(_self, **_kwargs):
+        return (hidden_states, None, None, None, None)
+
+    model._preprocess = MethodType(preprocess, model)
+    return model
+
+
+def test_fused_forward_without_labels_returns_logits_instead_of_crashing(monkeypatch):
+    """Regression test for https://github.com/verl-project/verl/issues/5273.
+
+    Previously, `_fused_GPTModel_forward` unconditionally called `linear_cross_entropy`
+    with `labels`, so a `labels=None` call (e.g. anything invoking the monkey-patched
+    `model.forward` directly, outside of `fused_forward_model`/`fused_forward_model_engine`)
+    crashed with `AttributeError: 'NoneType' object has no attribute 'shape'` inside
+    `verl/utils/kernel/linear_cross_entropy.py`. It must instead fall back to a plain
+    logits projection, mirroring the un-patched `GPTModel._postprocess` no-labels branch.
+    """
+    hidden_states = torch.arange(2 * 1 * 3, dtype=torch.float32).reshape(2, 1, 3)  # [s, b, h]
+    output_layer_weight = torch.eye(4, 3)  # [vocab, hidden]
+    model = _new_legacy_fused_model(hidden_states, output_layer_weight, gather_output=True)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("linear_cross_entropy must not be called when labels is None")
+
+    gathered = {}
+
+    def fake_gather_tp(logits, group=None):
+        gathered["logits"] = logits
+        gathered["group"] = group
+        return logits
+
+    monkeypatch.setattr(mff, "linear_cross_entropy", fail_if_called)
+    monkeypatch.setattr(mff, "gather_from_tensor_model_parallel_region", fake_gather_tp)
+    monkeypatch.setattr(mff.parallel_state, "get_tensor_model_parallel_group", lambda: None)
+
+    output = mff._fused_GPTModel_forward(
+        model,
+        input_ids=torch.tensor([[1, 2]]),
+        position_ids=torch.tensor([[0, 1]]),
+        attention_mask=None,
+        labels=None,
+    )
+
+    expected_logits = torch.matmul(hidden_states, output_layer_weight.t()).transpose(0, 1).contiguous()
+    assert "logits" in gathered  # gather_output=True must trigger the TP all-gather
+    assert torch.equal(output.logits, expected_logits)
+    assert output.log_probs is None
+    assert output.entropy is None
+
+
+def test_fused_forward_with_labels_still_uses_kernel(monkeypatch):
+    """The labels-provided path must remain untouched by the labels=None guard."""
+    hidden_states = torch.arange(2 * 1 * 3, dtype=torch.float32).reshape(2, 1, 3)
+    output_layer_weight = torch.eye(4, 3)
+    model = _new_legacy_fused_model(hidden_states, output_layer_weight)
+    labels = torch.tensor([1, 2])
+
+    seen = {}
+
+    def fake_linear_cross_entropy(hidden, weight, labels_arg, temperature, reduction, group):
+        seen.update(hidden=hidden, weight=weight, labels=labels_arg, temperature=temperature)
+        return torch.zeros(hidden.shape[0]), torch.zeros(hidden.shape[0])
+
+    def fail_if_gathered(*_args, **_kwargs):
+        raise AssertionError("gather_from_tensor_model_parallel_region must not run on the labels path")
+
+    monkeypatch.setattr(mff, "linear_cross_entropy", fake_linear_cross_entropy)
+    monkeypatch.setattr(mff, "gather_from_tensor_model_parallel_region", fail_if_gathered)
+    monkeypatch.setattr(mff.parallel_state, "get_tensor_model_parallel_group", lambda: None)
+
+    output = mff._fused_GPTModel_forward(
+        model,
+        input_ids=torch.tensor([[1, 2]]),
+        position_ids=torch.tensor([[0, 1]]),
+        attention_mask=None,
+        labels=labels,
+        temperature=0.7,
+    )
+
+    assert seen["labels"] is labels
+    assert seen["temperature"] == pytest.approx(0.7)
+    assert output.log_probs is not None
+    assert output.entropy is not None
+    assert output.logits is None
+
+
 @pytest.mark.parametrize(
     ("sequence_parallel", "use_tied_weight"),
     [(True, True), (False, False)],

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -26,7 +26,10 @@ from megatron.core.config_logger import has_config_logger_enabled, log_config_to
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
+from megatron.core.tensor_parallel.mappings import (
+    gather_from_sequence_parallel_region,
+    gather_from_tensor_model_parallel_region,
+)
 from megatron.core.utils import deprecate_inference_params
 from packaging import version
 from torch import Tensor
@@ -464,6 +467,28 @@ def _fused_GPTModel_forward(
     else:
         # When embeddings are tied, use the embedding weight
         output_weight = model.embedding.word_embeddings.weight
+
+    if labels is None:
+        # No labels means the caller just wants logits (e.g. a plain forward pass that
+        # doesn't go through the verl PPO log-prob/entropy code paths, such as MTP being
+        # disabled while other call sites still invoke the patched `forward` directly).
+        # `linear_cross_entropy` requires labels, so fall back to a plain logits
+        # projection instead of crashing on `labels.shape` inside the fused kernel.
+        # This mirrors the un-patched `GPTModel._postprocess` no-labels branch.
+        logits = torch.matmul(hidden_states, output_weight.t())
+
+        if runtime_gather_output is not None:
+            gather_output = runtime_gather_output
+        else:
+            gather_output = getattr(getattr(model, "output_layer", None), "gather_output", True)
+        if gather_output:
+            logits = gather_from_tensor_model_parallel_region(
+                logits, group=parallel_state.get_tensor_model_parallel_group()
+            )
+
+        # [s, b, v] => [b, s, v]
+        output.logits = logits.transpose(0, 1).contiguous()
+        return output
 
     logprobs, entropy = linear_cross_entropy(
         hidden_states,


### PR DESCRIPTION
## What

`patch_fused_forward()` monkey-patches `model.forward` to `_fused_GPTModel_forward` whenever `use_fused_kernels=True` (legacy pre-0.18 Megatron-Core mode). That function unconditionally fed `labels` into `linear_cross_entropy(...)`, but `labels` defaults to `None`, and `linear_cross_entropy.forward()` does `len(labels.shape)` unconditionally at `verl/utils/kernel/linear_cross_entropy.py:74` — so any caller invoking the patched forward without labels (e.g. `enable_mtp=False`) crashes with:

```
AttributeError: 'NoneType' object has no attribute 'shape'
```

Fixes #5273.

## Fix

When `labels is None`, `_fused_GPTModel_forward` now skips the fused cross-entropy kernel and instead projects `hidden_states` through the resolved `output_weight` to produce plain logits, mirroring the no-labels branch of the real (unpatched) `GPTModel._postprocess` (verified against `megatron-core==0.16.1` source). The labels-provided path is untouched.

`patch_fused_forward` itself is left unconditional — `verl/workers/engine/megatron/transformer_impl.py`'s `_maybe_enable_fused_kernels` already disables fused kernels whenever MTP is enabled, so the crash isn't really about MTP; it's that the monkey-patched `forward()` is reachable from other call sites without labels. Making the forward itself robust to `labels=None` is the more general fix.

## Testing

No GPU/`megatron-core` available in the environment this was developed in, so:
- `tests/models/test_model_forward_fused.py` (new) — written against the real module, will run in CI.
- A standalone harness that loads the actual, unmodified `model_forward_fused.py` via `importlib` with `megatron.core.*` stubbed out, driving `_fused_GPTModel_forward` directly with fakes: **13/13 checks pass** on the fixed code, and correctly **fails** when run against the pre-fix code (verified via `git stash`).
- `ruff check` / `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)