### PR TITLE
[training_utils, rollout] feat: nest MLflow experiments under VERL_MLFLOW_EXPERIMENT_PREFIX

### DIFF
--- a/docs/advance/rollout_trace.rst
+++ b/docs/advance/rollout_trace.rst
@@ -1,7 +1,7 @@
 Trace Function Usage Instructions
 ========================================
 
-Last updated: 07/10/2025.
+Last updated: 08/25/2026.
 
 Applicable Scenarios
 --------------------
@@ -119,7 +119,9 @@ Usage of mlflow
    1. Http and https URLs corresponding to online services
    2. Local files or directories, such as ``sqlite:////tmp/mlruns.db``, indicate that data is stored in ``/tmp/mlruns.db``. When using local files, it is necessary to initialize the file first (e.g., start the UI: ``mlflow ui --backend-store-uri sqlite:////tmp/mlruns.db``) to avoid conflicts when multiple workers create files simultaneously.
 
-2. Configuration Parameters
+2. Optionally set the ``VERL_MLFLOW_EXPERIMENT_PREFIX`` environment variable to nest the experiment under a root path. Managed backends such as Databricks require the experiment to be an absolute workspace path, while ``trainer.project_name`` is usually a bare name that is also reused as a path component (e.g. ``trainer.default_local_dir``). With ``VERL_MLFLOW_EXPERIMENT_PREFIX=/Workspace/Shared/verl``, ``trainer.project_name=my_project`` becomes the experiment ``/Workspace/Shared/verl/my_project``, for both the mlflow logger and the rollout trace. A ``project_name`` that is already absolute is left untouched, and leaving the variable unset keeps the previous behavior.
+
+3. Configuration Parameters
 
    1. ``actor_rollout_ref.rollout.trace.backend=mlflow``
    2. ``trainer.logger=['console', 'mlflow']``. This item is optional. Trace and logger are independent functions. When using mlflow, it is recommended to also enable the mlflow logger to implement both functions in one system.

