### PR TITLE
[trainer, perf] feat: skip unused old-policy entropy computation

### DIFF
--- a/tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py
+++ b/tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+pytest.importorskip("ray")
+
+from verl.protocol import DataProto
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.trainer.ppo.utils import should_calculate_actor_entropy
+from verl.utils import tensordict_utils as tu
+
+
+class _LogProbWorker:
+    def __init__(self):
+        self.calculate_entropy = None
+
+    def compute_log_prob(self, batch):
+        self.calculate_entropy = tu.get(batch, "calculate_entropy")
+        output = {"log_probs": torch.ones(2, 3)}
+        if self.calculate_entropy:
+            output["entropy"] = torch.full((2, 3), 0.5)
+        return tu.get_tensordict(output, non_tensor_dict={"metrics": {"mfu": 0.25}})
+
+
+@pytest.mark.parametrize(
+    ("calculate_entropy", "entropy_coeff", "expected"),
+    [(False, 0.0, False), (True, 0.0, True), (False, 0.01, True)],
+)
+def test_should_calculate_actor_entropy(calculate_entropy, entropy_coeff, expected):
+    actor_config = OmegaConf.create({"calculate_entropy": calculate_entropy, "entropy_coeff": entropy_coeff})
+
+    assert should_calculate_actor_entropy(actor_config) is expected
+
+
+@pytest.mark.parametrize("calculate_entropy", [False, True])
+def test_compute_old_log_prob_only_returns_requested_entropy(calculate_entropy):
+    trainer = RayPPOTrainer.__new__(RayPPOTrainer)
+    trainer.config = OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "actor": {
+                    "calculate_entropy": calculate_entropy,
+                    "entropy_coeff": 0.0,
+                    "calculate_sum_pi_squared": False,
+                }
+            }
+        }
+    )
+    trainer.actor_rollout_wg = _LogProbWorker()
+    batch = DataProto.from_single_dict({"input_ids": torch.ones(2, 3, dtype=torch.long)})
+
+    with (
+        patch("verl.trainer.ppo.ray_trainer.left_right_2_no_padding", side_effect=lambda data: data),
+        patch("verl.trainer.ppo.ray_trainer.no_padding_2_padding", side_effect=lambda tensor, _: tensor),
+    ):
+        old_log_prob, mfu = trainer._compute_old_log_prob(batch)
+
+    assert trainer.actor_rollout_wg.calculate_entropy is calculate_entropy
+    assert ("entropys" in old_log_prob.batch) is calculate_entropy
+    assert torch.equal(old_log_prob.batch["old_log_probs"], torch.ones(2, 3))
+    assert mfu == 0.25

--- a/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
@@ -14,7 +14,9 @@
 
 from unittest.mock import patch
 
+import torch
 from omegaconf import OmegaConf
+from tensordict import TensorDict
 
 from verl.trainer.ppo.v1.replay_buffer import ReplayBuffer, ReplayBufferAsync
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer
@@ -31,6 +33,21 @@ class _StubTrainer(PPOTrainer):
 class _CustomSampler:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+
+
+class _FakeKVBatchMeta:
+    def __init__(self):
+        self.keys = ["sample-0", "sample-1"]
+        self.partition_id = "partition-0"
+        self.extra_info = {}
+
+    def __len__(self):
+        return len(self.keys)
+
+
+class _LogProbWorker:
+    def compute_log_prob(self, batch):
+        return batch
 
 
 def _trainer_with_filter_groups(filter_groups: dict, trainer_mode: str = "sync") -> _StubTrainer:
@@ -163,3 +180,39 @@ def test_builtin_filter_groups_warns_when_total_generation_limit_is_configured()
         "use max_inflight_gen_batches to bound concurrent Sync DAPO generation.",
         10,
     )
