### PR TITLE
[trainer, ckpt, cfg] feat: add config-driven checkpoint callback hook

### DIFF
--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -3,7 +3,7 @@
 Using Checkpoints to Support Fault Tolerance Training
 =====================================================
 
-Last updated: 04/23/2026.
+Last updated: 08/24/2026.
 
 There could be training errors or machine failure during the whole RLHF training process, 
 so it is recommended to enable checkpoints to minimize your loss.
@@ -33,10 +33,51 @@ Megatron:
   path is used (no dist shards for weights), ``model`` and ``hf_model`` refer to the same HF tree
   and are deduplicated (saved once).
 
-.. note:: 
+.. note::
 
     For FSDP, ``checkpoint.save_contents`` other than ``hf_model`` are binded together to save and
     load. We recommend to include ``model``, ``optimizer`` and ``extra`` all.
+
+Checkpoint Callback
+-------------------
+
+Set ``trainer.checkpoint_callback_class`` to the fully qualified class name of a
+``verl.trainer.ppo.checkpoint_callback.CheckpointCallback`` subclass to run custom
+code after each trainer checkpoint save (v1 trainer, ``trainer.use_v1=true``) —
+for example uploading checkpoints to object storage, registering them in a model
+registry, or triggering evaluations.
+The interface mirrors the ``on_save`` event of the HuggingFace ``transformers``
+``TrainerCallback``:
+
+.. code:: yaml
+
+    trainer:
+      checkpoint_callback_class: my_pkg.callbacks.MyCheckpointCallback
+
+The class must be importable on the driver. It is instantiated once with the full
+trainer config (``cls(config=config)``), and its ``on_save`` hook is invoked with
+keyword arguments:
+
+.. code:: python
+
+    from verl.trainer.ppo.checkpoint_callback import CheckpointCallback
+
+    class MyCheckpointCallback(CheckpointCallback):
+        def on_save(self, trainer, global_step, checkpoint_dir, async_save=False, **kwargs):
+            upload_to_my_storage(checkpoint_dir, step=global_step)
+
+Hook semantics:
+
+- ``on_save`` is called after the save of a ``global_step_{N}`` directory and
+  only fires when the save path completed without raising. With
+  ``async_save=True`` (Megatron asynchronous checkpointing), worker-side writes
+  may still be in flight when ``on_save`` fires and
+  ``latest_checkpointed_iteration.txt`` has not been written, so do not assume
+  the checkpoint is durable yet.
+- The hook runs only on the driver process, after the worker-group RPCs.
+  Per-rank hooks inside the FSDP/Megatron checkpoint managers are not covered.
+- Exceptions raised by the hook propagate and abort training. Wrap the hook
+  body in ``try/except`` for best-effort semantics.
 
 Checkpoint Saving Directory Structure
 -------------------------------------

--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -3,7 +3,7 @@
 Config Explanation
 ===================
 
-Last updated: 06/18/2025.
+Last updated: 08/24/2026.
 
 ppo_trainer.yaml for RL FSDP Backend
 -------------------------------------
@@ -604,6 +604,7 @@ Trainer
      default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name} # local checkpoint path
      resume_mode: auto # or disable or resume_path if resume_from_path is set
      resume_from_path: null
+     checkpoint_callback_class: null
      remove_previous_ckpt_in_save: False
      del_local_ckpt_after_load: False
      ray_wait_register_center_timeout: 300
@@ -628,6 +629,11 @@ Trainer
   from the path specified in ``resume_from_path``.
 - ``trainer.resume_from_path``: The path to resume training from. Only
   effective when ``resume_mode`` is set to ``resume_path``.
+- ``trainer.checkpoint_callback_class``: Fully qualified class name of a
+  user-defined checkpoint callback (a ``CheckpointCallback`` subclass).
+  Instantiated on the driver; its ``on_save`` hook is called after each
+  checkpoint save. See :doc:`../advance/checkpoint` for the interface.
+  Default is null (no callback).
 - ``trainer.remove_previous_ckpt_in_save``: Whether to remove previous
   checkpoints in the save directory. Default is False.
 - ``trainer.del_local_ckpt_after_load``: Whether to delete local

