### PR TITLE
[ckpt, fsdp] feat: add NCCL M2N Reshard backend

### DIFF
--- a/tests/checkpoint_engine/test_nccl_m2n_checkpoint_engine_on_cpu.py
+++ b/tests/checkpoint_engine/test_nccl_m2n_checkpoint_engine_on_cpu.py
@@ -1,0 +1,629 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for the NCCL M2N checkpoint backend."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import torch
+from torch.distributed.tensor import Replicate, Shard
+
+import verl.checkpoint_engine.nccl_m2n_checkpoint_engine as m2n_module
+from verl.checkpoint_engine.base import CheckpointEngineRegistry
+from verl.checkpoint_engine.nccl_m2n_checkpoint_engine import (
+    NCCLM2NCheckpointEngine,
+    NCCLM2NMasterMetadata,
+    _nccl_stream,
+    _require_nccl,
+)
+from verl.models.transformers.hf_dense_decoder_tp import infer_dense_decoder_tp_shard_dim
+from verl.workers.engine.spec import ShardSpec
+
+
+class _Mesh:
+    ndim = 2
+
+    def __init__(self, source_shard_rank=3):
+        self.source_shard_rank = source_shard_rank
+
+    @staticmethod
+    def size(mesh_dim=None):
+        return 8 if mesh_dim is None else (2, 4)[mesh_dim]
+
+    def get_local_rank(self, mesh_dim=None):
+        return 7 if mesh_dim is None else (1, self.source_shard_rank)[mesh_dim]
+
+
+class _Stream:
+    def __init__(self):
+        self.waited_for = []
+        self.synchronize_calls = 0
+
+    def wait_stream(self, stream):
+        self.waited_for.append(stream)
+
+    def synchronize(self):
+        self.synchronize_calls += 1
+
+
+class _Handle:
+    def __init__(self):
+        self.calls = []
+        self.destroy_calls = 0
+
+    def reshard(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+    def destroy(self):
+        self.destroy_calls += 1
+
+
+class _Communicator:
+    def __init__(self):
+        self.destroy_calls = 0
+
+    def destroy(self):
+        self.destroy_calls += 1
+
+
+def _engine(**overrides):
+    kwargs = {
+        "bucket_size": 256,
+        "source_dp": 2,
+        "source_shard_size": 4,
+        "destination_dp": 3,
+        "destination_shard_size": 2,
+    }
+    kwargs.update(overrides)
+    return NCCLM2NCheckpointEngine(**kwargs)
+
+
+def _metadata(**overrides):
+    kwargs = {
+        "unique_id": b"test-id",
+        "zmq_ip": "127.0.0.1",
+        "zmq_port": 12345,
+        "source_dp": 2,
+        "source_shard_size": 4,
+        "destination_dp": 3,
+        "destination_shard_size": 2,
+    }
+    kwargs.update(overrides)
+    return NCCLM2NMasterMetadata(**kwargs)
+
+
+def _exported_weight(source_shard_rank=3):
+    return (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.arange(12, dtype=torch.float32),
+        ShardSpec(
+            full_shape=(8, 6),
+            mesh=_Mesh(source_shard_rank),
+            placements=(Replicate(), Shard(0)),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("model.embed_tokens.weight", 0),
+        ("model.layers.0.self_attn.q_proj.weight", 0),
+        ("model.layers.0.self_attn.o_proj.weight", 1),
+        ("model.layers.0.mlp.down_proj.weight", 1),
+        ("model.layers.0.input_layernorm.weight", None),
+    ],
+)
+def test_dense_decoder_tp_shard_dim(name, expected):
+    assert infer_dense_decoder_tp_shard_dim(name) == expected
+
+
+def test_dense_decoder_tp_shard_dim_rejects_unknown_weight():
+    with pytest.raises(NotImplementedError, match="unvalidated dense-decoder"):
+        infer_dense_decoder_tp_shard_dim("model.layers.0.unsupported.weight")
+
+
+def test_backend_is_registered_without_requiring_nccl_at_import_time():
+    assert CheckpointEngineRegistry.get("nccl_m2n") is NCCLM2NCheckpointEngine
+    assert NCCLM2NCheckpointEngine.wire_format == "rank_local_named_tensors"
+
+
+def test_constructor_requires_explicit_positive_topology():
+    with pytest.raises(ValueError, match="explicit values.*source_dp"):
+        NCCLM2NCheckpointEngine(bucket_size=256)
+    with pytest.raises(ValueError, match="sizes must be positive"):
+        _engine(source_dp=0)
+
+
+@pytest.mark.parametrize(("is_lora", "qat_enabled"), [(True, False), (False, True)])
+def test_fsdp_raw_export_rejects_lora_and_qat(is_lora, qat_enabled):
+    from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
+
+    engine = object.__new__(FSDPEngine)
+    engine._is_lora = is_lora
+    engine._qat_enabled = qat_enabled
+
+    with pytest.raises(NotImplementedError, match="does not support LoRA or QAT"):
+        engine.get_per_tensor_param_reshard()
+
+
+def test_optional_nccl_dependency_has_a_clear_error(monkeypatch):
+    import_error = ImportError("nccl is unavailable")
+    monkeypatch.setattr(m2n_module, "_NCCL_IMPORT_ERROR", import_error)
+
+    with pytest.raises(ImportError, match="requires NCCL4Py") as exc_info:
+        _require_nccl()
+
+    assert exc_info.value.__cause__ is import_error
+
+
+def test_prepare_creates_and_caches_master_metadata(monkeypatch):
+    class _UniqueId:
+        def __bytes__(self):
+            return b"unique-id"
+
+    engine = _engine()
+    engine.is_master = True
+    engine._metadata_ip = "10.0.0.1"
+    engine._metadata_port = 23456
+    monkeypatch.setattr(m2n_module, "_require_nccl", lambda: None)
+    monkeypatch.setattr(m2n_module, "get_unique_id", _UniqueId, raising=False)
+
+    first = engine.prepare()
+    second = engine.prepare()
+
+    assert first is second
+    assert first == NCCLM2NMasterMetadata(b"unique-id", "10.0.0.1", 23456, 2, 4, 3, 2)
+
+
+def test_metadata_server_uses_xpub_subscription_notifications(monkeypatch):
+    class _Socket:
+        def __init__(self):
+            self.options = []
+            self.bound = None
+
+        def setsockopt(self, option, value):
+            self.options.append((option, value))
+
+        def bind(self, address):
+            self.bound = address
+
+    socket = _Socket()
+
+    class _Context:
+        @staticmethod
+        def socket(socket_type):
+            assert socket_type == m2n_module.zmq.XPUB
+            return socket
+
+    engine = object.__new__(NCCLM2NCheckpointEngine)
+    monkeypatch.setattr(m2n_module.ray.util, "get_node_ip_address", lambda: "127.0.0.1")
+    monkeypatch.setattr(m2n_module, "get_free_port", lambda _: (23456, None))
+    monkeypatch.setattr(m2n_module.zmq, "Context", _Context)
+
+    engine._start_metadata_server()
+
+    assert (m2n_module.zmq.XPUB_VERBOSE, 1) in socket.options
+    assert socket.bound == "tcp://127.0.0.1:23456"
+
+
+def test_metadata_client_subscribes_to_common_topic_before_rank_readiness(monkeypatch):
+    class _Socket:
+        def __init__(self):
+            self.subscriptions = []
+
+        def connect(self, address):
+            self.address = address
+
+        def setsockopt_string(self, option, value):
+            assert option == m2n_module.zmq.SUBSCRIBE
+            self.subscriptions.append(value)
+
+    socket = _Socket()
+
+    class _Context:
+        @staticmethod
+        def socket(socket_type):
+            assert socket_type == m2n_module.zmq.SUB
+            return socket
+
+    engine = _engine()
+    engine.rank = 8
+    monkeypatch.setattr(m2n_module.zmq, "Context", _Context)
+
+    engine._connect_metadata_client(_metadata())
+
+    assert socket.address == "tcp://127.0.0.1:12345"
+    assert socket.subscriptions == [engine.topic, f"{engine.ready_topic_prefix}8"]
+    engine._socket = engine._zmq_context = None
+
+
+def test_master_waits_for_each_destination_readiness_subscription():
+    engine = _engine()
+    prefix = engine.ready_topic_prefix.encode()
+
+    class _Socket:
+        def __init__(self):
+            self.events = iter(
+                [
+                    b"\x01" + engine.topic.encode(),
+                    b"\x01" + prefix + b"10",
+                    b"\x01" + prefix + b"8",
+                    b"\x01" + prefix + b"10",
+                    b"\x00" + prefix + b"10",
+                    b"\x01" + prefix + b"9",
+                    b"\x01" + prefix + b"11",
+                    b"\x01" + prefix + b"12",
+                    b"\x01" + prefix + b"13",
+                    b"\x01" + prefix + b"10",
+                ]
+            )
+            self.recv_calls = 0
+            self.sent = []
+
+        def recv(self):
+            self.recv_calls += 1
+            return next(self.events)
+
+        def send_string(self, message):
+            self.sent.append(message)
+
+    engine._socket = _Socket()
+
+    engine._wait_for_metadata_subscribers()
+
+    assert engine._socket.recv_calls == 10
+    assert engine._socket.sent == [f"{engine.ready_topic_prefix}{rank}" for rank in range(8, 14)]
+    engine._socket = None
+
+
+def test_master_rejects_readiness_from_a_non_destination_rank():
+    engine = _engine()
+
+    class _Socket:
+        @staticmethod
+        def recv():
+            return b"\x01" + engine.ready_topic_prefix.encode() + b"7"
+
+    engine._socket = _Socket()
+
+    with pytest.raises(RuntimeError, match="unexpected.*readiness rank 7"):
+        engine._wait_for_metadata_subscribers()
+    engine._socket = None
+
+
+def test_destination_waits_for_its_readiness_acknowledgement():
+    engine = _engine()
+    engine.rank = 8
+
+    class _Socket:
+        @staticmethod
+        def recv_string():
+            return f"{engine.ready_topic_prefix}8"
+
+    engine._socket = _Socket()
+
+    engine._wait_for_metadata_publisher()
+
+    engine._socket = None
+
+
+def test_destination_rejects_another_ranks_readiness_acknowledgement():
+    engine = _engine()
+    engine.rank = 8
+
+    class _Socket:
+        @staticmethod
+        def recv_string():
+            return f"{engine.ready_topic_prefix}9"
+
+    engine._socket = _Socket()
+
+    with pytest.raises(RuntimeError, match="unexpected.*acknowledgement"):
+        engine._wait_for_metadata_publisher()
+    engine._socket = None
+
+
+def test_build_topology_assigns_all_trainers_and_destinations():
+    master = _metadata()
+
+    trainer, rollout = NCCLM2NCheckpointEngine.build_topology(8, 6, [master] + [None] * 13)
+
+    assert trainer["rank"] == list(range(8))
+    assert trainer["role"] == ["source"] * 8
+    assert rollout["rank"] == list(range(8, 14))
+    assert rollout["role"] == ["destination"] * 6
+    assert trainer["world_size"] == [14] * 8
+    assert rollout["world_size"] == [14] * 6
+    assert trainer["master_metadata"] == [master] * 8
+    assert rollout["master_metadata"] == [master] * 6
+
+
+@pytest.mark.parametrize(
+    ("trainer_world_size", "rollout_world_size"),
+    [(7, 6), (9, 6), (8, 5), (8, 7)],
+)
+def test_build_topology_rejects_incompatible_world_sizes(trainer_world_size, rollout_world_size):
+    with pytest.raises(ValueError, match="requires exactly 8 trainer and 6 rollout ranks"):
+        NCCLM2NCheckpointEngine.build_topology(
+            trainer_world_size,
+            rollout_world_size,
+            [_metadata()] + [None] * (trainer_world_size + rollout_world_size - 1),
+        )
+
+
+def test_build_topology_requires_exactly_one_master():
+    with pytest.raises(ValueError, match="exactly one trainer master, got 0"):
+        NCCLM2NCheckpointEngine.build_topology(8, 6, [None] * 14)
+    with pytest.raises(ValueError, match="exactly one trainer master, got 2"):
+        NCCLM2NCheckpointEngine.build_topology(8, 6, [_metadata(), _metadata()] + [None] * 12)
+
+
+def test_process_group_rejects_invalid_rank_and_role_before_requiring_nccl():
+    engine = _engine()
+
+    with pytest.raises(ValueError, match="rank must be non-negative"):
+        engine.init_process_group(-1, 14, _metadata(), "source")
+    with pytest.raises(ValueError, match="role must be source or destination"):
+        engine.init_process_group(0, 14, _metadata(), "inactive")
+
+
+def test_active_rank_rejects_runtime_topology_mismatch_before_bootstrap(monkeypatch):
+    engine = _engine()
+    monkeypatch.setattr(m2n_module, "_require_nccl", lambda: None)
+
+    with pytest.raises(ValueError, match="runtime world_size=13, expected 14"):
+        engine.init_process_group(0, 13, _metadata(), "source")
+    with pytest.raises(ValueError, match="does not match local config"):
+        engine.init_process_group(0, 14, _metadata(source_shard_size=2), "source")
+
+
+def test_nccl_stream_uses_modern_torch_raw_handle_and_preserves_legacy_objects():
+    class _ModernTorchStream:
+        cuda_stream = 12345
+
+    class _LegacyStream:
+        def __cuda_stream__(self):
+            return (0, 67890)
+
+    legacy = _LegacyStream()
+    assert _nccl_stream(_ModernTorchStream()) == 12345
+    assert _nccl_stream(legacy) is legacy
+    assert _nccl_stream(111) == 111
+
+
+def test_raw_fsdp_export_is_normalized_into_rank_local_layouts():
+    engine = _engine()
+
+    weight = engine._coerce_weight(_exported_weight())
+    source, destination = engine._layouts(weight)
+
+    assert weight.name == "model.layers.0.mlp.down_proj.weight"
+    assert weight.tensor.shape == (2, 6)
+    assert weight.source_shard_size == 4
+    assert weight.destination_shard_dim == 1
+    assert (source.mesh_dims, source.placements, source.local_shape) == ((2, 4), (None, 0), (2, 6))
+    assert (destination.mesh_dims, destination.placements, destination.local_shape) == (
+        (3, 2),
+        (None, 1),
+        (8, 3),
+    )
+
+
+def test_source_rank_validates_device_mesh_to_m2n_ordering():
+    engine = _engine()
+    engine.rank = 2
+
+    with pytest.raises(ValueError, match="DeviceMesh rank 3 does not match M2N mesh rank 2"):
+        engine._coerce_weight(_exported_weight(source_shard_rank=3))
+
+
+def test_layouts_are_converted_to_m2n_descriptors(monkeypatch):
+    descriptors = []
+
+    class _M2NMesh:
+        def __init__(self, dims, start_rank):
+            self.dims = dims
+            self.start_rank = start_rank
+
+    class _DistTensor:
+        def __init__(self, tensor, **kwargs):
+            self.tensor = tensor
+            self.kwargs = kwargs
+            descriptors.append(self)
+
+    monkeypatch.setattr(m2n_module, "Mesh", _M2NMesh, raising=False)
+    monkeypatch.setattr(m2n_module, "DistTensor", _DistTensor, raising=False)
+    monkeypatch.setattr(m2n_module, "Replicate", lambda: ("replicate", None), raising=False)
+    monkeypatch.setattr(m2n_module, "Shard", lambda dim: ("shard", dim), raising=False)
+
+    engine = _engine()
+    weight = engine._coerce_weight(_exported_weight())
+    source_tensor = torch.empty(2, 6)
+    destination_tensor = torch.empty(8, 3)
+
+    source, destination = engine._descriptors(weight, source_tensor, destination_tensor)
+
+    assert descriptors == [source, destination]
+    assert source.tensor is source_tensor
+    assert source.kwargs["mesh"].dims == (2, 4)
+    assert source.kwargs["mesh"].start_rank == 0
+    assert source.kwargs["placements"] == [("replicate", None), ("shard", 0)]
+    assert destination.tensor is destination_tensor
+    assert destination.kwargs["mesh"].dims == (3, 2)
+    assert destination.kwargs["mesh"].start_rank == 8
+    assert destination.kwargs["placements"] == [("replicate", None), ("shard", 1)]
+
+
+def test_send_weights_passes_source_tensor_to_handle_reshard(monkeypatch):
+    caller_stream = _Stream()
+    transfer_stream = _Stream()
+    handle = _Handle()
+    published = []
+    descriptor_tensors = []
+    engine = _engine()
+    engine.rank = 0
+    engine.role = "source"
+    engine._comm = _Communicator()
+    engine._handle = handle
+    engine._transfer_stream = transfer_stream
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: caller_stream)
+    monkeypatch.setattr(engine, "_publish", published.append)
+
+    def _descriptors(_weight, source, destination):
+        descriptor_tensors.append((source, destination))
+        return "source", "destination"
+
+    monkeypatch.setattr(engine, "_descriptors", _descriptors)
+
+    exported = _exported_weight(source_shard_rank=0)
+
+    result = asyncio.run(engine.send_weights(iter([exported])))
+
+    assert result == {}
+    assert transfer_stream.waited_for == [caller_stream]
+    assert caller_stream.waited_for == [transfer_stream]
+    assert transfer_stream.synchronize_calls == 0
+    assert handle.calls == [((engine._comm, "source", "destination"), {"stream": transfer_stream})]
+    assert descriptor_tensors[0][0].data_ptr() == exported[1].data_ptr()
+    assert descriptor_tensors[0][1] is None
+    assert published[0]["kind"] == "weight"
+    assert published[0]["name"] == "model.layers.0.mlp.down_proj.weight"
+    assert published[0]["destination_shard_dim"] == 1
+    assert "source_shard_rank" not in published[0]
+    assert published[-1] == {"kind": "end"}
+
+
+def test_finalize_waits_for_enqueued_transfer_and_consumer_work(monkeypatch):
+    transfer_stream = _Stream()
+    caller_stream = _Stream()
+    engine = _engine()
+    engine.rank = 0
+    engine._transfer_stream = transfer_stream
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: caller_stream)
+
+    engine.finalize()
+
+    assert transfer_stream.synchronize_calls == 1
+    assert caller_stream.synchronize_calls == 1
+
+
+def test_receive_weights_rebuilds_layout_calls_reshard_and_yields_rank_local_tensor(monkeypatch):
+    caller_stream = _Stream()
+    transfer_stream = _Stream()
+    handle = _Handle()
+    descriptor_tensors = []
+    messages = iter(
+        [
+            {
+                "kind": "weight",
+                "name": "model.layers.0.mlp.down_proj.weight",
+                "global_shape": (8, 6),
+                "dtype": torch.float32,
+                "destination_shard_dim": 1,
+                "source_shard_dim": 0,
+                "source_shard_size": 4,
+            },
+            {"kind": "end"},
+        ]
+    )
+    engine = _engine()
+    engine.rank = 8
+    engine.role = "destination"
+    engine._comm = _Communicator()
+    engine._handle = handle
+    engine._transfer_stream = transfer_stream
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: caller_stream)
+    monkeypatch.setattr(
+        m2n_module,
+        "_allocate_destination",
+        lambda shape, dtype: torch.empty(shape, dtype=dtype),
+    )
+    monkeypatch.setattr(engine, "_receive", lambda: next(messages))
+
+    def _descriptors(_weight, source, destination):
+        descriptor_tensors.append((source, destination))
+        return "source", "destination"
+
+    monkeypatch.setattr(engine, "_descriptors", _descriptors)
+
+    async def _collect():
+        return [item async for item in engine.receive_weights()]
+
+    weights = asyncio.run(_collect())
+
+    assert len(weights) == 1
+    assert weights[0][0] == "model.layers.0.mlp.down_proj.weight"
+    assert weights[0][1].shape == (8, 3)
+    assert weights[0][1].dtype == torch.float32
+    assert transfer_stream.waited_for == [caller_stream]
+    assert caller_stream.waited_for == [transfer_stream]
+    assert handle.calls == [((engine._comm, "source", "destination"), {"stream": transfer_stream})]
+    assert descriptor_tensors == [(None, weights[0][1])]
+
+
+def test_close_is_idempotent_and_releases_owned_resources():
+    engine = _engine()
+    stream = _Stream()
+    cleanup_order = []
+
+    class _OrderedHandle(_Handle):
+        def destroy(self):
+            cleanup_order.append("handle")
+            super().destroy()
+
+    class _OrderedCommunicator(_Communicator):
+        def destroy(self):
+            cleanup_order.append("communicator")
+            super().destroy()
+
+    handle = _OrderedHandle()
+    communicator = _OrderedCommunicator()
+
+    class _Socket:
+        def __init__(self):
+            self.linger = []
+
+        def close(self, linger):
+            self.linger.append(linger)
+
+    class _Context:
+        def __init__(self):
+            self.term_calls = 0
+
+        def term(self):
+            self.term_calls += 1
+
+    socket = _Socket()
+    context = _Context()
+    engine._transfer_stream = stream
+    engine._handle = handle
+    engine._comm = communicator
+    engine._socket = socket
+    engine._zmq_context = context
+
+    engine.close()
+    engine.close()
+
+    assert stream.synchronize_calls == 1
+    assert handle.destroy_calls == 1
+    assert communicator.destroy_calls == 1
+    assert cleanup_order == ["handle", "communicator"]
+    assert socket.linger == [0]
+    assert context.term_calls == 1
+    assert engine._comm is engine._handle is engine._transfer_stream is None
+    assert engine._socket is engine._zmq_context is None

