### PR TITLE
[vllm, rollout] fix: gate rollout submission during weight-sync drain for DP>1

### DIFF
--- a/tests/workers/rollout/rollout_vllm/test_submitter_gate_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_submitter_gate_on_cpu.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GPU-free tests for the vLLMHttpServer submission gate.
+
+vLLM's pause stops requests being scheduled but still accepts them. A request
+admitted between abort_all_requests() and resume_generation() is parked in the
+scheduler's waiting queue and masked out of the drain's liveness check, so
+wait_for_requests_to_drain() cannot return. These tests pin the ordering that
+makes such an admission impossible.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("ray")
+pytest.importorskip("vllm")
+
+from verl.workers.rollout.vllm_rollout import vllm_async_server
+
+
+class _FakeEngine:
+    """Records the state of the gate at the moment the engine is paused."""
+
+    def __init__(self):
+        self.output_processor = SimpleNamespace(request_states={})
+        self.server = None
+        self.pause_calls = 0
+        self.resume_calls = 0
+        self.admitting_at_pause = None
+
+    async def pause_generation(self, **kwargs):
+        self.pause_calls += 1
+        self.admitting_at_pause = self.server._admitting
+
+    async def resume_generation(self):
+        self.resume_calls += 1
+
+
+def _make_server(node_rank: int = 0):
+    server = object.__new__(vllm_async_server.vLLMHttpServer)
+    server.node_rank = node_rank
+    server.engine = _FakeEngine()
+    server.engine.server = server
+    server._submission_paused = False
+    server._admitting = 0
+    server._resume_event = asyncio.Event()
+    server._resume_event.set()
+    return server
+
+
+def test_abort_does_not_pause_until_inflight_admissions_land():
+    async def main():
+        server = _make_server()
+        server._admitting = 1  # a turn is past the gate but not yet in the engine
+
+        abort = asyncio.create_task(server.abort_all_requests())
+        await asyncio.sleep(0.05)
+
+        assert server._submission_paused is True, "gate must close before the barrier runs"
+        assert not abort.done(), "abort must not proceed while an admission is in flight"
+        assert server.engine.pause_calls == 0, "engine paused while an admission was in flight"
+
+        server._admitting = 0  # the in-flight admission reaches the engine
+        await asyncio.wait_for(abort, timeout=5)
+
+        assert server.engine.pause_calls == 1
+        assert server.engine.admitting_at_pause == 0
+
+    asyncio.run(main())
+
+
+def test_submission_parks_while_gate_closed_and_wakes_on_resume():
+    async def main():
+        server = _make_server()
+        await server.abort_all_requests()
+        assert server._submission_paused is True
+
+        admitted = asyncio.Event()
+
+        async def submitter():
+            # Mirrors the park loop at the head of generate().
+            while server._submission_paused:
+                await server._resume_event.wait()
+            admitted.set()
+
+        task = asyncio.create_task(submitter())
+        await asyncio.sleep(0.05)
+        assert not task.done(), "submission must park while the gate is closed"
+        assert not admitted.is_set()
+
+        await server.resume_generation()
+        await asyncio.wait_for(task, timeout=5)
+        assert admitted.is_set()
+
+    asyncio.run(main())
+
+
+def test_resume_reopens_gate_on_non_head_server():
+    async def main():
+        server = _make_server(node_rank=1)
+        server._submission_paused = True
+        server._resume_event.clear()
+
+        await server.resume_generation()
+
+        assert server._submission_paused is False, "non-head server stays gated forever"
+        assert server._resume_event.is_set()
+        assert server.engine.resume_calls == 0, "only node rank 0 drives the engine"
+
+    asyncio.run(main())
+
+
+def test_resume_on_head_server_also_resumes_engine():
+    async def main():
+        server = _make_server(node_rank=0)
+        await server.abort_all_requests()
+
+        await server.resume_generation()
+
+        assert server._submission_paused is False
+        assert server._resume_event.is_set()
+        assert server.engine.resume_calls == 1
+
+    asyncio.run(main())
+
+
+def test_barrier_times_out_instead_of_hanging(monkeypatch):
+    # raising=False: this asserts the barrier cannot deadlock, not that the constant exists.
+    monkeypatch.setattr(vllm_async_server, "_GATE_BARRIER_TIMEOUT_S", 0.05, raising=False)
+
+    async def main():
+        server = _make_server()
+        server._admitting = 1  # never clears
+
+        await asyncio.wait_for(server.abort_all_requests(), timeout=5)
+
+        assert server.engine.pause_calls == 1, "barrier must proceed rather than deadlock"
+
+    asyncio.run(main())

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -17,6 +17,7 @@ import inspect
 import json
 import logging
 import os
