### PR TITLE
[rollout, algo] fix: report zero ESS for fully filtered IcePop batches

### DIFF
--- a/tests/trainer/ppo/test_rollout_corr.py
+++ b/tests/trainer/ppo/test_rollout_corr.py
@@ -394,6 +394,30 @@ def test_exact_icepop_zeroes_weights_without_changing_mask():
     assert metrics["rollout_corr/rollout_is_eff_sample_size"] == pytest.approx(1.0 / 3.0, abs=1e-6)
 
 
+@pytest.mark.parametrize("rollout_is", ["token", "sequence"])
+def test_icepop_all_zero_weights_report_zero_ess(rollout_is):
+    """A fully filtered IcePop batch has zero effective samples and must not crash."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    raw_is_weights = torch.tensor([[0.1, 0.1], [10.0, 10.0]], device=device)
+    old_log_prob = torch.zeros_like(raw_is_weights)
+    rollout_log_prob = -torch.log(raw_is_weights)
+    response_mask = torch.ones_like(raw_is_weights)
+
+    weights_proto, modified_response_mask, metrics = compute_rollout_correction_and_rejection_mask(
+        old_log_prob=old_log_prob,
+        rollout_log_prob=rollout_log_prob,
+        response_mask=response_mask,
+        rollout_is=rollout_is,
+        rollout_is_threshold="0.5_5.0",
+        rollout_rs=None,
+    )
+
+    assert torch.count_nonzero(weights_proto.batch["rollout_is_weights"]) == 0
+    assert torch.equal(modified_response_mask, response_mask)
+    assert metrics["rollout_corr/rollout_is_eff_sample_size"] == 0.0
+
+
 def test_bool_rollout_is_threshold_is_rejected():
     """Boolean thresholds should not be silently accepted via bool <: int."""
     device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -754,8 +754,11 @@ def compute_is_metrics(
     weights_for_ess: torch.Tensor = rollout_is_weights.clamp(min=0.0, max=rollout_is_threshold)
     mean_for_ess: torch.Tensor = verl_F.masked_mean(weights_for_ess, response_mask)
     is_weights_normalized: torch.Tensor = weights_for_ess / (mean_for_ess + 1e-8)  # Avoid division by zero
+    normalized_weight_square_mean = verl_F.masked_mean(is_weights_normalized.square(), response_mask).item()
+    # IcePop can legitimately filter every weight in a batch. In that case there are no
+    # effective samples, so report zero instead of raising a Python ZeroDivisionError.
     metrics["rollout_is_eff_sample_size"] = (
-        1.0 / verl_F.masked_mean(is_weights_normalized.square(), response_mask).item()
+        0.0 if normalized_weight_square_mean == 0.0 else 1.0 / normalized_weight_square_mean
     )
 
     # Add sequence-level metrics if weights have batch dimension


### PR DESCRIPTION
### What does this PR do?

IcePop intentionally zeros importance-sampling weights outside its configured lower/upper bounds. If every valid token or sequence in a batch is filtered, `compute_is_metrics()` currently divides by a zero mean squared normalized weight and raises `ZeroDivisionError`.

This change reports an effective sample size (ESS) of `0.0` for that all-zero case. Nonzero ESS calculations remain unchanged. The patch does not alter importance weights, response masks, losses, configuration, or public APIs.

### Checklist Before Starting

- [x] Searched for similar PRs: [IcePop ESS](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+IcePop+ESS), [`rollout_is_eff_sample_size`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+rollout_is_eff_sample_size), and [all-zero rollout-correction weights](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+all-zero+weights+rollout+correction). No same-scope PR was found. Open PR #6800 adds a distinct KPop rejection mode and does not change the ESS calculation.
- [x] Formatted the PR title as `[{modules}] {type}: {description}`.

### Test

```text
pytest -q tests/trainer/ppo/test_rollout_corr.py tests/trainer/ppo/test_rollout_corr_integration.py
32 passed

pre-commit run --files verl/trainer/ppo/rollout_corr_helper.py tests/trainer/ppo/test_rollout_corr.py --show-diff-on-failure
14 hooks passed
```

The regression test covers both token-level and sequence-level IcePop on CPU. In the local environment, pytest was invoked after disabling Transformers' torchvision discovery because the installed CPU PyTorch and system torchvision builds are incompatible; the tested rollout-correction path itself is CPU-only.

### API and Usage Example

No API or configuration changes.

### Design & Code Changes

- Reuse the already computed mean squared normalized weight.
- Report ESS `0.0` only when that value is exactly zero; otherwise use the existing reciprocal calculation unchanged.
- Add token- and sequence-level regression coverage for fully filtered IcePop batches, including unchanged response masks.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md) and repository `AGENTS.md`.
- [x] Ran all applicable pre-commit hooks on the changed files.
- [x] Added CPU unit coverage in an existing CI-collected test file.
- [x] No documentation update is needed because behavior, configuration, and public APIs are unchanged.
- [ ] Request CI in the verl Slack or Feishu channel after the PR is opened.
- [x] This change does not touch the `recipe` submodule.

AI assistance disclosure: OpenAI Codex assisted with duplicate searching, investigation, implementation, test preparation, and PR drafting. The submitting human reviewed every changed line and is responsible for the change end to end.
