### PR TITLE
[megatron, perf] fix: make mini-batch BSHD padding opt-in

### DIFF
--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -125,6 +125,29 @@ def test_preprocess_bshd_engine_preserves_1d_input_shape_on_cpu(monkeypatch):
     torch.testing.assert_close(position_ids, torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long))
 
 
+def test_preprocess_bshd_engine_uses_final_microbatch_padding_target(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1)
+    short_microbatch = _nested_tensor([torch.arange(512)])
+    long_microbatch = _nested_tensor([torch.arange(14_010)])
+
+    short_local, _, _ = mcore_util.preprocess_bshd_engine(short_microbatch)
+    long_local, _, _ = mcore_util.preprocess_bshd_engine(long_microbatch)
+    short_global, short_global_mask, _ = mcore_util.preprocess_bshd_engine(
+        short_microbatch,
+        forced_max_seqlen=14_010,
+    )
+
+    assert short_local.shape == (1, 512)
+    assert long_local.shape == (1, 14_010)
+    assert short_local.numel() + long_local.numel() == 14_522
+
+    # The opt-in mini-batch-global target remains available to trade padding for
+    # fewer cuDNN execution-plan builds.
+    assert short_global.shape == (1, 14_010)
+    assert short_global.numel() + long_local.numel() == 28_020
+    assert short_global_mask.sum().item() == 512
+
+
 def test_preprocess_thd_engine_rounds_packed_length_to_bucket_without_cp(monkeypatch):
     mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=1, cp_size=1)
     input_ids = _nested_tensor([torch.arange(513)])

--- a/tests/workers/config/test_engine_config_on_cpu.py
+++ b/tests/workers/config/test_engine_config_on_cpu.py
@@ -22,6 +22,7 @@ class TestMcoreEngineConfig:
         config = McoreEngineConfig()
         assert config.tensor_model_parallel_size == 1
         assert config.sequence_parallel is False  # Should be auto-corrected
+        assert config.pad_bshd_to_minibatch_max is False
         assert config.seed == 42
 
     def test_post_init_validation(self):

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -77,7 +77,7 @@ actor_rollout_ref:
       use_mbridge: true
       vanilla_mbridge: false
       use_remove_padding: true
-      pad_bshd_to_minibatch_max: true
+      pad_bshd_to_minibatch_max: false
       pad_to_length: false
       pad_to_length_bucket: 512
       use_megatron_fsdp: false
@@ -289,7 +289,7 @@ actor_rollout_ref:
       use_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.use_mbridge,False}
       vanilla_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.vanilla_mbridge,False}
       use_remove_padding: ${oc.select:actor_rollout_ref.actor.megatron.use_remove_padding,True}
-      pad_bshd_to_minibatch_max: true
+      pad_bshd_to_minibatch_max: false
       pad_to_length: ${oc.select:actor_rollout_ref.actor.megatron.pad_to_length,False}
       pad_to_length_bucket: ${oc.select:actor_rollout_ref.actor.megatron.pad_to_length_bucket,512}
       use_megatron_fsdp: false
@@ -628,7 +628,7 @@ critic:
     use_mbridge: true
     vanilla_mbridge: false
     use_remove_padding: true
-    pad_bshd_to_minibatch_max: true
+    pad_bshd_to_minibatch_max: false
     pad_to_length: false
     pad_to_length_bucket: 512
     use_megatron_fsdp: false

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -105,9 +105,9 @@ vanilla_mbridge: False
 use_remove_padding: True
 
 # BSHD path only. Pad every micro-batch of a mini-batch to the mini-batch's global max sequence length instead of
-# each micro-batch's own max. Unifies padding across micro-batches to avoid repeated cuDNN compilation. Only takes
-# effect when use_remove_padding=False (BSHD); no-op on the THD path.
-pad_bshd_to_minibatch_max: True
+# each micro-batch's own max. Enabling this avoids repeated cuDNN compilation but increases padding for mixed-length
+# mini-batches. Only takes effect when use_remove_padding=False (BSHD); no-op on the THD path.
+pad_bshd_to_minibatch_max: False
 
 # Match the FSDP packed-padding controls. Set the bucket to 512 to reduce THD shape variability.
 pad_to_length: false

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -170,6 +170,8 @@ class McoreEngineConfig(EngineConfig):
         dist_checkpointing_path (Optional[str]): Path for distributed checkpointing.
         dist_ckpt_optim_fully_reshardable (bool): Use fully reshardable optimizer checkpoints.
         distrib_optim_fully_reshardable_mem_efficient (bool): Use memory-efficient fully reshardable format.