--- a/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
+++ b/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
@@ -50,7 +50,7 @@ def test_local_shape_rejects_tensor_ranks_unsupported_by_m2n(shape):
         local_shape(shape, shard_dim=None, shard_size=1)
 
 
-def test_shard_api_maps_raw_fsdp_to_rollout_tp():
+def test_shard_api_maps_sharded_source_to_sharded_destination():
     exported = (
         "model.layers.0.mlp.down_proj.weight",
         torch.empty(16, device="meta"),
@@ -59,7 +59,11 @@ def test_shard_api_maps_raw_fsdp_to_rollout_tp():
 
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
     source, destination = build_reshard_layouts(
-        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+        weight,
+        source_replica_size=2,
+        source_shard_size=16,
+        destination_replica_size=8,
+        destination_shard_size=4,
     )
 
     assert weight.tensor.shape == (2, 8)
@@ -79,7 +83,11 @@ def test_shard_api_preserves_replicated_layouts():
 
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=None)
     source, destination = build_reshard_layouts(
-        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+        weight,
+        source_replica_size=2,
+        source_shard_size=16,
+        destination_replica_size=8,
+        destination_shard_size=4,
     )
 
     assert weight.source_shard_dim is None
@@ -98,7 +106,11 @@ def test_shard_api_accepts_one_dimensional_source_mesh():
 
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
     source, _ = build_reshard_layouts(
-        weight, source_dp=1, source_shard_size=16, destination_dp=8, destination_tp_size=4
+        weight,
+        source_replica_size=1,
+        source_shard_size=16,
+        destination_replica_size=8,
+        destination_shard_size=4,
     )
 
     assert weight.source_mesh_dims == (1, 16)
