### PR TITLE
[trainer, perf] fix: skip unused entropy computation for old log probs

### DIFF
--- a/tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py
+++ b/tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+pytest.importorskip("ray")
+
+from verl import DataProto
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.utils import tensordict_utils as tu
+
+
+class _ActorRolloutWorkerGroup:
+    def __init__(self):
+        self.calculate_entropy = None
+
+    def compute_log_prob(self, batch):
+        self.calculate_entropy = tu.get_non_tensor_data(batch, "calculate_entropy", None)
+        output = {
+            "log_probs": torch.nested.as_nested_tensor(
+                [torch.tensor([10.0, 11.0, 12.0, 13.0]), torch.tensor([20.0, 21.0, 22.0, 23.0])],
+                layout=torch.jagged,
+            )
+        }
+        if self.calculate_entropy:
+            output["entropy"] = torch.nested.as_nested_tensor(
+                [torch.full((4,), 3.0), torch.full((4,), 3.0)],
+                layout=torch.jagged,
+            )
+        output = tu.get_tensordict(output)
+        tu.assign_non_tensor(output, metrics={"mfu": 0.5})
+        return output
+
+
+def _make_batch():
+    return DataProto.from_dict(
+        tensors={
+            "prompts": torch.tensor([[1, 2], [3, 4]]),
+            "responses": torch.tensor([[5, 6], [7, 8]]),
+            "input_ids": torch.tensor([[1, 2, 5, 6], [3, 4, 7, 8]]),
+            "attention_mask": torch.ones(2, 4, dtype=torch.long),
+            "response_mask": torch.ones(2, 2, dtype=torch.long),
+            "position_ids": torch.arange(4).repeat(2, 1),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("calculate_entropy", "entropy_coeff", "expected"),
+    [
+        (False, 0.0, False),
+        (True, 0.0, True),
+        (False, 0.01, True),
+        (True, 0.01, True),
+    ],
+)
+def test_compute_old_log_prob_respects_entropy_config(calculate_entropy, entropy_coeff, expected):
+    trainer = RayPPOTrainer.__new__(RayPPOTrainer)
+    trainer.config = OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "actor": {
+                    "calculate_entropy": calculate_entropy,
+                    "entropy_coeff": entropy_coeff,
+                    "calculate_sum_pi_squared": False,
+                }
+            }
+        }
+    )
+    trainer.actor_rollout_wg = _ActorRolloutWorkerGroup()
+
+    old_log_prob, old_log_prob_mfu = trainer._compute_old_log_prob(_make_batch())
+
+    assert trainer.actor_rollout_wg.calculate_entropy is expected
+    assert old_log_prob_mfu == 0.5
+    assert torch.equal(old_log_prob.batch["old_log_probs"], torch.tensor([[11.0, 12.0], [21.0, 22.0]]))
+    expected_entropy = torch.full((2, 2), 3.0) if expected else torch.zeros(2, 2)
+    assert torch.equal(old_log_prob.batch["entropys"], expected_entropy)

