### PR TITLE
[trainer] fix: enforce strict dynamic micro-batch token limits

### DIFF
--- a/tests/utils/test_prepare_micro_batches_with_group_size.py
+++ b/tests/utils/test_prepare_micro_batches_with_group_size.py
@@ -24,6 +24,7 @@ Focuses on verifying that:
 4. Token budget (max_token_len) is respected per micro-batch.
 """
 
+import pytest
 import torch
 from tensordict import TensorDict
 
@@ -102,7 +103,7 @@ def test_force_group_size_2_basic():
     seq_lens = [50, 60, 80, 90, 40, 45, 100, 110]
     force_group_size = 2
     batch_size = len(seq_lens)
-    max_token_len_per_gpu = 200
+    max_token_len_per_gpu = 220
 
     batch = _make_batch(seq_lens, force_group_size, max_token_len_per_gpu)
     micro_batches, batch_idx_list = prepare_micro_batches(batch)
@@ -136,7 +137,7 @@ def test_force_group_size_4_basic():
     ]
     force_group_size = 4
     batch_size = len(seq_lens)
-    max_token_len_per_gpu = 500
+    max_token_len_per_gpu = 850
 
     batch = _make_batch(seq_lens, force_group_size, max_token_len_per_gpu)
     micro_batches, batch_idx_list = prepare_micro_batches(batch)
@@ -151,7 +152,7 @@ def test_force_group_size_reconstruction():
     """Verify that micro-batches can be reconstructed back to the original batch order."""
     seq_lens = [80, 85, 120, 130, 60, 65, 200, 210]
     force_group_size = 2
-    max_token_len_per_gpu = 300
+    max_token_len_per_gpu = 420
 
     batch = _make_batch(seq_lens, force_group_size, max_token_len_per_gpu)
     micro_batches, batch_idx_list = prepare_micro_batches(batch)
@@ -213,7 +214,7 @@ def test_force_group_size_large_group():
     ]
     force_group_size = 3
     batch_size = len(seq_lens)
-    max_token_len_per_gpu = 400
+    max_token_len_per_gpu = 650
 
     batch = _make_batch(seq_lens, force_group_size, max_token_len_per_gpu)
     micro_batches, batch_idx_list = prepare_micro_batches(batch)
@@ -239,3 +240,10 @@ def test_force_group_size_1_unchanged():
     # All samples covered exactly once.
     all_indices = [idx for indices in batch_idx_list for idx in indices]
     assert sorted(all_indices) == list(range(len(seq_lens)))
+
+
+def test_force_group_exceeding_token_limit_raises():
+    batch = _make_batch(seq_lens=[200, 210], force_group_size=2, max_token_len_per_gpu=300)
+
+    with pytest.raises(ValueError, match="forced group exceeds max_token_len"):
+        prepare_micro_batches(batch)

--- a/tests/utils/test_seqlen_balancing.py
+++ b/tests/utils/test_seqlen_balancing.py
@@ -133,6 +133,46 @@ def _worker(rank, world_size, init_method, max_token_len, use_same_dp, min_mb):
     dist.destroy_process_group()
 
 
+def _constraint_error_worker(rank, world_size, init_method, scenario):
+    import verl.utils.seqlen_balancing as seqlen_balancing
+
+    dist.init_process_group(backend="gloo", init_method=init_method, world_size=world_size, rank=rank)
+    seqlen_balancing.get_device_name = lambda: "cpu"
+
+    if scenario == "oversized_group":
+        seq_lens = [6, 6, 1, 1] if rank == 0 else [4, 4, 1, 1]
+        force_group_size = 2
+        expected_error = "forced group exceeds max_token_len"
+    else:
+        seq_lens = [1, 1] if rank == 0 else [6, 6, 6]
+        force_group_size = 1
+        expected_error = "same micro-batch count across DP ranks"
+
+    max_seq_len = max(seq_lens)
+    attention_mask = torch.zeros((len(seq_lens), max_seq_len), dtype=torch.long)
+    for i, seq_len in enumerate(seq_lens):
+        attention_mask[i, :seq_len] = 1
+    batch = DataProto.from_single_dict(
+        {"input_ids": torch.zeros_like(attention_mask), "attention_mask": attention_mask}
+    ).batch
+
+    try:
+        seqlen_balancing.rearrange_micro_batches(
+            batch,
+            max_token_len=10,
+            dp_group=dist.group.WORLD,
+            same_micro_num_in_dp=True,
+            force_group_size=force_group_size,
+        )
+    except ValueError as error:
+        assert expected_error in str(error)
+    else:
+        raise AssertionError("Expected a synchronized ValueError")
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
 def test_dataproto_split_uneven():
     """Test DataProto.split with uneven splits"""
     # Create test data with 10 items
@@ -208,6 +248,19 @@ def test_seqlen_balancing_distributed_params(tmp_path):
         nprocs=world_size,
         join=True,
     )
+
+
+def test_seqlen_balancing_distributed_constraint_errors(tmp_path):
+    world_size = 2
+    for scenario in ("oversized_group", "insufficient_groups"):
+        init_file = tmp_path / f"dist_init_{scenario}"
+        init_file.write_text("")
+        mp.spawn(
+            _constraint_error_worker,
+            args=(world_size, f"file://{init_file}", scenario),
+            nprocs=world_size,
+            join=True,
+        )
 
 
 def test_group_balanced_partitions():

--- a/tests/utils/test_seqlen_balancing.py
+++ b/tests/utils/test_seqlen_balancing.py
@@ -47,6 +47,17 @@ def test_seqlen_balancing():
     torch.testing.assert_close(new_batch, dataproto.batch)
 
 
+def test_micro_batches_respect_max_token_len():
+    input_ids = torch.zeros((8, 7), dtype=torch.long)
+    attention_mask = torch.ones_like(input_ids)
+    dataproto = DataProto.from_single_dict({"input_ids": input_ids, "attention_mask": attention_mask})
+
+    micro_batches, _ = rearrange_micro_batches(dataproto.batch, max_token_len=8)
+
+    assert len(micro_batches) == 8
+    assert all(micro_batch["attention_mask"].sum().item() <= 8 for micro_batch in micro_batches)
+
+
 def test_dynamic_batch():
     input_ids = torch.randint(low=0, high=10, size=(20, 100))
 
@@ -93,24 +104,21 @@ def _worker(rank, world_size, init_method, max_token_len, use_same_dp, min_mb):
         min_num_micro_batch=min_mb,
     )
 
-    # 4) check the enforced counts
+    # 4) check the enforced counts and token limit
     seq_len_effective: torch.Tensor = batch["attention_mask"].sum(dim=1)
     total_seqlen = seq_len_effective.sum().item()
-    local = min(len(seq_len_effective), ceildiv(total_seqlen, max_token_len))
-
+    minimum = min(len(seq_len_effective), ceildiv(total_seqlen, max_token_len))
     if min_mb is not None:
-        expected = max(local, min_mb)
-        assert len(micros) == expected
+        minimum = max(minimum, min_mb)
+    assert len(micros) >= minimum
+    assert all(micro["attention_mask"].sum().item() <= max_token_len for micro in micros)
+
     if use_same_dp:
-        # gather all local_counts
+        # All ranks must use the same final count, including any upward search.
         counts = [torch.zeros(1, device=f"{get_device_name()}:{rank}") for _ in range(world_size)]
-        counts[rank].fill_(local)
+        counts[rank].fill_(len(micros))
         dist.all_gather(counts, counts[rank])
-        expected = max(int(c.item()) for c in counts)
-        assert len(micros) == expected
-    else:
-        # if neither, we get the local natural count
-        assert len(micros) == local
+        assert len({int(count.item()) for count in counts}) == 1
 
     # 5) reconstruction sanity: concat→reverse_idx→orig
     flat = torch.cat(micros, dim=0)

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -399,7 +399,8 @@ def rearrange_micro_batches(
     if min_num_micro_batch is not None:
         # used to support pp
         num_micro_batches = max(min_num_micro_batch, num_micro_batches)
-    if dist.is_initialized() and same_micro_num_in_dp and dp_group is not None:
+    sync_micro_batch_count = dist.is_initialized() and same_micro_num_in_dp and dp_group is not None
+    if sync_micro_batch_count:
         num_micro_batches = torch.tensor([num_micro_batches], device=get_device_name())
         dist.all_reduce(num_micro_batches, op=dist.ReduceOp.MAX, group=dp_group)
         num_micro_batches = num_micro_batches.cpu().item()
@@ -422,22 +423,37 @@ def rearrange_micro_batches(
         workloads = calculate_workload(seq_len_effective).cpu().tolist()
         group_token_lens = seq_len_effective.cpu().tolist()
 
-    assert max(group_token_lens) <= max_token_len, (
-        f"A forced group exceeds the token limit. Got {max(group_token_lens)=} and {max_token_len=}"
-    )
+    max_group_token_len = max(group_token_lens)
+    min_num_groups = num_groups
+    if sync_micro_batch_count:
+        # Fatal constraints must be agreed on before any rank raises; otherwise peers can hang in the next collective.
+        constraints = torch.tensor([max_group_token_len, -num_groups], dtype=torch.long, device=get_device_name())
+        dist.all_reduce(constraints, op=dist.ReduceOp.MAX, group=dp_group)
+        max_group_token_len = int(constraints[0].item())
+        min_num_groups = -int(constraints[1].item())
+
+    if max_group_token_len > max_token_len:
+        raise ValueError(
+            "A forced group exceeds max_token_len and cannot be split. "
+            f"Got max_group_token_len={max_group_token_len} and max_token_len={max_token_len}."
+        )
 
     # ceildiv(total_seqlen, max_token_len) is only a lower bound because samples are indivisible.
     # Increase the number of micro-batches until the balanced partition also respects the hard limit.
     step = num_batches_divided_by or 1
     while True:
-        assert num_micro_batches <= num_groups, (
-            f"Cannot split {num_groups} groups into {num_micro_batches} non-empty micro-batches"
-        )
+        if num_micro_batches > min_num_groups:
+            raise ValueError(
+                "Cannot satisfy max_token_len while keeping forced groups atomic and using the same "
+                "micro-batch count across DP ranks. "
+                f"Requested {num_micro_batches} non-empty micro-batches, but a rank has only "
+                f"{min_num_groups} forced groups."
+            )
         micro_bsz_group_idx = get_seqlen_balanced_partitions(workloads, num_micro_batches, equal_size=False)
         within_limit = all(
             sum(group_token_lens[idx] for idx in partition) <= max_token_len for partition in micro_bsz_group_idx
         )
-        if dist.is_initialized() and same_micro_num_in_dp and dp_group is not None:
+        if sync_micro_batch_count:
             within_limit_tensor = torch.tensor([int(within_limit)], device=get_device_name())
             dist.all_reduce(within_limit_tensor, op=dist.ReduceOp.MIN, group=dp_group)
             within_limit = bool(within_limit_tensor.item())

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -406,8 +406,6 @@ def rearrange_micro_batches(
     if num_batches_divided_by is not None:
         num_micro_batches = roundup_divisible(num_micro_batches, num_batches_divided_by)
 
-    assert num_micro_batches <= num_groups
-
     # upcast to int64 to avoid potential overflow im `calculate_workload` computation.
     seq_len_effective = seq_len_effective.long()
 
@@ -417,11 +415,38 @@ def rearrange_micro_batches(
         workloads_per_sample = calculate_workload(seq_len_effective)
         workloads_per_sample_grouped = workloads_per_sample.view(num_groups, force_group_size)
         group_workloads = workloads_per_sample_grouped.sum(dim=1).cpu().tolist()
+        group_token_lens = seq_len_effective.view(num_groups, force_group_size).sum(dim=1).cpu().tolist()
+        workloads = group_workloads
+    else:
+        # note that seq_len_effective is a GPU tensor. We need to make it a list to avoid D2H!
+        workloads = calculate_workload(seq_len_effective).cpu().tolist()
+        group_token_lens = seq_len_effective.cpu().tolist()
 
-        # Partition groups instead of individual samples
-        micro_bsz_group_idx = get_seqlen_balanced_partitions(group_workloads, num_micro_batches, equal_size=False)
+    assert max(group_token_lens) <= max_token_len, (
+        f"A forced group exceeds the token limit. Got {max(group_token_lens)=} and {max_token_len=}"
+    )
 
-        # Convert group indices back to sample indices
+    # ceildiv(total_seqlen, max_token_len) is only a lower bound because samples are indivisible.
+    # Increase the number of micro-batches until the balanced partition also respects the hard limit.
+    step = num_batches_divided_by or 1
+    while True:
+        assert num_micro_batches <= num_groups, (
+            f"Cannot split {num_groups} groups into {num_micro_batches} non-empty micro-batches"
+        )
+        micro_bsz_group_idx = get_seqlen_balanced_partitions(workloads, num_micro_batches, equal_size=False)
+        within_limit = all(
+            sum(group_token_lens[idx] for idx in partition) <= max_token_len for partition in micro_bsz_group_idx
+        )
+        if dist.is_initialized() and same_micro_num_in_dp and dp_group is not None:
+            within_limit_tensor = torch.tensor([int(within_limit)], device=get_device_name())
+            dist.all_reduce(within_limit_tensor, op=dist.ReduceOp.MIN, group=dp_group)
+            within_limit = bool(within_limit_tensor.item())
+        if within_limit:
+            break
+        num_micro_batches += step
+
+    if force_group_size > 1:
+        # Convert group indices back to sample indices.
         micro_bsz_idx = []
         for group_partition in micro_bsz_group_idx:
             sample_partition = []
@@ -429,13 +454,8 @@ def rearrange_micro_batches(
                 start_idx = group_idx * force_group_size
                 sample_partition.extend(range(start_idx, start_idx + force_group_size))
             micro_bsz_idx.append(sample_partition)
-
-        workloads = group_workloads
     else:
-        # Original logic for force_group_size == 1
-        # note that seq_len_effective is a GPU tensor. We need to make it a list to avoid D2H!
-        workloads = calculate_workload(seq_len_effective).cpu().tolist()
-        micro_bsz_idx = get_seqlen_balanced_partitions(workloads, num_micro_batches, equal_size=False)
+        micro_bsz_idx = micro_bsz_group_idx
 
     if use_dynamic_bsz_balance:
         # Use the sum of squared sequence lengths to approximate attention computation workload


### PR DESCRIPTION
### What does this PR do?

Dynamic micro-batch packing previously estimated the number of micro-batches using:

`ceil(total_sequence_length / max_token_len)`

This value is only a theoretical lower bound. Individual samples cannot be split, and the Karmarkar-Karp heuristic primarily balances computational workload. As a result, a generated micro-batch could still contain more tokens than max_token_len.

For example:
```
max_token_len = 8
sequence lengths = [7, 7, 7, 7, 7, 7, 7, 7]
```

The initial calculation produces seven micro-batches, but one of them must contain two samples, resulting in 14 tokens and violating the configured limit.

This change makes `max_token_len` a strict upper bound (If a sample or forced_group exceeds the limit, a ValueError is raised):

1. Calculate the initial number of micro-batches using the existing formula.
2. Partition samples using the existing Karmarkar-Karp workload-balancing algorithm.
3. Check the actual token sum of every generated partition.
4. If any partition exceeds the limit, increase the number of micro-batches and repartition.
Repeat until every partition satisfies the configured limit.

### Test

E2E SFT config:

Model: Qwen3-8B
Hardware: 8 × Hopper GPUs
Parallelism: TP=8
Batch: 16 × 30,720 tokens
max_token_len: 32,768

(16 × 30,720 == 15 × 32,768)

Peak memory and performance impact measured over steady-state steps 2–4:

Maximum tokens per micro-batch: 61,440 → 30,720 (50% reduction)
Number of micro-batches: 15 → 16
Incremental training memory peak: 10.92 GiB → 5.46 GiB (approximately 50% reduction)
Total allocated memory peak: 28.67 GiB → 22.98 GiB (approximately 19.9% reduction)
Reserved memory peak: 32.08 GiB → 24.82 GiB (approximately 22.6% reduction)
Training step time: approximately 21.16s → 21.31s (approximately the same)
