### PR TITLE
[vllm] fix: honor explicit False on Optional[bool] engine args in CLI serialization

### DIFF
--- a/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
@@ -56,8 +56,32 @@ class TestBuildCliArgsFromConfig:
         assert result == ["--enable-prefix-caching"]
 
     def test_bool_false(self):
-        """Bool False is skipped entirely."""
+        """Optional[bool] args emit '--no-key' for an explicit False."""
         config = {"enable-prefix-caching": False}
+        result = build_cli_args_from_config(config)
+        assert result == ["--no-enable-prefix-caching"]
+
+    def test_bool_false_plain_bool_omitted(self):
+        """Bool False on a plain-bool arg is skipped (parser default is False)."""
+        config = {"enforce_eager": False}
+        result = build_cli_args_from_config(config)
+        assert result == []
+
+    def test_bool_false_union_str_arg_omitted(self):
+        """Bool False on a `bool | str | None` arg is skipped (string flag, no --no- form)."""
+        config = {"hf_token": False}
+        result = build_cli_args_from_config(config)
+        assert result == []
+
+    def test_bool_false_underscore_key(self):
+        """Underscore keys emit the negative flag in the key's own spelling."""
+        config = {"enable_prefix_caching": False}
+        result = build_cli_args_from_config(config)
+        assert result == ["--no-enable_prefix_caching"]
+
+    def test_bool_false_non_engine_arg_omitted(self):
+        """Bool False on args unknown to AsyncEngineArgs is omitted."""
+        config = {"disable-log-requests": False}
         result = build_cli_args_from_config(config)
         assert result == []
 
@@ -136,6 +160,44 @@ class TestBuildCliArgsFromConfig:
         config = {"sizes": [42]}
         result = build_cli_args_from_config(config)
         assert result == ["--sizes", "42"]
+
+
+class TestCliArgsVllmParserRoundTrip:
+    """Serialized args must round-trip through vLLM's serve CLI parser."""
+
+    @staticmethod
+    def _build_parser():
+        import vllm.entrypoints.cli.serve as serve_mod
+        from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+        parser = FlexibleArgumentParser(description="test")
+        subparsers = parser.add_subparsers(required=False, dest="subparser")
+        for cmd in serve_mod.cmd_init():
+            cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
+        return parser
+
+    def test_explicit_false_survives_parsing(self):
+        """Explicit False survives parse_args and AsyncEngineArgs.from_cli_args."""
+        from vllm.engine.arg_utils import AsyncEngineArgs
+
+        parser = self._build_parser()
+        config = {
+            "skip_tokenizer_init": False,
+            "enable_chunked_prefill": True,
+            "enable_prefix_caching": False,  # the regression this guards
+            "enable_sleep_mode": True,
+            "enforce_eager": False,
+            "disable_log_stats": False,
+        }
+        argv = ["serve", "dummy-model"] + build_cli_args_from_config(config)
+        namespace = parser.parse_args(args=argv)
+        engine_args = AsyncEngineArgs.from_cli_args(namespace)
+        assert engine_args.enable_prefix_caching is False
+        assert engine_args.enable_chunked_prefill is True
+        assert engine_args.enable_sleep_mode is True
+        assert engine_args.skip_tokenizer_init is False
+        assert engine_args.enforce_eager is False
+        assert engine_args.disable_log_stats is False
 
 
 class TestVllmColocateZmqHandle:

