### PR TITLE
[worker] fix: preserve metadata-only TransferQueue output

### DIFF
--- a/tests/utils/test_transferqueue_utils_on_cpu.py
+++ b/tests/utils/test_transferqueue_utils_on_cpu.py
@@ -16,7 +16,9 @@ import gc
 import os
 
 import pytest
+from tensordict import TensorDict
 
+from verl.utils import tensordict_utils as tu
 from verl.utils import transferqueue_utils as tqu
 
 
@@ -67,3 +69,39 @@ def test_async_bridge_loop_reused_between_calls():
         assert tqu._ASYNC_BRIDGE_LOOP is first_loop
     finally:
         tqu._shutdown_async_bridge_runtime()
+
+
+def test_tqbridge_preserves_metadata_only_output(monkeypatch):
+    class FakeBatchMeta:
+        def __init__(self, size, extra_info):
+            self.size = size
+            self.extra_info = extra_info
+
+    class FakeKVBatchMeta:
+        pass
+
+    class FakeClient:
+        async def async_get_data(self, meta):
+            return TensorDict({}, batch_size=(meta.size,))
+
+    class FakeTransferQueue:
+        def init(self):
+            pass
+
+        def get_client(self):
+            return FakeClient()
+
+    monkeypatch.setattr(tqu, "BatchMeta", FakeBatchMeta)
+    monkeypatch.setattr(tqu, "KVBatchMeta", FakeKVBatchMeta)
+    monkeypatch.setattr(tqu, "tq", FakeTransferQueue())
+    monkeypatch.setattr(tqu, "TQ_INITIALIZED", False)
+
+    @tqu.tqbridge()
+    def metadata_only_stage(batch):
+        output = TensorDict({}, batch_size=batch.batch_size)
+        tu.assign_non_tensor_data(output, "metrics", {"reward": 1.5})
+        return output
+
+    result = metadata_only_stage(FakeBatchMeta(size=2, extra_info={"old": "value"}))
+
+    assert result.extra_info == {"metrics": {"reward": 1.5}}

--- a/verl/utils/transferqueue_utils.py
+++ b/verl/utils/transferqueue_utils.py
@@ -198,7 +198,7 @@ async def _async_update_meta_with_output(output: TensorDict, meta: BatchMeta, fu
         t2 = time.time()
 
         logger.info(f"Task {func_name} (pid={os.getpid()}) is writing to TransferQueue, cost time: {t2 - t1}s)")
-        meta.extra_info = meta_data
+    meta.extra_info = meta_data
     return meta
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes `tqbridge` silently dropping a metadata-only `TensorDict` output. The TrainerV1 `train_mini_batch` path returns metrics in this form, so those metrics could be lost before reaching the controller.

The root cause was that `_async_update_meta_with_output` assigned `meta.extra_info` only when there were TransferQueue payload fields. Metadata-only output has no payload fields, so the original metadata was returned unchanged. The assignment now runs after the conditional, preserving the existing tensor and mixed-output behavior.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr%20_async_update_meta_with_output
- [x] Checked all open PR file lists for both changed files. #7415 is a draft Mooncake refactor that retains this TransferQueue branch; #7000 and #5958 are unrelated.
- [x] Format the PR title as `[worker] fix: ...`.

### Test

- RED before the production change: `python -B -m pytest -q tests/utils/test_transferqueue_utils_on_cpu.py::test_tqbridge_preserves_metadata_only_output` failed because the result retained `{'old': 'value'}` instead of the output metrics.
- `python -B -m pytest -q tests/utils/test_transferqueue_utils_on_cpu.py` — 2 passed, 1 skipped.
- `python -B -m pytest -q tests/workers/test_engine_workers_mini_batch_trace_on_cpu.py` — 2 passed.
- `python -B -m ruff check verl/utils/transferqueue_utils.py tests/utils/test_transferqueue_utils_on_cpu.py` — passed.
- `python -B -m ruff format --check verl/utils/transferqueue_utils.py tests/utils/test_transferqueue_utils_on_cpu.py` — passed.
- `python -B -m pre_commit run --files verl/utils/transferqueue_utils.py tests/utils/test_transferqueue_utils_on_cpu.py --show-diff-on-failure --color=never` — all configured hooks passed.
- `git diff --check` — passed.

### API and Usage Example

No public API or configuration change.

### Design & Code Changes

- Always copy metadata-only output into `BatchMeta.extra_info`.
- Add a CPU regression that drives the real `@tqbridge()` decorator path with a fake TransferQueue client and no payload fields.

### Checklist Before Submitting

- [x] Read the Contribute Guide and repository AI-assisted contribution policy.
- [x] Run relevant tests and configured pre-commit checks.
- [x] Documentation is not required because this is an internal correctness fix with no API/configuration change.
- [x] Add regression coverage in the existing CPU test structure.
- [ ] CI request was not sent; external Slack/Feishu posting is outside this campaign authorization.
- [x] Recipe submodule is not applicable.

### AI assistance and human review

AI assistance was used to identify, implement, and validate this focused fix. The human submitter reviewed every changed line, understood the complete diff, and personally ran or witnessed the listed tests.
