### PR TITLE
[trainer, ckpt] fix: save final checkpoint when epochs exhaust

### DIFF
--- a/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from omegaconf import OmegaConf
 
@@ -31,6 +31,156 @@ class _StubTrainer(PPOTrainer):
 class _CustomSampler:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+
+
+def _epoch_exhaustion_trainer(**trainer_overrides) -> _StubTrainer:
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    trainer.config = OmegaConf.create(
+        {
+            "trainer": {
+                "total_epochs": 1,
+                "save_freq": 50,
+                **trainer_overrides,
+            }
+        }
+    )
+    trainer.global_steps = 1
+    return trainer
+
+
+def _fit_stub_trainer(
+    *,
+    global_steps: int,
+    steps_per_epoch: int,
+    total_epochs: int = 1,
+    total_training_steps: int = 1000,
+    save_freq: int = 50,
+) -> _StubTrainer:
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    trainer.trainer_mode = "sync"
+    trainer.parameter_sync_step = 1
+    trainer.steps_per_epoch = steps_per_epoch
+    trainer.total_training_steps = total_training_steps
+    trainer.global_steps = global_steps
+    trainer.logger = MagicMock()
+    trainer.config = OmegaConf.create(
+        {
+            "trainer": {
+                "project_name": "test",
+                "experiment_name": "test",
+                "logger": [],
+                "val_before_train": False,
+                "total_epochs": total_epochs,
+                "save_freq": save_freq,
+                "test_freq": 0,
+            },
+            "global_profiler": {"steps": None},
+            "data": {"train_batch_size": 64},
+        }
+    )
+    return trainer
+
+
+def _run_fit(trainer: _StubTrainer, *, step_side_effect=None):
+    batch = MagicMock(keys=[], partition_id="train")
+
+    with (
+        patch("verl.trainer.ppo.v1.trainer_base.SkipManager") as skip_manager,
+        patch("verl.trainer.ppo.v1.trainer_base.Tracking"),
+        patch("verl.trainer.ppo.v1.trainer_base.ValidationGenerationsLogger"),
+        patch("verl.trainer.ppo.v1.trainer_base.DapoFilteredRewardTableLogger"),
+        patch("verl.trainer.ppo.v1.trainer_base.tqdm", return_value=MagicMock()),
+        patch("verl.trainer.ppo.v1.trainer_base.tq.kv_clear"),
+        patch.object(trainer, "_reissue_inflight_prompts"),
+        patch.object(trainer, "on_train_begin"),
+        patch.object(trainer, "on_step_begin"),
+        patch.object(trainer, "_start_profiling"),
+        patch.object(trainer, "_stop_profiling"),
+        patch.object(trainer, "_consume_sync_metrics", return_value={}),
+        patch.object(trainer, "_compute_metrics"),
+        patch.object(trainer, "step", side_effect=step_side_effect or (lambda metrics, timing_raw: batch)),
+        patch.object(trainer, "on_train_end") as on_train_end,
+        patch.object(trainer, "_shutdown_dump_executor") as shutdown_dump_executor,
+        patch.object(trainer, "_save_checkpoint") as save_checkpoint,
+    ):
+        trainer.fit(agent_loop_manager=MagicMock())
+        skip_manager.init.assert_called_once()
+        skip_manager.set_step.assert_called()
+
+    return save_checkpoint, on_train_end, shutdown_dump_executor
+
+
+def test_should_force_save_when_epochs_exhaust_with_completed_steps():
+    trainer = _epoch_exhaustion_trainer(save_freq=50)
+    trainer.global_steps = 238
+
+    assert trainer._should_force_save_epoch_exhaustion_checkpoint(
+        completed_training_steps=1,
+        current_epoch=1,
+    )
+
+
+def test_should_not_force_save_on_zero_iteration_resume():
+    trainer = _epoch_exhaustion_trainer(save_freq=50)
+    trainer.global_steps = 238
+
+    assert not trainer._should_force_save_epoch_exhaustion_checkpoint(
+        completed_training_steps=0,
+        current_epoch=1,
+    )
+
+
+def test_should_not_force_save_on_save_boundary():
+    trainer = _epoch_exhaustion_trainer(save_freq=50)
+    trainer.global_steps = 101
+
+    assert not trainer._should_force_save_epoch_exhaustion_checkpoint(
+        completed_training_steps=1,
+        current_epoch=1,
+    )
+
+
+def test_fit_zero_iteration_resume_does_not_save_or_crash():
+    trainer = _fit_stub_trainer(global_steps=237, steps_per_epoch=100, save_freq=50)
+
+    save_checkpoint, on_train_end, shutdown_dump_executor = _run_fit(trainer)
+
+    save_checkpoint.assert_not_called()
+    on_train_end.assert_called_once()
+    shutdown_dump_executor.assert_called_once()
+    assert trainer.global_steps == 238
+
+
+def test_fit_saves_once_when_epochs_exhaust_off_boundary():
+    trainer = _fit_stub_trainer(
+        global_steps=0,
+        steps_per_epoch=2,
+        total_training_steps=100,
+        save_freq=3,
+    )
+
+    save_checkpoint, on_train_end, shutdown_dump_executor = _run_fit(trainer)
+
+    save_checkpoint.assert_called_once()
+    on_train_end.assert_called_once()
+    shutdown_dump_executor.assert_called_once()
+    assert trainer.global_steps == 3
+
+
+def test_fit_does_not_duplicate_save_on_save_boundary():
+    trainer = _fit_stub_trainer(
+        global_steps=0,
+        steps_per_epoch=2,
+        total_training_steps=100,
+        save_freq=2,
+    )
+
+    save_checkpoint, on_train_end, shutdown_dump_executor = _run_fit(trainer)
+
+    assert save_checkpoint.call_count == 1
+    on_train_end.assert_called_once()
+    shutdown_dump_executor.assert_called_once()
+    assert trainer.global_steps == 3
 
 
 def _trainer_with_filter_groups(filter_groups: dict, trainer_mode: str = "sync") -> _StubTrainer:

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -502,6 +502,27 @@ class PPOTrainer(ABC):
                 progress_bar.close()
                 return
 
