### PR TITLE
[perf] avoid repacking single micro-batches

### DIFF
--- a/tests/utils/test_seqlen_balancing.py
+++ b/tests/utils/test_seqlen_balancing.py
@@ -61,6 +61,30 @@ def test_dynamic_batch():
     torch.testing.assert_close(input_ids, dataproto.batch["input_ids"])
 
 
+def test_single_micro_batch_reuses_original_nested_batch():
+    """A one-micro-batch split must not repack large jagged fields."""
+    input_ids = torch.randint(low=0, high=10, size=(2, 8))
+    attention_mask = torch.ones_like(input_ids)
+    pixel_values = torch.nested.as_nested_tensor(
+        [torch.randn(2, 3), torch.randn(4, 3)],
+        layout=torch.jagged,
+    )
+    dataproto = DataProto.from_single_dict(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+        }
+    )
+
+    micro_batches, micro_bsz_idx_lst = rearrange_micro_batches(dataproto.batch, max_token_len=16)
+
+    assert len(micro_batches) == 1
+    assert micro_batches[0] is dataproto.batch
+    assert micro_batches[0]["pixel_values"] is pixel_values
+    assert micro_bsz_idx_lst == [[0, 1]]
+
+
 def _worker(rank, world_size, init_method, max_token_len, use_same_dp, min_mb):
     # 1) init process group & CUDA
     get_torch_device().set_device(rank)

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -408,6 +408,11 @@ def rearrange_micro_batches(
 
     assert num_micro_batches <= num_groups
 
+    # Fast path: avoid redundant repacking when the full batch fits in one micro-batch.
+    if num_micro_batches == 1:
+        identity_indices = list(range(batch_size))
+        return [batch], [identity_indices]
+
     # upcast to int64 to avoid potential overflow im `calculate_workload` computation.
     seq_len_effective = seq_len_effective.long()
 


### PR DESCRIPTION
## Summary

When sequence-length balancing determines that the local batch fits in a single micro-batch, return the original batch instead of re-indexing and rebuilding every field.

This is especially useful for multimodal batches with jagged/nested tensors, where the identity path can otherwise create unnecessary host-side buffers and copies.

## Changes

- Add a fast path in `rearrange_micro_batches` for `num_micro_batches == 1`.
- Preserve the existing return contract: the original batch and identity indices are returned.
- Add a regression test verifying that nested multimodal fields are reused without repacking.

## Compatibility

- No behavior change when more than one micro-batch is required.
- No configuration changes.
- Existing callers still receive the same tuple structure.

## Benchmark

CPU microbenchmark with `torch.set_num_threads(1)`:

- Batch size: 8
- Sequence length: 128
- `pixel_values`: jagged nested tensors with shapes `[256 + 8*i, 32]`
- 20 warmup iterations, 300 measured iterations
- `max_token_len=1024`, so the full batch fits in one micro-batch

| Version | Mean time |
| --- | ---: |
| Before (parent commit `8c4696e4`) | 0.6141 ms |
| After (`9a1199d1`) | 0.0099 ms |

This is approximately 62x faster for this identity-repacking case, with a 98.4% reduction in the local rearrangement time. The benchmark also confirms that the original batch and nested field object are reused.

## Tests

- `python -m pytest -q tests/utils/test_seqlen_balancing.py -k 'seqlen_balancing or dynamic_batch or single_micro_batch'`
- Result: 8 passed