### PR TITLE
[BREAKING][trainer, cfg] fix: derive TransferQueue storage units from node count

### DIFF
--- a/tests/utils/test_config_on_cpu.py
+++ b/tests/utils/test_config_on_cpu.py
@@ -19,6 +19,7 @@ from omegaconf import OmegaConf
 
 from verl.base_config import BaseConfig
 from verl.utils import omega_conf_to_dataclass
+from verl.utils.config import resolve_transfer_queue_config
 
 
 @dataclass
@@ -91,6 +92,34 @@ class TestPrintCfgCommand(unittest.TestCase):
         # Verify the output contains expected config information
         self.assertIn("critic", result.stdout)
         self.assertIn("profiler", result.stdout)
+
+
+class TestTransferQueueConfigOnCPU(unittest.TestCase):
+    @staticmethod
+    def _config(nnodes, num_data_storage_units=None):
+        return OmegaConf.create(
+            {
+                "trainer": {"nnodes": nnodes},
+                "transfer_queue": {"backend": {"SimpleStorage": {"num_data_storage_units": num_data_storage_units}}},
+            }
+        )
+
+    def test_storage_units_default_scales_with_nodes(self):
+        single_node_config = self._config(nnodes=1)
+        multi_node_config = self._config(nnodes=4)
+
+        resolve_transfer_queue_config(single_node_config)
+        resolve_transfer_queue_config(multi_node_config)
+
+        self.assertEqual(single_node_config.transfer_queue.backend.SimpleStorage.num_data_storage_units, 2)
+        self.assertEqual(multi_node_config.transfer_queue.backend.SimpleStorage.num_data_storage_units, 8)
+
+    def test_storage_units_explicit_override_is_preserved(self):
+        config = self._config(nnodes=4, num_data_storage_units=3)
+
+        resolve_transfer_queue_config(config)
+
+        self.assertEqual(config.transfer_queue.backend.SimpleStorage.num_data_storage_units, 3)
 
 
 if __name__ == "__main__":

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -981,7 +981,7 @@ transfer_queue:
     storage_backend: SimpleStorage
     SimpleStorage:
       total_storage_size: 100000
-      num_data_storage_units: 8
+      num_data_storage_units: null
     MooncakeStore:
       auto_init: false
       metadata_server: localhost:50123

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -873,7 +873,7 @@ transfer_queue:
     storage_backend: SimpleStorage
     SimpleStorage:
       total_storage_size: 100000
-      num_data_storage_units: 8
+      num_data_storage_units: null
     MooncakeStore:
       auto_init: false
       metadata_server: localhost:50123

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -939,7 +939,7 @@ transfer_queue:
     storage_backend: SimpleStorage
     SimpleStorage:
       total_storage_size: 100000
-      num_data_storage_units: 8
+      num_data_storage_units: null
     MooncakeStore:
       auto_init: false
       metadata_server: localhost:50123

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -904,7 +904,7 @@ transfer_queue:
     storage_backend: SimpleStorage
     SimpleStorage:
       total_storage_size: 100000
-      num_data_storage_units: 8
+      num_data_storage_units: null
     MooncakeStore:
       auto_init: false
       metadata_server: localhost:50123

--- a/verl/trainer/config/transfer_queue/transfer_queue.yaml
+++ b/verl/trainer/config/transfer_queue/transfer_queue.yaml
@@ -24,9 +24,9 @@ backend:
     # Maximum number of experience samples to hold across all storage units
     total_storage_size: 100000
 
-    # Number of distributed storage units.
-    # Recommended: >= 2 x number of nodes for load balancing and fault tolerance.
-    num_data_storage_units: 8
+    # Number of distributed storage units. If null, defaults to max(2, 2 x trainer.nnodes)
+    # for load balancing and fault tolerance.
+    num_data_storage_units: null
 
   # MooncakeStore (experimental): high-performance KV-based hierarchical storage
   # that supports RDMA transport between GPU and DRAM.

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -21,7 +21,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
 from verl.trainer.ppo.utils import need_critic, need_reference_policy
-from verl.utils.config import validate_config
+from verl.utils.config import resolve_transfer_queue_config, validate_config
 from verl.utils.device import auto_set_device, is_cuda_available
 from verl.utils.import_utils import load_class_from_fqn
 from verl.utils.logging_utils import configure_verl_logging
