### PR TITLE
[reward] fix: replace unsafe eval() with safe parsers in prime_math grader (#5331)

### DIFF
--- a/tests/utils/reward_score/test_prime_math_grader_on_cpu.py
+++ b/tests/utils/reward_score/test_prime_math_grader_on_cpu.py
@@ -1,0 +1,222 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Security regression tests for verl/utils/reward_score/prime_math/grader.py
+(verl-project/verl#5331 - "Critical Security Vulnerabilities in Mathematical
+Evaluation and Serialization Code").
+
+`grader.py` grades the policy model's own generated completion text as part
+of the RL reward computation, so it must never execute that text as code.
+The original implementation called Python's builtin ``eval()`` directly on
+model output in a few places. These tests:
+
+  1. Prove legitimate inputs still produce the same results as before the
+     fix (regression coverage for `handle_pi` and the matrix-literal path).
+  2. Prove concrete adversarial payloads that used to achieve real code
+     execution (verified against the pre-fix implementation while writing
+     this patch -- each PoC below created a real file on disk) no longer do
+     anything beyond failing to match / raising a caught exception.
+"""
+
+import math
+import os
+import tempfile
+
+from verl.utils.reward_score.prime_math.grader import (
+    _safe_symbolic_parse_expr,
+    handle_pi,
+    math_equal,
+    symbolic_equal,
+)
+
+# ---------------------------------------------------------------------------
+# Legitimate-input regression cases
+# ---------------------------------------------------------------------------
+
+
+def test_handle_pi_legit_multiple():
+    # "N\pi" -> N * pi, same as the previous eval()-based implementation.
+    result = handle_pi("2\\pi", math.pi)
+    assert isinstance(result, float)
+    assert math.isclose(result, 2 * math.pi, rel_tol=1e-9)
+
+
+def test_handle_pi_legit_bare():
+    # "\pi" with no preceding digit -> 1 * pi.
+    result = handle_pi("\\pi", math.pi)
+    assert isinstance(result, float)
+    assert math.isclose(result, math.pi, rel_tol=1e-9)
+
+
+def test_handle_pi_legit_decimal_multiple():
+    result = handle_pi("3.5\\pi", math.pi)
+    assert isinstance(result, float)
+    assert math.isclose(result, 3.5 * math.pi, rel_tol=1e-9)
+
+
+def test_handle_pi_no_pi_untouched():
+    # No "\pi" substring -> the function must not touch the string at all.
+    assert handle_pi("hello world", math.pi) == "hello world"
+
+
+def test_handle_pi_non_numeric_leaves_string_substituted_unevaluated():
+    # Mirrors the pre-fix eval() semantics: when the expression cannot be
+    # reduced to a plain number, the *substituted* (but unevaluated) string
+    # is returned unchanged, exactly as when eval() used to raise and get
+    # suppressed by contextlib.suppress(Exception).
+    result = handle_pi("x\\pi", math.pi)
+    assert result == f"1*{math.pi}x" or result == f"x1*{math.pi}"
+    # (the exact placement mirrors the substitution logic; the key invariant
+    # is that it is NOT reduced to a float since "x" is not a plain number)
+    assert not isinstance(result, float)
+
+
+def test_matrix_bracket_literal_matches_pmatrix_reference():
+    # "[5, 6]" vs a 2-row \begin{pmatrix} reference: this exercises the
+    # ast.literal_eval() path that replaced eval(prediction) in math_equal's
+    # bracket-matrix branch. Verified to also return True against the
+    # pre-fix eval()-based implementation, i.e. identical output.
+    prediction = "[5, 6]"
+    reference = "\\begin{pmatrix} 5 \\ 6 \\end{pmatrix}"
+    assert math_equal(prediction, reference) is True
+
+
+def test_matrix_matrix_prefixed_literal_matches_pmatrix_reference():
+    prediction = "Matrix([[1, 2]])"
+    reference = r"\begin{pmatrix} 1 & 2 \end{pmatrix}"
+    assert math_equal(prediction, reference) is True
+
+
+# ---------------------------------------------------------------------------
+# Adversarial-input security cases
+# ---------------------------------------------------------------------------
+
+
+def test_handle_pi_blocks_code_execution():
+    """
+    Before this fix, handle_pi() called eval() on the (\\pi-substituted)
+    answer text. This payload is a real, verified PoC: against the
+    pre-fix implementation it executed os.system(...) and created a file
+    on disk. After the fix it must not execute anything.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        marker = os.path.join(tmpdir, "pwned")
+        payload = f"__import__('os').system('touch {marker}') and 1\\pi"
+
+        # Must not raise out of handle_pi (contextlib.suppress covers it,
+        # same as it always did for eval() failures) and must not execute.
+        result = handle_pi(payload, math.pi)
+
+        assert not os.path.exists(marker), "adversarial payload executed code via handle_pi()"
+        # No crash, and no numeric coercion of attacker-controlled code.
+        assert not isinstance(result, float)
+
+
+def test_handle_pi_blocks_subclasses_gadget():
+    """
+    Even without any dangerous builtin name, walking the live object graph
+    (e.g. to reach subprocess.Popen) is a classic "safe eval" bypass. This
+    must not raise an unhandled exception nor return a live object graph.
+    """
+    payload = "[].__class__.__base__.__subclasses__()\\pi"
+    result = handle_pi(payload, math.pi)
+    # The strict arithmetic allow-list in _safe_parse_expr rejects this
+    # outright, so `string` is left as the substituted-but-unevaluated text.
+    assert not isinstance(result, float)
+    assert not isinstance(result, list)
+
+
+def test_matrix_bracket_branch_blocks_code_execution():
+    """
+    Before this fix, math_equal()'s bracket-matrix branch called
+    eval(prediction) directly. This payload is a real, verified PoC:
+    against the pre-fix implementation it opened and wrote a file on disk
+    and the overall math_equal() call returned False *silently* (masking
+    the fact that arbitrary code had just executed). After the fix it must
+    not execute anything, whether or not an exception is raised.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        marker = os.path.join(tmpdir, "pwnedmatrix")
+        payload = f"[open('{marker}','w').write('x')]"
+        reference = r"\begin{pmatrix} 5 \end{pmatrix}"
+
+        try:
+            math_equal(payload, reference)
+        except Exception:
+            # ast.literal_eval() raising ValueError/SyntaxError for
+            # non-literal syntax is acceptable ("graceful ... exception,
+            # not crash the process or execute code") -- the pre-existing
+            # code around this branch is not wrapped in try/except either.
+            pass
+
+        assert not os.path.exists(marker), "adversarial payload executed code via the bracket-matrix branch"
+
+
+def test_matrix_matrix_branch_blocks_code_execution():
+    """
+    Before this fix, math_equal()'s "Matrix(...)"-prefixed branch called
+    (an unrestricted) parse_expr(prediction) -- not a literal eval() call,
+    but sympy documents that parse_expr() "uses eval, and thus shouldn't be
+    used on unsanitized input". This payload is a real, verified PoC:
+    against the pre-fix implementation it wrote a file on disk AND
+    math_equal() returned True (a full reward for an exploit). After the
+    fix it must not execute anything.
+    """
+    # Deliberately not tempfile.TemporaryDirectory(): its random component can
+    # contain "_", which would trip the unrelated handle_base() "look for a
+    # numeric base suffix" behavior before the payload ever reaches the
+    # "Matrix(...)" branch this test targets. Use a fixed, underscore-free
+    # marker path instead.
+    marker = os.path.join(tempfile.gettempdir(), "verl-issue-5331-matrix-fn-marker")
+    if os.path.exists(marker):
+        os.remove(marker)
+    try:
+        payload = f"Matrix(open('{marker}','w').write('x') and [[1,2]] or [[1,2]])"
+        reference = r"\begin{pmatrix} 1 & 2 \end{pmatrix}"
+
+        result = math_equal(payload, reference)
+
+        assert not os.path.exists(marker), "adversarial payload executed code via the 'Matrix(...)' branch"
+        assert result is False
+    finally:
+        if os.path.exists(marker):
+            os.remove(marker)
+
+
+def test_safe_symbolic_parse_expr_blocks_subclasses_gadget():
+    """
+    Direct unit test of the hardened symbolic-expression helper used by
+    both the "Matrix(...)" branch and symbolic_equal(): the classic
+    sandbox-escape gadget (which needs no dangerous builtin name at all,
+    only live object-graph traversal) must be rejected outright.
+    """
+    payload = "[].__class__.__base__.__subclasses__()"
+    try:
+        result = _safe_symbolic_parse_expr(payload)
+    except Exception:
+        return  # rejecting via exception is the expected, safe outcome
+    # If it didn't raise, it must not have returned the live class list
+    # (i.e. it must not have actually walked the object graph).
+    assert not isinstance(result, list)
+
+
+def test_symbolic_equal_blocks_code_execution():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        marker = os.path.join(tmpdir, "pwnedsymbolic")
+        payload = f"__import__('os').system('touch {marker}')"
+
+        result = symbolic_equal(payload, "1", 1e-4, timeout=5)
+
+        assert not os.path.exists(marker), "adversarial payload executed code via symbolic_equal()"
+        assert result is False

--- a/verl/utils/reward_score/prime_math/grader.py
+++ b/verl/utils/reward_score/prime_math/grader.py
@@ -92,9 +92,12 @@ This logic is largely copied from the Hendrycks' MATH release (math_equivalence)
 - https://github.com/openai/prm800k
 """
 
+import ast
+import builtins
 import contextlib
 import math
 import re
+import types
 from math import isclose
 
 # sympy related
@@ -104,6 +107,115 @@ from sympy.parsing.sympy_parser import parse_expr
 
 # verl related
 from verl.utils.py_functional import timeout_limit
+
+# ---------------------------------------------------------------------------
+# Security hardening (verl-project/verl#5331 - "Critical Security
+# Vulnerabilities in Mathematical Evaluation and Serialization Code").
+#
+# `prediction` (and, to a lesser extent, `reference`) strings handled by this
+# module originate from the policy model's own generated completion text,
+# which is graded as part of the RL reward computation on *every* rollout.
+# The original implementation called Python's builtin eval() directly on
+# that text in a couple of places, which is a straightforward
+# arbitrary-code-execution vector (e.g. a completion containing
+# "__import__('os').system(...)" as part of its "answer").
+#
+# sympy.parsing.sympy_parser.parse_expr() is NOT a safe drop-in replacement
+# for eval() by itself: its own docstring warns "this function uses eval,
+# and thus shouldn't be used on unsanitized input". By default
+# (global_dict=None) it even copies every Python builtin function --
+# including __import__, eval, exec, open, compile, ... -- into the
+# namespace it evaluates against, so
+# `parse_expr("__import__('os').system(...)")` executes just as readily as
+# a bare eval() call would (verified while writing this patch). The helpers
+# below build a namespace that keeps sympy's own names (so numeric/symbolic
+# parsing keeps working exactly as before) but omits the dangerous
+# builtins, and separately validate the input before parsing.
+#
+# Note that removing dangerous builtins still cannot, by itself, stop
+# "sandbox escape via live object-graph traversal" tricks such as
+# `[].__class__.__base__.__subclasses__()` (walking the object graph this
+# way needs no builtin function name at all). `handle_pi()` is fully immune
+# to this because it is only ever handed a strictly-validated arithmetic
+# expression (see `_safe_parse_expr`). For the general-purpose symbolic
+# parsing elsewhere in this module we additionally reject any expression
+# containing "__", which blocks the concrete gadget above (no legitimate
+# LaTeX-derived math expression needs a double underscore); a fully
+# rigorous fix for arbitrary untrusted symbolic input would require running
+# the parser in a real sandbox (subprocess / restricted syscalls) rather
+# than namespace or string filtering.
+# ---------------------------------------------------------------------------
+
+_DANGEROUS_BUILTIN_NAMES = frozenset(
+    {
+        "__import__",
+        "__build_class__",
+        "eval",
+        "exec",
+        "compile",
+        "open",
+        "input",
+        "breakpoint",
+        "globals",
+        "locals",
+        "vars",
+        "getattr",
+        "setattr",
+        "delattr",
+        "help",
+        "exit",
+        "quit",
+        "memoryview",
+    }
+)
+
+_SAFE_ARITHMETIC_EXPR_RE = re.compile(r"^[\d\s+\-*/().eE]+$")
+
+
+def _safe_sympy_global_dict() -> dict:
+    """Namespace for ``parse_expr`` that mirrors its own default namespace
+    (``global_dict=None``), except that it omits builtins with no
+    legitimate use in a math expression that are the standard vector for
+    turning an expression parser into arbitrary code execution.
+    """
+    global_dict: dict = {}
+    exec("from sympy import *", global_dict)  # trusted, fixed source string
+    for name, obj in vars(builtins).items():
+        if name in _DANGEROUS_BUILTIN_NAMES:
+            continue
+        if isinstance(obj, types.BuiltinFunctionType):
+            global_dict[name] = obj
+    global_dict["max"] = global_dict["Max"]
+    global_dict["min"] = global_dict["Min"]
+    global_dict["__builtins__"] = {}
+    return global_dict
+
+
+def _safe_parse_expr(string: str):
+    """Safely evaluate the plain arithmetic expression built by
+    ``handle_pi`` (e.g. ``"2*3.141592653589793"``), replacing the previous
+    ``eval(string)`` call (verl-project/verl#5331). Only a strict allow-list
+    of arithmetic characters is accepted before parsing, which -- unlike a
+    bare/naive ``parse_expr()`` call -- also closes the object-graph
+    traversal gadgets described above.
+    """
+    if not _SAFE_ARITHMETIC_EXPR_RE.match(string):
+        raise ValueError(f"refusing to evaluate non-arithmetic expression: {string!r}")
+    return parse_expr(string, global_dict=_safe_sympy_global_dict(), evaluate=True)
+
+
+def _safe_symbolic_parse_expr(expr: str):
+    """Parse a general (possibly symbolic) expression through the hardened
+    namespace above (verl-project/verl#5331). Also rejects any expression
+    containing a double underscore, which blocks Python dunder-attribute
+    gadgets such as ``"[].__class__.__base__.__subclasses__()"`` that
+    survive even a builtins-free namespace. This is a pragmatic,
+    defense-in-depth filter -- not a substitute for real sandboxing -- since
+    no legitimate LaTeX-derived math expression needs a double underscore.
+    """
+    if "__" in expr:
+        raise ValueError(f"refusing to evaluate expression containing '__': {expr!r}")
+    return parse_expr(expr, global_dict=_safe_sympy_global_dict())
 
 
 def is_digit(s):
@@ -164,9 +276,21 @@ def handle_pi(string, pi):
             # Find the next occurrence of "\pi"
             idx = string.find("\\pi", idx + 1)
 
-        # Evaluate the expression using eval() function
+        # Evaluate the arithmetic expression. SECURITY (verl-project/verl#5331):
+        # this used to call eval(string) directly on the model's own answer
+        # text, which is arbitrary code execution. _safe_parse_expr() only
+        # accepts a strict arithmetic-character allow-list and evaluates it
+        # through a builtins-free sympy namespace; we only keep the result
+        # when it collapses to a plain number, matching what eval() produced
+        # for the numeric "N*math.pi"-style expressions this function
+        # builds. Any other outcome (validation failing, parsing raising, or
+        # the result not being numeric) leaves `string` as the
+        # substituted-but-unevaluated text, exactly as eval() raising an
+        # exception did before.
         with contextlib.suppress(Exception):
-            string = eval(string)
+            parsed = _safe_parse_expr(string)
+            if parsed.is_number:
+                string = float(parsed)
 
     return string
 
@@ -284,7 +408,11 @@ def math_equal(
     # if reference is a matrix
     if r"\begin{pmatrix}" in reference and prediction.startswith("Matrix"):
         try:
-            pred_matrix = parse_expr(prediction)
+            # SECURITY (verl-project/verl#5331): route through the hardened,
+            # builtins-restricted namespace instead of parse_expr()'s own
+            # (unsafe-by-default) namespace -- see module-level comment above
+            # _safe_sympy_global_dict for why this matters.
+            pred_matrix = _safe_symbolic_parse_expr(prediction)
             ref_matrix_items = reference.split()[1:-1:2]
             if len(pred_matrix) == len(ref_matrix_items) and all(
                 [
@@ -296,9 +424,16 @@ def math_equal(
         except Exception:
             pass
     elif r"\begin{pmatrix}" in reference and prediction.startswith("[") and prediction.endswith("]"):
-        if isinstance(eval(prediction), list):
+        # SECURITY (verl-project/verl#5331): eval(prediction) executed the
+        # model's own answer text as Python code. ast.literal_eval() only
+        # accepts Python literal syntax (lists/tuples/dicts/numbers/strings/
+        # booleans/None) -- it parses "[[1, 2], [3, 4]]" exactly like eval()
+        # did, but it is structurally incapable of calling functions,
+        # importing modules, or evaluating attribute access, so it cannot
+        # execute code.
+        if isinstance(ast.literal_eval(prediction), list):
             try:
-                pred_matrix = eval(prediction)
+                pred_matrix = ast.literal_eval(prediction)
                 # ref_matrix_items = reference.split()[1:-1:2]
                 ref_matrix_items = (
                     reference.removeprefix(r"\\begin{pmatrix}")
@@ -323,7 +458,10 @@ def math_equal(
 
 def symbolic_equal(a, b, tolerance, timeout=10.0):
     def _parse(s):
-        for f in [parse_expr, parse_latex]:
+        # SECURITY (verl-project/verl#5331): route parse_expr through the
+        # hardened namespace (see module-level comment above
+        # _safe_sympy_global_dict) instead of its own unsafe-by-default one.
+        for f in [_safe_symbolic_parse_expr, parse_latex]:
             try:
                 with timeout_limit(seconds=timeout):
                     return f(s)


### PR DESCRIPTION
## What

`verl/utils/reward_score/prime_math/grader.py` called Python's builtin `eval()` directly on strings that originate from the **policy model's own generated completion text** being graded as part of the RL reward computation, on every rollout:

1. `handle_pi()`: `eval(string)` on the model's answer text after `\pi` substitution.
2. `math_equal()`'s bracket-matrix branch: `eval(prediction)` (twice) on the model's raw answer text.

This is a straightforward arbitrary-code-execution vector (e.g. an answer containing `__import__('os').system(...)`).

Fixes #5331.

## Fix

- `handle_pi()`: routes through a new `_safe_parse_expr()` — rejects anything outside a strict arithmetic-character allow-list before parsing via a builtins-stripped `sympy` namespace, only accepting numeric results.
- Both matrix-literal `eval(prediction)` calls: replaced with `ast.literal_eval(prediction)`, which parses the same Python-literal syntax but is structurally incapable of executing code.
- **Also found and hardened a second, subtler RCE**: `sympy.parsing.sympy_parser.parse_expr()` is not a safe `eval()` replacement by itself — by default it copies every Python builtin (including `__import__`, `eval`, `exec`, `open`) into its evaluation namespace, so the *existing* (non-`eval()`-named) `parse_expr(prediction)` call in the `Matrix(...)`-prefixed branch of `math_equal()`, and the `parse_expr` fallback in `symbolic_equal()`, were also live code-execution paths. Both now go through a shared `_safe_symbolic_parse_expr()` helper (builtins-stripped namespace + reject any `__` substring, blocking `[].__class__.__base__.__subclasses__()`-style gadgets).

This is a pure security-hardening patch — behavior for all legitimate, non-adversarial input is unchanged.

Scope note: `verl/utils/reward_score/prime_code/testing_util.py`'s `exec()` was intentionally left untouched — running model-generated code against test cases *is* the point of that reward mechanism (a different, already-understood trust boundary), not an oversight.

## Testing

New `tests/utils/reward_score/test_prime_math_grader_on_cpu.py` (13 tests): **13/13 pass**, stable across repeated runs. Includes:
- Legitimate-input regression cases proving unchanged output for well-formed input.
- Adversarial cases using PoC payloads verified (via `git stash` against the pre-fix code) to actually create files / execute code before the fix, and confirmed to have zero side effects after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)