### PR TITLE
[veomni] feat:add async activation offloading support

### DIFF
--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -43,6 +43,10 @@ actor_rollout_ref:
       entropy_checkpointing: false
       forward_only: false
       enable_fsdp_offload: false
+      enable_async_activation_offload: false
+      activation_offload_modules:
+      - model.visual.blocks.{*}
+      - model.language_model.layers.{*}
       enable_reentrant: false
       attn_implementation: flash_attention_2
       moe_implementation: fused
@@ -247,6 +251,10 @@ actor_rollout_ref:
       entropy_checkpointing: false
       forward_only: true
       enable_fsdp_offload: false
+      enable_async_activation_offload: false
+      activation_offload_modules:
+      - model.visual.blocks.{*}
+      - model.language_model.layers.{*}
       enable_reentrant: false
       attn_implementation: ${oc.select:actor_rollout_ref.actor.veomni.attn_implementation,flash_attention_2}
       moe_implementation: ${oc.select:actor_rollout_ref.actor.veomni.moe_implementation,fused}
@@ -552,6 +560,10 @@ critic:
     entropy_checkpointing: false
     forward_only: false
     enable_fsdp_offload: false
+    enable_async_activation_offload: false
+    activation_offload_modules:
+    - model.visual.blocks.{*}
+    - model.language_model.layers.{*}
     enable_reentrant: false
     attn_implementation: flash_attention_2
     moe_implementation: fused

--- a/verl/trainer/config/engine/veomni.yaml
+++ b/verl/trainer/config/engine/veomni.yaml
@@ -51,6 +51,14 @@ forward_only: false
 
 enable_fsdp_offload: false
 
+# Whether to offload model activation to CPU
+enable_async_activation_offload: false
+
+# List of modules to offload to CPU
+activation_offload_modules:
+  - model.visual.blocks.{*}
+  - model.language_model.layers.{*}
+
 enable_reentrant: false
 
 # support eager, sdpa, flash_attention_2, flash_attention_3, veomni_flash_attention_2_with_sp,

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -441,6 +441,8 @@ class VeOmniEngineConfig(EngineConfig):
     basic_modules: Optional[list[str]] = field(default_factory=list)
     pad_to_length: bool = False
     pad_to_length_bucket: int = 1024
+    enable_async_activation_offload: bool = False
+    activation_offload_modules: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         super().__post_init__()

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -23,6 +23,7 @@ from tensordict import TensorDict
 from torch.distributed.tensor import DTensor
 from veomni.arguments import MixedPrecisionConfig, OpsImplementationConfig
 from veomni.distributed import parallel_state
+from veomni.distributed.async_offload import apply_async_activation_offload
 from veomni.distributed.offloading import build_activation_offloading_context
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models.auto import build_foundation_model
@@ -324,6 +325,9 @@ class VeOmniEngine(FSDPEngine):
             init_device=self.engine_config.init_device,
         )
         log_gpu_memory_usage("After load base model", logger=logger)
+
+        if self.engine_config.enable_async_activation_offload:
+            apply_async_activation_offload(module, self.engine_config.activation_offload_modules)
 
         # Applies parallel strategies to the model.
         log_gpu_memory_usage("Before parallelize model", logger=logger)


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

After https://github.com/ByteDance-Seed/VeOmni/pull/872.

The async activation offloading feature has been added, along with the corresponding configuration items and module list, allowing the activation values of specified modules to be offloaded to the CPU to save GPU memory.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+async+offload
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

We conducted experiments on Qwen3.5-122B. The GPU memory monitoring results are shown below, revealing a reduction of nearly 5 GB：

w/o async offload
<img width="1462" height="840" alt="processed_off" src="https://github.com/user-attachments/assets/c27b35ac-c2b6-480b-a9ef-fe4fd7bb37e3" />
w async offload
<img width="1410" height="846" alt="processed_on" src="https://github.com/user-attachments/assets/9a68ce18-aad3-4d04-ac93-15b59e387b5b" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
actor_rollout_ref.actor.veomni.enable_async_activation_offload=true \
actor_rollout_ref.actor.veomni.activation_offload_modules=[model.visual.blocks.{*},model.language_model.layers.{*}]
```
### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
