### PR TITLE
[fully_async] perf: skip CPU model snapshot when trigger_parameter_sync_step=1

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -662,6 +662,12 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         If local_trigger_step == 2, 3, ..., restore the parameters of version 1 to calculate the old_log_prob,
         then restore the parameters of the current version.
         """
+        # No snapshot is needed when every actor update is immediately followed
+        # by parameter synchronization. Avoid copying a 100B+ model to CPU on
+        # every step in the common trigger_parameter_sync_step=1 configuration.
+        if self.trigger_parameter_sync_step == 1:
+            return super()._compute_old_log_prob(batch)
+
         if self.local_trigger_step == 1:
             self.actor_rollout_wg.save_model_to_cpu(1)
             old_log_prob, old_log_prob_mfu = super()._compute_old_log_prob(batch)


### PR DESCRIPTION
### What does this PR do?

`FullyAsyncTrainer._compute_old_log_prob` snapshots the actor weights to CPU so that later local steps can restore the version-1 parameters for MIS. When `async_training.trigger_parameter_sync_step == 1`, every actor update is immediately followed by a parameter sync, so `local_trigger_step` is always 1 and the snapshot is never restored — yet the full model (100B+ in our runs) is still copied to CPU on every single step.

Early-return to `super()._compute_old_log_prob(batch)` in that configuration.

### Checklist / notes required by AGENTS.md

- **Duplicate check**: `gh pr list --state open --search "trigger_parameter_sync_step"` — only an unrelated total_training_steps fix (#6987).
- **Tests**: behavioral no-op by construction in this configuration (the skipped snapshot is provably never read); validated in fully-async runs — identical training metrics, large per-step wall-clock saving on 100B+ models.
- **AI assistance**: prepared with AI assistance (Claude); the submitter reviewed every line and takes responsibility for the change.
