### PR TITLE
[tool] fix: preserve explicit JSON Schema constraints

### DIFF
--- a/tests/tools/test_function_tool_on_cpu.py
+++ b/tests/tools/test_function_tool_on_cpu.py
@@ -163,7 +163,20 @@ def test_explicit_schema_dict_override_skips_inference():
         "function": {
             "name": "x",
             "description": "custom desc",
-            "parameters": {"type": "object", "properties": {}, "required": []},
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "offset": {"type": "integer", "description": "Start line", "minimum": 0},
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum lines",
+                        "minimum": 1,
+                        "maximum": 128,
+                    },
+                },
+                "required": ["offset"],
+                "additionalProperties": False,
+            },
         },
     }
 
@@ -177,8 +190,7 @@ def test_explicit_schema_dict_override_skips_inference():
         return ""
 
     schema = FUNCTION_TOOL_REGISTRY["x"].tool_schema.model_dump(exclude_unset=True, exclude_none=True)
-    assert schema["function"]["description"] == "custom desc"
-    assert schema["function"]["parameters"]["properties"] == {}
+    assert schema == custom
 
 
 def test_explicit_schema_object_override():

--- a/verl/tools/schemas.py
+++ b/verl/tools/schemas.py
@@ -15,11 +15,13 @@
 import json
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class OpenAIFunctionPropertySchema(BaseModel):
     """The schema of a parameter in OpenAI format."""
+
+    model_config = ConfigDict(extra="allow")
 
     # Union's type is list[str], e.g. ["integer", "number"] for int | float unions.
     type: str | list[str]
@@ -31,6 +33,8 @@ class OpenAIFunctionPropertySchema(BaseModel):
 
 class OpenAIFunctionParametersSchema(BaseModel):
     """The schema of parameters in OpenAI format."""
+
+    model_config = ConfigDict(extra="allow")
 
     type: str
     properties: dict[str, OpenAIFunctionPropertySchema]


### PR DESCRIPTION
### What does this PR do?

Fixes #7505. Explicit dictionary schemas passed to `@function_tool(..., schema=...)` were validated by narrow Pydantic carrier models, causing valid JSON Schema constraints to disappear before prompt rendering. This change preserves valid extra keywords on parameter and property schemas, including `minimum`, `maximum`, and `additionalProperties`.

This is not a duplicate: [the final open-PR search for #7505](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7505+in%3Abody) and a final target-file audit found no overlapping open PR.

AI assistance: OpenAI Codex assisted with this patch. The submitting human reviewed every changed line and ran the focused regression test.

### Checklist Before Starting

- [x] Search for similar PRs. [Final open-PR query](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7505+in%3Abody)
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

```text
VERL_USE_EXTERNAL_PLUGINS=none /private/tmp/verl-schema-venv/bin/python -m pytest -q tests/tools/test_function_tool_on_cpu.py::test_explicit_schema_dict_override_skips_inference
1 passed

/private/tmp/verl-schema-venv/bin/ruff check verl/tools/schemas.py tests/tools/test_function_tool_on_cpu.py
All checks passed!

/private/tmp/verl-schema-venv/bin/ruff format --check verl/tools/schemas.py tests/tools/test_function_tool_on_cpu.py
2 files already formatted
```

The full repository test matrix was not run. A full pre-commit run was not available in the temporary local environment; the changed Python files were checked with ruff.

### API and Usage Example

No API shape changes. Explicit function-tool schemas now retain their valid caller-provided JSON Schema constraints after validation and serialization.

### Design & Code Changes

- Configure the parameter and property schema carriers to preserve extra JSON Schema keywords.
- Extend the explicit dictionary schema regression to assert a complete round trip for property bounds and root-level `additionalProperties`.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] Apply the full pre-commit check; see the validation note above.
- [x] Documentation is not needed because the public API and usage do not change.
- [x] Add/update a CPU regression test covering the changed behavior.
- [ ] Send a CI request in the project community channel if required by maintainers.