+import time
 import uuid
 from pprint import pprint
 from typing import Any, Callable, Optional
@@ -65,6 +66,9 @@ from verl.workers.rollout.vllm_rollout.utils import (
 )
 
 _VLLM_VERSION = version.parse(vllm.__version__)
+
+# Max wait for admissions already past the submission gate to reach the engine.
+_GATE_BARRIER_TIMEOUT_S = 60.0
 
 if os.getenv("VERL_USE_GPT_OSS", "0") == "1":
     get_encoding()
@@ -155,6 +159,13 @@ class vLLMHttpServer:
         # model weights version, set by ServerAdapter when update weights.
         self.global_steps = None
         self._warned_missing_spec_decode_stats = False
+
+        # vLLM's pause stops requests being scheduled but still accepts them, and a request
+        # admitted after the pause is invisible to the drain's liveness check.
+        self._submission_paused = False
+        self._admitting = 0
+        self._resume_event = asyncio.Event()
+        self._resume_event.set()
 
         # used for http server
         self._server_address = ray.util.get_node_ip_address().strip("[]")
@@ -608,6 +619,13 @@ class vLLMHttpServer:
                     lora_name=VLLM_LORA_NAME, lora_int_id=VLLM_LORA_INT_ID, lora_path=VLLM_LORA_PATH
                 )
 