--- a/tests/trainer/ppo/v1/test_old_log_prob_entropy_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_old_log_prob_entropy_on_cpu.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+from tensordict import TensorDict
+
+pytest.importorskip("ray")
+pytest.importorskip("transfer_queue")
+
+from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+
+
+class _StubTrainer(PPOTrainer):
+    def on_step_end(self):
+        pass
+
+    def on_sample_end(self):
+        pass
+
+
+class _Batch:
+    def __init__(self):
+        self.keys = ["sample-0", "sample-1"]
+        self.partition_id = "train"
+        self.extra_info = {}
+
+    def __len__(self):
+        return len(self.keys)
+
+
+class _ActorRolloutWorkerGroup:
+    def compute_log_prob(self, batch):
+        return batch
+
+
+@pytest.mark.parametrize(
+    ("calculate_entropy", "entropy_coeff", "expected"),
+    [
+        (False, 0.0, False),
+        (True, 0.0, True),
+        (False, 0.01, True),
+        (True, 0.01, True),
+    ],
+)
+def test_compute_old_log_prob_respects_entropy_config(calculate_entropy, entropy_coeff, expected):
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    trainer.config = OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "actor": {
+                    "calculate_entropy": calculate_entropy,
+                    "entropy_coeff": entropy_coeff,
+                    "loss_agg_mode": "token-mean",
+                    "loss_scale_factor": None,
+                },
+                "rollout": {"temperature": 1.0, "calculate_log_probs": False},
+            },
+            "algorithm": {"rollout_correction": None},
+        }
+    )
+    trainer.actor_rollout_wg = _ActorRolloutWorkerGroup()
+    batch = _Batch()
+    data = TensorDict(
+        {
+            "log_probs": torch.nested.as_nested_tensor(
+                [torch.tensor([10.0, 11.0, 12.0, 13.0]), torch.tensor([20.0, 21.0, 22.0, 23.0])],
+                layout=torch.jagged,
+            ),
+            "response_mask": torch.nested.as_nested_tensor(
+                [torch.ones(2), torch.ones(2)],
+                layout=torch.jagged,
+            ),
+        },
+        batch_size=[2],
+    )
+    if expected:
+        data["entropy"] = torch.nested.as_nested_tensor(
+            [torch.full((4,), 3.0), torch.full((4,), 3.0)],
+            layout=torch.jagged,
+        )
+    metrics = {}
+
+    with (
+        patch("verl.trainer.ppo.v1.trainer_base.tq.kv_batch_get", return_value=data) as kv_batch_get,
+        patch("verl.trainer.ppo.v1.trainer_base.tq.kv_batch_put", return_value=batch) as kv_batch_put,
+    ):
+        result = trainer._compute_old_log_prob(batch, metrics)
+
+    assert result is batch
+    assert batch.extra_info["calculate_entropy"] is expected
+    expected_fields = ["log_probs", "response_mask", *(["entropy"] if expected else [])]
+    assert kv_batch_get.call_args.kwargs["select_fields"] == expected_fields
+    fields = kv_batch_put.call_args.kwargs["fields"]
+    assert torch.equal(fields["old_log_probs"].values(), torch.tensor([11.0, 12.0, 21.0, 22.0]))
+    expected_entropy = torch.full((4,), 3.0) if expected else torch.zeros(4)
+    assert torch.equal(fields["entropy"].values(), expected_entropy)
+    assert metrics["actor/entropy"] == (3.0 if expected else 0.0)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1294,24 +1294,26 @@ class RayPPOTrainer:
         # step 2: convert from padding to nopadding
         batch_td = left_right_2_no_padding(batch_td)
         # step 3: add meta info
+        actor_config = self.config.actor_rollout_ref.actor
+        calculate_entropy = actor_config.calculate_entropy or actor_config.entropy_coeff != 0.0
         calculate_sum_pi_squared = self.config.actor_rollout_ref.actor.get("calculate_sum_pi_squared", False)
         tu.assign_non_tensor(
             batch_td,
-            calculate_entropy=True,
+            calculate_entropy=calculate_entropy,
             calculate_sum_pi_squared=calculate_sum_pi_squared,
             compute_loss=False,
         )
         output = self.actor_rollout_wg.compute_log_prob(batch_td)
         # gather output
-        entropy = tu.get(output, "entropy")
+        entropy = tu.get(output, "entropy") if calculate_entropy else None
         log_probs = tu.get(output, "log_probs")
         routed_experts = tu.get(output, "routed_experts")
         sum_pi_squared = tu.get(output, "sum_pi_squared") if calculate_sum_pi_squared else None
 
         old_log_prob_mfu = tu.get(output, "metrics")["mfu"]
         # step 4. No padding to padding
-        entropy = no_padding_2_padding(entropy, batch_td)
         log_probs = no_padding_2_padding(log_probs, batch_td)
+        entropy = no_padding_2_padding(entropy, batch_td) if entropy is not None else torch.zeros_like(log_probs)
         if sum_pi_squared is not None:
             sum_pi_squared = no_padding_2_padding(sum_pi_squared, batch_td)
         # step 5: rebuild a tensordict and convert to dataproto

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1555,9 +1555,11 @@ class PPOTrainer(ABC):
             return batch
 
         # 1. compute log probs