+        pad_bshd_to_minibatch_max (bool): Whether BSHD micro-batches use the mini-batch maximum sequence length.
+            This reduces cuDNN graph rebuilds at the cost of padding every micro-batch to the longest sample.
         seed (int): Random seed for reproducibility.
         override_ddp_config (dict[str, Any]): Override configuration for DDP.
         override_transformer_config (dict[str, Any]): Override configuration for transformer.
@@ -196,7 +198,7 @@ class McoreEngineConfig(EngineConfig):
     max_seqlen_per_dp_cp_rank: Optional[int] = None
     sequence_parallel: bool = True
     use_distributed_optimizer: bool = True
-    pad_bshd_to_minibatch_max: bool = True
+    pad_bshd_to_minibatch_max: bool = False
     pad_to_length: bool = False
     pad_to_length_bucket: int = 512
     use_dist_checkpointing: bool = False


### PR DESCRIPTION
### What does this PR do?

Megatron BSHD currently defaults to padding every final micro-batch to the longest sequence in the surrounding mini-batch. That target is computed before dynamic micro-batch membership is finalized. For two final micro-batches containing 14,010 and 512 tokens, the default therefore materializes 28,020 dense token slots instead of 14,522 (1.93x by element count).

This makes mini-batch-global padding opt-in again. The implementation from #6901 remains intact: workloads where fewer cuDNN fused-attention graph builds outweigh the extra padding can continue to set `pad_bshd_to_minibatch_max: true`.

#6901 introduced this behavior as an opt-in and its PR description documented `default false`, but the merged configuration currently defaults to `true`. This PR aligns the code and generated configuration with that explicit tradeoff.

This is not a duplicate. Searches for [`pad_bshd_to_minibatch_max`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+pad_bshd_to_minibatch_max) and [BSHD micro-batch padding](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+BSHD+micro-batch+padding) found no overlapping open PR; #6901 is the feature this change preserves.

### Checklist Before Starting

- [x] Searched for similar PRs; links are above.
- [x] Formatted the title as `[megatron, perf] fix: ...`.

### Test

CPU shape evidence is sufficient for the changed default contract; this PR does not claim a measured CUDA peak-memory or throughput delta.

```text
PYTHONPATH=$PWD python -m pytest \
  tests/utils/test_megatron_bshd_preprocess.py \
  tests/workers/config/test_engine_config_on_cpu.py -q
27 passed, 1 skipped

pre-commit run --all-files --show-diff-on-failure --color=never
all hooks passed (ruff, mypy, generated configs, sanity checks, compileall)
```

The new geometry test protects both sides of the tradeoff:

- default/final-micro-batch targets: `512 + 14,010 = 14,522` dense slots;
- explicit mini-batch-global target: `14,010 + 14,010 = 28,020` dense slots, with the short row's mask still containing exactly 512 real tokens.

### API and Usage Example

There is no config schema or function-signature change. To retain the graph-build optimization from #6901:

```yaml
actor_rollout_ref:
  actor:
    megatron:
      use_remove_padding: false
      pad_bshd_to_minibatch_max: true
```

### Design & Code Changes

- Restore `McoreEngineConfig.pad_bshd_to_minibatch_max=False`.
- Document the padding-versus-cuDNN-plan-reuse tradeoff at the config boundary.
- Regenerate the Megatron trainer reference config.
- Test the default and both padding geometries without requiring a GPU.

The BSHD preprocessing path, TP/CP/FP8 alignment, VLM handling, and explicit opt-in behavior are unchanged.

### Checklist Before Submitting

- [x] Read the contribution guide and repository agent instructions.
- [x] Ran the full pre-commit suite.
- [x] Updated the config documentation and generated reference config.
- [x] Added regression coverage in existing automatically collected CPU/GPU unit-test surfaces; no workflow edit is needed.
- [ ] Request hosted GPU CI through the maintainer channel.
- [x] No recipe submodule change.

AI assistance disclosure: this PR was developed with AI assistance. The submitting human reviewed every changed line and is responsible for the change end-to-end.