+        # No await between the final gate check and the bump: on the actor's single event loop
+        # that keeps "gate closed and _admitting == 0" from being observed mid-admission.
+        while self._submission_paused:
+            logger.debug("parking request %s until weight sync completes", request_id)
+            await self._resume_event.wait()
+        self._admitting += 1
+
         with RLInsightLogger.trace_state("vllm_generate", state_lane_id=f"replica_{self.replica_rank}"):
             generator = self.engine.generate(
                 prompt=prompt,
@@ -619,8 +637,16 @@ class vLLMHttpServer:
 
             # Get final response
             final_res: Optional[RequestOutput] = None
-            async for output in generator:
-                final_res = output
+            admitted = False
+            try:
+                async for output in generator:
+                    if not admitted:
+                        admitted = True
+                        self._admitting -= 1
+                    final_res = output
+            finally:
+                if not admitted:
+                    self._admitting -= 1
             assert final_res is not None
 
         extra_fields = {"global_steps": self.global_steps}
@@ -861,11 +887,25 @@ class vLLMHttpServer:
                 - request_ids: List of aborted request IDs
         """
         try:
+            # Close the gate first, then let admissions already past it land, so the pause
+            # below actually covers them.
+            self._submission_paused = True
+            self._resume_event.clear()
+            deadline = time.monotonic() + _GATE_BARRIER_TIMEOUT_S
+            while self._admitting > 0:
+                if time.monotonic() > deadline:
+                    logger.warning(
+                        "Submission gate barrier timed out with %d admission(s) in flight, proceeding",
+                        self._admitting,
+                    )
+                    break
+                await asyncio.sleep(0.01)
+
             # Snapshot request IDs before pausing for reporting
             request_ids = list(self.engine.output_processor.request_states.keys())
 
             # pause_generation with wait_for_inflight_requests=False will:
-            # 1. Set engine to paused state (blocks new generate calls)
+            # 1. Set engine to paused state (new requests are accepted but not scheduled)
             # 2. Abort all in-flight requests
             # 3. Wait for requests to drain
             # 4. Clear prefix and mm caches if clear_cache=True.
@@ -888,6 +928,10 @@ class vLLMHttpServer:
 
     async def resume_generation(self):
         """Resume generation after abort_all_requests (pause_generation)."""
+        # Before the node_rank guard: every server in the replica closed the gate, so every
+        # server must reopen it.
+        self._submission_paused = False
+        self._resume_event.set()
         if self.node_rank != 0:
             return
         await self.engine.resume_generation()


### PR DESCRIPTION
### What does this PR do?

During a weight update, verl pauses the vLLM engines, waits for idle, swaps the weights,
and resumes. The pause is vLLM's `pause_generation`, and everything turns on what that actually
does: it stops the scheduler from running new requests, but it does not stop the engine from
accepting them. That is deliberate and documented on vLLM's side ("all pause modes queue new adds") 
(not vllm version dependent). verl treats the pause as though nothing more can arrive, and nothing on the verl side stops a rollout request from being submitted while paused, and one that arrives before the drain's first check sets engines_running with nothing left to clear it. 
Problem: those requests are never executed; it sets engines_running, which is the flag the drain polls, and only a wave_complete from rank 0 clears it. That never comes while paused, so the drain times out and raises TimeoutError.

This only happens when dp>1, because in vllm the drain, [see here](https://github.com/vllm-project/vllm/blob/6e448d0ea9bf3d88d898b65449ca6dc2aec170ac/vllm/v1/engine/async_llm.py#L1004-L1018), waits for `self.engine_core.dp_engines_running()`, which is set [here](https://github.com/vllm-project/vllm/blob/6e448d0ea9bf3d88d898b65449ca6dc2aec170ac/vllm/v1/engine/core_client.py#L904-L906), contingent on `self.is_dp`. (footnote: this is the 'sync' version of add request, but the async version also sets the flag, just a bit deeper and less obviously linkable).

The abort replicas [is](https://github.com/verl-project/verl/blob/7a830f6adb64839a5d798c0e5a790f5314a94993/verl/checkpoint_engine/base.py#L477-L480) a barrier; vllm pauses internally after completion of a full process engine step. For larger scale models this step takes longer and we have to be aligned between replicas, meaning larger model scale 'widens' the window between pause generation (that aborts) and the first dp engines running check (i.e. this error is seen more likely on large scale model with dp>1).


#### Relationship to #7393

#7393 deletes the drain, on the grounds that the flag "can lag behind the completed pause". That lag
is the symptom above. Deleting it does stop the crash, but that drain is also the only check that the
engines went quiet before verl writes weights into the live weight buffers. It is possible to go this deletion 
route, but it does allow the above 'orphan' requests and skips this waiting step, something that, in my opinion, might come back to bite us later in some way.

Maybe @HollowMan6 (or someone else) has an opinion on this?


### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+wait_for_requests_to_drain (returns #7393 only)
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+pause_generation
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Added some small unit tests about the sequence ordering, they don't literally reproduce the error, since it is a large scale training race. (let me know if you rather delete them)

```bash
pytest -q tests/workers/rollout/rollout_vllm/test_submitter_gate_on_cpu.py
# with the change:    5 passed
# change reverted:    3 failed, 2 passed
```

### API and Usage Example

None. 

### Design & Code Changes

Two new fields in `vLLMHttpServer`:
`_submission_paused` is a gate on rollout submission, and `_admitting` counts requests that have
passed the gate but not yet reached the engine.

- `abort_all_requests()`: close the gate, wait for `_admitting` to reach zero, then call
  `pause_generation()` as before. Zero means every request that exists is already at the engine, so
  the abort catches all of them (nothing enters after anymore). 
- `generate()`: parks while the gate is closed instead of rejecting, and counts itself in
  `_admitting` until the engine has the request.
- `resume_generation()`: reopens the gate, above the `node_rank != 0` return so every server reopens.


### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [x] Documentation: n/a, no user-facing surface.
- [x] Add unit test(s): `test_submitter_gate_on_cpu.py`.
- [ ] Send a message in the `ci-request` channel once ready for CI.
- [x] Not related to the `recipe` submodule.