@@ -177,10 +189,10 @@ def test_layout_builder_rejects_source_shard_size_mismatch():
     with pytest.raises(ValueError, match="source mesh shard size 16 does not match configured 8"):
         build_reshard_layouts(
             weight,
-            source_dp=2,
+            source_replica_size=2,
             source_shard_size=8,
-            destination_dp=8,
-            destination_tp_size=4,
+            destination_replica_size=8,
+            destination_shard_size=4,
         )
 
 
@@ -192,11 +204,11 @@ def test_layout_builder_rejects_source_replica_size_mismatch():
     )
     weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
 
-    with pytest.raises(ValueError, match="source replica size 2 does not match configured source_dp 4"):
+    with pytest.raises(ValueError, match="source replica size 2 does not match configured source replica size 4"):
         build_reshard_layouts(
             weight,
-            source_dp=4,
+            source_replica_size=4,
             source_shard_size=16,
-            destination_dp=8,
-            destination_tp_size=4,
+            destination_replica_size=8,
+            destination_shard_size=4,
         )

--- a/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
+++ b/tests/checkpoint_engine/test_reshard_layout_on_cpu.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for NCCL M2N Reshard layout construction."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.distributed.tensor import Replicate, Shard
+
+from verl.checkpoint_engine.reshard_layout import (
+    build_reshard_layouts,
+    local_shape,
+    local_weight_desc_from_shard_api,
+)
+from verl.workers.engine.spec import ShardSpec
+
+
+class _Mesh:
+    ndim = 2
+
+    @staticmethod
+    def size(mesh_dim=None):
+        return 32 if mesh_dim is None else (2, 16)[mesh_dim]
+
+
+class _OneDimensionalMesh:
+    ndim = 1
+
+    @staticmethod
+    def size(mesh_dim=None):
+        return 16
+
+
+@pytest.mark.parametrize("shape", [(), (2, 2, 2, 2)])
+def test_local_shape_rejects_tensor_ranks_unsupported_by_m2n(shape):
+    with pytest.raises(ValueError, match="supports tensor ranks 1 through 3"):
+        local_shape(shape, shard_dim=None, shard_size=1)
+
+
+def test_shard_api_maps_raw_fsdp_to_rollout_tp():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+    source, destination = build_reshard_layouts(
+        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+    )
+
+    assert weight.tensor.shape == (2, 8)
+    assert weight.source_shard_size == 16
+    assert weight.source_mesh_dims == (2, 16)
+    assert (source.mesh_dims, source.placements) == ((2, 16), (None, 0))
+    assert (destination.mesh_dims, destination.placements) == ((8, 4), (None, 1))
+    assert destination.local_shape == (32, 2)
+
+
+def test_shard_api_preserves_replicated_layouts():
+    exported = (
+        "model.layers.0.input_layernorm.weight",
+        torch.empty(32, device="meta"),
+        ShardSpec(full_shape=(32,), mesh=_Mesh(), placements=(Replicate(), Replicate())),
+    )
+
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=None)
+    source, destination = build_reshard_layouts(
+        weight, source_dp=2, source_shard_size=16, destination_dp=8, destination_tp_size=4
+    )
+
+    assert weight.source_shard_dim is None
+    assert weight.source_mesh_dims == (2, 16)
+    assert source.mesh_dims == destination.mesh_dims == (32, 1)
+    assert source.placements == destination.placements == (None, None)
+    assert source.local_shape == destination.local_shape == (32,)
+
+
+def test_shard_api_accepts_one_dimensional_source_mesh():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_OneDimensionalMesh(), placements=(Shard(0),)),
+    )
+
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+    source, _ = build_reshard_layouts(
+        weight, source_dp=1, source_shard_size=16, destination_dp=8, destination_tp_size=4
+    )
+
+    assert weight.source_mesh_dims == (1, 16)
+    assert (source.mesh_dims, source.placements) == ((1, 16), (None, 0))
+
+
+def test_shard_api_rejects_deferred_hf_conversion():
+    exported = (
+        "decoder.layers.0.self_attention.linear_qkv.weight",
+        torch.empty(1, device="meta"),
+        ShardSpec(
+            full_shape=(16,),
+            mesh=_Mesh(),
+            placements=(Replicate(), Shard(0)),
+            to_hf_chunk=lambda start, tensor: [],
+            hf_slots=[("model.layers.0.self_attn.q_proj.weight", (16,))],
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="converter metadata"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_explicit_placement_metadata():
+    exported = (
+        "decoder.layers.0.self_attention.linear_qkv.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(16,), place=0, gather_group=object()),
+    )
+
+    with pytest.raises(NotImplementedError, match="explicit ShardSpec placement metadata"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_multiple_sharded_mesh_dimensions():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(8, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Shard(0), Shard(1))),
+    )
+
+    with pytest.raises(NotImplementedError, match="one source Shard placement"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_outer_sharded_mesh_dimension():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(128, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Shard(0), Replicate())),
+    )
+
+    with pytest.raises(NotImplementedError, match="sharded source mesh dimension to be innermost"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_shard_api_rejects_wrong_local_tensor_size():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(15, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+
+    with pytest.raises(ValueError, match="has 15 elements, expected 16"):
+        local_weight_desc_from_shard_api(exported)
+
+
+def test_layout_builder_rejects_source_shard_size_mismatch():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+
+    with pytest.raises(ValueError, match="source mesh shard size 16 does not match configured 8"):
+        build_reshard_layouts(
+            weight,
+            source_dp=2,
+            source_shard_size=8,
+            destination_dp=8,
+            destination_tp_size=4,
+        )
+
+
+def test_layout_builder_rejects_source_replica_size_mismatch():
+    exported = (
+        "model.layers.0.mlp.down_proj.weight",
+        torch.empty(16, device="meta"),
+        ShardSpec(full_shape=(32, 8), mesh=_Mesh(), placements=(Replicate(), Shard(0))),
+    )
+    weight = local_weight_desc_from_shard_api(exported, destination_shard_dim=1)
+
+    with pytest.raises(ValueError, match="source replica size 2 does not match configured source_dp 4"):
+        build_reshard_layouts(
+            weight,
+            source_dp=4,
+            source_shard_size=16,
+            destination_dp=8,
+            destination_tp_size=4,
+        )

--- a/verl/checkpoint_engine/__init__.py
+++ b/verl/checkpoint_engine/__init__.py
@@ -71,3 +71,10 @@ try:
     __all__ += ["DeltaShardedCheckpointEngine"]
 except ImportError:
     DeltaShardedCheckpointEngine = None
+
+try:
+    from .nccl_m2n_checkpoint_engine import NCCLM2NCheckpointEngine
+
+    __all__ += ["NCCLM2NCheckpointEngine"]
+except ImportError:
+    NCCLM2NCheckpointEngine = None

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -108,8 +108,9 @@ class CheckpointEngine(ABC):
     """
 
     # How receive_weights yields weights to the server adapter:
-    #   "named_tensors" -- (name, tensor) pairs, bucketed into full-tensor loads.
-    #   "delta_flush"   -- per-flush sparse payloads applied via a custom loader.
+    #   "named_tensors"            -- (name, tensor) pairs containing full tensors.
+    #   "rank_local_named_tensors" -- (name, tensor) pairs already sharded for each destination rank.
+    #   "delta_flush"              -- per-flush sparse payloads applied via a custom loader.
     wire_format = "named_tensors"
 
     @abstractmethod
@@ -303,6 +304,8 @@ class CheckpointEngineWorker(Worker):
 
         self.server_adapter: BaseRollout = server_adapter
         backend = self.rollout_config.checkpoint_engine.backend
+        if backend == "nccl_m2n" and self.rollout_config.name != "vllm":
+            raise NotImplementedError("checkpoint_engine.backend='nccl_m2n' currently requires rollout.name='vllm'")
         if backend == "delta_sharded" and self.rollout_config.name != "sglang":
             raise NotImplementedError(
                 f"checkpoint_engine.backend={backend!r} currently supports only the sglang rollout "

--- a/verl/checkpoint_engine/nccl_m2n_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_m2n_checkpoint_engine.py
@@ -1,0 +1,587 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NCCL M2N checkpoint backend for layout-aware weight redistribution."""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Generator
+
+import ray
+import torch
+import zmq
+
+try:
+    from nccl.core import SUM, Communicator, UniqueId, get_unique_id
+    from nccl.m2n import DistTensor, Handle, Mesh, Replicate, Shard
+
+    _NCCL_IMPORT_ERROR = None
+except ImportError as exc:  # Optional experimental dependency.
+    _NCCL_IMPORT_ERROR = exc
+
+from verl.checkpoint_engine.base import CheckpointEngine, CheckpointEngineRegistry
+from verl.checkpoint_engine.reshard_layout import (
+    LocalWeightDesc,
+    ReshardLayout,
+    build_reshard_layouts,
+    local_weight_desc_from_shard_api,
+)
+from verl.models.transformers.hf_dense_decoder_tp import infer_dense_decoder_tp_shard_dim
+from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def _require_nccl() -> None:
+    if _NCCL_IMPORT_ERROR is not None:
+        raise ImportError(
+            "checkpoint_engine.backend='nccl_m2n' requires NCCL4Py with the nccl.m2n extension"
+        ) from _NCCL_IMPORT_ERROR
+
+
+@dataclass(frozen=True)
+class NCCLM2NMasterMetadata:
+    """Bootstrap data created by the trainer master.
+
+    Attributes:
+        unique_id: Serialized NCCL unique ID shared by all source and destination ranks.
+        zmq_ip: IP address of the master's weight-metadata publisher.
+        zmq_port: TCP port of the master's weight-metadata publisher.
+        source_dp: Size of the replicated dimension of the source mesh.
+        source_shard_size: Size of the sharded dimension of the source mesh.
+        destination_dp: Size of the replicated dimension of the destination mesh.
+        destination_shard_size: Size of the sharded dimension of the destination mesh.
+    """
+
+    unique_id: bytes
+    zmq_ip: str
+    zmq_port: int
+    source_dp: int
+    source_shard_size: int
+    destination_dp: int
+    destination_shard_size: int
+
+
+def _placement_objects(layout: ReshardLayout) -> list[Any]:
+    """Translate a reshard layout into NCCL M2N placement objects."""
+
+    return [Replicate() if dim is None else Shard(dim) for dim in layout.placements]
+
+
+def _nccl_stream(stream: Any) -> Any:
+    """Use the raw handle for torch streams that lack ``__cuda_stream__``."""
+
+    # NCCL4Py accepts integer handles on every supported release. Torch 2.9
+    # exposes ``cuda_stream`` but no longer implements the older protocol that
+    # the pinned NCCL4Py otherwise probes for non-cuda.core stream objects.
+    raw_stream = getattr(stream, "cuda_stream", None)
+    return int(raw_stream) if raw_stream is not None else stream
+
+
+def _allocate_destination(shape: torch.Size, dtype: torch.dtype) -> torch.Tensor:
+    """Allocate one destination rank's output tensor on its current CUDA device.
+
+    Args:
+        shape: Shape of the destination rank-local tensor.
+        dtype: Data type of the destination rank-local tensor.
+
+    Returns:
+        A newly allocated CUDA tensor with ``shape`` and ``dtype``.
+    """
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    return torch.empty(shape, dtype=dtype, device=device)
+
+
+@CheckpointEngineRegistry.register("nccl_m2n")
+class NCCLM2NCheckpointEngine(CheckpointEngine):
+    """Transfer source shards directly into destination rank-local shards.
+
+    Source and destination ranks form separate two-dimensional meshes with shapes
+    ``(source_dp, source_shard_size)`` and
+    ``(destination_dp, destination_shard_size)``. The first dimension contains
+    replicated model copies; the second is the rank-local sharding dimension.
+
+    Args:
+        bucket_size: Common checkpoint-engine bucket size in bytes. NCCL M2N
+            manages its staging pool internally, so this value is retained only
+            for checkpoint-engine interface compatibility.
+        is_master: Whether this source rank creates the NCCL unique ID and publishes
+            per-weight metadata. Exactly one source rank must be the master.
+        source_dp: Number of replicated groups in the source mesh.
+        source_shard_size: Number of ranks in the source mesh's sharded dimension.
+        destination_dp: Number of replicated groups in the destination mesh.
+        destination_shard_size: Number of ranks in the destination mesh's generic
+            sharded dimension. A consumer such as vLLM may interpret this as TP.
+    """
+
+    wire_format = "rank_local_named_tensors"
+    topic = "nccl_m2n_metadata"
+    ready_topic_prefix = "nccl_m2n_ready:"
+
+    def __init__(
+        self,
+        bucket_size: int,
+        is_master: bool = False,
+        source_dp: int | None = None,
+        source_shard_size: int | None = None,
+        destination_dp: int | None = None,
+        destination_shard_size: int | None = None,
+    ) -> None:
+        topology = {
+            "source_dp": source_dp,
+            "source_shard_size": source_shard_size,
+            "destination_dp": destination_dp,
+            "destination_shard_size": destination_shard_size,
+        }
+        missing = [name for name, value in topology.items() if value is None]
+        if missing:
+            raise ValueError(f"NCCL M2N topology requires explicit values for {', '.join(missing)}")
+
+        self.bucket_size = int(bucket_size)
+        self.is_master = bool(is_master)
+        self.source_dp = int(source_dp)
+        self.source_shard_size = int(source_shard_size)
+        self.destination_dp = int(destination_dp)
+        self.destination_shard_size = int(destination_shard_size)
+        if (
+            min(
+                self.bucket_size,
+                self.source_dp,
+                self.source_shard_size,
+                self.destination_dp,
+                self.destination_shard_size,
+            )
+            <= 0
+        ):
+            raise ValueError("NCCL M2N sizes must be positive")
+
+        self.source_world_size = self.source_dp * self.source_shard_size
+        self.reshard_world_size = self.source_world_size + self.destination_dp * self.destination_shard_size
+        self.rank: int | None = None
+        self.role: str | None = None
+        self._master_metadata: NCCLM2NMasterMetadata | None = None
+        self._comm = self._handle = self._transfer_stream = None
+        self._socket = self._zmq_context = None
+        self._closed = False
+        if self.is_master:
+            self._start_metadata_server()
+        atexit.register(self.close)
+
+    def _start_metadata_server(self) -> None:
+        ip = ray.util.get_node_ip_address().strip("[]")
+        port, _ = get_free_port(ip)
+        context = zmq.Context()
+        # XPUB exposes subscription notifications, allowing rank zero to wait
+        # until every destination's metadata subscription has reached this socket.
+        socket = context.socket(zmq.XPUB)
+        socket.setsockopt(zmq.XPUB_VERBOSE, 1)
+        address = f"tcp://[{ip}]:{port}" if is_valid_ipv6_address(ip) else f"tcp://{ip}:{port}"
+        if is_valid_ipv6_address(ip):
+            socket.setsockopt(zmq.IPV6, 1)
+        socket.bind(address)
+        self._zmq_context, self._socket = context, socket
+        self._metadata_ip, self._metadata_port = ip, port
+
+    def _connect_metadata_client(self, metadata: NCCLM2NMasterMetadata) -> None:
+        context = zmq.Context()
+        socket = context.socket(zmq.SUB)
+        address = (
+            f"tcp://[{metadata.zmq_ip}]:{metadata.zmq_port}"
+            if is_valid_ipv6_address(metadata.zmq_ip)
+            else f"tcp://{metadata.zmq_ip}:{metadata.zmq_port}"
+        )
+        if is_valid_ipv6_address(metadata.zmq_ip):
+            socket.setsockopt(zmq.IPV6, 1)
+        socket.connect(address)
+        # Subscribe to the common topic first. XPUB observes subscriptions from
+        # one connection in order, so seeing the rank-specific readiness topic
+        # proves that the common subscription is active at the publisher.
+        socket.setsockopt_string(zmq.SUBSCRIBE, self.topic)
+        socket.setsockopt_string(zmq.SUBSCRIBE, f"{self.ready_topic_prefix}{self.rank}")
+        self._zmq_context, self._socket = context, socket
+
+    def _wait_for_metadata_subscribers(self) -> None:
+        """Wait for every destination subscription and acknowledge each one."""
+
+        expected = set(range(self.source_world_size, self.reshard_world_size))
+        ready: set[int] = set()
+        prefix = self.ready_topic_prefix.encode()
+        while ready != expected:
+            event = self._socket.recv()
+            if not event:
+                raise RuntimeError("received an empty NCCL M2N subscription event")
+            subscription = event[1:]
+            if not subscription.startswith(prefix):
+                continue
+            try:
+                rank = int(subscription[len(prefix) :].decode("ascii"))
+            except (UnicodeDecodeError, ValueError) as exc:
+                raise RuntimeError(f"invalid NCCL M2N readiness subscription: {subscription!r}") from exc
+            if rank not in expected:
+                raise RuntimeError(f"unexpected NCCL M2N destination readiness rank {rank}")
+            if event[0] == 1:
+                ready.add(rank)
+            elif event[0] == 0:
+                ready.discard(rank)
+            else:
+                raise RuntimeError(f"invalid NCCL M2N subscription action {event[0]}")
+        for rank in sorted(expected):
+            self._socket.send_string(f"{self.ready_topic_prefix}{rank}")
+
+    def _wait_for_metadata_publisher(self) -> None:
+        """Wait until rank zero acknowledges this destination's subscriptions."""
+
+        expected = f"{self.ready_topic_prefix}{self.rank}"
+        received = self._socket.recv_string()
+        if received != expected:
+            raise RuntimeError(f"unexpected NCCL M2N readiness acknowledgement {received!r}; expected {expected!r}")
+
+    def prepare(self) -> NCCLM2NMasterMetadata | None:
+        """Create the communicator bootstrap metadata on the master source rank.
+
+        Returns:
+            Cached bootstrap metadata on the master, or ``None`` on every other rank.
+        """
+
+        if not self.is_master:
+            return None
+        _require_nccl()
+        if self._master_metadata is None:
+            self._master_metadata = NCCLM2NMasterMetadata(
+                bytes(get_unique_id()),
+                self._metadata_ip,
+                self._metadata_port,
+                self.source_dp,
+                self.source_shard_size,
+                self.destination_dp,
+                self.destination_shard_size,
+            )
+        return self._master_metadata
+
+    @classmethod
+    def build_topology(
+        cls, trainer_world_size: int, rollout_world_size: int, metadata: list[Any]
+    ) -> tuple[dict[str, list[Any]], dict[str, list[Any]]]:
+        """Build per-worker communicator arguments for source and destination ranks.
+
+        Args:
+            trainer_world_size: Number of trainer workers in the source mesh.
+            rollout_world_size: Number of rollout workers in the destination mesh.
+            metadata: Results of ``prepare`` ordered with trainer workers first.
+
+        Returns:
+            Trainer and rollout keyword-argument maps for ``init_process_group``.
+            Every value is a per-worker list suitable for worker-group dispatch.
+
+        Raises:
+            ValueError: If there is not exactly one trainer master or either worker
+                count does not match the configured mesh dimensions.
+        """
+
+        masters = [item for item in metadata[:trainer_world_size] if isinstance(item, NCCLM2NMasterMetadata)]
+        if len(masters) != 1:
+            raise ValueError(f"NCCL M2N requires exactly one trainer master, got {len(masters)}")
+        master = masters[0]
+        source_size = master.source_dp * master.source_shard_size
+        destination_size = master.destination_dp * master.destination_shard_size
+        world_size = source_size + destination_size
+        if trainer_world_size != source_size or rollout_world_size != destination_size:
+            raise ValueError(
+                f"NCCL M2N requires exactly {source_size} trainer and {destination_size} rollout ranks, "
+                f"got {trainer_world_size} and {rollout_world_size}"
+            )
+        return (
+            {
+                "rank": list(range(source_size)),
+                "world_size": [world_size] * trainer_world_size,
+                "master_metadata": [master] * trainer_world_size,
+                "role": ["source"] * source_size,
+            },
+            {
+                "rank": list(range(source_size, world_size)),
+                "world_size": [world_size] * rollout_world_size,
+                "master_metadata": [master] * rollout_world_size,
+                "role": ["destination"] * rollout_world_size,
+            },
+        )
+
+    def init_process_group(
+        self,
+        rank: int,
+        world_size: int,
+        master_metadata: NCCLM2NMasterMetadata,
+        role: str,
+    ) -> None:
+        """Create the combined NCCL M2N communicator and runtime handle.
+
+        Args:
+            rank: This worker's rank in the source-plus-destination communicator.
+            world_size: Total number of source and destination ranks.
+            master_metadata: Bootstrap and mesh metadata returned by the master.
+            role: This worker's role, either ``"source"`` or ``"destination"``.
+
+        Raises:
+            ValueError: If the rank, role, world size, or topology is invalid.
+            RuntimeError: If an existing communicator has a different topology or
+                communicator bootstrap fails.
+        """
+
+        self.rank, self.role = int(rank), role
+        if self.rank < 0:
+            raise ValueError(f"NCCL M2N rank must be non-negative, got {self.rank}")
+        if role not in {"source", "destination"}:
+            raise ValueError(f"NCCL M2N role must be source or destination, got {role!r}")
+
+        _require_nccl()
+        if world_size != self.reshard_world_size:
+            raise ValueError(f"runtime world_size={world_size}, expected {self.reshard_world_size}")
+        expected = (self.source_dp, self.source_shard_size, self.destination_dp, self.destination_shard_size)
+        actual = (
+            master_metadata.source_dp,
+            master_metadata.source_shard_size,
+            master_metadata.destination_dp,
+            master_metadata.destination_shard_size,
+        )
+        if actual != expected:
+            raise ValueError(f"NCCL M2N topology {actual} does not match local config {expected}")
+        if self._comm is not None:
+            if self._comm.rank != self.rank or self._comm.nranks != world_size:
+                raise RuntimeError("cannot reuse an NCCL M2N communicator with a different topology")
+            return
+
+        self._comm = Communicator.init(world_size, self.rank, UniqueId.from_bytes(master_metadata.unique_id))
+        self._handle = Handle.create()
+        self._transfer_stream = torch.cuda.Stream(device=torch.cuda.current_device())
+        if role == "destination":
+            self._connect_metadata_client(master_metadata)
+
+        sync = torch.ones(1, dtype=torch.int32, device="cuda")
+        stream = torch.cuda.current_stream()
+        self._comm.allreduce(sync, sync, SUM, stream=_nccl_stream(stream))
+        stream.synchronize()
+        if sync.item() != world_size:
+            raise RuntimeError("NCCL M2N communicator bootstrap failed")
+        if self.rank == 0:
+            # CheckpointEngineManager waits for every init_process_group call, so
+            # no weight can be published until this readiness barrier returns.
+            self._wait_for_metadata_subscribers()
+        elif self.role == "destination":
+            self._wait_for_metadata_publisher()
+
+    def _coerce_weight(self, exported: Any) -> LocalWeightDesc:
+        if isinstance(exported, LocalWeightDesc):
+            return exported
+
+        weight = local_weight_desc_from_shard_api(
+            exported,
+            destination_shard_dim=infer_dense_decoder_tp_shard_dim(exported[0]),
+        )
+        if self.rank is not None and weight.source_shard_dim is not None:
+            spec = exported[2]
+            mesh_dim = next(axis for axis, placement in enumerate(spec.placements) if placement.is_shard())
+            device_mesh_rank = int(spec.mesh.get_local_rank(mesh_dim=mesh_dim))
+            m2n_mesh_rank = self.rank % self.source_shard_size
+            if device_mesh_rank != m2n_mesh_rank:
+                raise ValueError(
+                    f"source DeviceMesh rank {device_mesh_rank} does not match M2N mesh rank {m2n_mesh_rank}"
+                )
+        return weight
+
+    def _layouts(self, weight: LocalWeightDesc) -> tuple[ReshardLayout, ReshardLayout]:
+        return build_reshard_layouts(
+            weight,
+            source_replica_size=self.source_dp,
+            source_shard_size=self.source_shard_size,
+            destination_replica_size=self.destination_dp,
+            destination_shard_size=self.destination_shard_size,
+        )
+
+    def _descriptors(
+        self,
+        weight: LocalWeightDesc,
+        source: torch.Tensor | None,
+        destination: torch.Tensor | None,
+    ) -> tuple[Any, Any]:
+        source_layout, destination_layout = self._layouts(weight)
+        return (
+            DistTensor(
+                source,
+                local_shape=source_layout.local_shape,
+                dtype=weight.tensor.dtype,
+                mesh=Mesh(source_layout.mesh_dims, start_rank=source_layout.start_rank),
+                placements=_placement_objects(source_layout),
+            ),
+            DistTensor(
+                destination,
+                local_shape=destination_layout.local_shape,
+                dtype=weight.tensor.dtype,
+                mesh=Mesh(destination_layout.mesh_dims, start_rank=destination_layout.start_rank),
+                placements=_placement_objects(destination_layout),
+            ),
+        )
+
+    def _publish(self, payload: dict[str, Any]) -> None:
+        self._socket.send_string(self.topic, flags=zmq.SNDMORE)
+        self._socket.send_pyobj(payload)
+
+    def _receive(self) -> dict[str, Any]:
+        if self._socket.recv_string() != self.topic:
+            raise RuntimeError("received an unexpected NCCL M2N metadata topic")
+        return self._socket.recv_pyobj()
+
+    @torch.no_grad()
+    async def send_weights(self, weights: Generator, global_steps: int | None = None) -> dict:
+        """Reshard local source tensors into destination rank-local tensors.
+
+        Args:
+            weights: Generator yielding ``LocalWeightDesc`` objects or
+                ``(name, local_tensor, ShardSpec)`` tuples.
+            global_steps: Optional trainer step associated with the update. Reserved
+                for checkpoint-engine interface compatibility.
+
+        Returns:
+            An empty metrics dictionary after all transfers have been enqueued.
+            ``finalize`` waits for their completion.
+        """
+
+        del global_steps
+        if self.rank is None:
+            raise RuntimeError("NCCL M2N process group is not initialized")
+        if self.role != "source" or any(resource is None for resource in (self._comm, self._handle)):
+            raise RuntimeError(f"invalid NCCL M2N sender state for role={self.role!r}")
+
+        caller_stream = torch.cuda.current_stream()
+        stream = self._transfer_stream
+        if stream is None:
+            raise RuntimeError("NCCL M2N transfer stream is not initialized")
+        for exported in weights:
+            weight = self._coerce_weight(exported)
+            stream.wait_stream(caller_stream)
+            if self.rank == 0:
+                self._publish(
+                    {
+                        "kind": "weight",
+                        "name": weight.name,
+                        "global_shape": tuple(weight.global_shape),
+                        "dtype": weight.tensor.dtype,
+                        "destination_shard_dim": weight.destination_shard_dim,
+                        "source_shard_dim": weight.source_shard_dim,
+                        "source_shard_size": weight.source_shard_size,
+                    }
+                )
+            source_desc, destination_desc = self._descriptors(weight, weight.tensor, None)
+            # This removes application-managed staging; M2N may still copy through
+            # the internal staging-buffer pipeline used by Handle.reshard().
+            self._handle.reshard(
+                self._comm,
+                source_desc,
+                destination_desc,
+                stream=_nccl_stream(stream),
+            )
+            # reshard reads the source asynchronously. Return the dependency to
+            # its owning stream so allocator reuse stays ordered without
+            # record_stream's nondeterministic lifetime tracking.
+            caller_stream.wait_stream(stream)
+        if self.rank == 0:
+            self._publish({"kind": "end"})
+        # finalize() fences every matching asynchronous M2N operation. The
+        # handle-owned staging pool remains alive until close() destroys the handle.
+        return {}
+
+    @torch.no_grad()
+    async def receive_weights(self, global_steps: int | None = None) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+        """Receive destination rank-local tensors in source publication order.
+
+        Args:
+            global_steps: Optional trainer step associated with the update. Reserved
+                for checkpoint-engine interface compatibility.
+
+        Yields:
+            The parameter name and its newly allocated destination rank-local tensor.
+        """
+
+        del global_steps
+        if self.rank is None or self.rank < 0 or self.role != "destination":
+            raise RuntimeError(f"invalid NCCL M2N receiver state: rank={self.rank}, role={self.role!r}")
+        if any(resource is None for resource in (self._comm, self._handle)):
+            raise RuntimeError("NCCL M2N receiver resources are not initialized")
+
+        caller_stream = torch.cuda.current_stream()
+        stream = self._transfer_stream
+        if stream is None:
+            raise RuntimeError("NCCL M2N transfer stream is not initialized")
+        while True:
+            metadata = self._receive()
+            if metadata.get("kind") == "end":
+                break
+            if metadata.get("kind") != "weight":
+                raise RuntimeError(f"invalid NCCL M2N metadata: {metadata!r}")
+
+            weight = LocalWeightDesc(
+                metadata["name"],
+                torch.empty(metadata["global_shape"], dtype=metadata["dtype"], device="meta"),
+                torch.Size(metadata["global_shape"]),
+                metadata["destination_shard_dim"],
+                metadata["source_shard_dim"],
+                int(metadata["source_shard_size"]),
+            )
+            _, destination_layout = self._layouts(weight)
+            destination = _allocate_destination(destination_layout.local_shape, weight.tensor.dtype)
+            source_desc, destination_desc = self._descriptors(weight, None, destination)
+            stream.wait_stream(caller_stream)
+            self._handle.reshard(
+                self._comm,
+                source_desc,
+                destination_desc,
+                stream=_nccl_stream(stream),
+            )
+            caller_stream.wait_stream(stream)
+            yield weight.name, destination
+
+    def finalize(self) -> None:
+        """Host-wait for outstanding transfer and consumer work after an update."""
+
+        if self.rank is not None and self.rank >= 0:
+            if self._transfer_stream is not None:
+                self._transfer_stream.synchronize()
+            torch.cuda.current_stream().synchronize()
+
+    def close(self) -> None:
+        """Wait for M2N work and release the handle, communicator, and ZMQ resources."""
+
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._transfer_stream is not None:
+                self._transfer_stream.synchronize()
+            if self._handle is not None:
+                self._handle.destroy()
+            if self._comm is not None:
+                self._comm.destroy()
+            if self._socket is not None:
+                self._socket.close(linger=0)
+            if self._zmq_context is not None:
+                self._zmq_context.term()
+        except Exception:
+            logger.exception("failed to close NCCL M2N resources")
+        finally:
+            self._comm = self._handle = self._transfer_stream = None
+            self._socket = self._zmq_context = None

--- a/verl/checkpoint_engine/reshard_layout.py
+++ b/verl/checkpoint_engine/reshard_layout.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Layout helpers shared by NCCL M2N Reshard checkpoint backends."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+import torch
+
+from verl.workers.engine.spec import ShardSpec
+
+__all__ = [
+    "LocalWeightDesc",
+    "ReshardLayout",
+    "build_reshard_layouts",
+    "local_shape",
+    "local_weight_desc_from_shard_api",
+]
+
+
+@dataclass(frozen=True)
+class LocalWeightDesc:
+    """Describe one rank-local tensor and how it is partitioned.
+
+    "source_shard_dim" and "destination_shard_dim" are tensor dimensions,
+    not device-mesh dimensions. "None" means that the tensor is replicated on
+    that side of the transfer.
+
+    For a sharded source, "source_shard_size" is the size of the device-mesh
+    dimension that shards the tensor. It is ignored for a replicated source.
+    "source_mesh_dims" records the source mesh as the logical
+    ``(replica_size, shard_size)`` expected by M2N. It is ``None`` when the
+    shard export has no mesh and therefore cannot describe its replica count.
+    """
+
+    # The producer has already converted this to the consumer's parameter name.
+    name: str
+    tensor: torch.Tensor
+    # Shape before either the source or destination partition is applied.
+    global_shape: torch.Size
+    destination_shard_dim: int | None
+    source_shard_dim: int | None
+    source_shard_size: int
+    source_mesh_dims: tuple[int, int] | None = None
+
+
+@dataclass(frozen=True)
+class ReshardLayout:
+    """Describe one side of a transfer as a logical two-dimensional mesh.
+
+    "mesh_dims" gives the number of ranks along each mesh dimension.
+    "placements" has one entry for each mesh dimension: an integer means that
+    mesh dimension shards the corresponding tensor dimension, while "None"
+    means replication. For example, placements=(None, 0) replicates the tensor
+    along mesh dimension 0 and shards tensor dimension 0 along mesh dimension 1.
+
+    "start_rank" is the first rank occupied by this mesh in the dedicated M2N
+    communicator, not a rank in the trainer's global process group. The backend
+    maps participating processes into contiguous M2N source and destination
+    ranges before building this layout. "local_shape" is the tensor shape held
+    by one rank after applying the placements.
+    """
+
+    mesh_dims: tuple[int, int]
+    start_rank: int
+    placements: tuple[int | None, int | None]
+    local_shape: torch.Size
+
+
+def local_shape(global_shape: Sequence[int], shard_dim: int | None, shard_size: int) -> torch.Size:
+    """Return one rank's shape after an even partition on "shard_dim".
+
+    A "None" shard dimension represents replication, so it leaves the global
+    shape unchanged.
+    """
+
+    if shard_size <= 0:
+        raise ValueError(f"shard_size must be positive, got {shard_size}")
+    shape = list(global_shape)
+    if not 1 <= len(shape) <= 3:
+        raise ValueError(f"NCCL M2N supports tensor ranks 1 through 3, got {len(shape)} for shape {tuple(shape)}")
+    if shard_dim is not None:
+        if not 0 <= shard_dim < len(shape) or shape[shard_dim] % shard_size:
+            raise ValueError(f"shape {tuple(shape)} cannot be sharded on dim {shard_dim} by {shard_size}")
+        shape[shard_dim] //= shard_size
+    return torch.Size(shape)
+
+
+def local_weight_desc_from_shard_api(
+    exported: tuple[str, torch.Tensor, ShardSpec],
+    *,
+    destination_shard_dim: int | None | Literal["source"] = "source",
+) -> LocalWeightDesc:
+    """Convert one engine shard export into a transport-independent descriptor.
+
+    "ShardSpec.placements" describes the trainer tensor over its device mesh.
+    Destination placement is supplied by the producer because it is a
+    model/consumer policy, not a property of the generic layout library. Passing
+    "source" preserves the source tensor placement.
+    """
+
+    if not isinstance(exported, tuple) or len(exported) != 3:
+        raise TypeError("get_per_tensor_param_shard() must yield (name, tensor, ShardSpec)")
+    name, tensor, spec = exported
+    if not isinstance(name, str) or not isinstance(tensor, torch.Tensor) or not isinstance(spec, ShardSpec):
+        raise TypeError("invalid get_per_tensor_param_shard() item")
+    if spec.to_hf_chunk is not None or spec.hf_slots is not None:
+        # A deferred format conversion may need multiple source shards. The
+        # no-gather path requires conversion before constructing this descriptor.
+        raise NotImplementedError(
+            f"Reshard requires {name!r} in final HF-local form; ShardSpec converter metadata is unsupported"
+        )
+    if spec.place is not None or spec.gather_group is not None or not spec.contributes:
+        # These fields describe sharding that is not necessarily represented by
+        # mesh/placements. Treating mesh=None as replication would silently send
+        # an incomplete tensor for Megatron and veomni explicit-placement exports.
+        raise NotImplementedError(f"Reshard does not support explicit ShardSpec placement metadata for {name!r}")
+    if spec.mesh is None and spec.placements is not None:
+        raise ValueError(f"source placements for {name!r} require a source mesh")
+
+    source_dim, source_size, source_mesh_dims = None, 1, None
+    if spec.mesh is not None:
+        mesh_ndim = int(spec.mesh.ndim)
+        if mesh_ndim not in (1, 2):
+            raise NotImplementedError(f"Reshard supports one- or two-dimensional source meshes for {name!r}")
+        if not isinstance(spec.placements, tuple) or len(spec.placements) != mesh_ndim:
+            raise ValueError(f"invalid source placements for {name!r}")
+
+        mesh_shape = tuple(int(spec.mesh.size(mesh_dim=axis)) for axis in range(mesh_ndim))
+        source_mesh_dims = (1, mesh_shape[0]) if mesh_ndim == 1 else mesh_shape
+
+        # Each placement belongs to a device-mesh dimension; Shard.dim is the
+        # tensor dimension split along that mesh dimension. For example,
+        # (Replicate(), Shard(0)) on a (DP, FSDP) mesh splits tensor dimension 0
+        # across FSDP while DP replicas hold identical shards. The current M2N
+        # descriptor supports at most one such sharded mesh dimension.
+        sharded = []
+        unsupported = []
+        for axis, placement in enumerate(spec.placements):
+            if placement.is_shard():
+                sharded.append((axis, placement))
+            elif not placement.is_replicate():
+                unsupported.append(placement)
+        if unsupported or len(sharded) > 1:
+            raise NotImplementedError(f"Reshard supports one source Shard placement for {name!r}")
+        if sharded:
+            mesh_dim, placement = sharded[0]
+            if mesh_dim != mesh_ndim - 1:
+                raise NotImplementedError(
+                    f"Reshard requires the sharded source mesh dimension to be innermost for {name!r}"
+                )
+            source_dim = int(placement.dim)
+            source_size = source_mesh_dims[1]
+        else:
+            source_size = source_mesh_dims[1]
+
+    full_shape = torch.Size(spec.full_shape)
+    destination_dim = source_dim if destination_shard_dim == "source" else destination_shard_dim
+    expected = local_shape(full_shape, source_dim, source_size)
+    if tensor.numel() != math.prod(expected):
+        raise ValueError(f"local shard for {name!r} has {tensor.numel()} elements, expected {math.prod(expected)}")
+
+    # FSDP may expose a flattened local shard. The element-count check above
+    # makes this reshape safe and restores the expected rank-local tensor shape.
+    return LocalWeightDesc(
+        name=name,
+        tensor=tensor.reshape(expected),
+        global_shape=full_shape,
+        destination_shard_dim=destination_dim,
+        source_shard_dim=source_dim,
+        source_shard_size=source_size,
+        source_mesh_dims=source_mesh_dims,
+    )
+
+
+def build_reshard_layouts(
+    weight: LocalWeightDesc,
+    *,
+    source_dp: int,
+    source_shard_size: int,
+    destination_dp: int,
+    destination_tp_size: int,
+) -> tuple[ReshardLayout, ReshardLayout]:
+    """Build source and destination layouts in one combined communicator.
+
+    A sharded source is modeled as (source_dp, source_shard_size), and a
+    sharded destination as (destination_dp, destination_tp_size). For a
+    replicated weight, all ranks are flattened onto the first mesh dimension
+    and the second dimension is one. This lets every weight use the same
+    two-placement representation.
+
+    Source ranks occupy the first contiguous communicator range. Destination
+    ranks immediately follow them, so the destination "start_rank" equals the
+    source world size. Selecting participants, including any pipeline-stage
+    filtering, is the caller's responsibility and happens before this function.
+    """
+
+    if min(source_dp, source_shard_size, destination_dp, destination_tp_size) <= 0:
+        raise ValueError("Reshard topology sizes must be positive")
+    if weight.source_mesh_dims is not None:
+        source_replica_size, exported_shard_size = weight.source_mesh_dims
+        if source_replica_size != source_dp:
+            raise ValueError(
+                f"source replica size {source_replica_size} does not match configured source_dp {source_dp}"
+            )
+        if exported_shard_size != source_shard_size:
+            raise ValueError(
+                f"source mesh shard size {exported_shard_size} does not match configured {source_shard_size}"
+            )
+    if weight.source_shard_dim is not None and weight.source_shard_size != source_shard_size:
+        raise ValueError(f"source shard size {weight.source_shard_size} does not match configured {source_shard_size}")
+
+    # With no tensor shard dimension, placements=(None, None) replicates the
+    # full tensor across the flattened rank dimension and a singleton dimension.
+    source_world_size = source_dp * source_shard_size
+    source_dims = (source_dp, source_shard_size) if weight.source_shard_dim is not None else (source_world_size, 1)
+    destination_dims = (
+        (destination_dp, destination_tp_size)
+        if weight.destination_shard_dim is not None
+        else (destination_dp * destination_tp_size, 1)
+    )
+    return (
+        ReshardLayout(
+            mesh_dims=source_dims,
+            start_rank=0,
+            placements=(None, weight.source_shard_dim),
+            local_shape=local_shape(weight.global_shape, weight.source_shard_dim, weight.source_shard_size),
+        ),
+        ReshardLayout(
+            mesh_dims=destination_dims,
+            start_rank=source_world_size,
+            placements=(None, weight.destination_shard_dim),
+            local_shape=local_shape(weight.global_shape, weight.destination_shard_dim, destination_tp_size),
+        ),
+    )

--- a/verl/checkpoint_engine/reshard_layout.py
+++ b/verl/checkpoint_engine/reshard_layout.py
@@ -191,18 +191,17 @@ def local_weight_desc_from_shard_api(
 def build_reshard_layouts(
     weight: LocalWeightDesc,
     *,
-    source_dp: int,
+    source_replica_size: int,
     source_shard_size: int,
-    destination_dp: int,
-    destination_tp_size: int,
+    destination_replica_size: int,
+    destination_shard_size: int,
 ) -> tuple[ReshardLayout, ReshardLayout]:
     """Build source and destination layouts in one combined communicator.
 
-    A sharded source is modeled as (source_dp, source_shard_size), and a
-    sharded destination as (destination_dp, destination_tp_size). For a
-    replicated weight, all ranks are flattened onto the first mesh dimension
-    and the second dimension is one. This lets every weight use the same
-    two-placement representation.
+    A sharded side is modeled as (replica_size, shard_size). For a replicated
+    weight, all ranks are flattened onto the first mesh dimension and the
+    second dimension is one. This lets every weight use the same two-placement
+    representation without assigning parallelism roles to the mesh dimensions.
 
     Source ranks occupy the first contiguous communicator range. Destination
     ranks immediately follow them, so the destination "start_rank" equals the
@@ -210,13 +209,14 @@ def build_reshard_layouts(
     filtering, is the caller's responsibility and happens before this function.
     """
 
-    if min(source_dp, source_shard_size, destination_dp, destination_tp_size) <= 0:
+    if min(source_replica_size, source_shard_size, destination_replica_size, destination_shard_size) <= 0:
         raise ValueError("Reshard topology sizes must be positive")
     if weight.source_mesh_dims is not None:
-        source_replica_size, exported_shard_size = weight.source_mesh_dims
-        if source_replica_size != source_dp:
+        exported_replica_size, exported_shard_size = weight.source_mesh_dims
+        if exported_replica_size != source_replica_size:
             raise ValueError(
-                f"source replica size {source_replica_size} does not match configured source_dp {source_dp}"
+                f"source replica size {exported_replica_size} does not match configured source replica size "
+                f"{source_replica_size}"
             )
         if exported_shard_size != source_shard_size:
             raise ValueError(
@@ -227,12 +227,14 @@ def build_reshard_layouts(
 
     # With no tensor shard dimension, placements=(None, None) replicates the
     # full tensor across the flattened rank dimension and a singleton dimension.
-    source_world_size = source_dp * source_shard_size
-    source_dims = (source_dp, source_shard_size) if weight.source_shard_dim is not None else (source_world_size, 1)
+    source_world_size = source_replica_size * source_shard_size
+    source_dims = (
+        (source_replica_size, source_shard_size) if weight.source_shard_dim is not None else (source_world_size, 1)
+    )
     destination_dims = (
-        (destination_dp, destination_tp_size)
+        (destination_replica_size, destination_shard_size)
         if weight.destination_shard_dim is not None
-        else (destination_dp * destination_tp_size, 1)
+        else (destination_replica_size * destination_shard_size, 1)
     )
     return (
         ReshardLayout(
@@ -245,6 +247,6 @@ def build_reshard_layouts(
             mesh_dims=destination_dims,
             start_rank=source_world_size,
             placements=(None, weight.destination_shard_dim),
-            local_shape=local_shape(weight.global_shape, weight.destination_shard_dim, destination_tp_size),
+            local_shape=local_shape(weight.global_shape, weight.destination_shard_dim, destination_shard_size),
         ),
     )

--- a/verl/models/transformers/hf_dense_decoder_tp.py
+++ b/verl/models/transformers/hf_dense_decoder_tp.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conventional HF tensor-parallel placement for dense decoder weights."""
+
+from __future__ import annotations
+
+
+def infer_dense_decoder_tp_shard_dim(name: str) -> int | None:
+    """Infer the conventional HF tensor-parallel placement from a weight name."""
+
+    if name.endswith(
+        (
+            "embed_tokens.weight",
+            "lm_head.weight",
+            "self_attn.q_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.v_proj.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+        )
+    ):
+        return 0
+    if name.endswith(("self_attn.o_proj.weight", "mlp.down_proj.weight")):
+        return 1
+    if name.endswith("norm.weight"):
+        return None
+    raise NotImplementedError(f"unvalidated dense-decoder TP parameter: {name}")

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -274,7 +274,7 @@ checkpoint_engine:
   # Target class for checkpoint engine config
   _target_: verl.workers.config.CheckpointEngineConfig
 
-  # Backend for checkpoint engine: naive, nccl, nixl, hccl
+  # Backend for checkpoint engine: naive, nccl, nixl, hccl, nccl_m2n
   backend: naive
 
   # Specifies the tensor bucket size (in megabytes) for batch weight updates during rollout operations.

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -129,7 +129,7 @@ class CheckpointEngineConfig(BaseConfig):
 
     _mutable_fields = {"backend"}
 
-    # Backend for checkpoint engine: naive, nccl, nixl, hccl
+    # Backend for checkpoint engine: naive, nccl, nixl, hccl, nccl_m2n
     backend: Optional[str] = "naive"
     # Bucket size in MB to transfer multiple weights at one time
     update_weights_bucket_megabytes: int = 2048

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -180,6 +180,19 @@ class BaseEngine:
         """
         raise NotImplementedError
 
+    def get_per_tensor_param_reshard(self, **kwargs) -> tuple[Generator, Optional[dict]]:
+        """Yield final-name rank-local tensors accepted by Reshard backends.
+
+        Unlike :meth:`get_per_tensor_param_shard`, which may carry
+        backend-specific placement or conversion metadata for the delta engine,
+        this export must already be representable as an M2N source layout.
+
+        Returns:
+            Generator: A generator yielding ``(name, local_shard, ShardSpec)``.
+            Optional[dict]: Optional PEFT configuration.
+        """
+        raise NotImplementedError
+
     # Host-memory policy for the delta diff base: pinned (cudaHostAlloc) gives a
     # faster H2D on the diff read-back but competes with every other pinned pool
     # on the node; backends whose memory profile makes that competition

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -891,7 +891,8 @@ class FSDPEngine(BaseEngine):
         """Like :meth:`get_per_tensor_param`, but yields each rank's *local* FSDP shard
         ``(name, local_flat_shard_bf16, ShardSpec)`` instead of all-gathering the full
         tensor. Pure DTensor export, no side effects -- delta bookkeeping lives in
-        :meth:`get_per_tensor_param_delta_shard`. Non-LoRA base path only."""
+        :meth:`get_per_tensor_param_delta_shard`; the ``nccl_m2n`` checkpoint
+        backend consumes the rank-local tensors directly. Non-LoRA base path only."""
 
         # FSDP1's (SHARDED_)STATE_DICT export runs through the unshard machinery and
         # asserts flat params are GPU-resident; FSDP2 state_dict() only collects
@@ -918,6 +919,13 @@ class FSDPEngine(BaseEngine):
                 yield name, local.reshape(-1), spec
 
         return _gen(), None
+
+    def get_per_tensor_param_reshard(self, **kwargs):
+        """Yield raw FSDP shards in the Reshard transport contract."""
+
+        if self._is_lora or self._qat_enabled:
+            raise NotImplementedError("FSDP Reshard export does not support LoRA or QAT")
+        return self.get_per_tensor_param_shard(**kwargs)
 
     def _hf_delta_entry(self, name, spec, place, lidx, lval):
         """Per-param HF delta entry builder: this engine handles DTensor identity

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -753,7 +753,10 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 # snapshot prime), so it drives the training engine itself.
                 metrics = await self.checkpoint_engine.send_weights(self.actor.engine, global_steps=global_steps)
                 return metrics or {}
-            per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
+            if effective_mode == "nccl_m2n":
+                per_tensor_param, _ = self.actor.engine.get_per_tensor_param_reshard()
+            else:
+                per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
             metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
             return metrics or {}
 


### PR DESCRIPTION
### What does this PR do?

Adds the NCCL M2N Reshard checkpoint backend and connects it to veRL's FSDP rank-local shard export.

This is PR 2 in the staged NCCL M2N integration and depends on #7432. Until #7432 merges, GitHub will also show PR1's layout primitives in this PR's diff. The matching vLLM receiver for the new `rank_local_named_tensors` wire format is intentionally isolated in the next stacked PR.

The backend:

- consumes `(name, local_tensor, ShardSpec)` without gathering full parameters;
- builds NCCL M2N `DistTensor` descriptors from PR1's validated layouts;
- calls `Handle.reshard()` on a dedicated CUDA transfer stream;
- uses an XPUB/SUB readiness handshake so no destination can miss the first weight message; and
- fences outstanding work in `finalize()` and releases the M2N handle, communicator, and sockets in `close()`.

This does not duplicate an existing PR. Searches for [NCCL M2N](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22NCCL+M2N%22), [reshard checkpoint engine](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+reshard+checkpoint+engine), and [`rank_local_named_tensors`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22rank_local_named_tensors%22) found only #7432, this PR's prerequisite, and unrelated work.

Related to #400 and #1063.

### Checklist Before Starting

- [x] Searched for similar PRs and documented the results above.
- [x] Formatted the title as `[{modules}] {type}: {description}`.

### Test

```bash
uv run --active --no-sync pytest -q \
  tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py \
  tests/checkpoint_engine/test_global_steps_on_cpu.py \
  tests/checkpoint_engine/test_reshard_layout_on_cpu.py \
  tests/checkpoint_engine/test_nccl_m2n_checkpoint_engine_on_cpu.py
# 64 passed

uv run --active --no-sync pre-commit run --all-files \
  --show-diff-on-failure --color=always
# All 13 hooks passed
```

I also replayed PR1 and PR2 without conflicts on current upstream `main` (`fefb0802`). The 46 PR-specific CPU tests and all 14 current-main pre-commit hooks, including `check-uv-gpu-only`, passed there.

The new CPU suite mocks NCCL M2N and covers registration, optional-dependency errors, topology validation, metadata readiness, layout/descriptors, stream ordering, FSDP export selection, finalization, and cleanup. Native multi-GPU transfer coverage requires NCCL M2N plus the receiver from the next stacked PR, so it is not included in this split.

### API and Usage Example

Once the matching receiver PR lands, the backend is selected through the existing checkpoint-engine configuration:

```yaml
actor_rollout_ref:
  rollout:
    checkpoint_engine:
      backend: nccl_m2n
      engine_kwargs:
        nccl_m2n:
          source_dp: 1
          source_shard_size: 8
          destination_dp: 1
          destination_shard_size: 8
```

The initial producer path supports FSDP base weights with a fixed two-axis replica/shard topology. It fails closed for LoRA, QAT, deferred HF conversion metadata, unsupported placements, multiple shard axes, and unrecognized dense-decoder weight names. Megatron export and broader model mappings are follow-ups.

### Design & Code Changes

- Register `nccl_m2n` as an optional checkpoint backend and define its rank-local wire format.
- Add `get_per_tensor_param_reshard()` to the engine contract and implement it for raw FSDP shards.
- Use NCCL4Py's `nccl.m2n` bindings and `Handle.reshard()`; this removes the application-level source copy, although M2N may still use internal staging.
- Keep transfers on a dedicated CUDA stream with explicit producer/consumer dependencies and a single completion boundary in `finalize()`.
- Add a fail-closed conventional HF dense-decoder TP placement policy.
- Add CPU-CI-discoverable tests in `test_nccl_m2n_checkpoint_engine_on_cpu.py`.

### Acknowledgements

This backend is adapted from the original NCCL M2N Reshard prototype and RFC by Alexandre Chidiac (@achidiac). Thanks to Ke Wen (@kwen2501) and Pouya Kousha (@pkousha) for design and code-review feedback.

### AI assistance disclosure

OpenAI Codex was used for code exploration, implementation assistance, test orchestration, and preparation of this PR.

The human submitter must review every changed line and understand and be able to defend the change before requesting upstream review.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied the complete pre-commit suite; all checks passed on both the exact branch and a current-main replay.
- [ ] Add / update documentation. The backend contract, configuration, and limitations are documented here and in code.
- [x] Added unit tests discoverable by the CPU CI workflow.
- [ ] Request upstream CI in the veRL community channel when ready.
- [ ] Recipe submodule update is not applicable.
