### PR TITLE
[megatron, ckpt] fix: restore legacy merger config discovery

### DIFF
--- a/scripts/legacy_model_merger.py
+++ b/scripts/legacy_model_merger.py
@@ -93,6 +93,8 @@ class ModelMergerConfig:
 
 
 class BaseModelMerger(ABC):
+    _legacy_hf_model_config_subdir = None
+
     def __init__(self, config: ModelMergerConfig):
         self.config = config
         self.hf_model_config_path = config.hf_model_config_path
@@ -103,15 +105,18 @@ class BaseModelMerger(ABC):
             )
             self.hf_model_config_path = config.hf_model_path
 
-        # Auto-detect the huggingface subdirectory.  v2 Megatron layout
-        # nests it under model/huggingface; v1 (FSDP or pre-refactor
-        # Megatron) places it directly under the checkpoint root.
+        # Auto-detect the HuggingFace artifacts saved by each checkpoint layout.
         v2_subdir = os.path.join(self.hf_model_config_path, "model", "huggingface")
         v1_subdir = os.path.join(self.hf_model_config_path, "huggingface")
+        legacy_subdir = None
+        if self._legacy_hf_model_config_subdir and config.hf_model_path is None:
+            legacy_subdir = os.path.join(self.hf_model_config_path, self._legacy_hf_model_config_subdir)
         if os.path.isdir(v2_subdir):
             self.hf_model_config_path = v2_subdir
         elif os.path.isdir(v1_subdir):
             self.hf_model_config_path = v1_subdir
+        elif legacy_subdir and os.path.isdir(legacy_subdir):
+            self.hf_model_config_path = legacy_subdir
 
         self.model_config = AutoConfig.from_pretrained(self.hf_model_config_path)
 
@@ -439,11 +444,9 @@ class FSDPModelMerger(BaseModelMerger):
 
 
 class MegatronModelMerger(BaseModelMerger):
-    def __init__(self, config: ModelMergerConfig):
-        from verl.utils.megatron_utils import \
-            get_hf_config_and_tokenizer_checkpoint_path
+    _legacy_hf_model_config_subdir = "hf_config_and_tokenizer"
 
