### PR TITLE
[fully_async, rollout] fix: assign unique priorities before streaming generation

### DIFF
--- a/tests/experimental/fully_async_policy/test_deterministic_priority_on_cpu.py
+++ b/tests/experimental/fully_async_policy/test_deterministic_priority_on_cpu.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from verl.experimental.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
+from verl.experimental.fully_async_policy.detach_utils import prepare_single_generation_data
+from verl.workers.rollout import llm_server as llm_server_module
+from verl.workers.rollout.llm_server import GlobalRequestLoadBalancer
+from verl.workers.rollout.replica import TokenOutput
+
+
+def _config(rollout_n: int):
+    return SimpleNamespace(
+        actor_rollout_ref=SimpleNamespace(
+            rollout=SimpleNamespace(
+                n=rollout_n,
+                multi_turn=SimpleNamespace(enable=False),
+            )
+        )
+    )
+
+
+def _batch(priority: int | None = None):
+    batch = {"input_ids": torch.tensor([[1, 2, 3]])}
+    if priority is not None:
+        batch["priority"] = np.array([priority], dtype=np.int64)
+    return batch
+
+
+def _priorities(sample_step: int, rollout_n: int = 4) -> np.ndarray:
+    batch = prepare_single_generation_data(_batch(), _config(rollout_n), sample_step=sample_step)
+    return batch.non_tensor_batch["priority"]
+
+
+def test_expanded_rollouts_get_unique_int64_priorities():
+    priorities = _priorities(sample_step=7, rollout_n=4)
+
+    assert priorities.dtype == np.int64
+    np.testing.assert_array_equal(priorities, np.array([28, 29, 30, 31], dtype=np.int64))
+
+
+def test_consecutive_sample_steps_get_disjoint_priority_ranges():
+    first = _priorities(sample_step=7)
+    second = _priorities(sample_step=8)
+
+    assert set(first).isdisjoint(second)
+    assert first[-1] + 1 == second[0]
+
+
+def test_existing_sample_priority_is_not_overwritten():
+    batch = prepare_single_generation_data(_batch(priority=23), _config(4), sample_step=7)
+
+    np.testing.assert_array_equal(batch.non_tensor_batch["priority"], np.array([23, 23, 23, 23], dtype=np.int64))
+
+
+@pytest.mark.asyncio
+async def test_expanded_priorities_reach_single_turn_as_distinct_request_ids():
+    request_ids = []
+
+    class CapturingServer:
+        async def generate(self, **kwargs):
+            request_ids.append(kwargs["request_id"])
+            return TokenOutput(token_ids=[4], extra_fields={})
+
+    agent_loop = object.__new__(SingleTurnAgentLoop)
+    agent_loop.rollout_config = SimpleNamespace(full_determinism=True)
+    agent_loop.response_length = 8
+    agent_loop.server_manager = CapturingServer()
+
+    async def process_multi_modal_info(_messages):
+        return {}
+
+    async def build_initial_tokens(_messages, **_kwargs):
+        return [1, 2, 3]
+
+    async def merge_assistant_token(prompt_ids, token_ids, *_args, **_kwargs):
+        return SimpleNamespace(token_ids=[*prompt_ids, *token_ids]), [1] * len(token_ids), None
+
+    agent_loop.process_multi_modal_info = process_multi_modal_info
+    agent_loop._get_mm_processor_kwargs = lambda _audios: None
+    agent_loop._assert_mm_supported = lambda _has_multimodal_data: None
+    agent_loop.ct_build_initial_tokens = build_initial_tokens
+    agent_loop.ct_merge_assistant_token = merge_assistant_token
+
+    priorities = _priorities(sample_step=7)
+    for priority in priorities:
+        await agent_loop.run(sampling_params={}, priority=priority, raw_prompt=[])
+
+    assert request_ids == [f"det-{priority}" for priority in priorities]
+    assert len(set(request_ids)) == len(priorities)
+
+
+def test_unique_request_ids_avoid_sticky_routing_collapse(monkeypatch):
+    # Make the routing assertion independent of the process's PYTHONHASHSEED.
+    monkeypatch.setattr(
+        llm_server_module,
+        "hash",
+        lambda request_id: int(request_id.removeprefix("det-")),
+        raising=False,
+    )
+    servers = {f"replica-{index}": None for index in range(4)}
+
+    collapsed_lb = GlobalRequestLoadBalancer(servers, full_determinism=True)
+    collapsed = [collapsed_lb.acquire_server("det-0")[0] for _ in range(16)]
+    assert len(set(collapsed)) == 1
+
+    priorities = np.concatenate([_priorities(sample_step=step) for step in range(1, 5)])
+    distributed_lb = GlobalRequestLoadBalancer(servers, full_determinism=True)
+    distributed = [distributed_lb.acquire_server(f"det-{priority}")[0] for priority in priorities]
+
+    assert set(distributed) == set(servers)
+    assert all(distributed.count(server_id) == 4 for server_id in servers)