+        actor_config = self.config.actor_rollout_ref.actor
+        calculate_entropy = actor_config.calculate_entropy or actor_config.entropy_coeff != 0.0
         batch.extra_info.update(
             {
-                "calculate_entropy": True,
+                "calculate_entropy": calculate_entropy,
                 "compute_loss": False,
                 "temperature": self.config.actor_rollout_ref.rollout.temperature,
             }
@@ -1565,14 +1567,19 @@ class PPOTrainer(ABC):
         output: KVBatchMeta = self.actor_rollout_wg.compute_log_prob(batch)
         assert len(output) == len(batch)
 
-        fields = ["entropy", "log_probs", "response_mask"]
+        fields = ["log_probs", "response_mask"]
+        if calculate_entropy:
+            fields.append("entropy")
         if self.config.actor_rollout_ref.rollout.calculate_log_probs:
             fields.extend(["responses", "rollout_log_probs"])
         data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
 
         # 2. write old_log_probs and entropy back to TransferQueue
         data["old_log_probs"] = response_from_nested(data.pop("log_probs"), data["response_mask"])
-        data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
+        if calculate_entropy:
+            data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
+        else:
+            data["entropy"] = torch.zeros_like(data["old_log_probs"])
         batch = tq.kv_batch_put(
             keys=batch.keys, partition_id=batch.partition_id, fields=data.select("old_log_probs", "entropy")
         )
@@ -1580,7 +1587,6 @@ class PPOTrainer(ABC):
         data = DataProto(batch=data.to_padded_tensor())
 
         # 3. calculate actor entroy metrics
-        actor_config = self.config.actor_rollout_ref.actor
         entropy_agg = agg_loss(
             loss_mat=data.batch["entropy"],
             loss_mask=data.batch["response_mask"],


### PR DESCRIPTION
### What does this PR do?

This PR avoids unnecessary full-vocabulary entropy computation when recomputing old log probabilities.

Both the legacy `RayPPOTrainer` and the V1 trainer currently force `calculate_entropy=True` in `_compute_old_log_prob()`, even when the existing configuration disables entropy:

```yaml
actor_rollout_ref:
  actor:
    entropy_coeff: 0
    calculate_entropy: false
```

This can cause unnecessary memory and compute overhead for long sequences. In the reported workload with approximately 12K-token sequences, entropy computation required about 6–7 GiB of additional device memory and could cause OOM.

The old-log-prob paths now request entropy only when:

```python
actor.calculate_entropy or actor.entropy_coeff != 0
```

When entropy is disabled, the trainer creates a response-shaped zero tensor to preserve the existing entropy field and metric for downstream compatibility.

This does not change the loss or gradients when `entropy_coeff=0`. It also does not change colocated execution, teacher models, rollout behavior, or the training architecture.

Related PRs:

- #4239 introduced `actor_rollout_ref.actor.calculate_entropy`.
- #6016 applied the same configuration condition to actor updates, but the old-log-prob recomputation paths still forced entropy computation.

This PR is not a duplicate of #6016 because it fixes `_compute_old_log_prob()` in both the legacy and V1 trainers.

### Checklist Before Starting

- [x] Search for similar PRs. Search queries:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+calculate_entropy+old_log_prob
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+entropy+OOM+trainer
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Added parameterized CPU regression tests for both the legacy and V1 trainer implementations.

The tests cover all combinations of the two entropy settings:

| `calculate_entropy` | `entropy_coeff` | Entropy requested |
| --- | ---: | --- |
| `false` | `0` | No |
| `true` | `0` | Yes |
| `false` | nonzero | Yes |
| `true` | nonzero | Yes |

The disabled case verifies that:

- `calculate_entropy=False` is passed to the worker;
- the worker does not need to return an `entropy` field;
- old log probabilities are preserved;
- a zero-valued response-shaped entropy field is generated for downstream compatibility.

Legacy trainer test:

```bash
/root/python_env/verl/bin/python -m pytest -q \
  tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py
```

Result:

```text
4 passed
```

V1 trainer test:

```bash
/root/python_env/verl/bin/python -m pytest -q \
  tests/trainer/ppo/v1/test_old_log_prob_entropy_on_cpu.py
```

Result:

```text
4 passed
```

Pre-commit:

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

Result: all checks passed.

### API and Usage Example

There is no API or configuration schema change.

With the existing configuration:

```yaml
actor_rollout_ref:
  actor:
    entropy_coeff: 0
    calculate_entropy: false
```

Entropy is no longer computed while recomputing old log probabilities.

Setting either `calculate_entropy=true` or a nonzero `entropy_coeff` preserves the existing entropy computation behavior:

```yaml
actor_rollout_ref:
  actor:
    calculate_entropy: true
```

or:

```yaml
actor_rollout_ref:
  actor:
    entropy_coeff: 0.01
```

### Design & Code Changes

- Update `verl/trainer/ppo/ray_trainer.py` to derive the old-log-prob entropy flag from `actor.calculate_entropy` and `actor.entropy_coeff`.
- Apply the same behavior to `verl/trainer/ppo/v1/trainer_base.py`.
- Avoid requesting or reading the worker's entropy output when entropy is disabled.
- Use a response-shaped zero tensor when entropy is disabled to preserve existing fields and metrics.
- Add parameterized CPU tests for both trainer implementations.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not applicable: this fixes the behavior of existing configuration options and introduces no new user-facing API.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Added `_on_cpu.py` regression tests for both the legacy and V1 trainer paths; the existing CPU workflow automatically discovers these tests.
- [x] Once this PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in the [verl Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, use the [Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If this PR is related to the `recipe` submodule, update the reference via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable: this PR does not modify the `recipe` submodule.

AI assistance was used (OpenAI Codex) for code analysis, implementation, and test drafting. The human submitter reviewed every changed line and ran the tests listed above.
