### PR TITLE
[training_utils] fix: validate remove-padding batches by effective length

### DIFF
--- a/tests/utils/test_seqlen_balancing.py
+++ b/tests/utils/test_seqlen_balancing.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
 from verl import DataProto
+from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device
 from verl.utils.model import create_random_mask
 from verl.utils.seqlen_balancing import (
@@ -45,6 +47,75 @@ def test_seqlen_balancing():
     reverse_idx_map = torch.tensor(reverse_idx_map)
     new_batch = batch[reverse_idx_map]
     torch.testing.assert_close(new_batch, dataproto.batch)
+
+
+def test_rearrange_micro_batches_uses_effective_lengths_when_removing_padding():
+    input_ids = torch.arange(2 * 128).reshape(2, 128)
+    attention_mask = torch.zeros((2, 128), dtype=torch.long)
+    attention_mask[:, -16:] = 1
+    batch = DataProto.from_single_dict({"input_ids": input_ids, "attention_mask": attention_mask}).batch
+    tu.assign_non_tensor_data(batch, "use_remove_padding", True)
+
+    micro_batches, micro_bsz_idx_lst = rearrange_micro_batches(batch, max_token_len=20)
+
+    assert len(micro_batches) == 2
+
+    rearranged_batch = torch.cat(micro_batches)
+    rearranged_indices = [idx for micro_bsz_idx in micro_bsz_idx_lst for idx in micro_bsz_idx]
+    reverse_idx_map = torch.tensor(get_reverse_idx(rearranged_indices))
+    torch.testing.assert_close(rearranged_batch[reverse_idx_map], batch)
+
+
+@pytest.mark.parametrize("use_remove_padding", [False, None])
+def test_rearrange_micro_batches_preserves_padded_guard_without_remove_padding(use_remove_padding):
+    input_ids = torch.arange(128).reshape(1, 128)
+    attention_mask = torch.zeros((1, 128), dtype=torch.long)
+    attention_mask[:, -16:] = 1
+    batch = DataProto.from_single_dict({"input_ids": input_ids, "attention_mask": attention_mask}).batch
+    if use_remove_padding is not None:
+        tu.assign_non_tensor_data(batch, "use_remove_padding", use_remove_padding)
+
+    with pytest.raises(AssertionError, match="maximum padded sequence length"):
+        rearrange_micro_batches(batch, max_token_len=20)
+
+
+def test_rearrange_micro_batches_rejects_effective_sequence_over_cap():
+    input_ids = torch.arange(2 * 128).reshape(2, 128)
+    attention_mask = torch.zeros((2, 128), dtype=torch.long)
+    attention_mask[0, -16:] = 1
+    attention_mask[1, -21:] = 1
+    batch = DataProto.from_single_dict({"input_ids": input_ids, "attention_mask": attention_mask}).batch
+    tu.assign_non_tensor_data(batch, "use_remove_padding", True)
+
+    with pytest.raises(AssertionError, match="maximum effective sequence length"):
+        rearrange_micro_batches(batch, max_token_len=20)
+
+
+def test_rearrange_micro_batches_rejects_nested_effective_sequence_over_cap():
+    input_ids = torch.nested.nested_tensor([torch.arange(4), torch.arange(7)], layout=torch.jagged)
+    attention_mask = torch.nested.nested_tensor(
+        [torch.ones(4, dtype=torch.long), torch.ones(7, dtype=torch.long)], layout=torch.jagged
+    )
+    batch = tu.get_tensordict({"input_ids": input_ids, "attention_mask": attention_mask})
+
+    with pytest.raises(AssertionError, match="maximum effective sequence length"):
+        rearrange_micro_batches(batch, max_token_len=6)
+
+
+@pytest.mark.parametrize("use_remove_padding", [True, False, None])
+def test_rearrange_micro_batches_uses_nested_tensor_offsets(use_remove_padding):
+    input_ids = torch.nested.nested_tensor([torch.arange(4), torch.arange(6)], layout=torch.jagged)
+    attention_mask = torch.nested.nested_tensor(
+        [torch.ones(4, dtype=torch.long), torch.ones(6, dtype=torch.long)], layout=torch.jagged
+    )
+    batch = tu.get_tensordict({"input_ids": input_ids, "attention_mask": attention_mask})
+    if use_remove_padding is not None:
+        tu.assign_non_tensor_data(batch, "use_remove_padding", use_remove_padding)
+
+    micro_batches, micro_bsz_idx_lst = rearrange_micro_batches(batch, max_token_len=6)
+
+    assert len(micro_batches) == 2
+    assert sorted(idx for micro_bsz_idx in micro_bsz_idx_lst for idx in micro_bsz_idx) == [0, 1]
 
 
 def test_dynamic_batch():

--- a/tests/utils/test_seqlen_balancing_on_cpu.py
+++ b/tests/utils/test_seqlen_balancing_on_cpu.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from verl import DataProto
+from verl.utils import tensordict_utils as tu
+from verl.utils.seqlen_balancing import rearrange_micro_batches
+
+
+def _uneven_effective_length_worker(rank, world_size, rendezvous_file):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=5),
+    )
+    try:
+        effective_length = (16, 21)[rank]
+        input_ids = torch.arange(128).reshape(1, 128)
+        attention_mask = torch.zeros((1, 128), dtype=torch.long)
+        attention_mask[:, -effective_length:] = 1
+        batch = DataProto.from_single_dict({"input_ids": input_ids, "attention_mask": attention_mask}).batch
+        tu.assign_non_tensor_data(batch, "use_remove_padding", True)
+
+        with (
+            patch("verl.utils.seqlen_balancing.get_device_name", return_value="cpu"),
+            pytest.raises(AssertionError, match="max_seq_len=21"),
+        ):
+            rearrange_micro_batches(batch, max_token_len=20, dp_group=dist.group.WORLD, same_micro_num_in_dp=True)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+def test_effective_length_guard_is_synchronized_across_dp_ranks(tmp_path):
+    world_size = 2
+    rendezvous_file = str(tmp_path / "seqlen_balancing_rdzv")
+    mp.spawn(
+        _uneven_effective_length_worker,
+        args=(world_size, rendezvous_file),
+        nprocs=world_size,
+        join=True,
+    )

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -376,14 +376,14 @@ def rearrange_micro_batches(
     input_ids = batch["input_ids"]
     if input_ids.is_nested:
         seq_len_effective: torch.Tensor = input_ids.offsets().diff()
-        max_seq_len = max(seq_len_effective)
     else:
-        max_seq_len = batch["attention_mask"].shape[-1]
         seq_len_effective: torch.Tensor = batch["attention_mask"].sum(dim=1)
 
-    assert max_token_len >= max_seq_len, (
-        f"max_token_len must be greater than the sequence length. Got {max_token_len=} and {max_seq_len=}"
+    use_effective_seq_len = input_ids.is_nested or tu.get_non_tensor_data(
+        batch, key="use_remove_padding", default=False
     )
+    max_seq_len = seq_len_effective.max().item() if use_effective_seq_len else batch["attention_mask"].shape[-1]
+    seq_len_kind = "effective" if use_effective_seq_len else "padded"
 
     # Validate force_group_size
     batch_size = len(seq_len_effective)
@@ -400,9 +400,14 @@ def rearrange_micro_batches(
         # used to support pp
         num_micro_batches = max(min_num_micro_batch, num_micro_batches)
     if dist.is_initialized() and same_micro_num_in_dp and dp_group is not None:
-        num_micro_batches = torch.tensor([num_micro_batches], device=get_device_name())
-        dist.all_reduce(num_micro_batches, op=dist.ReduceOp.MAX, group=dp_group)
-        num_micro_batches = num_micro_batches.cpu().item()
+        sync_values = torch.tensor([num_micro_batches, max_seq_len], dtype=torch.long, device=get_device_name())
+        dist.all_reduce(sync_values, op=dist.ReduceOp.MAX, group=dp_group)
+        num_micro_batches, max_seq_len = sync_values.cpu().tolist()
+
+    assert max_token_len >= max_seq_len, (
+        f"max_token_len must be greater than or equal to the maximum {seq_len_kind} sequence length. "
+        f"Got {max_token_len=} and {max_seq_len=}"
+    )
     if num_batches_divided_by is not None:
         num_micro_batches = roundup_divisible(num_micro_batches, num_batches_divided_by)
 


### PR DESCRIPTION
### What does this PR do?

Fixes #3088.

`rearrange_micro_batches` currently rejects a dense padded batch when its
padded width exceeds `max_token_len`, even when padding is removed and every
sample's effective token count fits the limit. The same function then uses
effective lengths for micro-batch sizing and partitioning, so the initial guard
does not match the remove-padding workload.

This change:

- validates effective lengths for nested inputs and dense inputs with
  `use_remove_padding=True`;
- preserves the padded-width guard for dense inputs that retain padding or omit
  the metadata;
- synchronizes the selected maximum through the existing DP `MAX` collective
  before applying the guard, so uneven local lengths cannot strand another
  rank in the collective; and
- adds focused layout/metadata tests plus a two-rank Gloo regression test.

This changes only the single-sequence admission guard. It does not change the
partitioning algorithm or claim aggregate post-partition cap enforcement.

### Checklist Before Starting

- [x] Searched for similar PRs: [issue number](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+3088+in%3Abody) and [guard semantics](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+rearrange_micro_batches+max_token_len).
- [x] Formatted the title as `[{modules}] {type}: {description}`.

No open PR implements this padded-versus-effective admission guard. Related
PR #6735 handles aggregate token totals after partitioning, #7506 adds a
single-micro-batch fast path, and #7097 optimizes later jagged TensorDict
materialization. They are not duplicate fixes.

### Test

```bash
PYTHONPATH="$PWD" /home/liuhao/verl/.venv/bin/python -m pytest -q \
  -p no:cacheprovider \
  tests/utils/test_seqlen_balancing_on_cpu.py \
  tests/utils/test_seqlen_balancing.py \
  --deselect=tests/utils/test_seqlen_balancing.py::test_seqlen_balancing_distributed_params
```

Result: `15 passed, 1 deselected`. The deselected existing case requires two
accelerators; all nine new regression cases passed.

```bash
/home/liuhao/verl/.venv/bin/pre-commit run --files \
  verl/utils/seqlen_balancing.py \
  tests/utils/test_seqlen_balancing.py \
  tests/utils/test_seqlen_balancing_on_cpu.py \
  --show-diff-on-failure
```

Result: all hooks passed for the exact three-file change.

The repository-wide pytest command was also attempted, but collection stopped
with 10 optional-dependency/environment errors. An unchanged `origin/main`
worktree produced the same 10 error nodes, 6 skips, and 33 warnings. A continued
CPU-workflow comparison likewise had identical failure/error/skip node sets;
this branch had one additional pass from the new Gloo test. This PR therefore
does not claim a green repository-wide run or NCCL/HCCL/NPU coverage.

### API and Usage Example

There is no function-signature, configuration, CLI, or serialized-data change.
Existing callers require no changes.

### Design & Code Changes

- Reuse the already-computed per-sample effective lengths.
- Select the guard using the nested layout or existing
  `use_remove_padding` TensorDict metadata.
- Preserve the conservative padded guard for all other dense inputs.
- Reuse the existing DP collective to synchronize the selected maximum before
  any rank applies the guard.
- Cover every layout/metadata branch and uneven DP-rank lengths.

The remove-padding branch adds one local `.max().item()` synchronization. The
function already synchronizes token totals and partition materialization; the
DP path widens its existing scalar `int64 MAX` payload to two values without
adding another collective.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Run `pre-commit run --all-files`; focused hooks for every changed file passed as recorded above.
- [x] Documentation update is not applicable: there is no public API or configuration change.
- [x] Added CI-discoverable CPU and accelerator-workflow regression coverage; no workflow edit is required.
- [ ] Request CI in the community channel after maintainer triage.
- [x] Recipe submodule update is not applicable.

