### PR TITLE
[fully_async] fix: stamp rollouts with the parameter version as their step

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -446,6 +446,11 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         self._completed_steps: int = 1
         # we start from step 1
         self.global_steps = 1
+        # Parameter (policy-weight) version, set by the trainer on each weight
+        # sync via reset_staleness / do_validate. This — NOT self.global_steps,
+        # which is a per-sample feed counter — is the RL "step" a rollout
+        # starts sampling against.
+        self.current_param_version = 0
         self.idle_start_time = time.time()
         self.step_start_time = time.time()
 
@@ -591,11 +596,12 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
 
         return utilization
 
-    async def reset_staleness(self):
+    async def reset_staleness(self, current_param_version: int = 0):
         """
         Reset staleness samples after parameter update.
         Returns timing_raw dictionary for metrics.
         """
+        self.current_param_version = current_param_version
         async with self.lock:
             self.paused = False
             # Wake the drain loop in _processor_worker so it can exit early and resume submitting
@@ -645,12 +651,23 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """Stop rollout profiling on all replicas before the next weight sync."""
         await self.llm_server_manager.stop_profile()
 
-    def do_validate(self):
+    def do_validate(self, current_param_version: int = 0):
         """Run validation and return metrics"""
-        timing_raw = {}
-        with marked_timer("rollouter/validate_time", timing_raw, color="green"):
-            val_metrics: dict = self._validate()
-        return timing_raw | val_metrics
+        self.current_param_version = current_param_version
+        # The inherited _validate stamps test_gen_batch.meta_info["global_steps"]
+        # from self.global_steps (a per-sample feed counter here), which is what
+        # made validation rollouts show up as e.g. step 210 at param version 4.
+        # Swap in the true parameter version for the duration of validation so
+        # the gen batch records the policy version.
+        saved_global_steps = self.global_steps
+        self.global_steps = current_param_version
+        try:
+            timing_raw = {}
+            with marked_timer("rollouter/validate_time", timing_raw, color="green"):
+                val_metrics: dict = self._validate()
+            return timing_raw | val_metrics
+        finally:
+            self.global_steps = saved_global_steps
 
     async def save_checkpoint(self, local_global_step_folder: str):
         # WARNING!: Due to the asynchronous nature, there are some in-flight samples
@@ -995,6 +1012,11 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         rollout_sample.full_batch.non_tensor_batch["uid"] = np.array(
             [f"uid_{rollout_sample.sample_id}"] * len(rollout_sample.full_batch), dtype=object
         )
+        # Stamp the current parameter version so the agent loop's trajectory
+        # step is the policy version this rollout starts sampling against.
+        # Async training never set this, so every training rollout previously
+        # landed with no step.
+        rollout_sample.full_batch.meta_info["global_steps"] = self.current_param_version
         ret = await self.async_rollout_manager.generate_sequences_single(rollout_sample.full_batch)
 
         rollout_sample.full_batch = ret

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -753,7 +753,9 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
 
                 self.dynamic_schedule_ctx.last_activate_duration_s += time.time() - _act_start
 
-        timing_raw = await asyncio.wrap_future(self.rollouter.reset_staleness.remote().future())
+        timing_raw = await asyncio.wrap_future(
+            self.rollouter.reset_staleness.remote(self.current_param_version).future()
+        )
 
         print(
             f"[FullyAsyncTrainer] _fit_update_weights, "
@@ -826,7 +828,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         if self.config.async_training.use_trainer_do_validate:
             await self._trainer_side_validate()
         else:
-            val_metrics = await self.rollouter.do_validate.remote()
+            val_metrics = await self.rollouter.do_validate.remote(self.current_param_version)
             self.logger.log(data=val_metrics, step=self.current_param_version)
 
     async def _trainer_side_validate(self):
@@ -852,7 +854,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         # Phase 2: Run validation via RPC to rollouter
         # ================================================================
         print("[FullyAsyncTrainer] Phase 2: Running validation")
-        val_metrics = await self.rollouter.do_validate.remote()
+        val_metrics = await self.rollouter.do_validate.remote(self.current_param_version)
         self.logger.log(data=val_metrics, step=self.current_param_version)
 
         # ================================================================


### PR DESCRIPTION
### What does this PR do?

In fully-async training, rollouts do not record which policy version generated them:

- training rollouts never get `meta_info["global_steps"]` set at all, and
- validation rollouts inherit the rollouter's `self.global_steps`, which is a per-sample feed counter — a validation rollout can record "step 210" while the policy is at parameter version 4.

Trajectory descriptors and downstream staleness accounting need the policy-weight version a rollout starts sampling against. This PR tracks `current_param_version` in the rollouter (pushed by the trainer on every weight sync via `reset_staleness(...)` / `do_validate(...)`, backward-compatible default 0), stamps it into `meta_info["global_steps"]` for training rollouts, and swaps it into `self.global_steps` for the duration of `_validate()` so validation gen batches record the policy version too.

### Checklist / notes required by AGENTS.md

- **Duplicate check**: `gh pr list --state open --search "param version"` / `"global_steps rollouter"` — no open PR addresses this.
- **Tests**: Ray-actor plumbing, no unit test; validated in fully-async runs — trajectory step now matches parameter version for both training and validation rollouts.
- **AI assistance**: prepared with AI assistance (Claude); the submitter reviewed every line and takes responsibility for the change.