+
+
+def test_compute_old_log_prob_skips_unused_entropy():
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    trainer.config = OmegaConf.create(
+        {
+            "algorithm": {"rollout_correction": {"bypass_mode": False}},
+            "actor_rollout_ref": {
+                "actor": {"calculate_entropy": False, "entropy_coeff": 0.0},
+                "rollout": {"temperature": 1.0, "calculate_log_probs": False},
+            },
+        }
+    )
+    trainer.actor_rollout_wg = _LogProbWorker()
+    batch = _FakeKVBatchMeta()
+    data = TensorDict(
+        {
+            "log_probs": torch.ones(2, 3),
+            "response_mask": torch.ones(2, 3, dtype=torch.bool),
+        },
+        batch_size=[2],
+    )
+
+    with (
+        patch("verl.trainer.ppo.v1.trainer_base.tq.kv_batch_get", return_value=data) as kv_batch_get,
+        patch("verl.trainer.ppo.v1.trainer_base.tq.kv_batch_put", return_value=batch) as kv_batch_put,
+        patch("verl.trainer.ppo.v1.trainer_base.response_from_nested", side_effect=lambda tensor, _: tensor),
+    ):
+        metrics = {}
+        result = trainer._compute_old_log_prob(batch, metrics)
+
+    assert result is batch
+    assert batch.extra_info["calculate_entropy"] is False
+    assert kv_batch_get.call_args.kwargs["select_fields"] == ["log_probs", "response_mask"]
+    assert list(kv_batch_put.call_args.kwargs["fields"].keys()) == ["old_log_probs"]
+    assert "actor/entropy" not in metrics

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -58,6 +58,7 @@ from verl.trainer.ppo.utils import (
     need_reference_policy,
     need_reward_model,
     need_teacher_policy,
+    should_calculate_actor_entropy,
 )
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, should_save_ckpt_esi
@@ -1294,28 +1295,33 @@ class RayPPOTrainer:
         # step 2: convert from padding to nopadding
         batch_td = left_right_2_no_padding(batch_td)
         # step 3: add meta info
-        calculate_sum_pi_squared = self.config.actor_rollout_ref.actor.get("calculate_sum_pi_squared", False)
+        actor_config = self.config.actor_rollout_ref.actor
+        calculate_entropy = should_calculate_actor_entropy(actor_config)
+        calculate_sum_pi_squared = actor_config.get("calculate_sum_pi_squared", False)
         tu.assign_non_tensor(
             batch_td,
-            calculate_entropy=True,
+            calculate_entropy=calculate_entropy,
             calculate_sum_pi_squared=calculate_sum_pi_squared,
             compute_loss=False,
         )
         output = self.actor_rollout_wg.compute_log_prob(batch_td)
         # gather output
-        entropy = tu.get(output, "entropy")
+        entropy = tu.get(output, "entropy") if calculate_entropy else None
         log_probs = tu.get(output, "log_probs")
         routed_experts = tu.get(output, "routed_experts")
         sum_pi_squared = tu.get(output, "sum_pi_squared") if calculate_sum_pi_squared else None
 
         old_log_prob_mfu = tu.get(output, "metrics")["mfu"]
         # step 4. No padding to padding
-        entropy = no_padding_2_padding(entropy, batch_td)
+        if entropy is not None:
+            entropy = no_padding_2_padding(entropy, batch_td)
         log_probs = no_padding_2_padding(log_probs, batch_td)
         if sum_pi_squared is not None:
             sum_pi_squared = no_padding_2_padding(sum_pi_squared, batch_td)
         # step 5: rebuild a tensordict and convert to dataproto
-        result = {"old_log_probs": log_probs.float(), "entropys": entropy.float()}
+        result = {"old_log_probs": log_probs.float()}
+        if entropy is not None:
+            result["entropys"] = entropy.float()
         if routed_experts is not None:
             result["routed_experts"] = routed_experts
         if sum_pi_squared is not None:
@@ -1333,9 +1339,7 @@ class RayPPOTrainer:
         batch_td = batch.to_tensordict()
         # step 2: convert from padding to no-padding
         batch_td = left_right_2_no_padding(batch_td)
