### PR TITLE
[ray] fix: skip unused TensorDict consolidation in NumPy DataProto serialization

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1205,6 +1205,30 @@ def test_serialize_deserialize_tensordict_with_device():
         assert original_tensor.dtype == reconstructed_tensor.dtype
 
 
+def test_numpy_dataproto_serialization_skips_tensordict_consolidation(monkeypatch):
+    """NumPy serialization should not allocate an unused consolidated TensorDict."""
+    monkeypatch.setenv("VERL_DATAPROTO_SERIALIZATION_METHOD", "numpy")
+
+    data = DataProto.from_dict(
+        tensors={"obs": torch.arange(12).reshape(3, 4)},
+        non_tensors={"labels": np.array(["a", "b", "c"], dtype=object)},
+        meta_info={"step": 1},
+    )
+
+    def fail_on_consolidate(*args, **kwargs):
+        pytest.fail("TensorDict.consolidate() should not be called in NumPy serialization mode")
+
+    monkeypatch.setattr(TensorDict, "consolidate", fail_on_consolidate)
+
+    state = data.__getstate__()
+    restored = DataProto()
+    restored.__setstate__(state)
+
+    torch.testing.assert_close(restored.batch["obs"], data.batch["obs"])
+    assert restored.non_tensor_batch["labels"].tolist() == ["a", "b", "c"]
+    assert restored.meta_info == {"step": 1}
+
+
 def test_serialize_dataproto_with_empty_tensordict():
     """Tests that serializing a DataProto with an empty TensorDict does not crash.
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -375,25 +375,22 @@ class DataProto:
             raise TypeError(f"Indexing with {type(item)} is not supported")
 
     def __getstate__(self):
-        if version.parse(tensordict.__version__) >= version.parse("0.5.0") and self.batch is not None:
-            # Check if batch is empty to avoid torch.cat error in consolidate
-            if len(self.batch.keys()) > 0:
-                batch = self.batch.contiguous().consolidate()
-            else:
-                batch = self.batch
-        else:
-            batch = self.batch
-
         if os.getenv("VERL_DATAPROTO_SERIALIZATION_METHOD") == "numpy":
-            if batch is not None:
-                batch = serialize_tensordict(self.batch)
-
             return (
-                batch,
+                serialize_tensordict(self.batch) if self.batch is not None else None,
                 self.non_tensor_batch,
                 self.meta_info,
             )
         else:
+            if version.parse(tensordict.__version__) >= version.parse("0.5.0") and self.batch is not None:
+                # Check if batch is empty to avoid torch.cat error in consolidate
+                if len(self.batch.keys()) > 0:
+                    batch = self.batch.contiguous().consolidate()
+                else:
+                    batch = self.batch
+            else:
+                batch = self.batch
+
             import io
 
             buffer = io.BytesIO()


### PR DESCRIPTION
<!--
PR title: [ray] fix: skip unused TensorDict consolidation in NumPy DataProto serialization
Base: verl-project/verl:main
Head: Sky-Trigger:numpy-dataproto-serialization
Commit: 4d7b20eb
-->

### What does this PR do?

Fixes an unnecessary full-batch TensorDict allocation in
`DataProto.__getstate__()` when
`VERL_DATAPROTO_SERIALIZATION_METHOD=numpy` is selected.

Previously, `DataProto.__getstate__()` called:

```python
self.batch.contiguous().consolidate()
```

before checking the serialization method. The NumPy branch then serialized the
original `self.batch` through `serialize_tensordict(self.batch)`, so the
consolidated copy was never used. This PR selects the NumPy branch first and
serializes `self.batch` directly. The existing torch serialization path retains
its original `consolidate()` behavior.

This is the upstream root-cause fix for the compatibility workaround in
[verl-omni#423](https://github.com/verl-project/verl-omni/pull/423). The issue
was investigated in the context of host-RAM OOM reports such as
[verl-omni#402](https://github.com/verl-project/verl-omni/issues/402). PR #423
patches the pinned `verl` dependency from `verl-omni`; this PR removes the
unused allocation at its source in `verl` and lets downstream users remove that
monkey patch after updating their `verl` revision.

For the Qwen-Image FlowGRPO workload used during the investigation, one rollout
shard had a payload of about 464 MiB. The `verl-omni` compatibility workaround
reduced the measured worker-side per-serialization RSS/RssAnon/private-dirty
increment from about 466 MiB to about 0 MiB for that payload. This PR removes
the same unused consolidation directly in `verl`.

This does not claim to resolve every source of CPU-memory growth reported in
#402. It removes one verified, batch-sized allocation in the NumPy serialization
path; Ray transport, deserialization, model/runtime allocations, and other
workload-specific retention remain outside this change.

### Checklist Before Starting

- [x] Search for similar PRs:
  [DataProto NumPy serialization](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+DataProto+numpy+serialization),
  [DataProto consolidation](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+DataProto+consolidate).
  No open `verl` PR was found that applies this targeted branch reordering.
  The open NeoProto RFC is a separate, larger data-plane redesign rather than a
  fix for this existing serialization behavior.
- [x] PR title follows the required format:
  `[ray] fix: skip unused TensorDict consolidation in NumPy DataProto serialization`.

### Test

The following checks were run on the branch:

```bash
cd /data/8T/wangmb/LLM-Infra/verl

/data/8T/wangmb/LLM-Infra/myenv/bin/python -m py_compile verl/protocol.py
git diff --check 3c62a15d1e9f99a95e763043023a693146648309..HEAD

VERL_DATAPROTO_SERIALIZATION_METHOD=numpy \
  /data/8T/wangmb/LLM-Infra/myenv/bin/python -c '
from types import SimpleNamespace
import verl.protocol as protocol

sentinel = object()
batch = object()
seen = []
original = protocol.serialize_tensordict
protocol.serialize_tensordict = lambda value: seen.append(value) or sentinel
state = protocol.DataProto.__getstate__(
    SimpleNamespace(batch=batch, non_tensor_batch={"x": 1}, meta_info={})
)
assert seen == [batch]
assert state == (sentinel, {"x": 1}, {})
protocol.serialize_tensordict = original
'
```

Result: all checks passed.

No new repository test file is included in this one-file fix. The direct check
above verifies that NumPy mode serializes the original batch and does not need
to access the consolidation path. Full `pre-commit run --all-files` has not
been run locally; CI is requested for the repository-wide checks.

### API and Usage Example

No API or configuration change is introduced. Existing NumPy serialization
users continue to select it as before:

```bash
export VERL_DATAPROTO_SERIALIZATION_METHOD=numpy
```

Non-NumPy serialization remains unchanged.

### Design & Code Changes

Only `verl/protocol.py` changes.

- Move the NumPy check ahead of the TensorDict consolidation logic.
- In NumPy mode, return `serialize_tensordict(self.batch)` directly, preserving
  the existing `None` behavior for an empty batch.
- Keep `contiguous().consolidate()` exclusively in the default torch/
  `torch.save()` path, where its result is serialized.