@@ -141,6 +141,7 @@ class TaskRunnerV1:
         trainer_cls = get_trainer_cls(config.trainer.v1.trainer_mode)
 
         config.transfer_queue.enable = True
+        resolve_transfer_queue_config(config)
         pprint(OmegaConf.to_container(config, resolve=True))
         OmegaConf.resolve(config)
         self.config = config

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -71,6 +71,13 @@ def update_dict_with_config(dictionary: dict, config: DictConfig):
             dictionary[key] = getattr(config, key)
 
 
+def resolve_transfer_queue_config(config: DictConfig) -> None:
+    """Resolve node-dependent defaults before initializing TransferQueue."""
+    simple_storage = config.transfer_queue.backend.SimpleStorage
+    if simple_storage.num_data_storage_units is None:
+        simple_storage.num_data_storage_units = max(2, 2 * config.trainer.nnodes)
+
+
 def validate_config(
     config: DictConfig,
     use_reference_policy: bool,


### PR DESCRIPTION
### What does this PR do?

Fixes #7398 by making the default number of TransferQueue `SimpleStorage` units depend on `trainer.nnodes`. A null default now resolves to `max(2, 2 * trainer.nnodes)` immediately before TransferQueue initialization, while an explicit `num_data_storage_units` override is preserved.

The generated trainer configs are updated and CPU tests cover both node-aware defaults and explicit overrides.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+num_data_storage_units+SimpleStorage
- [x] Also checked `7398 in:body`, `TransferQueue CPU storage units`, and `SimpleStorage cluster size`; no overlapping open PR was found on 2026-08-23.
- [x] Reviewed #6663: it adds a fail-fast message for insufficient Ray CPUs but does not change `num_data_storage_units`; this PR fixes the storage-unit resource count that causes the failure.
- [x] PR title follows the required format.

### Test

```text
pytest -q tests/utils/test_config_on_cpu.py
5 passed, 2 pre-existing collection warnings

scripts/generate_trainer_config.sh
All good

pre-commit run --all-files --show-diff-on-failure --color=always
ruff, ruff-format, mypy, generated config verification, docstrings, license,
device/DataProto checks, test structure, naming, example naming, uv policy, and
compileall passed.
```

An additional Hydra composition smoke test verified that the shipped single-node configuration resolves to 2 units and that an explicit override of 5 remains 5.

### API and Usage Example

The existing override remains unchanged:

```bash
transfer_queue.backend.SimpleStorage.num_data_storage_units=5
```

Leaving the value at its default (`null`) selects `max(2, 2 * trainer.nnodes)`.

TransferQueue checkpoints must be restored with the same storage-unit count used when they were written. For example,
resume a single-node checkpoint created with the previous implicit default using:

```bash
transfer_queue.backend.SimpleStorage.num_data_storage_units=8
```

### Design & Code Changes

- Change the YAML default from the fixed value `8` to `null`.
- Resolve the node-aware default before `tq.init` and before printing the resolved runtime configuration.
- Preserve every explicit user-provided value.
- Regenerate all flattened PPO trainer configs.
- Add CPU coverage for single-node, multi-node, and override behavior.

### Compatibility

This changes the implicit default. Existing jobs that explicitly configure `num_data_storage_units` retain their current behavior. A one-node job now creates 2 storage units instead of 8; a four-node job still creates 8.

This is breaking for checkpoint recovery when the derived count differs from the count stored in the checkpoint. In particular, a single-node checkpoint written with the previous implicit default of 8 units must be resumed with the explicit override shown above. The same requirement applies when changing `trainer.nnodes`: preserve the checkpoint's original unit count explicitly for the resumed run.

### AI assistance disclosure

OpenAI Codex assisted with issue triage, implementation, and initial test execution. The human submitter reviewed every changed line, verified the node-aware default and override behavior, and reran the listed checks before submission.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied `pre-commit run --all-files` in a clean worktree.
- [x] Added CPU unit tests.
- [x] Updated generated configuration references.
- [x] Documented the TransferQueue checkpoint recovery requirement and marked the PR breaking.
- [x] Human submitter reviewed every changed line and reran the tests.
- [ ] Request upstream CI after the PR is opened.
