### PR TITLE
[doc] refactor: reframe Megatron Lite doc as Megatron Agent Compose preview

### DIFF
--- a/docs/advance/megatron_lite_backend.rst
+++ b/docs/advance/megatron_lite_backend.rst
@@ -1,33 +1,25 @@
-Megatron Lite backend
-=====================
+Experimental Megatron Agent Compose preview
+===========================================
 
-Last updated: 06/17/2026.
+Last updated: 07/28/2026.
 
-Megatron Lite (``mlite``) is Megatron's experimental, agent-friendly training
-path for work that needs to move quickly. It is optimized for fast iteration,
-small reviewable changes, and agentic development: model/runtime code can be
-changed without touching unrelated Megatron subsystems, and new experiments can
-live in their own source checkout instead of being copied into the verl tree.
-
-The verl integration intentionally keeps the backend glue outside this
-repository. The ``mlite`` checkout provides ``megatron.lite`` and the
-``verl_mlite`` launcher/config package used by the example scripts here. Put
-custom extensions in your own code path, add that path through ``MLITE_ROOT`` or
-``PYTHONPATH``, and keep verl focused on orchestration. See the upstream
-Megatron Lite path at
-`NVIDIA/Megatron-LM experimental/lite <https://github.com/NVIDIA/Megatron-LM/tree/dev/experimental/lite>`_.
-
-For the ``dist_opt`` optimizer path, Megatron Lite is intended to preserve
-Megatron-Core behavior rather than trade correctness for flexibility. In
-deterministic runs, the ``mlite`` path has been validated against the
-Megatron-Core distributed optimizer path with bitwise-aligned loss and gradient
-norms, and its step time / throughput are also aligned with the Core path.
-
-Install the backend
+Current naming note
 -------------------
 
-Clone Megatron-LM's upstream ``dev`` branch and install its Megatron Lite verl
-integration:
+`Megatron Agent Compose <https://github.com/NVIDIA/Megatron-LM/tree/main/experimental/agent_compose>`_
+is the intended upstream experimental path. Its previous name, under hot
+development, was
+`Megatron Lite <https://github.com/NVIDIA/Megatron-LM/tree/dev/experimental/lite>`_.
+
+The current development preview still uses legacy names such as ``mlite``,
+``megatron.lite``, ``verl_mlite``, ``MLITE_ROOT``, and ``megatron_lite`` script
+names. Treat those as preview implementation details that will be changed. The
+reviewed upstream namespace is ``megatron.experimental.agent_compose``.
+
+Evaluate the development preview
+--------------------------------
+
+Clone Megatron-LM's ``dev`` branch and install the current verl preview glue:
 
 .. code-block:: bash
 
@@ -35,34 +27,39 @@ integration:
    pip install -e Megatron-LM/experimental/lite/examples/verl
 
 Alternatively, keep the checkout outside the Python environment and set
-``MLITE_ROOT`` when running a launcher. The scripts add both
-``$MLITE_ROOT/experimental/lite`` and
-``$MLITE_ROOT/experimental/lite/examples/verl`` to ``PYTHONPATH``.
+``MLITE_ROOT`` when running a launcher. The current scripts add the preview
+paths to ``PYTHONPATH`` at runtime.
 
-Run an example
---------------
+Run an evaluation example
+-------------------------
 
-The DeepSeek-V4 examples use the ``mlite`` engine for training and vLLM for
-rollout where applicable:
+The current DeepSeek-V4 examples exercise the development-preview training path
+with vLLM rollout where applicable:
 
 .. code-block:: bash
 
    MODEL_PATH=/path/to/deepseek-v4 \
-   MLITE_ROOT=/path/to/mlite \
+   MLITE_ROOT=/path/to/Megatron-LM \
    OPTIMIZER=fsdp2 \
    bash examples/sft/gsm8k/run_deepseek_v4_megatron_lite.sh
 
 .. code-block:: bash
 
    MODEL_PATH=/path/to/deepseek-v4 \
-   MLITE_ROOT=/path/to/mlite \
+   MLITE_ROOT=/path/to/Megatron-LM \
    OPTIMIZER=fsdp2 \
    bash examples/grpo_trainer/run_deepseek_v4_megatron_lite.sh
 
 ``OPTIMIZER`` accepts ``dist_opt`` for the vanilla Megatron distributed
-optimizer and ``fsdp2`` for the Megatron Lite FSDP2 wrapper. The DeepSeek-V4
+optimizer and ``fsdp2`` for the preview's FSDP2 wrapper. The DeepSeek-V4
 launchers default to a 128-GPU mesh with PP4, EP8, CP4, full activation
 recompute, and ``fsdp2``.
+
+For the ``dist_opt`` optimizer path, the preview is intended to preserve
+Megatron-Core behavior rather than trade correctness for flexibility. In
+deterministic runs, the ``mlite`` path has been validated against the
+Megatron-Core distributed optimizer path with bitwise-aligned loss and gradient
+norms, and its step time / throughput are also aligned with the Core path.
 
 Further reading
 ---------------