+        # The dataloader can exhaust an epoch before total_training_steps is reached.
+        # In that case is_last_step never becomes true, so a non-aligned final step
+        # (for example step 237 with save_freq=50) would otherwise not be saved.
+        final_completed_step = self.global_steps - 1
+        if (
+            self.config.trainer.save_freq > 0
+            and final_completed_step > 0
+            and final_completed_step % self.config.trainer.save_freq != 0
+        ):
+            logger.info(
+                "Training ended because all configured epochs were exhausted; "
+                f"force-saving final checkpoint at step {final_completed_step}"
+            )
+            next_global_step = self.global_steps
+            self.global_steps = final_completed_step
+            try:
+                with marked_timer("save_final_checkpoint", self.timing_raw, color="green"):
+                    self._save_checkpoint()
+            finally:
+                self.global_steps = next_global_step
+
         self.on_train_end()
         # Ensure dump executor is shut down when training loop ends without reaching is_last_step
         self._shutdown_dump_executor()

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -440,6 +440,7 @@ class PPOTrainer(ABC):
 
         self.on_train_begin()
         last_val_metrics = None
+        completed_training_steps = 0
         while current_epoch < self.config.trainer.total_epochs and self.global_steps <= self.total_training_steps:
             is_last_step = self.global_steps >= self.total_training_steps
             metrics = {}
@@ -493,6 +494,7 @@ class PPOTrainer(ABC):
                     self.config.trainer.logger, dapo_filtered_reward_counts, self.global_steps
                 )
             progress_bar.update(1)
+            completed_training_steps += 1
             self.global_steps += 1
             SkipManager.set_step(self.global_steps)
             current_epoch = (self.global_steps - 1) // self.steps_per_epoch
@@ -505,24 +507,18 @@ class PPOTrainer(ABC):
         # The dataloader can exhaust an epoch before total_training_steps is reached.
         # In that case is_last_step never becomes true, so a non-aligned final step
         # (for example step 237 with save_freq=50) would otherwise not be saved.