--- a/docs/extend_guide.rst
+++ b/docs/extend_guide.rst
@@ -1,7 +1,7 @@
 How to Extend verl
 ===================
 
-Last updated: 06/23/2026.
+Last updated: 08/24/2026.
 
 Author: `Xibin Wu <https://github.com/wuxibin89>`_
 
@@ -129,6 +129,21 @@ provides a set of hooks to customize trainer behavior:
 - on_sample_end
 
 These hooks are also used by the ``sync``, ``colocate_async``, and ``separate_async`` trainers to change model engine, LLM server, and checkpoint engine behavior.
+
+How do I run custom code when the trainer checkpoints?
+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Subclass ``verl.trainer.ppo.checkpoint_callback.CheckpointCallback`` and override
+``on_save`` (similar to the ``on_save`` event of the ``transformers`` ``TrainerCallback``),
+then point the trainer at it with a fully qualified class name (the class must be
+importable on the driver):
+
+.. code:: bash
+
+    trainer.checkpoint_callback_class=my_package.module.MyCheckpointCallback
+
+The hook runs on the driver after each checkpoint save in the v1 PPO trainer.
+See :ref:`checkpoint-page` for the full hook semantics.
 
 Agent Framework Developer
 -------------------------

--- a/tests/trainer/ppo/v1/test_checkpoint_callback_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_checkpoint_callback_on_cpu.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.trainer.ppo.checkpoint_callback import CheckpointCallback
+from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+
+
+class _StubTrainer(PPOTrainer):
+    def on_step_end(self):
+        pass
+
+    def on_sample_end(self):
+        pass
+
+
+class _RecordingCallback(CheckpointCallback):
+    def __init__(self, config=None, events=None):
+        super().__init__(config=config)
+        self.events = events if events is not None else []
+
+    def on_save(self, trainer, global_step, checkpoint_dir, async_save=False, **kwargs):
+        self.events.append(("on_save", global_step, checkpoint_dir, async_save))
+
+
+def _make_trainer(tmp_path, events, async_save=False):
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    trainer.trainer_mode = "sync"
+    trainer.global_steps = 3
+    trainer.use_critic = False
+    trainer.config = OmegaConf.create(
+        {
+            "trainer": {
+                "default_local_dir": str(tmp_path),
+                "default_hdfs_dir": None,
+                "resume_mode": "auto",
+                "resume_from_path": None,
+                "del_local_ckpt_after_load": False,
+                "checkpoint_callback_class": None,
+            },
+            "actor_rollout_ref": {"actor": {"checkpoint": {"async_save": async_save}}},
+        }
+    )
+    trainer.checkpoint_callback = _RecordingCallback(config=trainer.config, events=events)
+    trainer.actor_rollout_wg = MagicMock()
+    trainer.actor_rollout_wg.save_checkpoint.side_effect = lambda *a, **k: events.append(("wg_save",))
+    dataloader = MagicMock()
+    dataloader.state_dict.return_value = {}
+    trainer.train_dataloader = dataloader
+    return trainer
+
+
+def test_save_fires_on_save_after_worker_save(tmp_path):
+    events = []
+    trainer = _make_trainer(tmp_path, events)
+
+    trainer._save_checkpoint()
+
+    expected_dir = os.path.join(str(tmp_path), "global_step_3")
+    assert events == [
+        ("wg_save",),
+        ("on_save", 3, expected_dir, False),
+    ]
+    tracker = os.path.join(str(tmp_path), "latest_checkpointed_iteration.txt")
+    with open(tracker) as f:
+        assert f.read() == "3"
+
+
+def test_async_save_fires_on_save_with_flag(tmp_path):
+    events = []
+    trainer = _make_trainer(tmp_path, events, async_save=True)
+
+    trainer._save_checkpoint()
+
+    expected_dir = os.path.join(str(tmp_path), "global_step_3")
+    assert events[-1] == ("on_save", 3, expected_dir, True)
+    assert not os.path.exists(os.path.join(str(tmp_path), "latest_checkpointed_iteration.txt"))
+
+
+def test_on_save_not_fired_on_worker_failure(tmp_path):
+    events = []
+    trainer = _make_trainer(tmp_path, events)
+    trainer.actor_rollout_wg.save_checkpoint.side_effect = RuntimeError("save failed")
+
+    with pytest.raises(RuntimeError, match="save failed"):
+        trainer._save_checkpoint()
+
+    assert events == []
+
+
+def test_callback_exception_propagates(tmp_path):
+    events = []
+    trainer = _make_trainer(tmp_path, events)
+    trainer.checkpoint_callback.on_save = MagicMock(side_effect=RuntimeError("callback failed"))
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        trainer._save_checkpoint()

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -1009,6 +1009,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   resume_from_path: null
+  checkpoint_callback_class: null
   val_before_train: true
   val_only: false
   test_freq: -1

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -901,6 +901,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   resume_from_path: null
+  checkpoint_callback_class: null
   val_before_train: true
   val_only: false
   test_freq: -1

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -967,6 +967,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   resume_from_path: null
+  checkpoint_callback_class: null
   val_before_train: true
   val_only: false
   test_freq: -1

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -932,6 +932,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   resume_from_path: null
+  checkpoint_callback_class: null
   val_before_train: true
   val_only: false
   test_freq: -1

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -185,6 +185,12 @@ trainer:
   # Path to resume training from (only used when resume_mode is "resume_path")
   resume_from_path: null
 