--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -39,13 +39,45 @@ class RolloutSample:
     rollout_status: dict[str, Any]
 
 
-def prepare_single_generation_data(batch_dict, config) -> DataProto:
+def resolve_rollout_priorities(
+    sample_step: int | None,
+    num_rollouts: int,
+) -> np.ndarray:
+    """Derive a unique per-rollout range from the fully async producer step.
+
+    Fully async samples are expanded and queued by a single producer before
+    generation tasks run concurrently. Combining that producer's monotonic
+    sample step with the rollout index makes automatically assigned priorities
+    deterministic and unique within that producer lifecycle.
     """
-    Similar to the logic of ray_trainer._prepare_generate_batch, but for a single sample.
-    Separate the data used for generation from the original data.
+    if num_rollouts <= 0:
+        raise ValueError(f"num_rollouts must be positive, got {num_rollouts}")
+
+    if sample_step is None:
+        raise ValueError("sample_step is required to derive rollout priorities")
+    if sample_step < 0:
+        raise ValueError(f"sample_step must be non-negative, got {sample_step}")
+
+    first_priority = sample_step * num_rollouts
+    last_priority = first_priority + num_rollouts - 1
+    int64_info = np.iinfo(np.int64)
+    if first_priority < int64_info.min or last_priority > int64_info.max:
+        raise OverflowError("rollout priority exceeds int64 range")
+
+    return np.arange(num_rollouts, dtype=np.int64) + np.int64(first_priority)
+
+
+def prepare_single_generation_data(batch_dict, config, *, sample_step: int | None = None) -> DataProto:
+    """Build the generation batch for one fully async dataset sample.
+
+    Args:
+        batch_dict: Collated single-sample input from the fully async dataloader.
+        config: Trainer configuration containing rollout settings.
+        sample_step: Monotonic producer step used to derive per-rollout priorities
+            when the input does not already provide them.
 
     Returns:
-        tuple: (original_batch_dict, gen_data_for_single_sample)
+        DataProto: The sample repeated once per configured rollout.
     """
 
     full_batch = DataProto.from_single_dict(batch_dict)
@@ -66,8 +98,16 @@ def prepare_single_generation_data(batch_dict, config) -> DataProto:
     if not config.actor_rollout_ref.rollout.multi_turn.enable:
         full_batch.non_tensor_batch["agent_name"] = np.array(["single_turn_agent"] * len(full_batch), dtype=object)
 
-    # Add global step count to generated data
+    # Expand one dataset sample into independently scheduled trajectories.
     full_batch = full_batch.repeat(repeat_times=config.actor_rollout_ref.rollout.n, interleave=True)
+
+    # Match AgentLoopManager: inject priorities only when the caller did not
+    # provide them. Explicit scheduling priorities remain caller-owned.
+    if sample_step is not None and "priority" not in full_batch.non_tensor_batch:
+        full_batch.non_tensor_batch["priority"] = resolve_rollout_priorities(
+            sample_step=sample_step,
+            num_rollouts=len(full_batch),
+        )
     return full_batch
 
 

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -861,7 +861,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
 
         for epoch, batch_dict in continuous_iterator:
             # Similar to _prepare_generate_batch: Separate data
-            full_batch = prepare_single_generation_data(batch_dict, self.config)
+            full_batch = prepare_single_generation_data(batch_dict, self.config, sample_step=self.global_steps)
 
             sample_id = f"sample_{epoch}_{self.global_steps}"
 


### PR DESCRIPTION
### What does this PR do?

When a fully async input does not already provide priorities, assigns a stable, distinct priority to every trajectory before it enters concurrent agent-loop generation.

The base `AgentLoopManager` injects priorities for ordinary batch generation, but fully async dispatches through `generate_sequences_single()` and bypasses that code. With `full_determinism=true`, inputs without an explicit priority consequently used the default `priority=0`, produced the same `det-0` request ID, and stuck to one rollout replica. This PR derives disjoint per-rollout priority ranges from the fully async producer's monotonic sample step. Caller-supplied priorities remain unchanged, matching the base manager's existing contract.

Closes #7546.

AI assistance was used for repository auditing, reproduction, implementation review, test design, duplicate searches, and preparation of this description. The human submitter must review every changed line, understand the fix, and rerun the relevant tests before requesting review.

### Checklist Before Starting

