### PR TITLE
[doc] fix: refresh agentic RL training guide

### DIFF
--- a/docs/start/agentic_rl.rst
+++ b/docs/start/agentic_rl.rst
@@ -1,7 +1,7 @@
 Agentic RL Training
 ===================
 
-Last updated: 07/15/2025.
+Last updated: 08/23/2026.
 
 Overview
 ----------
@@ -62,14 +62,12 @@ Follow :doc:`GSM8K example<../examples/gsm8k_example>` to prepare the dataset an
 
 There are two options required to use agent loop:
 
-- `data.return_raw_chat=True`
-- `actor_rollout_ref.rollout.mode=async`
+- ``data.return_raw_chat=True``
+- ``actor_rollout_ref.rollout.mode=async``
 
-This example uses the sglang inference engine by default, and you can also modify rollout_name to use vllm.
-
-.. code-block:: bash
-
-    bash examples/grpo_trainer/run_qwen3_8b_fsdp.sh
+Use the maintained `Agent Loop get-started tutorial <https://github.com/verl-project/verl/blob/main/examples/tutorial/agent_loop_get_started/agent_loop_tutorial.ipynb>`_
+for a complete asynchronous rollout example. The tutorial supports both vLLM and SGLang; select the backend with
+``rollout_name``. Its training configuration sets the two required options shown above.
 
 
 Multi-turn Conversations and Tool Calls
@@ -77,32 +75,19 @@ Multi-turn Conversations and Tool Calls
 
 Follow :doc:`Multi-turn Rollout Support<../sglang_multiturn/multiturn>` to prepare tool and configuration files.
 
-The Tool Agent Loop has an additional requirement: adding an "agent_name" field to the dataset. During rollout, it will choose to use tool_agent_loop or single_turn_agent (default) based on this field.
+The agent loop can be selected per sample with the dataset's ``agent_name`` field. If that field is absent,
+``actor_rollout_ref.rollout.agent.default_agent_loop`` is used. Set the default to ``tool_agent`` to use tools for
+every sample without modifying the dataset.
 
 Usage Example
 ~~~~~~~~~~~~~
 
-.. code-block:: bash
-
-    # install mlflow to view toolcall and llm trace
-    pip install mlflow
-
-    # This will download and preprocess the GSM8K dataset into ~/data/gsm8k/ and add the "agent_name" field.
-    python examples/data_preprocess/gsm8k_tool_agent_loop.py
-
-    # Start training with tool calls and enabled mlflow based trace helping to debug the rollout details
-    bash examples/sglang_multiturn/run_qwen2_5_3b_gsm8k_tool_agent_mlflow_fsdp.sh
-
-    # When training is done, start a mlflow server to view trace
-    mlflow ui -h 0.0.0.0 -p 5000 --backend-store-uri sqlite:////tmp/mlruns.db
-
-    # then you can open http://<your ip address>:5000 from browser to view trace
+The `end-to-end training section of the Agent Loop tutorial <https://github.com/verl-project/verl/blob/main/examples/tutorial/agent_loop_get_started/agent_loop_tutorial.ipynb>`_
+walks through dataset preparation, tool configuration, asynchronous rollout, and a short ``ToolAgentLoop`` training
+run. It replaces the retired launcher previously referenced here.
 
 
-Note: During training, because the model may sometimes fail to generate correct toolcall tags, an error message "Failed to decode tool call" will be output to the console, which does not indicate an abnormality in training.
-
-
-Follow :doc:`Rollout trace<../advance/rollout_trace>` to known more about trace feature.
+Follow :doc:`Rollout trace<../advance/rollout_trace>` to learn more about the trace feature.
 
 
 
@@ -130,4 +115,5 @@ System Components
 +--------------------------+-----------------------------------------------------------------------------------------------+
 
 
-Follow doc "recipe/langgraph_agent/example/README.md" for more details.
+See the `LangGraph agent example <https://github.com/verl-project/verl-recipe/tree/main/langgraph_agent/example>`_
+for an end-to-end custom agent loop.


### PR DESCRIPTION
### What does this PR do?

Refresh the Agentic RL training guide so that it points to examples that exist and are maintained on the current `main` branch.

- Replace the retired `examples/sglang_multiturn` launcher with the Agent Loop get-started notebook.
- Document the current `agent_name` fallback and `default_agent_loop` behavior.
- Clarify that the tutorial supports both vLLM and SGLang through `rollout_name`.
- Repair the rollout-trace wording and the stale LangGraph recipe reference.

This addresses the stale example and setup path reported in #2812. It does not claim to resolve every historical Python, Ray, uvloop, or SGLang compatibility report in that issue.

### Checklist Before Starting

- [x] Searched [open PR bodies for #2812](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+2812+in%3Abody) and [open PRs for agentic_rl.rst](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+agentic_rl.rst); neither search found overlapping work on 2026-08-23.
- [x] Formatted the title as `[{modules}] {type}: {description}`.

### Test

```bash
cd docs
uv run --isolated --no-project --with-requirements requirements-docs.txt \
  sphinx-build --keep-going -w _build/sphinx.log -b html . _build/html

cd ..
PATH=/home/liuhao/verl/.venv/bin:$PATH \
  pre-commit run --all-files --show-diff-on-failure --color=never
```

- Sphinx build succeeded. The CI error/warning gate was clean, and no warning referenced `docs/start/agentic_rl.rst`.
- All pre-commit hooks passed across the repository.
- Both newly referenced GitHub URLs returned HTTP 200.
- A repository-wide `pytest -q` collection was attempted, but this CPU environment does not contain the optional backend dependencies (`openai`, `flash_attn`, `vllm`, `sglang`, `torch_npu`, `veomni`, and `pynvml`). No Python or runtime code is changed by this PR.

### API and Usage Example

No API change. Readers are directed to the maintained Agent Loop notebook for the executable end-to-end workflow.

### Design & Code Changes

Only `docs/start/agentic_rl.rst` changes. The obsolete inline workflow is replaced with maintained references, while the current configuration semantics are documented next to them.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied pre-commit checks to all files.
- [x] Updated the documentation.
- [x] Unit and end-to-end tests are not applicable to this documentation-only change; the full Sphinx build covers it.
- [ ] Request CI in the project Slack or Feishu channel after the PR is ready.
- [x] Recipe submodule update is not applicable; this PR only links to its current example.

