### PR TITLE
[algo, trainer, tests] fix: align distillation response masks to padded log-probs

### DIFF
--- a/tests/workers/test_distillation_reverse_kl_response_mask_on_cpu.py
+++ b/tests/workers/test_distillation_reverse_kl_response_mask_on_cpu.py
@@ -29,9 +29,11 @@ import torch
 from tensordict import TensorDict
 
 from verl.trainer.distillation.losses import (
+    align_padded_tensor,
     align_response_mask,
     compute_distillation_loss_range,
     compute_distillation_loss_reverse_kl_estimator,
+    distillation_loss,
 )
 from verl.utils import tensordict_utils as tu
 from verl.workers.config import ActorConfig, DistillationConfig, DistillationLossConfig
@@ -95,6 +97,35 @@ def _build_inputs(prompt_lens, response_lens, mask_len_override=None):
 def _run(model_output, data, cfg):
     losses, metrics = compute_distillation_loss_reverse_kl_estimator(None, cfg, model_output, data)
     return losses.detach().clone(), float(metrics["distillation/abs_loss"].aggregate())
+
+
+def _build_pg_inputs(length_offset):
+    prompt_lens = [3, 4, 3, 5]
+    response_lens = [5, 7, 4, 6]
+    model_output, data = _build_inputs(prompt_lens, response_lens)
+    target_len = max(response_lens)
+    source_len = target_len + length_offset
+
+    old_log_prob_segs = []
+    rollout_is_weight_segs = []
+    for _ in response_lens:
+        old_log_probs = torch.zeros(source_len)
+        old_log_probs[: min(source_len, target_len)] = -0.1
+        old_log_prob_segs.append(old_log_probs)
+
+        rollout_is_weights = torch.zeros(source_len)
+        rollout_is_weights[: min(source_len, target_len)] = 1.0
+        rollout_is_weight_segs.append(rollout_is_weights)
+
+    data["old_log_probs"] = torch.nested.nested_tensor(old_log_prob_segs, layout=torch.jagged)
+    data["rollout_is_weights"] = torch.nested.nested_tensor(rollout_is_weight_segs, layout=torch.jagged)
+    tu.assign_non_tensor(
+        data,
+        dp_size=1,
+        batch_num_tokens=None,
+        global_batch_size=None,
+    )
+    return model_output, data
 
 
 def test_reverse_kl_shape_consistent_is_noop():
@@ -161,6 +192,34 @@ def test_align_response_mask_rejects_truncating_valid_tokens():
 
     with pytest.raises(ValueError, match="valid tokens beyond"):
         align_response_mask(response_mask, losses)
+
+
+@pytest.mark.parametrize("length_offset", [-2, 2])
+def test_distillation_loss_pg_aligns_nested_ppo_inputs(length_offset):
+    actor_cfg = ActorConfig(strategy="fsdp", rollout_n=1, use_dynamic_bsz=True)
+    distillation_cfg = _make_distillation_config()
+    model_output, data = _build_pg_inputs(length_offset)
+
+    loss, metrics = distillation_loss(actor_cfg, distillation_cfg, model_output, data)
+
+    assert torch.isfinite(loss)
+    assert "distillation/ppo_kl" in metrics
+    assert "distillation/pg_clipfrac" in metrics
+
+
+def test_align_padded_tensor_preserves_dtype_and_rejects_nonzero_tail():
+    target = torch.zeros((2, 4), dtype=torch.float32)
+    source = torch.ones((2, 2), dtype=torch.float64)
+
+    aligned = align_padded_tensor(source, target, name="test tensor")
+
+    assert aligned.shape == target.shape
+    assert aligned.dtype == source.dtype
+    assert aligned.device == source.device
+    assert not aligned[:, 2:].any()
+
+    with pytest.raises(ValueError, match="nonzero values beyond"):
+        align_padded_tensor(torch.ones((2, 5)), target, name="test tensor")
 
 
 def test_global_batch_info_is_refreshed_from_current_micro_batch():

