### PR TITLE
[deployment] fix: parse Slurm hostnames into node array

### DIFF
--- a/examples/tutorial/slurm/ray_on_slurm.slurm
+++ b/examples/tutorial/slurm/ray_on_slurm.slurm
@@ -43,8 +43,19 @@ get_node_ipv4() {
 }
 
 # Getting the node names
-nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
-nodes_array=("$nodes")
+mapfile -t nodes_array < <(scontrol show hostnames "$SLURM_JOB_NODELIST")
+node_count=${#nodes_array[@]}
+
+if ((node_count == 0)); then
+    printf 'scontrol did not return any nodes for SLURM_JOB_NODELIST=%s.\n' "$SLURM_JOB_NODELIST" >&2
+    exit 1
+fi
+
+if ((node_count != SLURM_JOB_NUM_NODES)); then
+    printf 'Expected %s Slurm nodes, but scontrol returned %s for SLURM_JOB_NODELIST=%s.\n' \
+        "$SLURM_JOB_NUM_NODES" "$node_count" "$SLURM_JOB_NODELIST" >&2
+    exit 1
+fi
 
 head_node=${nodes_array[0]}
 if [[ -n "$RAY_NETWORK_INTERFACE" ]]; then

--- a/tests/special_sanity/test_ray_on_slurm.py
+++ b/tests/special_sanity/test_ray_on_slurm.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SLURM_SCRIPT = REPO_ROOT / "examples" / "tutorial" / "slurm" / "ray_on_slurm.slurm"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _launcher_env(tmp_path: Path, hostnames: str, expected_nodes: int = 2) -> tuple[dict[str, str], Path]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    srun_log = tmp_path / "srun.log"
+
+    _write_executable(
+        fake_bin / "scontrol",
+        """#!/bin/bash
+if [[ "$1" != "show" || "$2" != "hostnames" ]]; then
+    echo "unexpected scontrol arguments: $*" >&2
+    exit 2
+fi
+if [[ -n "${FAKE_SCONTROL_HOSTS:-}" ]]; then
+    printf '%s\n' "$FAKE_SCONTROL_HOSTS"
+fi
+""",
+    )
+    _write_executable(
+        fake_bin / "srun",
+        """#!/bin/bash
+printf '%s\n' "$*" >>"$FAKE_SRUN_LOG"
+if [[ " $* " == *" hostname --ip-address "* ]]; then
+    printf '10.0.0.1\n'
+fi
+""",
+    )
+    _write_executable(fake_bin / "sleep", "#!/bin/bash\nexit 0\n")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "FAKE_SCONTROL_HOSTS": hostnames,
+            "FAKE_SRUN_LOG": str(srun_log),
+            "LC_ALL": "C",
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "RAY_NETWORK_INTERFACE": "",
+            "SLURM_CPUS_PER_TASK": "4",
+            "SLURM_GPUS_PER_NODE": "1",
+            "SLURM_JOB_NODELIST": "node-[a-b]",
+            "SLURM_JOB_NUM_NODES": str(expected_nodes),
+            "SLURM_NNODES": str(expected_nodes),
+        }
+    )
+    return env, srun_log
+
+
+def _run_launcher(tmp_path: Path, hostnames: str, expected_nodes: int = 2) -> tuple[subprocess.CompletedProcess, Path]:
+    env, srun_log = _launcher_env(tmp_path, hostnames, expected_nodes)
+    result = subprocess.run(
+        ["bash", str(SLURM_SCRIPT)],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    return result, srun_log
+
+
+def test_launcher_passes_each_hostname_to_srun(tmp_path: Path):
+    result, srun_log = _run_launcher(tmp_path, "node-a\nnode-b")
+
+    assert result.returncode == 0, result.stderr
+    commands = srun_log.read_text(encoding="utf-8").splitlines()
+    head_command = next(command for command in commands if "ray start --head" in command)
+    worker_command = next(command for command in commands if "ray start --address" in command)
+    assert "-w node-a" in head_command
+    assert "-w node-b" in worker_command
+    assert "Starting HEAD at node-a" in result.stdout
+    assert "Starting WORKER 1 at node-b" in result.stdout
+
+
+def test_launcher_rejects_node_count_mismatch(tmp_path: Path):
+    result, srun_log = _run_launcher(tmp_path, "node-a")
+
+    assert result.returncode == 1
+    assert "Expected 2 Slurm nodes, but scontrol returned 1" in result.stderr
+    assert not srun_log.exists()
+
+
+def test_launcher_rejects_empty_node_list(tmp_path: Path):
+    result, srun_log = _run_launcher(tmp_path, "")
+
+    assert result.returncode == 1
+    assert "scontrol did not return any nodes" in result.stderr
+    assert not srun_log.exists()


### PR DESCRIPTION
### What does this PR do?

Fixes #548 by reading `scontrol show hostnames` output into one Bash array element per allocated node. The Slurm Ray launcher now rejects an empty result or a hostname count that differs from `SLURM_JOB_NUM_NODES` before passing an invalid node constraint to `srun`.

A CPU end-to-end regression test executes the complete launcher with fake Slurm commands and verifies that the head launch receives `-w node-a`, the worker launch receives `-w node-b`, and invalid node lists fail before the first `srun` call.

### Checklist Before Starting

- [x] Confirmed #548 is open and unassigned, with no closing PR.
- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ray_on_slurm
- [x] Searched `ray_on_slurm`, `nodes_array`, `scontrol show hostnames`, `mapfile Slurm`, and the reported error text; no overlapping open PR was found on 2026-08-23.
- [x] Reviewed the two broad Slurm search results, #2530 and #4933; neither changes this launcher or its hostname parsing.
- [x] Reviewed the only `548 in:body` result, #7263; it is an unrelated checkpoint-engine PR whose benchmark contains the number `5.548`.
- [x] PR title passes `tests/special_sanity/check_pr_title.py`.

### Test

```text
pytest -q tests/special_sanity/test_ray_on_slurm.py
3 passed

bash -n examples/tutorial/slurm/ray_on_slurm.slurm
passed

pre-commit run --all-files --show-diff-on-failure --color=always
ruff, ruff-format, mypy, generated config verification, docs metadata,
docstrings, license, device/DataProto checks, test structure, naming, example
naming, uv policy, and compileall passed.
```

The positive regression test was also run against the unchanged `origin/main` launcher and failed as expected because the head hostname contained both lines and the worker hostname was unset.

### API and Usage Example

There is no API or command-line change. Existing Slurm submissions continue to use:

```bash
sbatch examples/tutorial/slurm/ray_on_slurm.slurm
```

### Design & Code Changes

- Replace the single-element `nodes_array=("$nodes")` assignment with Bash `mapfile -t` line parsing.
- Compare the parsed node count with `SLURM_JOB_NUM_NODES` before starting Ray.
- Emit actionable errors for an empty or inconsistent node list.
- Add CPU coverage for correct head/worker placement and both failure paths.

### Compatibility

The launcher remains a Bash script and now uses `mapfile`, which is available in Bash 4 and newer; the issue reporter's Bash 4.4 environment is supported. Local end-to-end tests ran with Bash 5.2, so Bash 4.4 compatibility was verified from the used language features rather than by executing a Bash 4.4 binary. The change affects only invalid multi-line parsing and fail-fast behavior. A valid one-node or multi-node allocation keeps the existing Ray and `srun` command lines.


### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied `pre-commit run --all-files` in a clean worktree.
- [x] Applied pre-commit checks to every changed file.
- [x] Added a CPU end-to-end regression test.
- [x] Human submitter reviewed every changed line and reran the checks.
- [x] Request upstream CI after the PR is opened.
