### PR TITLE
[sglang, rollout] fix: re-key spec-decode stats to SGLang's current `meta_info` names

### DIFF
--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -708,9 +708,9 @@ class SGLangHttpServer:
         # Re-key backend spec-decoding stats to the rollout-common names.
         if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
             extra_fields["spec_num_draft_tokens"] = int(
-                meta_info.get("spec_draft_token_num", self.config.mtp.speculative_num_draft_tokens)
+                meta_info.get("spec_num_proposed_drafts", self.config.mtp.speculative_num_draft_tokens)
             )
-            extra_fields["spec_num_accepted_tokens"] = int(meta_info.get("spec_accept_token_num", 0))
+            extra_fields["spec_num_accepted_tokens"] = int(meta_info.get("spec_num_correct_drafts", 0))
             extra_fields["spec_num_verify_steps"] = int(meta_info.get("spec_verify_ct", 0))
 
         return TokenOutput(


### PR DESCRIPTION
### What does this PR do?

`rollout/spec_accept_rate` and `rollout/spec_accept_length` are always reported as `0.0` / `1.0` when running MTP rollout on SGLang, no matter how well speculative decoding is actually performing.

The cause is a key mismatch in [async_sglang_server.py:708-714](verl/workers/rollout/sglang_rollout/async_sglang_server.py#L708-L714). verl reads the per-request spec-decode counters out of SGLang's `meta_info` under the names `spec_draft_token_num` / `spec_accept_token_num`, but SGLang renamed those keys in `TokenizerManager._calculate_spec_decoding_metrics`:

| SGLang version | proposed-drafts key | accepted-drafts key |
| --- | --- | --- |
| `<= 0.5.10.post1` | `spec_draft_token_num` | `spec_accept_token_num` |
| `0.5.11` | `spec_proposed_drafts` | `spec_accepted_drafts` |
| `>= 0.5.12` | `spec_num_proposed_drafts` | `spec_num_correct_drafts` |

Since [pyproject.toml:110](pyproject.toml#L110) pins `sglang==0.5.12`, both `meta_info.get(...)` lookups miss on every request:

- `spec_num_draft_tokens` silently falls back to the static config value `mtp.speculative_num_draft_tokens` (`4` by default),
- `spec_num_accepted_tokens` falls back to `0`.

`spec_num_verify_steps` (`spec_verify_ct`) is unaffected — that key was never renamed. Feeding `accepts == 0` into `compute_spec_decode_metrics` ([ray_trainer.py:176-184](verl/trainer/ppo/ray_trainer.py#L176-L184)) pins the two reported metrics to constants:

```python
per_sample_accept_rate   = a / d      -> 0 / 4 = 0.0
per_sample_accept_length = 1.0 + a / v -> 1.0 + 0 = 1.0
```

so the dashboards read "speculative decoding accepts nothing" while throughput plainly shows otherwise. This is a metrics-reporting bug only — no training signal, weights, or rollout behavior is affected.

Related to #6432, which introduced this re-keying block. Not overlapping with #7079 (trainer-side container normalization for the same three fields) or #5925 (vLLM EAGLE/EAGLE3 rollout).


*AI assistance was used to research the SGLang `meta_info` key history and to draft this
description. The change itself is a two-line key rename that I have reviewed line by line
and can defend end-to-end.*