--- a/tests/workers/test_distillation_reverse_kl_response_mask_on_cpu.py
+++ b/tests/workers/test_distillation_reverse_kl_response_mask_on_cpu.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression for nested ``response_mask`` alignment in reverse-KL distillation.
+
+``no_padding_2_padding`` pads student/teacher log-probs to ``max_response_len``,
+while a nested ``response_mask`` is padded by ``to_padded_tensor`` to its own
+max ragged length. Those baselines can disagree and trip the shape assert.
+``align_response_mask`` pads with ``False`` or truncates trailing ``False``
+cells so masked reductions stay unchanged.
+"""
+
+import os
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl.trainer.distillation.losses import (
+    align_response_mask,
+    compute_distillation_loss_range,
+    compute_distillation_loss_reverse_kl_estimator,
+)
+from verl.utils import tensordict_utils as tu
+from verl.workers.config import ActorConfig, DistillationConfig, DistillationLossConfig
+from verl.workers.utils.losses import update_global_batch_info
+
+
+def _make_distillation_config() -> DistillationConfig:
+    loss_cfg = DistillationLossConfig(
+        loss_mode="k1",
+        topk=64,
+        use_task_rewards=False,
+        use_policy_gradient=True,
+        loss_max_clamp=10.0,
+        log_prob_min_clamp=-10.0,
+    )
+    return DistillationConfig(distillation_loss=loss_cfg)
+
+
+def _build_inputs(prompt_lens, response_lens, mask_len_override=None):
+    """Build packed reverse-KL inputs. ``mask_len_override`` decouples the nested
+    mask's ``to_padded_tensor`` length from ``max(response_lens)``.
+
+    Valid ``mask=True`` cells stay in the first ``r_i - 2`` slots so pad/truncate
+    only touch trailing ``False`` positions.
+    """
+    bsz = len(prompt_lens)
+    assert len(response_lens) == bsz
+    total_nnz = sum(p + r for p, r in zip(prompt_lens, response_lens, strict=True))
+
+    student_packed = torch.arange(total_nnz, dtype=torch.float32) * 0.01 + 0.3
+    teacher_packed = (torch.arange(total_nnz, dtype=torch.float32) * 0.007 - 0.2).reshape(total_nnz, 1)
+
+    prompts_nested = torch.nested.as_nested_tensor(
+        [torch.zeros(p, dtype=torch.long) for p in prompt_lens], layout=torch.jagged
+    )
+    responses_nested = torch.nested.as_nested_tensor(
+        [torch.zeros(r, dtype=torch.long) for r in response_lens], layout=torch.jagged
+    )
+
+    seg_lens = response_lens if mask_len_override is None else [mask_len_override] * bsz
+    n_true_per_sample = [max(1, r - 2) for r in response_lens]
+    mask_segs = []
+    for i, length in enumerate(seg_lens):
+        seg = torch.zeros(length)
+        seg[: min(n_true_per_sample[i], length)] = 1.0
+        mask_segs.append(seg)
+    rmask_nested = torch.nested.nested_tensor(mask_segs, layout=torch.jagged)
+
+    data = TensorDict(
+        {
+            "prompts": prompts_nested,
+            "responses": responses_nested,
+            "teacher_logprobs": teacher_packed,
+            "response_mask": rmask_nested,
+        },
+        batch_size=[],
+    )
+    return {"log_probs": student_packed}, data
+
+
+def _run(model_output, data, cfg):
+    losses, metrics = compute_distillation_loss_reverse_kl_estimator(None, cfg, model_output, data)
+    return losses.detach().clone(), float(metrics["distillation/abs_loss"].aggregate())
+
+
+def test_reverse_kl_shape_consistent_is_noop():
+    cfg = _make_distillation_config()
+    prompt_lens = [3, 4, 3, 5]
+    response_lens = [5, 7, 4, 6]
+    max_resp = max(response_lens)
+
+    losses, abs_loss = _run(*_build_inputs(prompt_lens, response_lens), cfg)
+
+    assert losses.shape == (len(prompt_lens), max_resp)
+    assert torch.isfinite(losses).all()
+    assert torch.isfinite(torch.tensor(abs_loss))
+
+
+def test_reverse_kl_pad_shorter_matches_baseline():
+    cfg = _make_distillation_config()
+    prompt_lens = [3, 4, 3, 5]
+    response_lens = [5, 7, 4, 6]
+    max_resp = max(response_lens)
+
+    _, abs_base = _run(*_build_inputs(prompt_lens, response_lens), cfg)
+    losses_pad, abs_pad = _run(*_build_inputs(prompt_lens, response_lens, mask_len_override=max_resp - 2), cfg)
+
+    assert losses_pad.shape == (len(prompt_lens), max_resp)
+    assert torch.isfinite(losses_pad).all()
+    assert abs_pad == pytest.approx(abs_base, rel=0.0, abs=1e-10)
+
+
+def test_reverse_kl_truncate_longer_masked_metric_stable():
+    cfg = _make_distillation_config()
+    prompt_lens = [3, 4, 3, 5]
+    response_lens = [5, 7, 4, 6]
+    max_resp = max(response_lens)
+
+    _, abs_base = _run(*_build_inputs(prompt_lens, response_lens), cfg)
+    losses_tr, abs_tr = _run(*_build_inputs(prompt_lens, response_lens, mask_len_override=max_resp + 3), cfg)
+
+    assert losses_tr.shape == (len(prompt_lens), max_resp)
+    assert torch.isfinite(losses_tr).all()
+    assert abs_tr == pytest.approx(abs_base, rel=0.0, abs=1e-10)
+
+
+def test_outer_loss_range_reuses_aligned_response_mask():
+    losses = torch.arange(14, dtype=torch.float32).reshape(2, 7)
+    response_mask = torch.nested.nested_tensor(
+        [torch.tensor([1, 1, 0, 0]), torch.tensor([1, 0, 0, 0])],
+        layout=torch.jagged,
+    )
+
+    aligned = align_response_mask(response_mask, losses)
+    metrics = compute_distillation_loss_range(losses, response_mask)
+
+    assert aligned.shape == losses.shape
+    assert aligned.dtype == torch.bool
+    assert not aligned[:, 4:].any()
+    assert float(metrics["distillation/loss_min"].aggregate()) == 0.0
+    assert float(metrics["distillation/loss_max"].aggregate()) == 7.0
+
+
+def test_align_response_mask_rejects_truncating_valid_tokens():
+    losses = torch.zeros(1, 3)
+    response_mask = torch.tensor([[1, 1, 1, 1]], dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="valid tokens beyond"):
+        align_response_mask(response_mask, losses)
+
+
+def test_global_batch_info_is_refreshed_from_current_micro_batch():
+    config = ActorConfig(strategy="fsdp", rollout_n=1, use_dynamic_bsz=True)
+    config.global_batch_info["stale"] = 1
+    data = TensorDict({}, batch_size=[])
+    tu.assign_non_tensor(
+        data,
+        dp_size=4,
+        batch_num_tokens=123,
+        global_batch_size=16,
+    )
+
+    info = update_global_batch_info(config, data)
+    unwrapped = {key: tu.unwrap_non_tensor_data(value) for key, value in info.items()}
+
+    assert unwrapped == {
+        "dp_size": 4,
+        "batch_num_tokens": 123,
+        "global_batch_size": 16,
+        "loss_scale_factor": None,
+    }
+    assert config.global_batch_info == info
+    assert "stale" not in config.global_batch_info

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -106,6 +106,44 @@ def get_distillation_loss_settings(loss_name: str) -> DistillationLossSettings:
     return DISTILLATION_SETTINGS_REGISTRY[loss_name]
 
 
+def align_padded_tensor(
+    tensor: torch.Tensor,
+    target: torch.Tensor,
+    *,
+    name: str,
+    truncated_value_name: str = "nonzero values",
+) -> torch.Tensor:
+    """Convert ``tensor`` to dense and align its final dimension to ``target``.
+
+    Nested inputs are padded with zero. Dense and converted nested inputs are
+    then zero-padded or truncated along the final dimension while preserving
+    their dtype and device. Truncation is only safe for zero-valued padding;
+    rejecting nonzero tails prevents valid log-probs, importance weights, or
+    mask entries from being silently discarded.
+    """
+    if tensor.is_nested:
+        tensor = tensor.to_padded_tensor(0)
+
+    if tensor.ndim != target.ndim or tensor.shape[:-1] != target.shape[:-1]:
+        raise ValueError(f"{name} shape {tensor.shape} cannot align to target shape {target.shape}")
+
+    target_length = target.shape[-1]
+    current_length = tensor.shape[-1]
+    if current_length < target_length:
+        padding = torch.zeros(
+            (*tensor.shape[:-1], target_length - current_length),
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        tensor = torch.cat((tensor, padding), dim=-1)
+    elif current_length > target_length:
+        truncated = tensor[..., target_length:]
+        if torch.count_nonzero(truncated):
+            raise ValueError(f"{name} contains {truncated_value_name} beyond the target length")
+        tensor = tensor[..., :target_length]
+    return tensor
+
+
 def align_response_mask(response_mask: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     """Convert a response mask to dense bool and align it to a padded loss tensor.
 
