### PR TITLE
[hardware] fix: respect externally set NCCL_CUMEM_ENABLE for rollout workers

### DIFF
--- a/verl/plugin/platform/platform_cuda.py
+++ b/verl/plugin/platform/platform_cuda.py
@@ -149,7 +149,7 @@ class PlatformCUDA(PlatformBase):
         # in disaggregated mode. See:
         # https://docs.vllm.ai/en/latest/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues
         # https://github.com/vllm-project/vllm/blob/c6b0a7d3ba03ca414be1174e9bd86a97191b7090/vllm/worker/worker_base.py#L445
-        return {"NCCL_CUMEM_ENABLE": "0"}
+        return {"NCCL_CUMEM_ENABLE": os.environ.get("NCCL_CUMEM_ENABLE", "0")}
 
     # ------------------------------------------------------------------
     # Collective communication


### PR DESCRIPTION
### What does this PR do?

verl hard-forces `NCCL_CUMEM_ENABLE=0` for vLLM rollout workers (workaround for a known vLLM issue in disaggregated mode). On stacks that require CUDA cumem-based NCCL allocation (e.g. GB300-class systems tuned to run with `NCCL_CUMEM_ENABLE=1`), this silent override breaks the user's NCCL configuration and is hard to debug. Keep `0` as the default, but respect an externally set `NCCL_CUMEM_ENABLE`.

### Checklist / notes required by AGENTS.md

- **Duplicate check**: `gh pr list --state open --search "NCCL_CUMEM"` returns no open PR touching this behavior.
- **Tests**: one-line env plumbing; no unit test. Validated on a GB300 cluster running with `NCCL_CUMEM_ENABLE=1` (rollout workers previously reverted it to 0).
- **AI assistance**: this change was prepared with AI assistance (Claude); the submitter reviewed every line and takes responsibility for the change.
