### PR TITLE
[trainer] fix: guard SFT validation without val data

### DIFF
--- a/tests/trainer/test_sft_validation_on_cpu.py
+++ b/tests/trainer/test_sft_validation_on_cpu.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.trainer.sft_trainer import _should_run_validation
+
+
+@pytest.mark.parametrize(
+    ("has_val_dataloader", "is_last_step", "global_step", "test_freq", "expected"),
+    [
+        (False, False, 2, 1, False),
+        (False, True, 2, 1, False),
+        (True, False, 2, 1, True),
+        (True, False, 2, 3, False),
+        (True, True, 2, -1, True),
+        (True, False, 2, 0, False),
+    ],
+)
+def test_should_run_validation(has_val_dataloader, is_last_step, global_step, test_freq, expected):
+    val_dataloader = object() if has_val_dataloader else None
+
+    assert _should_run_validation(val_dataloader, is_last_step, global_step, test_freq) is expected

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -47,6 +47,13 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_SFT_LOGGING_LEVEL", "WARN"))
 
 
+def _should_run_validation(val_dataloader, is_last_step, global_step, test_freq):
+    """Return whether validation should run for the current training step."""
+    if val_dataloader is None:
+        return False
+    return is_last_step or (test_freq > 0 and global_step % test_freq == 0)
+
+
 class SFTTrainer:
     def __init__(
         self,
@@ -410,11 +417,10 @@ class SFTTrainer:
                         tracking.log(data=metrics, step=global_step)
 
                 is_last_step = global_step >= self.total_training_steps
-                is_valid_step = global_step % self.test_freq == 0
                 is_save_step = global_step % self.save_freq == 0
 
                 # early exit or validation step
-                if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
+                if _should_run_validation(self.val_dataloader, is_last_step, global_step, self.test_freq):
                     # Perform validation
                     val_losses = []
                     for val_data in self.val_dataloader:

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -32,6 +32,7 @@ from torch.utils.data import DistributedSampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
+from verl.trainer.sft_trainer import _should_run_validation
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint import CheckpointHandler, OrchestrationMode
 from verl.utils.dataset.dataset_utils import SFTTensorCollator
@@ -350,11 +351,10 @@ class SFTTrainer:
                 tracking.log(data=metrics, step=global_step)
 
                 is_last_step = global_step >= self.total_training_steps
-                is_valid_step = global_step % self.test_freq == 0
                 is_save_step = global_step % self.save_freq == 0
 
                 # early exit or validation step
-                if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
+                if _should_run_validation(self.val_dataloader, is_last_step, global_step, self.test_freq):
                     # Perform validation
                     val_losses = []
                     for val_data in self.val_dataloader:


### PR DESCRIPTION
### What does this PR do?

Prevents both SFT trainers from entering validation when no validation dataset is configured.

Previously, the periodic-validation branch bypassed the `val_dataloader is not None` guard because of boolean-operator precedence. A job with `data.val_files=null` and `trainer.test_freq>0` therefore completed a training update and then crashed while iterating `None`. This PR centralizes the validation predicate, preserves final-step validation when data exists, and also avoids modulo by zero when `test_freq=0`.

Closes #7545.

AI assistance was used for repository auditing, reproduction, implementation, test design, duplicate searches, and preparation of this description. The human submitter must review every changed line, understand the fix, and rerun the relevant tests before requesting review.

### Checklist Before Starting

- [x] Search for similar PRs: [`SFT val_files test_freq`](https://github.com/verl-project/verl/pulls?q=is%3Apr%20SFT%20%22val_files%22%20%22test_freq%22), [`SFT val_dataloader None`](https://github.com/verl-project/verl/pulls?q=is%3Apr%20SFT%20%22val_dataloader%22%20None), [`sft_trainer.py validation`](https://github.com/verl-project/verl/pulls?q=is%3Apr%20sft_trainer.py%20validation)
- [x] Post-Issue check on 2026-08-25: #7545 had no comments, no open PR referenced it, and the area-keyword search returned no open PR.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

Proposed title: `[trainer] fix: guard SFT validation without val data`

### Test

Baseline production-control-flow reproduction:

```bash
python reproduce.py \
  --repo /path/to/verl \
  --revision fefb080262e1c015a0ea05f958822a6a512dc795 \
  --expect bug
# SPMD 3/3 and Ray 3/3: TypeError: 'NoneType' object is not iterable
```

Candidate production-control-flow reproduction:

```bash
python reproduce.py \
  --repo /path/to/verl \
  --revision b59e5586cf069b9b8f11bd7eef270e0a8f1fbc53 \
  --expect fixed
# SPMD 3/3 and Ray 3/3 completed
```

Focused CPU regression tests:

```bash
python -m pytest -q tests/trainer/test_sft_validation_on_cpu.py
# 6 passed
```

Quality gates:

```bash
pre-commit run --files \
  verl/trainer/sft_trainer.py \
  verl/trainer/sft_trainer_ray.py \
  tests/trainer/test_sft_validation_on_cpu.py
# All configured hooks passed.

ruff check \
  verl/trainer/sft_trainer.py \
  verl/trainer/sft_trainer_ray.py \
  tests/trainer/test_sft_validation_on_cpu.py
# Passed.

ruff format --check \
  verl/trainer/sft_trainer.py \
  verl/trainer/sft_trainer_ray.py \
  tests/trainer/test_sft_validation_on_cpu.py
# 3 files already formatted.

git diff --check
# Passed.
```

An additional dataset suite was attempted:

```bash
python -m pytest -q tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
# 6 setup failures: the suite hard-codes model fixtures under ~/models/Qwen and
# ~/models/openai that are not installed at those paths in this environment.
```

No dataset/trainer assertion ran in those six cases; each failed while loading the missing tokenizer or model fixture. This PR does not modify dataset code.

The first targeted pre-commit invocation exposed the system `python3` to the config-generation hook and failed because that interpreter lacks `hydra-core`. Re-running the complete command with the repository virtual environment first on `PATH` passed every hook and produced no additional diff.

This is a CPU control-flow bug. The regression test reaches the production validation predicate without allocating a model, so a GPU run would add cost without exercising a different root-cause path.

### API and Usage Example

No public API or configuration change. The existing valid configuration now trains without attempting validation:

```yaml
data:
  val_files: null
trainer:
  test_freq: 100
```

When validation data exists, periodic and final-step validation behavior is unchanged.

### Design & Code Changes

- Add a shared `_should_run_validation` predicate used by both SPMD and Ray SFT trainers.
- Guard the entire periodic/final validation decision on a real validation loader.
- Short-circuit the frequency check before modulo, so `test_freq=0` does not raise.
- Add a CPU truth-table regression test covering absent/present loaders, periodic/final validation, disabled validation, and zero frequency.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md`, `AGENTS.md`, and the PR template.
- [x] Applied targeted pre-commit checks to every changed file.
- [x] Documentation update is not applicable; this restores the intended behavior of existing SFT configuration and changes no public API.
- [x] Added a CPU unit test discovered by `cpu_unit_tests.yml` through the `*_on_cpu.py` suffix.
- [x] Human submitter reviewed every changed line and reran the commands claimed above.
- [x] Once ready for upstream CI, request CI in the verl Slack or Feishu channel.
- [x] Recipe submodule update evaluated as not applicable; neither recipe contents nor its gitlink changed.