--- a/tests/utils/test_mlflow_experiment_prefix_on_cpu.py
+++ b/tests/utils/test_mlflow_experiment_prefix_on_cpu.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from verl.utils.tracking import mlflow_experiment_name
+
+
+class TestMlflowExperimentName(unittest.TestCase):
+    def test_no_prefix_returns_bare_name(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(mlflow_experiment_name("my_project"), "my_project")
+
+    def test_empty_prefix_is_noop(self):
+        with patch.dict(os.environ, {"VERL_MLFLOW_EXPERIMENT_PREFIX": ""}):
+            self.assertEqual(mlflow_experiment_name("my_project"), "my_project")
+
+    def test_prefix_nests_bare_name(self):
+        with patch.dict(os.environ, {"VERL_MLFLOW_EXPERIMENT_PREFIX": "/Workspace/Shared/mlflow"}):
+            self.assertEqual(mlflow_experiment_name("my_project"), "/Workspace/Shared/mlflow/my_project")
+
+    def test_unrooted_name_with_slash_is_nested(self):
+        # Only a leading slash marks a name as already rooted; inner slashes do not.
+        with patch.dict(os.environ, {"VERL_MLFLOW_EXPERIMENT_PREFIX": "/Workspace/Shared/mlflow"}):
+            self.assertEqual(mlflow_experiment_name("team/my_project"), "/Workspace/Shared/mlflow/team/my_project")
+
+    def test_trailing_slash_is_normalized(self):
+        with patch.dict(os.environ, {"VERL_MLFLOW_EXPERIMENT_PREFIX": "/root/"}):
+            self.assertEqual(mlflow_experiment_name("p"), "/root/p")
+
+    def test_absolute_name_is_left_untouched(self):
+        with patch.dict(os.environ, {"VERL_MLFLOW_EXPERIMENT_PREFIX": "/root"}):
+            self.assertEqual(mlflow_experiment_name("/Users/me/exp"), "/Users/me/exp")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -23,6 +23,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 from verl.utils.ray_utils import get_event_loop
+from verl.utils.tracking import mlflow_experiment_name
 
 _trace_enabled: ContextVar[bool] = ContextVar("_trace_enabled", default=True)
 _trace_attributes: ContextVar[dict | None] = ContextVar("_trace_attributes", default=None)
@@ -99,7 +100,7 @@ class RolloutTraceConfig:
             MLFLOW_TRACKING_URI = os.environ.get("MLFLOW_TRACKING_URI", "sqlite:////tmp/mlruns.db")
             mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
-            mlflow.set_experiment(project_name)
+            mlflow.set_experiment(mlflow_experiment_name(project_name))
         elif backend == "trackio":
             import trackio
             from trackio import context_vars

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -35,6 +35,21 @@ MLFLOW_MAX_ATTEMPTS = 3
 MLFLOW_SLEEP_SECONDS = 5
 
 
+def mlflow_experiment_name(project_name: str) -> str:
+    """Optionally nest the MLflow experiment under a root path.
+
+    Managed MLflow backends (e.g. Databricks) require the experiment to be an absolute workspace path,
+    whereas ``project_name`` is typically a bare name that is also reused as a path component
+    (e.g. ``trainer.default_local_dir``). ``VERL_MLFLOW_EXPERIMENT_PREFIX`` nests a bare ``project_name``
+    under that prefix; an already-absolute name is left untouched, and an unset or empty prefix returns
+    ``project_name`` unchanged.
+    """
+    prefix = os.environ.get("VERL_MLFLOW_EXPERIMENT_PREFIX")
+    if prefix and not project_name.startswith("/"):
+        return f"{prefix.rstrip('/')}/{project_name}"
+    return project_name
+
+
 class Tracking:
     """A unified tracking interface for logging experiment data to multiple backends.
 
@@ -113,7 +128,7 @@ class Tracking:
                     else:
                         # Project_name is actually experiment_name in MLFlow
                         # If experiment does not exist, will create a new experiment
-                        experiment = mlflow.set_experiment(project_name)
+                        experiment = mlflow.set_experiment(mlflow_experiment_name(project_name))
                         mlflow.start_run(experiment_id=experiment.experiment_id, run_name=experiment_name)
 
                     mlflow.log_params(_compute_mlflow_params_from_objects(config))


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in `VERL_MLFLOW_EXPERIMENT_PREFIX` environment variable that nests the MLflow experiment under a root path. Managed MLflow backends such as Databricks require the experiment to be an absolute workspace path, but `trainer.project_name` is typically a bare name that is also reused as a path component (e.g. `trainer.default_local_dir`), so it cannot simply be made absolute. When the variable is set, a project name that is not already rooted is nested under it for `mlflow.set_experiment` only, at both call sites — the MLflow logger in `Tracking` and the rollout trace backend. Behavior is unchanged when the variable is unset or empty.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [`is:pr is:open mlflow`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+mlflow), [`is:pr set_experiment`](https://github.com/verl-project/verl/pulls?q=is%3Apr+set_experiment), [`is:pr VERL_MLFLOW`](https://github.com/verl-project/verl/pulls?q=is%3Apr+VERL_MLFLOW). No open PR addresses MLflow experiment naming. #5135 edits the same MLflow init block in `verl/utils/tracking.py`, but for an unrelated concern (resuming a run by name), so it may cost a trivial rebase rather than overlapping in scope.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

New CPU unit test with six cases: no prefix, empty prefix, nesting a bare name, nesting a name containing inner slashes, prefix trailing-slash normalization, and an already-rooted name left untouched.

```
$ pytest -q tests/utils/test_mlflow_experiment_prefix_on_cpu.py
6 passed

# existing suites covering both touched modules
$ pytest -q --asyncio-mode=auto tests/utils/test_rollout_trace_on_cpu.py tests/utils/test_mlflow_key_sanitization.py tests/utils/test_mlflow_experiment_prefix_on_cpu.py
17 passed, 2 skipped     # 11 passed, 2 skipped on main without this change — delta is the 6 new cases

$ pre-commit run --all-files
all 14 hooks passed
```

Also verified that `mlflow.set_experiment` receives the prefixed name at both call sites (and the bare name when the variable is unset), and that the `_on_cpu` suffix routes the test to `cpu_unit_tests` while `gpu_unit_tests` skips it via its `--ignore-glob='*on_cpu.py'`. No workflow change is needed: `cpu_unit_tests.yml` already matches on `paths: "**/*.py"`.

### API and Usage Example

No API or config surface changes — the variable is read from the environment, and leaving it unset preserves current behavior.

```bash
export VERL_MLFLOW_EXPERIMENT_PREFIX=/Workspace/Shared/verl

python -m verl.trainer.main_ppo \
  trainer.project_name=my_project \
  trainer.experiment_name=run1 \
  trainer.logger=['console','mlflow'] \
  actor_rollout_ref.rollout.trace.backend=mlflow
```

The MLflow experiment becomes `/Workspace/Shared/verl/my_project` for both the logger and the rollout trace, while `trainer.default_local_dir` is unaffected.

### Design & Code Changes

- `verl/utils/tracking.py`: adds a four-line `mlflow_experiment_name()` helper and applies it at `mlflow.set_experiment`.
- `verl/utils/rollout_trace.py`: applies the same helper at the trace backend's `mlflow.set_experiment`.
- `docs/advance/rollout_trace.rst`: documents the variable in the existing "Usage of mlflow" section, alongside `MLFLOW_TRACKING_URI`.
- `tests/utils/test_mlflow_experiment_prefix_on_cpu.py`: new test.

Semantics worth flagging for review:

- "Already rooted" means a leading `/`. Inner slashes do not count, so a bare `team/my_project` is still nested.
- Runs attached via `MLFLOW_RUN_ID` are unaffected, because that branch never reaches `set_experiment`.
- The prefix is MLflow-specific: `weave.init()` and `trackio.init()` keep the raw `project_name`.

Two alternatives were considered, and I'm happy to switch if maintainers prefer either:

1. **mlflow's own `MLFLOW_EXPERIMENT_NAME`.** It is currently inert in verl, since `set_experiment` is called unconditionally and takes precedence over `_get_experiment_id_from_env()`. Using it would also mean restating the full absolute path per run rather than composing with `project_name`.
2. **A config property instead of an environment variable.** `actor_rollout_ref.rollout.trace.project_name` already exists and can be overridden today (added in #5418 as plumbing for the config refactor; not documented in the English docs), and a `trainer.`-level property could be read opportunistically the way `trainer.wandb_proxy` is. I chose the environment variable because the prefix is a per-environment constant rather than a per-run value: one variable covers both the logger and the trace, across every entry point, without launcher changes. A config property would need to be set for the logger and the trace separately.

AI assistance (Claude Code) was used to prepare this change; I have reviewed every line and run the tests above.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit — not applicable.