-        calculate_entropy = self.config.actor_rollout_ref.actor.calculate_entropy or (
-            self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
-        )
+        calculate_entropy = should_calculate_actor_entropy(self.config.actor_rollout_ref.actor)
         distillation_use_topk = (
             self.distillation_config.distillation_loss.loss_settings.use_topk
             if is_distillation_enabled(self.config.get("distillation"))
@@ -1584,21 +1588,18 @@ class RayPPOTrainer:
                     else:  # Recompute old_log_probs
                         with marked_timer("old_log_prob", timing_raw, color="blue"):
                             old_log_prob, old_log_prob_mfu = self._compute_old_log_prob(batch)
-                            entropys = old_log_prob.batch["entropys"]
-                            response_masks = batch.batch["response_mask"]
-                            actor_config = self.config.actor_rollout_ref.actor
-                            entropy_agg = agg_loss(
-                                loss_mat=entropys,
-                                loss_mask=response_masks,
-                                loss_agg_mode=actor_config.loss_agg_mode,
-                                loss_scale_factor=actor_config.loss_scale_factor,
-                            )
-                            old_log_prob_metrics = {
-                                "actor/entropy": entropy_agg.detach().item(),
-                                "perf/mfu/actor_infer": old_log_prob_mfu,
-                            }
+                            old_log_prob_metrics = {"perf/mfu/actor_infer": old_log_prob_mfu}
+                            if "entropys" in old_log_prob.batch:
+                                entropys = old_log_prob.batch.pop("entropys")
+                                actor_config = self.config.actor_rollout_ref.actor
+                                entropy_agg = agg_loss(
+                                    loss_mat=entropys,
+                                    loss_mask=batch.batch["response_mask"],
+                                    loss_agg_mode=actor_config.loss_agg_mode,
+                                    loss_scale_factor=actor_config.loss_scale_factor,
+                                )
+                                old_log_prob_metrics["actor/entropy"] = entropy_agg.detach().item()
                             metrics.update(old_log_prob_metrics)
-                            old_log_prob.batch.pop("entropys")
                             if "routed_experts" in batch.batch and "routed_experts" in old_log_prob.batch:
                                 raise ValueError(
                                     "Detected conflicting router replay configuration: "

--- a/verl/trainer/ppo/utils.py
+++ b/verl/trainer/ppo/utils.py
@@ -107,6 +107,11 @@ def need_critic(config: DictConfig) -> bool:
         return False
 
 
+def should_calculate_actor_entropy(actor_config: DictConfig) -> bool:
+    """Return whether an actor forward pass needs token-level entropy."""
+    return bool(actor_config.calculate_entropy or actor_config.entropy_coeff != 0.0)
+
+
 def create_rl_dataset(data_paths, data_config, tokenizer, processor, is_train=True, max_samples: int = -1):
     """Create a dataset.
 

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -71,6 +71,7 @@ from verl.trainer.ppo.utils import (
     need_critic,
     need_reference_policy,
     need_teacher_policy,
+    should_calculate_actor_entropy,
 )
 from verl.trainer.ppo.v1.replay_buffer import DAPO_FILTERED_REWARD_COUNTS_KEY, ReplayBuffer, ReplayBufferAsync
 from verl.trainer.ppo.v1.utils import MetricsAggregator, compute_advantage_for_multi_trajectories
@@ -1555,9 +1556,11 @@ class PPOTrainer(ABC):
             return batch
 
         # 1. compute log probs
+        actor_config = self.config.actor_rollout_ref.actor
+        calculate_entropy = should_calculate_actor_entropy(actor_config)
         batch.extra_info.update(
             {
-                "calculate_entropy": True,
+                "calculate_entropy": calculate_entropy,
                 "compute_loss": False,
                 "temperature": self.config.actor_rollout_ref.rollout.temperature,
             }
@@ -1565,37 +1568,38 @@ class PPOTrainer(ABC):
         output: KVBatchMeta = self.actor_rollout_wg.compute_log_prob(batch)
         assert len(output) == len(batch)
 
-        fields = ["entropy", "log_probs", "response_mask"]
+        fields = ["log_probs", "response_mask"]
+        if calculate_entropy:
+            fields.append("entropy")
         if self.config.actor_rollout_ref.rollout.calculate_log_probs:
             fields.extend(["responses", "rollout_log_probs"])
         data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
 
-        # 2. write old_log_probs and entropy back to TransferQueue
+        # 2. write old_log_probs and optional entropy back to TransferQueue
         data["old_log_probs"] = response_from_nested(data.pop("log_probs"), data["response_mask"])
-        data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
-        batch = tq.kv_batch_put(
-            keys=batch.keys, partition_id=batch.partition_id, fields=data.select("old_log_probs", "entropy")
-        )
+        output_fields = ["old_log_probs"]
+        if calculate_entropy:
+            data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
+            output_fields.append("entropy")
+        batch = tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data.select(*output_fields))
 
-        data = DataProto(batch=data.to_padded_tensor())
+        metric_data = None
+        if calculate_entropy or self.config.actor_rollout_ref.rollout.calculate_log_probs:
+            metric_data = DataProto(batch=data.to_padded_tensor())
 
-        # 3. calculate actor entroy metrics
-        actor_config = self.config.actor_rollout_ref.actor
-        entropy_agg = agg_loss(
-            loss_mat=data.batch["entropy"],
-            loss_mask=data.batch["response_mask"],
-            loss_agg_mode=actor_config.loss_agg_mode,
-            loss_scale_factor=actor_config.loss_scale_factor,
-        )
-        old_log_prob_metrics = {
-            "actor/entropy": entropy_agg.detach().item(),
-            # "perf/mfu/actor_infer": old_log_prob_mfu,
-        }
-        metrics.update(old_log_prob_metrics)
+        # 3. calculate actor entropy metrics when entropy was requested
+        if calculate_entropy:
+            entropy_agg = agg_loss(
+                loss_mat=metric_data.batch["entropy"],
+                loss_mask=metric_data.batch["response_mask"],
+                loss_agg_mode=actor_config.loss_agg_mode,
+                loss_scale_factor=actor_config.loss_scale_factor,
+            )
+            metrics["actor/entropy"] = entropy_agg.detach().item()
 
         # 4. calculate rollout vs actor logprobs diff
         if self.config.actor_rollout_ref.rollout.calculate_log_probs:
-            metrics.update(calculate_debug_metrics(data))
+            metrics.update(calculate_debug_metrics(metric_data))
 
         return batch
 
@@ -1735,9 +1739,7 @@ class PPOTrainer(ABC):
         """Update the actor network."""
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
         ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
-        calculate_entropy = self.config.actor_rollout_ref.actor.calculate_entropy or (
-            self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
-        )
+        calculate_entropy = should_calculate_actor_entropy(self.config.actor_rollout_ref.actor)
         distillation_use_topk = (
             self.distillation_config.distillation_loss.loss_settings.use_topk
             if is_distillation_enabled(self.config.get("distillation"))


### PR DESCRIPTION
### What does this PR do?

Avoid computing and transferring token-level entropy during old-policy log-probability recomputation when neither entropy diagnostics nor entropy regularization requires it.

The classic and v1 PPO trainers currently force `calculate_entropy=True` for the old-policy forward pass, even though actor updates already gate entropy on:

```python
actor.calculate_entropy or actor.entropy_coeff != 0.0
```

This PR applies that same condition consistently to old-policy recomputation. When entropy is disabled, it also skips entropy padding/TransferQueue handling and omits the `actor/entropy` metric instead of logging a misleading zero. Existing behavior is preserved when `calculate_entropy=true` or `entropy_coeff != 0`.

**Why this is not duplicating existing work:** searched open PRs for [old-policy entropy](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+old-policy+entropy), [old log-prob entropy](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+old+log-prob+entropy), and [skip entropy](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+skip+entropy); no open PR addresses this path. Issue #3996 discusses bypassing old-log-prob recomputation under rollout correction, while this change retains recomputation and only skips its unused entropy output. PR #5990 concerns a fully asynchronous standalone log-prob server and is unrelated to this trainer-side gating.

**AI assistance statement:** This change was developed with OpenAI Codex assistance. Every changed line was reviewed by the submitter, and the tests below were run locally.

### Checklist Before Starting

- [x] Searched for similar PRs and issues; links and distinctions are included above.
- [x] Formatted the title as `[{modules}] {type}: {description}`.

### Test

```bash
.venv/bin/pytest -q \
  tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py \
  tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
# 13 passed

.venv/bin/pre-commit run ruff --files \
  verl/trainer/ppo/utils.py \
  verl/trainer/ppo/ray_trainer.py \
  verl/trainer/ppo/v1/trainer_base.py \
  tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py \
  tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
# Passed

.venv/bin/pre-commit run ruff-format --files \
  verl/trainer/ppo/utils.py \
  verl/trainer/ppo/ray_trainer.py \
  verl/trainer/ppo/v1/trainer_base.py \
  tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py \
  tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
# Passed

.venv/bin/pre-commit run mypy --files \
  verl/trainer/ppo/utils.py \
  verl/trainer/ppo/ray_trainer.py \
  verl/trainer/ppo/v1/trainer_base.py \
  tests/trainer/ppo/test_old_log_prob_entropy_on_cpu.py \
  tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
# Passed

env PATH="$PWD/.venv/bin:$PATH" \
  .venv/bin/pre-commit run autogen-trainer-cfg --all-files
# Passed

git diff --check HEAD^
# Passed
```

GPU end-to-end throughput and memory measurements are pending; this PR is opened as a draft until they are available.

### API and Usage Example

No API or configuration schema change.

- Default configurations (`calculate_entropy=false`, `entropy_coeff=0`) skip old-policy entropy computation.
- Set `actor_rollout_ref.actor.calculate_entropy=true` to retain the diagnostic `actor/entropy` metric.
- A nonzero `actor_rollout_ref.actor.entropy_coeff` also keeps entropy enabled.

### Design & Code Changes

- Add a shared helper for deciding whether an actor forward pass needs token-level entropy.
- Apply it to old-log-prob recomputation and actor updates in both classic and v1 trainers.
- Make entropy outputs, padding, TransferQueue fields, and metrics conditional.
- Avoid constructing padded v1 metric data when neither entropy nor rollout-vs-actor debug metrics are requested.
- Add focused CPU coverage for the config condition and both trainer paths.

### Checklist Before Submitting

- [x] Read the contribution guide and repository agent instructions.
- [x] Run focused formatting, lint, type, generated-config, and CPU unit checks.
- [x] Add CPU tests collected by the existing `_on_cpu.py` workflows; no CI workflow change is needed.
- [x] No documentation update is required because there is no API or configuration change.
- [ ] Add GPU throughput and memory measurements before marking the PR ready for review.
