### PR TITLE
[fully_async] fix: only require rollout log-probs when they anchor PPO

### DIFF
--- a/tests/experimental/fully_async_policy/test_rollout_log_prob_config.py
+++ b/tests/experimental/fully_async_policy/test_rollout_log_prob_config.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_MODULE_PATH = Path(__file__).parents[3] / "verl" / "experimental" / "fully_async_policy" / "config_validation.py"
+_SPEC = importlib.util.spec_from_file_location("fully_async_config_validation", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+validate_rollout_log_prob_config = _MODULE.validate_rollout_log_prob_config
+
+
+def _make_config(*, bypass_mode: bool, calculate_log_probs: bool):
+    return SimpleNamespace(
+        algorithm=SimpleNamespace(rollout_correction=SimpleNamespace(bypass_mode=bypass_mode)),
+        actor_rollout_ref=SimpleNamespace(rollout=SimpleNamespace(calculate_log_probs=calculate_log_probs)),
+    )
+
+
+def test_trainer_recomputed_log_probs_do_not_require_rollout_log_probs():
+    config = _make_config(bypass_mode=False, calculate_log_probs=False)
+
+    validate_rollout_log_prob_config(config)
+
+
+def test_bypass_mode_requires_rollout_log_probs():
+    config = _make_config(bypass_mode=True, calculate_log_probs=False)
+
+    with pytest.raises(ValueError, match="bypass_mode=True requires"):
+        validate_rollout_log_prob_config(config)
+
+
+def test_bypass_mode_accepts_rollout_log_probs():
+    config = _make_config(bypass_mode=True, calculate_log_probs=True)
+
+    validate_rollout_log_prob_config(config)

--- a/verl/experimental/fully_async_policy/config_validation.py
+++ b/verl/experimental/fully_async_policy/config_validation.py
@@ -1,0 +1,23 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def validate_rollout_log_prob_config(config) -> None:
+    """Require rollout log-probs only when they are used as the PPO anchor."""
+    bypass_mode = config.algorithm.rollout_correction.bypass_mode
+    if bypass_mode and not config.actor_rollout_ref.rollout.calculate_log_probs:
+        raise ValueError(
+            "[FullyAsyncRollouter] algorithm.rollout_correction.bypass_mode=True requires "
+            "actor_rollout_ref.rollout.calculate_log_probs=True"
+        )

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -25,6 +25,7 @@ import torch
 from omegaconf import DictConfig, open_dict
 
 from verl.experimental.agent_loop.agent_loop import AgentLoopManager
+from verl.experimental.fully_async_policy.config_validation import validate_rollout_log_prob_config
 from verl.experimental.fully_async_policy.detach_utils import (
     RolloutSample,
     prepare_single_generation_data,
@@ -730,7 +731,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         # Validate asynchronous training configuration
         if not hasattr(self.config, "async_training"):
             raise ValueError("[FullyAsyncRollouter] Missing async_training configuration")
-        assert self.config.actor_rollout_ref.rollout.calculate_log_probs, "must rollout calculate log_probs"
+        validate_rollout_log_prob_config(self.config)
 
     async def init_workers(self):
         """Initialize distributed training workers using Ray backend.


### PR DESCRIPTION
### What does this PR do?

The fully-async rollouter unconditionally asserts `actor_rollout_ref.rollout.calculate_log_probs=True`, but rollout log-probs are only actually consumed when `algorithm.rollout_correction.bypass_mode=True` (rollout log-probs as the PPO anchor). When the trainer recomputes log-probs (`bypass_mode=False`), forcing rollout-side log-prob calculation is pure overhead.

Replace the blanket assert with `validate_rollout_log_prob_config()`, which validates the actual dependency: `bypass_mode=True` requires `calculate_log_probs=True`; otherwise nothing is required.

### Checklist / notes required by AGENTS.md

- **Duplicate check**: `gh pr list --state open --search "calculate_log_probs"` returns no open PR.
- **Tests**: `pytest tests/experimental/fully_async_policy/test_rollout_log_prob_config.py` — 3 passed.
- **AI assistance**: prepared with AI assistance (Claude); the submitter reviewed every line and takes responsibility for the change.