@@ -114,29 +152,12 @@ def align_response_mask(response_mask: torch.Tensor, target: torch.Tensor) -> to
     Those two baselines can disagree, so align the mask to ``target`` before masked
     reductions. Padding cells are ``False`` and do not contribute.
     """
-    if response_mask.is_nested:
-        response_mask = response_mask.bool().to_padded_tensor(False)
-    else:
-        response_mask = response_mask.bool()
-
-    if response_mask.ndim != target.ndim or response_mask.shape[:-1] != target.shape[:-1]:
-        raise ValueError(f"response mask shape {response_mask.shape} cannot align to target shape {target.shape}")
-
-    target_length = target.shape[-1]
-    current_length = response_mask.shape[-1]
-    if current_length < target_length:
-        padding = torch.zeros(
-            (*response_mask.shape[:-1], target_length - current_length),
-            dtype=torch.bool,
-            device=response_mask.device,
-        )
-        response_mask = torch.cat((response_mask, padding), dim=-1)
-    elif current_length > target_length:
-        truncated = response_mask[..., target_length:]
-        if truncated.any():
-            raise ValueError("response mask contains valid tokens beyond the target loss length")
-        response_mask = response_mask[..., :target_length]
-    return response_mask
+    return align_padded_tensor(
+        response_mask.bool(),
+        target,
+        name="response mask",
+        truncated_value_name="valid tokens",
+    )
 
 
 def compute_distillation_loss_range(
@@ -298,10 +319,12 @@ def distillation_loss(
         # Use negative distillation loss as reward, as done by https://thinkingmachines.ai/blog/on-policy-distillation/.
         policy_loss_fn = get_policy_loss_fn(loss_config.policy_loss_mode)
         log_prob = no_padding_2_padding(model_output["log_probs"], data)
-        old_log_prob = data["old_log_probs"]
-        if old_log_prob.is_nested:
-            old_log_prob = data["old_log_probs"].to_padded_tensor(0.0)
+        old_log_prob = align_padded_tensor(data["old_log_probs"], log_prob, name="old log probs")
         rollout_is_weights = data.get("rollout_is_weights", None)
+        if rollout_is_weights is not None:
+            rollout_is_weights = align_padded_tensor(
+                rollout_is_weights, log_prob, name="rollout importance weights"
+            )
         distillation_loss, pg_metrics = policy_loss_fn(
             old_log_prob=old_log_prob,
             log_prob=log_prob,

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -22,7 +22,7 @@ from verl.base_config import BaseConfig
 from verl.trainer.ppo.core_algos import agg_loss, get_policy_loss_fn, kl_penalty
 from verl.utils.metric import AggregationType, Metric
 from verl.workers.config import ActorConfig, DistillationConfig, DistillationLossConfig
-from verl.workers.utils.losses import ppo_loss
+from verl.workers.utils.losses import ppo_loss, update_global_batch_info
 from verl.workers.utils.padding import no_padding_2_padding
 
 DistillationLossFn = Callable[
@@ -106,14 +106,45 @@ def get_distillation_loss_settings(loss_name: str) -> DistillationLossSettings:
     return DISTILLATION_SETTINGS_REGISTRY[loss_name]
 
 
+def align_response_mask(response_mask: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Convert a response mask to dense bool and align it to a padded loss tensor.
+
+    ``no_padding_2_padding`` pads log-probs to ``max_response_len``, while a nested
+    ``response_mask`` is padded by ``to_padded_tensor`` to its own max ragged length.
+    Those two baselines can disagree, so align the mask to ``target`` before masked
+    reductions. Padding cells are ``False`` and do not contribute.
+    """
+    if response_mask.is_nested:
+        response_mask = response_mask.bool().to_padded_tensor(False)
+    else:
+        response_mask = response_mask.bool()
+
+    if response_mask.ndim != target.ndim or response_mask.shape[:-1] != target.shape[:-1]:
+        raise ValueError(f"response mask shape {response_mask.shape} cannot align to target shape {target.shape}")
+
+    target_length = target.shape[-1]
+    current_length = response_mask.shape[-1]
+    if current_length < target_length:
+        padding = torch.zeros(
+            (*response_mask.shape[:-1], target_length - current_length),
+            dtype=torch.bool,
+            device=response_mask.device,
+        )
+        response_mask = torch.cat((response_mask, padding), dim=-1)
+    elif current_length > target_length:
+        truncated = response_mask[..., target_length:]
+        if truncated.any():
+            raise ValueError("response mask contains valid tokens beyond the target loss length")
+        response_mask = response_mask[..., :target_length]
+    return response_mask
+
+
 def compute_distillation_loss_range(
     distillation_losses: torch.Tensor, response_mask: torch.Tensor
 ) -> dict[str, Metric]:
     """Compute min and max distillation loss over valid response tokens."""
