### PR TITLE
[data] fix: offload multimodal dataset processing

### DIFF
--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 import os
+import threading
 from copy import deepcopy
 from pathlib import Path
 
@@ -185,6 +187,36 @@ def test_maybe_filter_out_long_prompts_accepts_image_path(monkeypatch):
         {"type": "text", "text": "Describe "},
         {"type": "image", "image": image_path},
     ]
+
+
+def test_process_multi_modal_info_keeps_event_loop_responsive(monkeypatch):
+    processing_started = threading.Event()
+    observer_ran = threading.Event()
+
+    def blocking_process_multi_modal_info(cls, messages, image_patch_size, config):
+        processing_started.set()
+        observer_ran.wait(timeout=0.2)
+        return None, None, None
+
+    monkeypatch.setattr(
+        RLHFDataset,
+        "_process_multi_modal_info",
+        classmethod(blocking_process_multi_modal_info),
+    )
+
+    async def run():
+        async def observe_event_loop():
+            await asyncio.sleep(0)
+            observer_ran.set()
+
+        observer = asyncio.create_task(observe_event_loop())
+        await RLHFDataset.process_multi_modal_info([], image_patch_size=14, config=OmegaConf.create({}))
+        observer_ran_while_processing = observer_ran.is_set()
+        await observer
+        return observer_ran_while_processing
+
+    assert asyncio.run(run())
+    assert processing_started.is_set()
 
 
 def test_image_rl_data():

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -505,7 +505,11 @@ class RLHFDataset(Dataset):
         image_patch_size,
         config: DictConfig,
     ) -> tuple[list[Image.Image], list[Any], list[Any]]:
-        return cls._process_multi_modal_info(messages, image_patch_size=image_patch_size, config=config)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: cls._process_multi_modal_info(messages, image_patch_size=image_patch_size, config=config),
+        )
 
     def split(self, num_splits: int):
         """


### PR DESCRIPTION
### What does this PR do?

`RLHFDataset.process_multi_modal_info` is an async method used by the agent loop, but it calls the synchronous image/video extractor directly on the event-loop thread. That prevents other coroutine work from progressing while multimodal inputs are being processed.

This patch offloads only the synchronous extractor to the default executor and preserves the existing awaited API and return tuple. It complements the earlier async agent-loop path in #6804; #6789 offloaded the older `process_vision_info` path, while the active path now goes through `process_multi_modal_info`.

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+process_multi_modal_info
- [x] Format the PR title as `[data] fix: offload multimodal dataset processing`

### Test

A new CPU regression uses a blocking patched extractor and a concurrent coroutine. Before this change, the observer cannot run while the extractor blocks; after it, the observer runs during processing.

The committed lockfile only supports Python 3.12+ on x86_64 Linux, so `uv sync --extra cpu` cannot create the repository test environment on this macOS host. I therefore ran the same RED/GREEN async timing harness against the actual `rl_dataset.py` source, with only unrelated imports stubbed: it reported `observer_ran_while_processing=False` before the patch and `True` after it.

Also executed:

```text
uvx ruff format --check verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py
uvx ruff check verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py
git diff --check
```

### API and Usage Example

No public API or configuration changes. Existing callers continue to await `process_multi_modal_info` as before.

### Design & Code Changes

- Obtain the running event loop in the existing async wrapper.
- Run `_process_multi_modal_info` in the default executor.
- Add a deterministic CPU regression proving the event loop remains responsive.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply full pre-commit checks. Focused Ruff checks passed; the local repository environment cannot be synced on this platform as described above.
- [ ] Add / Update the documentation. No documentation update is needed because the awaited API is unchanged.
- [x] Add a CPU unit test to cover the changed code.
- [ ] Send a CI request in Slack/Feishu.
- [ ] This PR is related to `recipe`.

### AI assistance

AI assistance was used to investigate, draft, and test this change. The human submitter reviewed every changed line, understands the behavior, and witnessed the tests listed above.
