### PR TITLE
[doc] fix: document ARM64 Apptainer workflow for Slurm

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -49,11 +49,23 @@ docker build -f docker/Dockerfile.stable.vllm \
 
 ### GB200 / aarch64
 
-Pre-built images for GB200 (aarch64) are not yet published. Users should build locally on an aarch64 machine. Pre-built images will be added once available.
+Stable, officially supported pre-built images for GB200 (aarch64) are not yet published. Users should build locally on
+an aarch64 machine. Stable pre-built images will be documented once available.
 
 ```sh
 docker build -f docker/Dockerfile.stable.vllm -t verl:vllm-arm64 .
+docker image inspect verl:vllm-arm64 --format '{{.Os}}/{{.Architecture}}'
 ```
+
+The inspection output should report `linux/arm64`. If Docker is on a different aarch64 host from the Slurm cluster,
+export the image for transfer:
+
+```sh
+docker save -o verl-vllm-arm64.tar verl:vllm-arm64
+```
+
+The [multi-node Slurm guide](../docs/start/multinode.rst#option-3-launch-via-slurm) covers converting either the local
+Docker daemon image or the transferred archive into an Apptainer SIF.
 
 ## uv image (`Dockerfile.uv.cu130`)
 

--- a/docs/faq/faq.rst
+++ b/docs/faq/faq.rst
@@ -1,7 +1,7 @@
 Frequently Asked Questions
 ====================================
 
-Last updated: 09/24/2025.
+Last updated: 08/23/2026.
 
 Ray related
 ------------
@@ -34,28 +34,8 @@ Then in the configuration, set the ``trainer.nnode`` config to the number of mac
 How to use verl on a Slurm-managed cluster?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Ray provides users with `this <https://docs.ray.io/en/latest/cluster/vms/user-guides/community/slurm.html>`_ official
-tutorial to start a Ray cluster on top of Slurm. We have verified the :doc:`GSM8K example<../examples/gsm8k_example>`
-on a Slurm cluster under a multi-node setting with the following steps.
-
-1. [Optional] If your cluster support `Apptainer or Singularity <https://apptainer.org/docs/user/main/>`_ and you wish
-to use it, convert verl's Docker image to an Apptainer image. Alternatively, set up the environment with the package
-manager available on your cluster or use other container runtimes (e.g. through `Slurm's OCI support <https://slurm.schedmd.com/containers.html>`_) available to you.
-
-.. code:: bash
-
-    apptainer pull /your/dest/dir/vemlp-th2.4.0-cu124-vllm0.6.3-ray2.10-te1.7-v0.0.3.sif docker://verlai/verl:vemlp-th2.4.0-cu124-vllm0.6.3-ray2.10-te1.7-v0.0.3
-
-2. Follow :doc:`GSM8K example<../examples/gsm8k_example>` to prepare the dataset and model checkpoints.
-
-3. Modify `examples/tutorial/slurm/ray_on_slurm.slurm <https://github.com/verl-project/verl/blob/main/examples/tutorial/slurm/ray_on_slurm.slurm>`_ with your cluster's own information.
-
-4. Submit the job script to the Slurm cluster with `sbatch`.
-
-Please note that Slurm cluster setup may vary. If you encounter any issues, please refer to Ray's
-`Slurm user guide <https://docs.ray.io/en/latest/cluster/vms/user-guides/community/slurm.html>`_ for common caveats.
-
-If you changed Slurm resource specifications, please make sure to update the environment variables in the job script if necessary.
+See :ref:`the Slurm deployment guide <slurm-deployment>` for the Ray cluster setup, ARM64 Docker-to-Apptainer
+workflow, network interface configuration, and job submission steps.
 
 
 Install related

--- a/docs/start/multinode.rst
+++ b/docs/start/multinode.rst
@@ -1,7 +1,7 @@
 Multinode Training
 ==================
 
-Last updated: 07/29/2026.
+Last updated: 08/23/2026.
 
 .. _wuxibin89: https://github.com/wuxibin89
 
@@ -274,6 +274,8 @@ $ sky status --endpoint 8265 verl
 .. image:: https://github.com/yottalabsai/open-source/blob/main/static/verl/saved_model.png?raw=true
 
 
+.. _slurm-deployment:
+
 Option 3: Launch via Slurm
 ------------------------------
 
@@ -281,13 +283,48 @@ Ray provides users with `this <https://docs.ray.io/en/latest/cluster/vms/user-gu
 tutorial to start a Ray cluster on top of Slurm. We have verified the :doc:`GSM8K example<../examples/gsm8k_example>`
 on a Slurm cluster under a multi-node setting with the following steps.
 
-1. [Optional] If your cluster support `Apptainer or Singularity <https://apptainer.org/docs/user/main/>`_ and you wish
-to use it, convert verl's Docker image to an Apptainer image. Alternatively, set up the environment with the package
-manager available on your cluster or use other container runtimes (e.g. through `Slurm's OCI support <https://slurm.schedmd.com/containers.html>`_) available to you.
+1. [Optional] If your cluster supports `Apptainer or Singularity <https://apptainer.org/docs/user/main/>`_,
+convert a verl Docker image that matches the CPU architecture of the Slurm compute nodes. Alternatively, set up the
+environment with the package manager available on your cluster or use another container runtime, such as
+`Slurm's OCI support <https://slurm.schedmd.com/containers.html>`_.
 
-.. code:: bash
+   If a registry image publishes a manifest for the compute nodes' architecture, pull it on an Apptainer login or build
+   host with the same CPU architecture after replacing the placeholder with a current, compatible image reference:
 
-    apptainer pull /your/dest/dir/vemlp-th2.4.0-cu124-vllm0.6.3-ray2.10-te1.7-v0.0.3.sif docker://verlai/verl:vemlp-th2.4.0-cu124-vllm0.6.3-ray2.10-te1.7-v0.0.3
+   .. code-block:: bash
+
+       apptainer pull verl.sif docker://<registry>/<repository>:<tag>
+
+   Stable, officially supported pre-built GB200/aarch64 images are not currently published. On an aarch64 Docker host,
+   follow the `ARM64 build instructions
+   <https://github.com/verl-project/verl/tree/main/docker#gb200--aarch64>`_ and verify the resulting image architecture:
+
+   .. code-block:: bash
+
+       docker build -f docker/Dockerfile.stable.vllm -t verl:vllm-arm64 .
+       docker image inspect verl:vllm-arm64 --format '{{.Os}}/{{.Architecture}}'
+
+   If Apptainer and Docker are available on the same host, build the SIF directly from the local Docker daemon:
+
+   .. code-block:: bash
+
+       apptainer build verl-vllm-arm64.sif docker-daemon:verl:vllm-arm64
+
+   If Docker is only available on a separate build host, export and transfer the image before building the SIF on an
+   aarch64 Slurm login or build node:
+
+   .. code-block:: bash
+
+       # Run on the aarch64 Docker build host, then transfer the archive.
+       docker save -o verl-vllm-arm64.tar verl:vllm-arm64
+
+       # Run where Apptainer is available.
+       apptainer build verl-vllm-arm64.sif docker-archive:/path/to/verl-vllm-arm64.tar
+
+   The ``docker-daemon:`` and ``docker-archive:`` URI forms are documented in the
+   `Apptainer Docker and OCI guide <https://apptainer.org/docs/user/main/docker_and_oci.html#archives-docker-daemon>`_.
+   Set ``APPTAINER_TMPDIR`` to a scratch location with enough free space if the default temporary directory is too
+   small for the image conversion.
 
 2. Follow :doc:`GSM8K example<../examples/gsm8k_example>` to prepare the dataset and model checkpoints.
 


### PR DESCRIPTION
### What does this PR do?

Fixes #613 by replacing the stale amd64-only Docker image in the Slurm documentation with architecture-aware container guidance.

The canonical multi-node guide keeps a generic registry conversion path for images that publish the target architecture and requires the Apptainer build host to match the compute-node architecture. For ARM64, it documents how to build an image from `Dockerfile.stable.vllm` on an aarch64 Docker host, convert it directly through Apptainer's `docker-daemon:` transport, or export it with `docker save` and convert it through `docker-archive:` when Docker and Apptainer are on separate hosts. The FAQ links to that canonical guide instead of duplicating an image tag and workflow that can drift.

### Checklist Before Starting

- [x] Confirmed #613 is open and unassigned, with no closing PR.
- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+Apptainer
- [x] Searched `613 in:body`, `Apptainer`, `Singularity`, `arm64 Slurm`, and `aarch64 Docker`; no overlapping open PR was found on 2026-08-23.
- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] PR title follows the required format.

