### PR TITLE
[misc] fix: handle zero-element numpy serialization

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1007,6 +1007,23 @@ def test_serialize_deserialize_single_tensor():
     assert original_tensor.dtype == reconstructed_tensor.dtype
 
 
+@pytest.mark.parametrize("shape", [(0,), (0, 3), (2, 0)])
+def test_numpy_serialization_round_trips_zero_element_tensor(monkeypatch, shape):
+    """A DataProto field with no elements must round-trip through the NumPy serializer."""
+    import pickle
+
+    monkeypatch.setenv("VERL_DATAPROTO_SERIALIZATION_METHOD", "numpy")
+    original = torch.empty(shape, dtype=torch.float32)
+    data = DataProto.from_dict(tensors={"empty": original})
+
+    restored = pickle.loads(pickle.dumps(data))
+
+    assert restored.batch.batch_size == data.batch.batch_size
+    assert restored.batch["empty"].shape == original.shape
+    assert restored.batch["empty"].dtype == original.dtype
+    assert torch.equal(restored.batch["empty"], original)
+
+
 def test_serialize_deserialize_tensordict_regular_tensors():
     """Test serialization and deserialization of TensorDict with regular tensors"""
     # Create test data

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -265,6 +265,9 @@ def deserialize_single_tensor(arr: Any) -> torch.Tensor:
     torch_dtype = getattr(torch, dtype)
     assert isinstance(torch_dtype, torch.dtype)
 
+    if len(data) == 0:
+        return torch.empty(shape, dtype=torch_dtype)
+
     buffer = bytearray(data)
     # Create uint8 array
     arr = torch.frombuffer(buffer, dtype=torch.uint8)


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the opt-in NumPy `DataProto` serializer when a TensorDict contains a field with zero elements. Serialization produces an empty `uint8` array, but deserialization passed that empty buffer to `torch.frombuffer`, which raises `ValueError`.

The fix reconstructs an empty CPU tensor from the encoded shape and dtype only when the serialized byte buffer is empty. Non-empty decoding is unchanged. This is distinct from #4379, which handles a TensorDict with no fields; this PR handles a TensorDict that has a field whose tensor has `numel() == 0`. #3425 introduced the opt-in serializer.

### Checklist Before Starting

- [x] Searched [all PRs for the serializer symbol](https://github.com/verl-project/verl/pulls?q=is%3Apr+deserialize_single_tensor) and related issues; no competing implementation was found.
- [x] Formatted the title as `[misc] fix: ...`.

### Test

- `PYTHONPATH=. python -m pytest tests/test_protocol_on_cpu.py -q` — 40 passed (one existing PyTorch nested-tensor warning).
- `python -m pre_commit run --files verl/protocol.py tests/test_protocol_on_cpu.py` — passed.

### API and Usage Example

No public API changes. The existing `VERL_DATAPROTO_SERIALIZATION_METHOD=numpy` path now also round-trips zero-element tensor fields.

### Design & Code Changes

- Return `torch.empty(shape, dtype=dtype)` before calling `torch.frombuffer` for zero-byte serialized data.
- Add CPU regression coverage for `(0,)`, `(0, 3)`, and `(2, 0)` tensor shapes through a full `DataProto` pickle round trip.

### AI Assistance

This patch was prepared with AI assistance. The submitter personally reviewed every changed line and ran or witnessed the listed tests.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Applied pre-commit checks to the changed files.
- [x] Added CPU unit-test coverage for the changed behavior.
- [x] Documentation is not needed because this makes no API or usage change.
- [ ] CI request was not sent because no Slack or Feishu access was requested.