@@ -75,7 +72,6 @@ DeepSeek-V4 DSA note
 --------------------
 
 DeepSeek-V4 uses fused DSA kernels on Hopper and Blackwell GPUs. In addition to
-the normal verl runtime, the critical DSA-only dependencies are
-``nvidia-cutlass-dsl==4.5.2`` and ``nvidia-cudnn-frontend``. The
-``nvidia-cudnn-frontend`` 1.24.1 release is sufficient for Blackwell, while
-Hopper still needs a develop-branch build with ``IndexerForwardSm90`` support.
+the normal verl runtime dependencies, current DSA-only dependencies include
+``nvidia-cutlass-dsl`` and ``nvidia-cudnn-frontend``. Keep exact version
+guidance close to the launcher or environment file that validates it.


### PR DESCRIPTION
### What does this PR do?

Reframes `docs/advance/megatron_lite_backend.rst` around **Megatron Agent Compose**, the intended
upstream experimental path in Megatron-LM. "Megatron Lite" was the name this component carried
during hot development; the doc previously described it exclusively under that name, which no longer
matches where the code is heading upstream.

The doc now leads with a **naming note** that maps the legacy identifiers the development preview
still ships (`mlite`, `megatron.lite`, `verl_mlite`, `MLITE_ROOT`, `megatron_lite` script names) onto
the reviewed upstream namespace `megatron.experimental.agent_compose`, so readers can follow the
current scripts without treating those names as stable API.

Two content fixes ride along:

- `MLITE_ROOT` in the examples pointed at `/path/to/mlite`. It is the **Megatron-LM** checkout — the
  launchers append `experimental/lite` themselves — so the placeholder was misleading. Now
  `/path/to/Megatron-LM`.
- The DSA note pinned `nvidia-cutlass-dsl==4.5.2` and called out `nvidia-cudnn-frontend` 1.24.1 /
  `IndexerForwardSm90`. Those versions move faster than the doc does; the note now names the
  dependencies and defers exact versions to the launcher / environment file that actually validates
  them.

Substantive technical content is preserved: the `OPTIMIZER` value reference, the DeepSeek-V4 launcher
defaults, the `dist_opt` bitwise-alignment result against Megatron-Core, and the long-context MoE RL
tuning writeup under Further reading all remain.

Doc-only change. No code, config, or example scripts touched.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  https://github.com/verl-project/verl/pulls?q=is%3Apr+megatron+lite+doc
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

No runtime behavior changes. Verified locally:

- `python3 tests/special_sanity/check_docs_time_info.py` — passes (`Last updated: 07/28/2026.` present)
- naming-convention hook (`veRL` / `Sglang` grep) — passes; the doc uses `verl` throughout
- `sphinx-build --keep-going` over the changed file — builds with zero warnings and zero errors, so
  the `doc_test` workflow's `: ERROR:` / toctree / inline-emphasis / definition-list grep gates are clean
- The file keeps its existing name, so its `docs/index.rst` toctree entry is unchanged; the sidebar
  label follows the new document title automatically

### API and Usage Example

No API change. The documented invocation is unchanged apart from the corrected `MLITE_ROOT` placeholder:

```bash
MODEL_PATH=/path/to/deepseek-v4 \
MLITE_ROOT=/path/to/Megatron-LM \
OPTIMIZER=fsdp2 \
bash examples/grpo_trainer/run_deepseek_v4_megatron_lite.sh
```

### Design & Code Changes

Single file, `docs/advance/megatron_lite_backend.rst`:

| Section | Change |
| --- | --- |
| Title | `Megatron Lite backend` → `Experimental Megatron Agent Compose preview`; date bumped to 07/28/2026 |
| Current naming note | **New.** Agent Compose vs. Megatron Lite, plus the legacy-identifier map |
| Evaluate the development preview | Former "Install the backend"; preview framing, `PYTHONPATH` detail condensed |
| Run an evaluation example | Former "Run an example"; `MLITE_ROOT` placeholder fixed. `OPTIMIZER` reference and `dist_opt` fidelity paragraph retained here |
| Further reading | Unchanged |
| DeepSeek-V4 DSA note | Pinned versions replaced with a pointer to the validating launcher / env file |

The filename stays `megatron_lite_backend.rst` deliberately — renaming it would break inbound links
while the upstream rename is still in flight. It can follow once the `agent_compose` path lands on
`main`.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] Apply pre-commit checks: `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update the documentation. (This PR *is* the documentation update.)
- [ ] Add unit or end-to-end test(s) to the CI workflow. Not feasible: doc-only change with no
      executable surface. Covered by the existing `doc_test` and `pre-commit` workflows.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] Not related to the `recipe` submodule.