+  # Fully qualified class name of a user-defined checkpoint callback,
+  # e.g. "my_pkg.callbacks.MyCheckpointCallback". Instantiated on the driver with the
+  # full trainer config; its on_save hook is called after each checkpoint save,
+  # similar to the on_save event of the transformers TrainerCallback. No callback is used if null.
+  checkpoint_callback_class: null
+
   # Whether to run validation before training begins
   val_before_train: True
 

--- a/verl/trainer/ppo/checkpoint_callback.py
+++ b/verl/trainer/ppo/checkpoint_callback.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Driver-side checkpoint callback hook for the v1 PPO trainer.
+
+Users plug in a custom callback by setting ``trainer.checkpoint_callback_class``
+to the fully qualified class name of a :class:`CheckpointCallback` subclass.
+The trainer instantiates it on the driver process and calls :meth:`CheckpointCallback.on_save`
+after each checkpoint save, mirroring the ``on_save`` event of the HuggingFace
+``transformers`` ``TrainerCallback``. The hook runs only on the driver, after the
+worker-group RPCs; per-rank hooks inside the FSDP/Megatron checkpoint managers
+are out of scope.
+
+Exceptions raised by the hook propagate and abort training: checkpoint callbacks
+typically perform durability-critical side effects (uploading shards, registering
+a model version), and silently swallowing a failure could lose checkpoints without
+any signal. Wrap the hook body in ``try/except`` for best-effort semantics.
+"""
+
+from verl.utils.import_utils import load_class_from_fqn
+
+
+class CheckpointCallback:
+    """No-op base class for trainer checkpoint callbacks.
+
+    Subclass and override :meth:`on_save`. The hook is invoked with keyword
+    arguments and must accept ``**kwargs`` so that additional context can be
+    passed in future versions without breaking user subclasses.
+    """
+
+    def __init__(self, config=None):
+        """Store the full trainer config for use by subclass hooks.
+
+        Args:
+            config: The full trainer ``DictConfig``.
+        """
+        self.config = config
+
+    def on_save(self, trainer, global_step: int, checkpoint_dir: str, async_save: bool = False, **kwargs) -> None:
+        """Event called after a checkpoint save.
+
+        Not called when a save step raises. With ``async_save=True`` (Megatron
+        asynchronous checkpointing), worker-side writes may still be in flight
+        when this fires and ``latest_checkpointed_iteration.txt`` has not been
+        written, so the checkpoint must not be assumed durable yet.
+
+        Args:
+            trainer: The trainer instance performing the save.
+            global_step: The training step that was checkpointed.
+            checkpoint_dir: The local ``global_step_{N}`` directory that was written.
+            async_save: Whether the checkpoint was saved asynchronously.
+            **kwargs: Reserved for future context.
+        """
+
+
+def build_checkpoint_callback(config) -> CheckpointCallback:
+    """Instantiate the callback named by ``trainer.checkpoint_callback_class``.
+
+    Returns a no-op :class:`CheckpointCallback` when the key is unset or null, so
+    trainer call sites never need a None guard.
+
+    Args:
+        config: The full trainer ``DictConfig``.
+
+    Returns:
+        A :class:`CheckpointCallback` instance constructed with ``config``.
+    """
+    fqn = config.trainer.get("checkpoint_callback_class", None)
+    if not fqn:
+        return CheckpointCallback(config=config)
+    callback_cls = load_class_from_fqn(fqn, "CheckpointCallback")
+    return callback_cls(config=config)

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -49,6 +49,7 @@ from verl.single_controller.ray import (
 )
 from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.ppo import core_algos
+from verl.trainer.ppo.checkpoint_callback import build_checkpoint_callback
 from verl.trainer.ppo.core_algos import agg_loss
 from verl.trainer.ppo.metric_utils import (
     RolloutMoELoadBalanceMetricsAccumulator,
@@ -124,6 +125,7 @@ class PPOTrainer(ABC):
 
     def __init__(self, config: DictConfig):
         self.config = config
+        self.checkpoint_callback = build_checkpoint_callback(config)
         self.use_critic = need_critic(self.config)
         self.use_reference_policy = need_reference_policy(self.config)
         self.use_teacher_policy = need_teacher_policy(self.config)
@@ -949,12 +951,22 @@ class PPOTrainer(ABC):
         actor_ckpt_cfg = self.config.actor_rollout_ref.actor.get("checkpoint", {})
         if actor_ckpt_cfg.get("async_save", False):
             logger.info("skip write latest_checkpointed_iteration.txt when async_save is True")
+            self.checkpoint_callback.on_save(
+                trainer=self,
+                global_step=self.global_steps,
+                checkpoint_dir=local_global_step_folder,
+                async_save=True,
+            )
             return
         local_latest_checkpointed_iteration = os.path.join(
             self.config.trainer.default_local_dir, "latest_checkpointed_iteration.txt"
         )
         with open(local_latest_checkpointed_iteration, "w") as f:
             f.write(str(self.global_steps))
+
+        self.checkpoint_callback.on_save(
+            trainer=self, global_step=self.global_steps, checkpoint_dir=local_global_step_folder, async_save=False
+        )
 
     def _validate(self) -> dict[str, float]:
         # Lists to collect samples for the table


### PR DESCRIPTION
### What does this PR do?

Adds `trainer.checkpoint_callback_class`: a config key naming a user-defined `CheckpointCallback` subclass (fully qualified class name) that the driver instantiates and whose `on_save` hook it calls after each checkpoint save in the v1 `PPOTrainer` — mirroring the `on_save` event of the HuggingFace `transformers` `TrainerCallback`. This gives users a supported extension point for checkpoint side effects (uploading to object storage, registering in a model registry, triggering evaluations, retention policies) without forking or subclassing the trainer.

**AI assistance statement**: This change was developed with AI assistance (Claude Code). Every changed line has been reviewed by the submitter, and all tests below were run locally.

**Why this is not duplicating an existing PR**: Searched open PRs and issues for checkpoint callback/hook work ([query link](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+checkpoint+callback)); no existing PR or issue proposes a trainer-level checkpoint callback. Closest matches are unrelated checkpoint bug fixes (#7363, #7396, #7402) and the RemoteBackend RFC (#6537, which concerns rollout backends). This is also distinct from the existing `actor_rollout_ref.rollout.checkpoint_manager_class` (weight-sync engine, not disk checkpoints) and from the v1 trainer's `on_*` methods (subclass override points, not config-pluggable).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+checkpoint+callback
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

New CPU unit tests (picked up automatically by `cpu_unit_tests.yml` via the `_on_cpu.py` suffix) cover the v1 trainer's hook wiring: `on_save` firing after the worker-group save RPC, the `async_save=True` flag on the early-return path, `on_save` suppression when a worker save raises, and callback exceptions propagating.

Commands run locally (macOS, CPU):

```bash
pytest tests/trainer/ppo/v1/test_checkpoint_callback_on_cpu.py -q
# 4 passed
pytest tests/trainer/ppo/v1/test_trainer_base_on_cpu.py tests/utils/ckpt/test_checkpoint_cleanup_on_cpu.py tests/utils/ckpt/test_esi_save_ckpt_on_cpu.py tests/special_sanity/test_config_docs.py -q
# 21 passed (regressions)
pre-commit run --all-files
# all hooks pass (ruff, ruff-format, mypy, check-license, check-docstrings, autogen-trainer-cfg, ...)
```

### API and Usage Example

New optional config key (default `null`, no behavior change when unset):

```yaml
trainer:
  checkpoint_callback_class: my_pkg.callbacks.MyCheckpointCallback
```

```python
from verl.trainer.ppo.checkpoint_callback import CheckpointCallback

class MyCheckpointCallback(CheckpointCallback):
    def on_save(self, trainer, global_step, checkpoint_dir, async_save=False, **kwargs):
        upload_to_my_storage(checkpoint_dir, step=global_step)
```

Hook contract (documented in `docs/advance/checkpoint.rst`):

- `on_save` is called after a checkpoint save (same semantics as `transformers` `TrainerCallback.on_save`); it fires only when the save path completed without raising, and with `async_save=True` (Megatron async checkpointing) it fires before durability — worker writes may still be in flight and the iteration tracker is not written.
- The hook runs only on the driver, after the worker-group RPCs; per-rank hooks inside the FSDP/Megatron checkpoint managers are out of scope.
- Hook exceptions propagate and abort training (fail-fast, matching the surrounding code style); wrap the hook body in `try/except` for best-effort semantics.

### Design & Code Changes

- New `verl/trainer/ppo/checkpoint_callback.py`: no-op `CheckpointCallback` base class with a single `on_save` hook (keyword args plus `**kwargs` for forward compatibility) and `build_checkpoint_callback(config)`, which returns a no-op instance when the key is unset (null-object pattern, so trainer call sites need no guards) or loads the FQN via the existing `load_class_from_fqn` utility — the same pattern as `rollout.checkpoint_manager_class` and `agent_loop_manager_class`.
- `verl/trainer/ppo/v1/trainer_base.py`: instantiate the callback in `__init__` (fail-fast on a bad FQN before Ray resources are allocated) and invoke `on_save` at the end of `_save_checkpoint`. Hook calls are placed explicitly rather than via `try/finally` so `on_save` cannot fire after a failed worker save. Per review feedback, the legacy `RayPPOTrainer` is deliberately not modified (it is deprecated); the feature is v1-only.
- `verl/trainer/config/ppo_trainer.yaml`: new documented `trainer.checkpoint_callback_class: null` key; the four `_generated_ppo_*_trainer.yaml` files are regenerated via `scripts/generate_trainer_config.sh`.
- Docs: key reference in `docs/examples/config.rst`, a "Checkpoint Callback" usage section in `docs/advance/checkpoint.rst`, and an entry in `docs/extend_guide.rst`.
- Interface intentionally minimal: a single `on_save` event, matching `transformers` `TrainerCallback.on_save`; more events (e.g. load hooks) can be added later without breaking subclasses thanks to `**kwargs` and the no-op base class.
- Known non-coverage (intentional): the legacy `RayPPOTrainer` (deprecated) and `verl/experimental/fully_async_policy/fully_async_trainer.py` do not fire the hook; the v1 trainer's `on_*` methods were not reused because they are subclass override points rather than config-pluggable objects.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: new `_on_cpu.py` tests are collected automatically by `cpu_unit_tests.yml`; no workflow file changes needed.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