--- a/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
@@ -184,7 +184,7 @@ class TestCliArgsVllmParserRoundTrip:
         config = {
             "skip_tokenizer_init": False,
             "enable_chunked_prefill": True,
-            "enable_prefix_caching": False,  # the regression this guards
+            "enable_prefix_caching": False,
             "enable_sleep_mode": True,
             "enforce_eager": False,
             "disable_log_stats": False,

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ctypes
+import dataclasses
 import json
 import logging
 import os
@@ -432,6 +433,19 @@ class SuppressSignalInThread:
         signal.signal = self.original_signal
 
 
+def _optional_bool_vllm_args() -> set[str]:
+    """Return the names of vLLM `AsyncEngineArgs` fields typed exactly `bool | None`.
+
+    For such fields an omitted flag leaves the None default, which vLLM can
+    resolve to True at engine-config time (e.g. `enable_prefix_caching`), so
+    an explicit False must be serialized as `--no-<flag>` instead of being
+    dropped.
+    """
+    from vllm.engine.arg_utils import AsyncEngineArgs
+
+    return {f.name for f in dataclasses.fields(AsyncEngineArgs) if set(get_args(f.type)) == {bool, type(None)}}
+
+
 def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
     """
     Convert a config dictionary to CLI arguments for vLLM server.
@@ -439,7 +453,8 @@ def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
     Handles different value types appropriately:
     - None: skipped
     - bool True: adds '--key'
-    - bool False: skipped
+    - bool False: adds '--no-key' for Optional[bool] engine args (whose None
+      default resolves to True), otherwise skipped
     - list: expands to '--key item1 item2 ...'
     - empty list: skipped (vLLM uses nargs="+" which requires at least one value)
     - dict: JSON serialized
@@ -458,6 +473,9 @@ def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
         if isinstance(v, bool):
             if v:
                 cli_args.append(f"--{k}")
+            elif k.replace("-", "_") in _optional_bool_vllm_args():
+                # Absent flag resolves to True at engine-config time.
+                cli_args.append(f"--no-{k}")
         elif isinstance(v, list):
             if not v:
                 # Skip empty lists - vLLM uses nargs="+" which requires at least one value

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import ctypes
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -433,6 +434,7 @@ class SuppressSignalInThread:
         signal.signal = self.original_signal
 
 
+@functools.lru_cache(maxsize=1)
 def _optional_bool_vllm_args() -> set[str]:
     """Return the names of vLLM `AsyncEngineArgs` fields typed exactly `bool | None`.
 


### PR DESCRIPTION
### What does this PR do?

`build_cli_args_from_config` dropped every `False` boolean, so an explicit `enable_prefix_caching=False` emitted **no flag at all**. For vLLM `Optional[bool]` engine args an omitted flag means `None`, which resolves to **enabled** at engine-config time — so the trainer config printed `False` while the rollout engine silently ran with prefix caching on. `enable_prefix_caching=False` was documented in #3395 as the supported way to disable caching, but it never took effect on the async vLLM server path.

This is masked on vanilla verl+vLLM (verl resets the prefix cache after each `wake_up`), but it silently corrupts training on engines whose sleep/wake discards KV while leaving the scheduler's prefix-hash table intact (observed as a full reward collapse in a downstream colocated RL setup).

**Fix**: serialize an explicit `False` as `--no-<flag>` for `AsyncEngineArgs` fields typed exactly `bool | None` (introspected at runtime, so it tracks the installed vLLM). Plain-`bool` args (parser default is already `False`) and `bool | str | None` unions like `hf_token` (string flag, no `--no-` form) are still omitted.

**Behavior change to note**: configs setting `enable_chunked_prefill=False` now genuinely disable chunked prefill instead of silently running with it enabled. An existing unit test (`test_bool_false`) pinned the old drop-False rule and is updated accordingly.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+build_cli_args_from_config
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+enable_prefix_caching+cli
  - No open or merged PR touches this serializer.
- [x] PR title follows `[{modules}] {type}: {description}`.

### Test

```
CUDA_VISIBLE_DEVICES= python -m pytest tests/workers/rollout/test_vllm_cli_args_on_cpu.py -q
→ 23 passed  (vllm 0.24.0, Python 3.12)
```

New `TestCliArgsVllmParserRoundTrip` builds the real vLLM serve parser (mirroring `vllm_async_server`'s construction) and asserts an explicit `False` survives `parse_args` → `AsyncEngineArgs.from_cli_args`. Validated against vLLM 0.13.0 and the pinned 0.24.0.

### API and Usage Example

No API change. Existing config now works as documented:

```bash
actor_rollout_ref.rollout.enable_prefix_caching=False   # now actually disables prefix caching
```

### Design & Code Changes

- `_optional_bool_vllm_args()`: returns `AsyncEngineArgs` fields typed exactly `bool | None` via `dataclasses.fields` (whole-class `get_type_hints` raises on vLLM's lazy string annotations; per-field `get_args` avoids that).
- `build_cli_args_from_config()`: on `False`, emits `--no-<flag>` iff the key is in that set; otherwise skipped as before.
- Tests: updated `test_bool_false`; added plain-bool / `hf_token`-union / underscore-key / non-engine-arg cases and the parser round-trip.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] `pre-commit run --files ...` — all hooks passed.
- [ ] Documentation: N/A (bug fix, no API change).
- [x] Unit tests added (CI: `vllm.yml` runs this file in the vllm venv).
- [ ] Request CI run in the `ci-request` Slack channel once ready.

---

**AI assistance disclosure**: this fix was developed with AI assistance (commit carries a `Co-authored-by: opencode` trailer). Every changed line was reviewed, understood, and validated by the human submitter, including the downstream root-cause investigation that motivated it.
