### PR TITLE
[ray] fix: read the DataProto serialization method from the payload

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1229,6 +1229,59 @@ def test_numpy_dataproto_serialization_skips_tensordict_consolidation(monkeypatc
     assert restored.meta_info == {"step": 1}
 
 
+@pytest.mark.parametrize(
+    ("sender_method", "receiver_method"),
+    [("numpy", None), (None, "numpy")],
+)
+def test_dataproto_state_survives_a_serialization_method_mismatch(monkeypatch, sender_method, receiver_method):
+    """__getstate__ runs on the sender and __setstate__ on the receiver.
+
+    VERL_DATAPROTO_SERIALIZATION_METHOD is not part of the Ray runtime-env whitelist, so the two
+    processes do not always read the same value. The payload has to say which branch wrote it.
+    """
+    data = DataProto.from_dict(
+        tensors={"obs": torch.arange(12).reshape(3, 4)},
+        non_tensors={"labels": np.array(["a", "b", "c"], dtype=object)},
+        meta_info={"step": 1},
+    )
+
+    monkeypatch.delenv("VERL_DATAPROTO_SERIALIZATION_METHOD", raising=False)
+    if sender_method is not None:
+        monkeypatch.setenv("VERL_DATAPROTO_SERIALIZATION_METHOD", sender_method)
+    state = data.__getstate__()
+
+    monkeypatch.delenv("VERL_DATAPROTO_SERIALIZATION_METHOD", raising=False)
+    if receiver_method is not None:
+        monkeypatch.setenv("VERL_DATAPROTO_SERIALIZATION_METHOD", receiver_method)
+    restored = DataProto()
+    restored.__setstate__(state)
+
+    torch.testing.assert_close(restored.batch["obs"], data.batch["obs"])
+    assert restored.non_tensor_batch["labels"].tolist() == ["a", "b", "c"]
+    assert restored.meta_info == {"step": 1}
+
+
+def test_dataproto_state_without_a_batch_survives_a_mismatch(monkeypatch):
+    """NumPy serialization writes None for an absent batch, which is not a torch.save payload."""
+    data = DataProto.from_dict(
+        tensors={},
+        non_tensors={"labels": np.array(["a"], dtype=object)},
+        meta_info={"step": 1},
+    )
+    data.batch = None
+
+    monkeypatch.setenv("VERL_DATAPROTO_SERIALIZATION_METHOD", "numpy")
+    state = data.__getstate__()
+    assert state[0] is None
+
+    monkeypatch.delenv("VERL_DATAPROTO_SERIALIZATION_METHOD", raising=False)
+    restored = DataProto()
+    restored.__setstate__(state)
+
+    assert restored.batch is None
+    assert restored.non_tensor_batch["labels"].tolist() == ["a"]
+
+
 def test_serialize_dataproto_with_empty_tensordict():
     """Tests that serializing a DataProto with an empty TensorDict does not crash.
 

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -399,23 +399,26 @@ class DataProto:
             return buffer_bytes, self.non_tensor_batch, self.meta_info
 
     def __setstate__(self, data):
-        batch_deserialized_bytes, non_tensor_batch, meta_info = data
+        serialized_batch, non_tensor_batch, meta_info = data
 
-        if os.getenv("VERL_DATAPROTO_SERIALIZATION_METHOD") == "numpy":
-            if batch_deserialized_bytes is not None:
-                self.batch = deserialize_tensordict(batch_deserialized_bytes)
-            else:
-                self.batch = None
-        else:
+        # Which branch produced the payload is read off the payload itself, not off this
+        # process's VERL_DATAPROTO_SERIALIZATION_METHOD. __getstate__ runs on the sender and
+        # __setstate__ on the receiver, and the variable is not part of the Ray runtime env
+        # whitelist, so the two do not always agree. ``torch.save`` writes bytes;
+        # ``serialize_tensordict`` returns a tuple, or None for an absent batch.
+        if isinstance(serialized_batch, bytes | bytearray):
             import io
 
-            batch_deserialized = io.BytesIO(initial_bytes=batch_deserialized_bytes)
-            batch = torch.load(
+            batch_deserialized = io.BytesIO(initial_bytes=serialized_batch)
+            self.batch = torch.load(
                 batch_deserialized,
                 weights_only=False,
                 map_location="cpu" if not get_torch_device().is_available() else None,
             )
-            self.batch = batch
+        elif serialized_batch is not None:
+            self.batch = deserialize_tensordict(serialized_batch)
+        else:
+            self.batch = None
 
         self.non_tensor_batch = non_tensor_batch
         self.meta_info = meta_info


### PR DESCRIPTION
### What does this PR do?

`DataProto.__getstate__` and `__setstate__` each read `VERL_DATAPROTO_SERIALIZATION_METHOD` from their own process, but they run on opposite sides of a Ray transfer. The variable is not part of the runtime-env whitelist in `verl/trainer/constants_ppo.py` and nothing else adds it, so exporting it on the driver of a multi-node run leaves the workers reading an unset value.

The two branches do not produce the same payload — `torch.save` writes `bytes`, `serialize_tensordict` returns a `(batch_size, device, items)` tuple — so a disagreement is not a slower path, it is a crash:

```
sender / receiver    payload   result
numpy  / numpy       tuple     OK
unset  / unset       bytes     OK
numpy  / unset       tuple     TypeError: a bytes-like object is required, not 'tuple'
unset  / numpy       bytes     ValueError: too many values to unpack (expected 3)
```

Neither message names the environment variable, and a single-node run cannot reproduce it: the workers are children of a raylet started from the driver's shell, so they inherit it.

`__setstate__` now reads which branch wrote the payload off the payload itself. `bytes` came from `torch.save`; anything else came from `serialize_tensordict`; `None` is an absent batch, which only the numpy branch emits. The wire format is untouched, so a sender on either side of this change stays readable.

Follows #7539 and #7534, which both touched the numpy branch.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [serialization / DataProto](https://github.com/verl-project/verl/pulls?q=is%3Apr+serializ+OR+dataproto) — the closest are #7539 (skip consolidation) and #7534 (zero-element tensors), both inside one branch rather than the choice between them.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Three cases in `tests/test_protocol_on_cpu.py`, next to the existing numpy-serialization coverage. They drive `__getstate__` and `__setstate__` under different values of the variable, which is what a cross-process transfer does.

On `main` (`fefb0802`):

```
FAILED test_dataproto_state_survives_a_serialization_method_mismatch[numpy-None]
FAILED test_dataproto_state_survives_a_serialization_method_mismatch[None-numpy]
FAILED test_dataproto_state_without_a_batch_survives_a_mismatch
3 failed
```

With this branch:

```
3 passed
```

Full file and neighbours:

```
$ pytest tests/test_protocol_on_cpu.py
41 passed

$ pytest tests/test_protocol_on_cpu.py tests/test_protocol_v2_on_cpu.py tests/test_base_config_on_cpu.py tests/single_controller
91 passed, 1 failed
```

The one failure is `test_protocol_v2_on_cpu.py::test_contiguous` (`DID NOT RAISE RuntimeError`), which fails the same way on a clean checkout of `main` here and does not touch this path.

### API and Usage Example

No API change. The payload layout is the same on both branches; only the decision of how to read it moves from the receiver's environment to the payload.

```python
# Sender with the variable set, receiver without it — previously a TypeError.
state = data.__getstate__()
restored = DataProto()
restored.__setstate__(state)
```

### Design & Code Changes

- `verl/protocol.py`: `__setstate__` dispatches on `isinstance(serialized_batch, bytes | bytearray)` instead of on `os.getenv(...)`, with `None` handled as an absent batch.
- `tests/test_protocol_on_cpu.py`: both mismatch directions, plus the no-batch payload.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks (ruff check / ruff format on the changed files: clean).
- [ ] Add / Update the documentation — no user-facing behaviour changes, so nothing to document.
- [x] Add unit or end-to-end test(s) to the CI workflow. `tests/test_protocol_on_cpu.py` is picked up by `cpu_unit_tests.yml` through the `_on_cpu.py` suffix.
