### PR TITLE
[vllm, hardware] fix: support modular FusedMoE on NPU

### DIFF
--- a/tests/utils/test_npu_vllm_patch_on_cpu.py
+++ b/tests/utils/test_npu_vllm_patch_on_cpu.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import Mock
+
+
+def _load_npu_vllm_patch_module():
+    module_path = Path(__file__).parents[2] / "verl" / "utils" / "vllm" / "npu_vllm_patch.py"
+    spec = importlib.util.spec_from_file_location("test_npu_vllm_patch", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_apply_npu_vllm_patches_accepts_modular_fused_moe(monkeypatch):
+    npu_vllm_patch = _load_npu_vllm_patch_module()
+    monkeypatch.setattr(npu_vllm_patch, "is_torch_npu_available", lambda check_device=False: True)
+    rotary_patch = Mock()
+    monkeypatch.setattr(npu_vllm_patch, "patch_vllm013_rotary_emb", rotary_patch)
+
+    vllm = ModuleType("vllm")
+    model_executor = ModuleType("vllm.model_executor")
+    layers = ModuleType("vllm.model_executor.layers")
+    fused_moe = ModuleType("vllm.model_executor.layers.fused_moe")
+    fused_moe.FusedMoEFactory = lambda *args, **kwargs: None
+    layers.fused_moe = fused_moe
+
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor", model_executor)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.layers", layers)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.layers.fused_moe", fused_moe)
+
+    npu_vllm_patch.apply_npu_vllm_patches()
+
+    rotary_patch.assert_called_once_with()

--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -80,7 +80,7 @@ def apply_npu_vllm_patches() -> None:
         return
 
     # Disable flash_attn in RotaryEmbedding (NPU)
-    from vllm.model_executor.layers.fused_moe import FusedMoE
+    from vllm.model_executor.layers import fused_moe
 
     patch_vllm013_rotary_emb()
-    _patch_legacy_fused_moe_weight_loader(FusedMoE)
+    _patch_legacy_fused_moe_weight_loader(getattr(fused_moe, "FusedMoE", None))


### PR DESCRIPTION
### What does this PR do?

Fix NPU startup with modular vLLM releases that expose `FusedMoEFactory` but no longer export the legacy `FusedMoE` class.

`apply_npu_vllm_patches()` previously imported `FusedMoE` unconditionally, so importing `verl.utils.vllm` failed before the existing legacy-class guard could run. This PR imports the `fused_moe` module and passes its optional `FusedMoE` attribute to that guard. Modular vLLM therefore skips only the obsolete class-level weight-loader patch while retaining the NPU rotary embedding patch.

This is not a duplicate: searches for open PRs and issues using `FusedMoE NPU`, `cannot import FusedMoE`, and `modular FusedMoE NPU` returned no matches.

### Checklist Before Starting

- [x] Searched for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+FusedMoE+NPU
- [x] Formatted the PR title as `[{modules}] {type}: {description}`.

### Test

Before the fix:

```text
python3 -m pytest -q tests/utils/test_npu_vllm_patch_on_cpu.py
ImportError: cannot import name 'FusedMoE' from 'vllm.model_executor.layers.fused_moe'
```

After the fix:

```text
python3 -m pytest -q tests/utils/test_npu_vllm_patch_on_cpu.py
1 passed in 3.08s

pre-commit run --all-files --show-diff-on-failure --color=always
All hooks passed
```

### API and Usage Example

No API change. Importing `verl.utils.vllm` on NPU with modular vLLM no longer raises an `ImportError`.

### Design & Code Changes

- Detect the optional legacy `FusedMoE` class at runtime.
- Preserve the existing weight-loader patch for class-based vLLM versions.
- Skip only the inapplicable legacy patch on factory-based modular vLLM versions.
- Add a CPU regression test that simulates modular vLLM exposing only `FusedMoEFactory`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Documentation update is not required because there is no API or user-facing configuration change.
- [x] Added a unit test under the existing CPU test suite; no workflow change is required.
- [ ] Request CI in the project Slack or Feishu channel after maintainer triage.
- [x] This PR is unrelated to the `recipe` submodule.

### AI assistance

OpenAI Codex assisted with diagnosis, implementation, and test preparation. The human submitter reviewed the changes and test results.