-    if response_mask.is_nested:
-        distillation_losses_response = distillation_losses[response_mask.bool().to_padded_tensor(False)]
-    else:
-        distillation_losses_response = distillation_losses[response_mask.bool()]
+    response_mask = align_response_mask(response_mask, distillation_losses)
+    distillation_losses_response = distillation_losses[response_mask]
     return {
         "distillation/loss_min": Metric(AggregationType.MIN, distillation_losses_response.min()),
         "distillation/loss_max": Metric(AggregationType.MAX, distillation_losses_response.max()),
@@ -242,6 +273,10 @@ def distillation_loss(
     """
     assert distillation_config is not None
     loss_config: DistillationLossConfig = distillation_config.distillation_loss
+    global_batch_info = update_global_batch_info(config, data)
+    loss_config.global_batch_info.clear()
+    loss_config.global_batch_info.update(global_batch_info)
+
     distillation_loss_fn = get_distillation_loss_fn(loss_config.loss_mode)
     distillation_losses, distillation_metrics = distillation_loss_fn(
         config=config,
@@ -249,7 +284,7 @@ def distillation_loss(
         model_output=model_output,
         data=data,
     )
-    response_mask = data["response_mask"]
+    response_mask = align_response_mask(data["response_mask"], distillation_losses)
     loss_agg_mode = config.loss_agg_mode
 
     distillation_metrics.update(
@@ -259,23 +294,13 @@ def distillation_loss(
         # clamping min is for k1 loss which can be negative
         distillation_losses = distillation_losses.clamp(min=-loss_config.loss_max_clamp, max=loss_config.loss_max_clamp)
 
-    # global batch info for loss aggregation
-    config.global_batch_info["dp_size"] = data["dp_size"]
-    config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
-    config.global_batch_info["global_batch_size"] = data["global_batch_size"]
-    config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
-
     if loss_config.use_policy_gradient:
         # Use negative distillation loss as reward, as done by https://thinkingmachines.ai/blog/on-policy-distillation/.
         policy_loss_fn = get_policy_loss_fn(loss_config.policy_loss_mode)
-        for k, v in config.global_batch_info.items():
-            loss_config.global_batch_info[k] = v
         log_prob = no_padding_2_padding(model_output["log_probs"], data)
         old_log_prob = data["old_log_probs"]
         if old_log_prob.is_nested:
             old_log_prob = data["old_log_probs"].to_padded_tensor(0.0)
-        if response_mask.is_nested:
-            response_mask = response_mask.to_padded_tensor(False)
         rollout_is_weights = data.get("rollout_is_weights", None)
         distillation_loss, pg_metrics = policy_loss_fn(
             old_log_prob=old_log_prob,
@@ -290,8 +315,6 @@ def distillation_loss(
         distillation_metrics.update(pg_metrics)
     else:
         # Directly backpropagate distillation loss as a supervised loss, as in https://arxiv.org/abs/2306.13649.
-        if response_mask.is_nested:
-            response_mask = response_mask.to_padded_tensor(False)
         distillation_loss = agg_loss(
             loss_mat=distillation_losses,
             loss_mask=response_mask,
@@ -324,10 +347,7 @@ def compute_forward_kl_topk(
     if overlap_count is not None and overlap_token_advantage is not None:
         overlap_count = no_padding_2_padding(overlap_count, data)
         overlap_token_advantage = no_padding_2_padding(overlap_token_advantage, data)
-    if data["response_mask"].is_nested:
-        response_mask_bool = data["response_mask"].bool().to_padded_tensor(False)
-    else:
-        response_mask_bool = data["response_mask"].bool()
+    response_mask_bool = align_response_mask(data["response_mask"], distillation_losses)
     assert distillation_losses.shape == student_mass.shape == teacher_mass.shape == response_mask_bool.shape
 
     overlap_metrics = {}
@@ -388,11 +408,11 @@ def compute_distillation_loss_reverse_kl_estimator(
     """
     student_log_probs = no_padding_2_padding(model_output["log_probs"], data)
     teacher_log_probs = no_padding_2_padding(data["teacher_logprobs"], data).squeeze(-1)
-    if data["response_mask"].is_nested:
-        response_mask_bool = data["response_mask"].bool().to_padded_tensor(False)
-    else:
-        response_mask_bool = data["response_mask"].bool()
-    assert teacher_log_probs.shape == student_log_probs.shape == response_mask_bool.shape
+    response_mask_bool = align_response_mask(data["response_mask"], student_log_probs)
+    assert teacher_log_probs.shape == student_log_probs.shape == response_mask_bool.shape, (
+        f"shape mismatch: teacher={teacher_log_probs.shape} student={student_log_probs.shape} "
+        f"mask={response_mask_bool.shape}"
+    )
 
     loss_config: DistillationLossConfig = distillation_config.distillation_loss
     distillation_losses = kl_penalty(

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -54,6 +54,19 @@ def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     return loss, {}
 
 
+def update_global_batch_info(config: ActorConfig, data: TensorDict) -> dict:
+    """Refresh loss-normalization metadata from the current micro-batch."""
+    global_batch_info = {
+        "dp_size": data["dp_size"],
+        "batch_num_tokens": data["batch_num_tokens"],
+        "global_batch_size": data["global_batch_size"],
+        "loss_scale_factor": config.loss_scale_factor,
+    }
+    config.global_batch_info.clear()
+    config.global_batch_info.update(global_batch_info)
+    return global_batch_info
+
+
 def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
     """Computes ppo loss from model output (log_prob, entropy, values, etc. ) and old_log_probs from data."""
     log_prob = no_padding_2_padding(model_output["log_probs"], data)
@@ -61,11 +74,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     if entropy is not None:
         entropy = no_padding_2_padding(entropy, data)
 
-    # global batch info for loss aggregation
-    config.global_batch_info["dp_size"] = data["dp_size"]
-    config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
-    config.global_batch_info["global_batch_size"] = data["global_batch_size"]
-    config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
+    update_global_batch_info(config, data)
 
     # assumes that if any of the global batch info is set, the policy_loss_fn will
     # normalize using dp_size/global_bsz/global_token; in this case, metric aggregation should be SUM


### PR DESCRIPTION
### What does this PR do?

Nested `response_mask` and `no_padding_2_padding` log-probs can pad to different lengths, so reverse-KL / top-k distillation hits a shape assert on some batches. This also refreshes `global_batch_info` from the current micro-batch instead of inheriting stale normalization metadata.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+align+response+mask+distillation
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

CPU regression in `tests/workers/test_distillation_reverse_kl_response_mask_on_cpu.py`:

- shape-consistent path is a no-op
- shorter nested mask is padded with `False` and masked `abs_loss` matches baseline
- longer nested mask is truncated (trailing `False` only) and masked `abs_loss` matches baseline
- truncating a mask that still has valid tokens raises
- `update_global_batch_info` drops stale keys

```bash
pytest tests/workers/test_distillation_reverse_kl_response_mask_on_cpu.py -q
```

### API and Usage Example

No user-facing API change. Distillation trainers pick this up automatically.

### Design & Code Changes

- Add `align_response_mask()` and use it in reverse-KL, top-k metrics, and outer distillation loss.
- Add `update_global_batch_info()` so actor/distillation loss normalization reads the current micro-batch.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks on the touched files (`ruff format` + `ruff check`).
- [ ] Add / Update the documentation. Not user-facing.
- [x] Add unit tests: `tests/workers/test_distillation_reverse_kl_response_mask_on_cpu.py` is picked up by `cpu_unit_tests.yml`.
- [ ] Slack `ci-request` will be sent after CI is ready.
- [x] Not related to the `recipe` submodule.

### Duplicate-work / AI assistance

No open PR addresses nested `response_mask` vs `no_padding_2_padding` length mismatch. Search only surfaced unrelated Ascend OPD recipes (#7333).

AI assistance was used to port this fix onto current `main` and open this PR. The submitting author reviewed every changed line.

### End-to-End Validation

The original implementation was validated in a complete Qwen3.5-35B-A3B on-policy distillation (OPD) training run, which completed successfully. The follow-up review fixes are covered by focused CPU regression tests; the full end-to-end training run has not been repeated after those follow-up changes.

### Full-training failure evidence

This was observed in a complete Qwen3.5-35B-A3B OPD run using Megatron + SGLang on PyTorch 2.11.0+cu130, Transformers 5.6, and TensorDict 0.10. Step 1 happened to have matching padded widths; step 2 failed at the shape assertion.

The per-sample semantic response lengths were consistent. The mismatch was between two dense padding baselines: no_padding_2_padding retained the batch-level max_response_len, while nested response_mask.to_padded_tensor(False) used the current micro-batch's maximum ragged length. The original full training completed after aligning only the masked padding tail. The follow-up commits were validated with focused CPU regression tests; the 35B end-to-end run was not repeated after review-only hardening.