-        final_completed_step = self.global_steps - 1
-        if (
-            self.config.trainer.save_freq > 0
-            and final_completed_step > 0
-            and final_completed_step % self.config.trainer.save_freq != 0
+        if self._should_force_save_epoch_exhaustion_checkpoint(
+            completed_training_steps=completed_training_steps,
+            current_epoch=current_epoch,
         ):
+            final_completed_step = self.global_steps - 1
             logger.info(
                 "Training ended because all configured epochs were exhausted; "
                 f"force-saving final checkpoint at step {final_completed_step}"
             )
-            next_global_step = self.global_steps
-            self.global_steps = final_completed_step
-            try:
-                with marked_timer("save_final_checkpoint", self.timing_raw, color="green"):
-                    self._save_checkpoint()
-            finally:
-                self.global_steps = next_global_step
+            self._force_save_epoch_exhaustion_checkpoint(final_completed_step)
 
+        progress_bar.close()
         self.on_train_end()
         # Ensure dump executor is shut down when training loop ends without reaching is_last_step
         self._shutdown_dump_executor()
@@ -621,6 +617,35 @@ class PPOTrainer(ABC):
     def on_train_end(self):
         """Called after the training loop ends."""
         return
+
+    def _should_force_save_epoch_exhaustion_checkpoint(
+        self, *, completed_training_steps: int, current_epoch: int
+    ) -> bool:
+        """Return True when epoch exhaustion should trigger a final off-boundary save."""
+        if completed_training_steps <= 0:
+            return False
+        if current_epoch < self.config.trainer.total_epochs:
+            return False
+
+        save_freq = self.config.trainer.save_freq
+        if save_freq <= 0:
+            return False
+
+        final_completed_step = self.global_steps - 1
+        if final_completed_step <= 0:
+            return False
+        return final_completed_step % save_freq != 0
+
+    def _force_save_epoch_exhaustion_checkpoint(self, final_completed_step: int) -> None:
+        """Save the last completed step without leaving global_steps advanced."""
+        next_global_step = self.global_steps
+        self.global_steps = final_completed_step
+        try:
+            timing_raw: dict[str, float] = {}
+            with marked_timer("save_final_checkpoint", timing_raw, color="green"):
+                self._save_checkpoint()
+        finally:
+            self.global_steps = next_global_step
 
     def on_validate_begin(self):
         """Called before the validation loop starts."""


### PR DESCRIPTION
### What does this PR do?

When `total_epochs` runs out before `total_training_steps`, `is_last_step` never becomes true. A final step that is not on `save_freq` (for example step 237 with `save_freq=50`) is then discarded. Force-save that last completed step after the train loop exits.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+final+checkpoint+epochs+exhaust
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

This is trainer control-flow around checkpoint I/O, so it is not covered by a new CPU unit test.

Manual check:

1. Set `trainer.total_epochs` so the dataloader ends off a `save_freq` boundary.
2. Confirm a checkpoint is written for the last completed step.
3. Confirm a run that already ends on `is_last_step` or `save_freq` does not write a duplicate extra checkpoint.

### API and Usage Example

No new config. Existing `trainer.save_freq > 0` now also covers epoch-exhaust exits.

### Design & Code Changes

After the `fit()` loop, if `save_freq > 0` and the last completed step is not on the save boundary, temporarily set `self.global_steps` to that step, call `_save_checkpoint()`, then restore the counter.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks on the touched files (`ruff format` + `ruff check`).
- [ ] Add / Update the documentation. Not user-facing.
- [ ] Unit test not added: requires a full trainer/checkpoint fixture. Explained above.
- [ ] Slack `ci-request` will be sent after CI is ready.
- [x] Not related to the `recipe` submodule.

### Duplicate-work / AI assistance

No open PR force-saves the last step when epochs exhaust before `total_training_steps`. Related older issues (#481, #5013) discuss last-step / epoch-budget exits but do not land this save.

AI assistance was used to port this fix onto current `main` and open this PR. The submitting author reviewed every changed line.

### End-to-End Validation

The original implementation was validated in a complete Qwen3.5-35B-A3B on-policy distillation (OPD) training run, which completed successfully. The follow-up review fixes are covered by focused CPU regression tests; the full end-to-end training run has not been repeated after those follow-up changes.