### PR TITLE
[rollout] fix: surface vLLM prefix-cache hit counts in TokenOutput

### DIFF
--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -400,6 +400,12 @@ class FullyAsyncLLMServerClient(LLMServerClient):
             num_preempted=0,
         )
         min_global_steps, max_global_steps = None, None
+        # Prefix-cache hits are reported per prefill. The base client returns the
+        # server's TokenOutput directly (so sync mode surfaces num_cached_tokens),
+        # but here we rebuild a fresh TokenOutput across resume iterations, so we
+        # must carry it forward explicitly or the consumer sees 0. Take the first
+        # (initial-prompt) prefill's hit count, matching single-prefill semantics.
+        num_cached_tokens = None
 
         while True:
             # 1. generate tokens
@@ -431,6 +437,10 @@ class FullyAsyncLLMServerClient(LLMServerClient):
                 final_output.num_preempted += output.num_preempted
             final_output.stop_reason = output.stop_reason
 
+            # carry the initial prefill's prefix-cache hit count forward
+            if num_cached_tokens is None:
+                num_cached_tokens = output.extra_fields.get("num_cached_tokens")
+
             # update model weights version
             global_steps = output.extra_fields.get("global_steps", None)
             if min_global_steps is None:
@@ -458,6 +468,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
         final_output.extra_fields["global_steps"] = global_steps
         final_output.extra_fields["min_global_steps"] = min_global_steps
         final_output.extra_fields["max_global_steps"] = max_global_steps
+        final_output.extra_fields["num_cached_tokens"] = num_cached_tokens
         return final_output
 
 

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -664,6 +664,9 @@ class vLLMHttpServer:
                 extra_fields=extra_fields,
             )
 
+        # Prefix-cache hit count for this request; consumers surface it as
+        # OpenAI usage.prompt_tokens_details.cached_tokens.
+        extra_fields["num_cached_tokens"] = getattr(final_res, "num_cached_tokens", None)
         extract_prompt_logprobs(
             output=final_res,
             num_prompt_logprobs=sampling_params.prompt_logprobs,


### PR DESCRIPTION
### What does this PR do?

Prefix-cache hit counts are currently invisible to `TokenOutput` consumers:

1. the vLLM async server never exposes vLLM's per-request `num_cached_tokens`, and
2. `FullyAsyncLLMServerClient.generate` rebuilds a fresh `TokenOutput` across partial-rollout resume iterations, so fully-async mode always reports 0 cache hits even once (1) is fixed.

This PR sets `extra_fields["num_cached_tokens"]` on every vLLM generate result (consumers can surface it as OpenAI `usage.prompt_tokens_details.cached_tokens`), and carries the initial prefill's hit count forward across resume iterations, matching single-prefill semantics.

### Checklist / notes required by AGENTS.md

- **Duplicate check**: `gh pr list --state open --search "num_cached_tokens"` / `"prefix cache"` — no open PR exposes cache-hit counts in TokenOutput (hits are unrelated: KV-cache-aware load balancing, extra prefix cache).
- **Tests**: plumbing only, no unit test; validated in agent-loop training runs where cache-hit stats went from constant 0 to expected values (custom OpenAI-compatible endpoint reporting `cached_tokens`).
- **AI assistance**: prepared with AI assistance (Claude); the submitter reviewed every line and takes responsibility for the change.