-        config.hf_model_config_path = get_hf_config_and_tokenizer_checkpoint_path(config.local_dir)
+    def __init__(self, config: ModelMergerConfig):
         super().__init__(config)
 
         self.params_mapping = {

--- a/tests/model_merger/test_legacy_model_merger_on_cpu.py
+++ b/tests/model_merger/test_legacy_model_merger_on_cpu.py
@@ -1,0 +1,159 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+import torch
+
+from scripts.legacy_model_merger import FSDPModelMerger, MegatronModelMerger, ModelMergerConfig
+
+
+def _write_model_config(path):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(
+        json.dumps({"architectures": ["GPT2LMHeadModel"], "model_type": "gpt2"}), encoding="utf-8"
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_config_dir",
+    ("hf_config_and_tokenizer", "huggingface", "model/huggingface"),
+)
+def test_megatron_merger_finds_checkpoint_model_config(tmp_path, relative_config_dir):
+    config_dir = tmp_path / relative_config_dir
+    _write_model_config(config_dir)
+
+    merger = MegatronModelMerger(
+        ModelMergerConfig(
+            operation="merge",
+            backend="megatron",
+            local_dir=str(tmp_path),
+            hf_model_config_path=str(tmp_path),
+        )
+    )
+
+    assert merger.hf_model_config_path == str(config_dir)
+
+
+def test_megatron_merger_respects_explicit_hf_model_path(tmp_path):
+    checkpoint_dir = tmp_path / "checkpoint"
+    explicit_config_dir = tmp_path / "model-config"
+    _write_model_config(checkpoint_dir / "hf_config_and_tokenizer")
+    _write_model_config(explicit_config_dir)
+    _write_model_config(explicit_config_dir / "hf_config_and_tokenizer")
+
+    merger = MegatronModelMerger(
+        ModelMergerConfig(
+            operation="merge",
+            backend="megatron",
+            local_dir=str(checkpoint_dir),
+            hf_model_config_path=str(checkpoint_dir),
+            hf_model_path=str(explicit_config_dir),
+        )
+    )
+
+    assert merger.hf_model_config_path == str(explicit_config_dir)
+
+
+def test_fsdp_merger_ignores_megatron_config_subdirectory(tmp_path):
+    _write_model_config(tmp_path)
+    _write_model_config(tmp_path / "hf_config_and_tokenizer")
+
+    merger = FSDPModelMerger(
+        ModelMergerConfig(
+            operation="merge",
+            backend="fsdp",
+            local_dir=str(tmp_path),
+            hf_model_config_path=str(tmp_path),
+        )
+    )
+
+    assert merger.hf_model_config_path == str(tmp_path)
+
+
+def test_megatron_merger_prefers_current_checkpoint_layout(tmp_path):
+    legacy_config_dir = tmp_path / "hf_config_and_tokenizer"
+    v1_config_dir = tmp_path / "huggingface"
+    v2_config_dir = tmp_path / "model" / "huggingface"
+    for config_dir in (legacy_config_dir, v1_config_dir, v2_config_dir):
+        _write_model_config(config_dir)
+
+    merger = MegatronModelMerger(
+        ModelMergerConfig(
+            operation="merge",
+            backend="megatron",
+            local_dir=str(tmp_path),
+            hf_model_config_path=str(tmp_path),
+        )
+    )
+
+    assert merger.hf_model_config_path == str(v2_config_dir)
+
+
+def test_megatron_merger_prefers_v1_over_pre_v1_layout(tmp_path):
+    legacy_config_dir = tmp_path / "hf_config_and_tokenizer"
+    v1_config_dir = tmp_path / "huggingface"
+    _write_model_config(legacy_config_dir)
+    _write_model_config(v1_config_dir)
+
+    merger = MegatronModelMerger(
+        ModelMergerConfig(
+            operation="merge",
+            backend="megatron",
+            local_dir=str(tmp_path),
+            hf_model_config_path=str(tmp_path),
+        )
+    )
+
+    assert merger.hf_model_config_path == str(v1_config_dir)
+
+
+def test_megatron_merger_uses_checkpoint_root_as_fallback(tmp_path):
+    _write_model_config(tmp_path)
+
+    merger = MegatronModelMerger(
+        ModelMergerConfig(
+            operation="merge",
+            backend="megatron",
+            local_dir=str(tmp_path),
+            hf_model_config_path=str(tmp_path),
+        )
+    )
+
+    assert merger.hf_model_config_path == str(tmp_path)
+
+
+def test_megatron_merger_loads_pre_dist_checkpoint_shards(monkeypatch, tmp_path):
+    _write_model_config(tmp_path / "hf_config_and_tokenizer")
+    shard_dir = tmp_path / "model" / "mp_rank_00"
+    shard_dir.mkdir(parents=True)
+    embedding = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    torch.save([{"embedding.word_embeddings.weight": embedding}], shard_dir / "model.pt")
+
+    merger = MegatronModelMerger(
+        ModelMergerConfig(
+            operation="merge",
+            backend="megatron",
+            local_dir=str(tmp_path),
+            hf_model_config_path=str(tmp_path),
+        )
+    )
+    saved_state_dict = {}
+    monkeypatch.setattr(merger, "save_hf_model_and_tokenizer", saved_state_dict.update)
+
+    merger.merge_and_save()
+
+    assert set(saved_state_dict) == {"model.embed_tokens.weight"}
+    torch.testing.assert_close(saved_state_dict["model.embed_tokens.weight"], embedding)


### PR DESCRIPTION
### What does this PR do?

Fixes #6065.

The legacy Megatron merger imports
`get_hf_config_and_tokenizer_checkpoint_path`, which has been removed from
`verl.utils.megatron_utils`. As a result, it raises `ImportError` before
loading a checkpoint or reaching any Transformers serialization code.

This PR resolves the pre-v1 `hf_config_and_tokenizer` layout through the
shared model-configuration resolver. It preserves the existing precedence for
an explicit `--hf_model_path`, v2 `model/huggingface`, v1 `huggingface`, and
checkpoint-root fallbacks. The new pre-v1 fallback is Megatron-specific and
does not change FSDP behavior.

This is not a Transformers-version pin: the regression reproduces on current
`main`, and the fix passes with the repository's current Transformers version.

### Checklist Before Starting

- [x] Searched for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6065+in%3Abody
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22get_hf_config_and_tokenizer_checkpoint_path%22
- [x] This does not duplicate #4496, which removes the entire legacy path, or
  #4701, which only changes VLM key validation.
- [x] PR title follows the required format.

### Test

```bash
python -m pytest -q -p no:cacheprovider \
  tests/model_merger/test_legacy_model_merger_on_cpu.py \
  tests/model_merger/test_output_validation_on_cpu.py
# 25 passed, 21 warnings

python scripts/legacy_model_merger.py --help
# passed

pre-commit run --all-files --show-diff-on-failure
# all hooks passed

pre-commit run --files scripts/legacy_model_merger.py \
  tests/model_merger/test_legacy_model_merger_on_cpu.py
# all hooks passed
```

Repository-wide `pytest -q` stops during collection in both this branch and
clean `main` with the same 10 errors and 6 skips because this local environment
lacks optional OpenAI, FlashAttention, vLLM/SGLang, NPU, VeOmni, and TRTLLM
dependencies, plus an existing duplicate test-module basename.

The CPU-workflow discovery A/B comparison was also baseline-identical:

- Candidate: 1047 passed, 13 failed, 13 errors, 55 skipped.
- Clean `main`: 1038 passed, 13 failed, 13 errors, 55 skipped.
- Failure, error, and skip node-ID sets were identical. The nine additional
  candidate cases are the new regression tests, and all nine passed.

### API and Usage Example

No API change. Existing legacy Megatron merger commands continue to work:

```bash
python scripts/legacy_model_merger.py merge \
  --backend megatron \
  --local_dir <checkpoint> \
  --target_dir <output>
```

### Design & Code Changes

- Add a class-scoped legacy configuration subdirectory to the shared resolver.
- Enable `hf_config_and_tokenizer` discovery only for `MegatronModelMerger`.
- Preserve explicit-path and current checkpoint-layout precedence.
- Add nine CPU cases, including a real minimal pre-dist-checkpoint shard merge.

### AI Assistance Disclosure

This PR was developed with OpenAI Codex assistance. I reviewed every changed
line, reran the relevant tests listed above, and can defend the change
end-to-end.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied pre-commit checks.
- [x] Documentation is unchanged because the existing checkpoint guide already
  directs older checkpoints to the legacy merger.
- [x] Added an automatically collected `test_*_on_cpu.py` regression suite.
- [ ] Send the CI request when the PR is ready for CI.
- [x] Not applicable to the `recipe` submodule.