- [x] Search for similar PRs: [`generate_sequences_single priority`](https://github.com/verl-project/verl/pulls?q=is%3Apr+%22generate_sequences_single%22+priority), [`fully_async deterministic priority`](https://github.com/verl-project/verl/pulls?q=is%3Apr+fully_async+deterministic+priority), [`fully_async det-0`](https://github.com/verl-project/verl/pulls?q=is%3Apr+fully_async+%22det-0%22)
- [x] Reviewed related determinism work [#6572](https://github.com/verl-project/verl/pull/6572) and [#7518](https://github.com/verl-project/verl/pull/7518); neither covers the fully async priority source.
- [x] Post-Issue check on 2026-08-25: #7546 had no comments, no open PR referenced it, and the area-keyword search returned no open PR.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

Proposed title: `[fully_async, rollout] fix: assign unique priorities before streaming generation`

### Test

Latest-main production-control-flow reproduction:

```bash
python reproduce.py \
  --repo /path/to/verl \
  --revision fefb080262e1c015a0ea05f958822a6a512dc795 \
  --expect bug
# 12/12 trajectories used det-0; 1/4 rollout replicas used.
```

Candidate production-control-flow reproduction:

```bash
python reproduce.py \
  --repo /path/to/verl \
  --revision 46eea9e3e73f209f048d1d86691fb906b29c7c35 \
  --expect fixed
# 12/12 trajectories received distinct IDs det-28 through det-39.
# This run reached all 4 replicas; exact hash distribution is seed-dependent.
```

The reproducer loads the real `prepare_single_generation_data()` implementation from the requested Git revision, calls the real `SingleTurnAgentLoop.run()` boundary with CPU server/tokenizer stubs, and routes the resulting request IDs through the real `GlobalRequestLoadBalancer`.

Focused CPU regression tests:

```bash
python -m pytest -q \
  tests/experimental/fully_async_policy/test_deterministic_priority_on_cpu.py
# 5 passed
```

Fully async CPU test directory:

```bash
python -m pytest -q tests/experimental/fully_async_policy
# 10 passed
```

Existing load-balancer regression classes, run outside the filesystem/network sandbox so Ray GCS could bind normally:

```bash
python -m pytest -q \
  tests/experimental/agent_loop/test_basic_agent_loop.py::TestLoadBalancerRouting \
  tests/experimental/agent_loop/test_basic_agent_loop.py::TestLoadBalancerStickySession \
  tests/experimental/agent_loop/test_basic_agent_loop.py::TestLoadBalancerHybrid
# 15 passed
```

Targeted quality gates after rebasing onto the latest main:

```bash
pre-commit run --files \
  verl/experimental/fully_async_policy/detach_utils.py \
  verl/experimental/fully_async_policy/fully_async_rollouter.py \
  tests/experimental/fully_async_policy/test_deterministic_priority_on_cpu.py
# All 14 configured hooks passed.

git diff fefb080262e1c015a0ea05f958822a6a512dc795..HEAD --check
# Passed.
```

A GPU end-to-end run was not started because, at validation time, all four local RTX 3090 cards were already occupied by an existing user-owned TP=4 vLLM workload, with only about 1.6-2.0 GiB free per card. The regression is at the CPU-testable priority/request-ID/routing boundary; no running GPU process was interrupted.

### API and Usage Example

No public API or configuration change. Existing fully async configurations continue to use the same setting:

```yaml
actor_rollout_ref:
  rollout:
    full_determinism: true
```

The internal `prepare_single_generation_data()` helper accepts an optional producer step used by `FullyAsyncRollouter`. Callers that provide neither a producer step nor an explicit priority retain the previous behavior. Explicit priorities are never overwritten.

### Design & Code Changes

- Detect whether the repeated generation batch already contains a caller-supplied priority.
- When it does not, expand the producer step into a disjoint `int64` priority range, one value per rollout.
- Leave explicit scheduling priorities unchanged, matching `AgentLoopManager` behavior.
- Pass the monotonic fully async producer step from `_feed_samples()` before samples enter the pending queue.
- Add CPU tests for priority type/ranges, consecutive samples, non-overwriting of explicit priorities, the real single-turn request-ID boundary, and deterministic sticky routing.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md`, `AGENTS.md`, and the PR template.
- [x] Applied every configured pre-commit hook to all changed files after the latest-main rebase.
- [x] Documentation update is not applicable; this restores the intended behavior of an existing configuration and changes no public API.
- [x] Added a CPU unit test discovered by `cpu_unit_tests.yml` through the `*_on_cpu.py` suffix.
- [x] Human submitter reviewed every changed line and reran the commands claimed above.
- [x] Once ready for upstream CI, request CI in the verl Slack or Feishu channel.
- [x] Recipe submodule update evaluated as not applicable; neither recipe contents nor its gitlink changed.