### Test

```text
python tests/special_sanity/check_docs_time_info.py
All checked files contain 'Last updated'.

make html SPHINXOPTS="--keep-going -w _build/sphinx.log"
Build succeeded; the edited sections introduced no Sphinx errors or warnings.

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed.

docker info --format '{{.OSType}}/{{.Architecture}}'
linux/aarch64
```

The available Docker daemon reports `linux/aarch64`. The full stable image build, inspection/export of the resulting image, and SIF conversion were not run locally. Apptainer is not installed on the host; the `docker://`, `docker-daemon:`, and `docker-archive:` command forms were checked against Apptainer's official Docker and OCI documentation.

### API and Usage Example

There is no API or runtime change. The guide now offers a generic same-architecture registry path and two ARM64 local-image paths for Slurm users.

### Design & Code Changes

- Replace the obsolete amd64-only image reference with a generic same-architecture registry pull.
- Document a build of `docker/Dockerfile.stable.vllm` for ARM64 users without a stable pre-built image.
- Verify the built image reports `linux/arm64` before conversion.
- Document direct Docker daemon conversion and portable Docker archive conversion.
- Point users with limited temporary storage to `APPTAINER_TMPDIR`.
- Deduplicate the FAQ by linking it to a stable labeled Slurm section.
- Extend the Docker README with architecture inspection, archive export, and the canonical Slurm guide link.

### Compatibility

This is documentation-only and does not change runtime behavior. It deliberately does not recommend an experimental ARM64 image tag or claim that every GPU kernel supports every ARM64 GPU. The documented workflow addresses CPU-architecture-compatible image packaging; backend and CUDA-kernel compatibility still depends on the target GPU and the selected image dependencies.


### Checklist Before Submitting

- [x] Applied `pre-commit run --all-files` in a clean worktree.
- [x] Removed duplicated, stale Slurm instructions.
- [x] Built the Sphinx documentation locally.
- [x] Verified the host Docker daemon architecture.
- [x] Unit/E2E tests are not applicable because this PR changes documentation only; Sphinx and documentation checks cover it.
- [x] Human submitter reviewed every changed line and reran the checks.
- [ ] Request upstream CI after the PR is opened.
