### PR TITLE
[trainer] fix: pass min/max seqlen when rebuilding jagged nested tensors

### DIFF
--- a/tests/test_protocol_v2_on_cpu.py
+++ b/tests/test_protocol_v2_on_cpu.py
@@ -128,6 +128,44 @@ def test_index_select_tensor_dict():
     tu.assert_tensordict_eq(selected_data, target_select_data)
 
 
+def test_chunk_tensordict_3d_nested_padding_width_is_max_not_sum():
+    """Rebuilt jagged tensors must keep their max seqlen (ragged_idx == 1).
+
+    ``chunk_tensordict`` rebuilds nested tensors via ``nested_tensor_from_tensor_list``.
+    Without an explicit ``max_seqlen``, ``to_padded_tensor`` derives the width from
+    ``values.size(0)`` -- the sum of the per-sample lengths -- so a ``[K, T]``
+    per-sample tensor pads to ``(B, B*K, T)`` instead of ``(B, K, T)``.
+    """
+    B, K, T = 8, 33, 16
+    per_sample = [torch.zeros(K, T, dtype=torch.long) for _ in range(B)]
+    nt = torch.nested.as_nested_tensor(per_sample, layout=torch.jagged)
+    assert nt._ragged_idx == 1
+    td = tu.get_tensordict({"codes": nt})
+
+    padded = tu.chunk_tensordict(td, chunks=1)[0]["codes"].to_padded_tensor(0)
+    assert padded.shape == (B, K, T), f"expected {(B, K, T)}, got {tuple(padded.shape)}"
+
+
+def test_chunk_tensordict_3d_nested_ragged_last_dim_does_not_truncate():
+    """Rebuilt jagged tensors must keep their max seqlen (ragged_idx > 1).
+
+    When the ragged dim is not the first per-sample dim, ``values.size(0)`` is the
+    *non-ragged* dim and bears no relation to the lengths, so the fallback is not
+    even an upper bound: it silently truncates whenever it is below the max seqlen.
+    """
+    K, lengths = 4, [6, 3, 5]
+    per_sample = [torch.arange(K * n).reshape(K, n) + 1 for n in lengths]
+    nt = tu.nested_tensor_from_tensor_list(per_sample, ragged_idx=2)
+    td = tu.get_tensordict({"codes": nt})
+
+    padded = tu.chunk_tensordict(td, chunks=1)[0]["codes"].to_padded_tensor(0)
+    assert padded.shape == (len(lengths), K, max(lengths)), (
+        f"expected {(len(lengths), K, max(lengths))}, got {tuple(padded.shape)}"
+    )
+    for i, n in enumerate(lengths):
+        assert torch.equal(padded[i][:, :n], per_sample[i]), f"row {i} content lost"
+
+
 def test_index_select_tensor_dict_preserves_3d_nested_tensor_layout_with_equal_seq_len():
     position_ids = tu.nested_tensor_from_tensor_list(
         [

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -173,11 +173,20 @@ def nested_tensor_from_tensor_list(tensors: list[torch.Tensor], ragged_idx: int 
 
     cat_dim = ragged_idx - 1
     values = torch.cat(tensors, dim=cat_dim)
-    lengths = torch.tensor([tensor.shape[cat_dim] for tensor in tensors], dtype=torch.long, device=values.device)
+    sample_lengths = [tensor.shape[cat_dim] for tensor in tensors]
+    lengths = torch.tensor(sample_lengths, dtype=torch.long, device=values.device)
     offsets = torch.zeros(len(tensors) + 1, dtype=torch.long, device=values.device)
     torch.cumsum(lengths, dim=0, out=offsets[1:])
 
-    nested_tensor = torch.nested.nested_tensor_from_jagged(values=values, offsets=offsets)
+    # Without max_seqlen, `to_padded_tensor` can fall back to `values.size(0)`, over-padding or
+    # silently truncating depending on ragged_idx. See https://github.com/pytorch/pytorch/issues/159380.
+    # The `as_nested_tensor` early return uses the same logic internally; min_seqlen is passed for consistency.
+    nested_tensor = torch.nested.nested_tensor_from_jagged(
+        values=values,
+        offsets=offsets,
+        min_seqlen=min(sample_lengths),
+        max_seqlen=max(sample_lengths),
+    )
     nested_tensor._ragged_idx = ragged_idx
     return nested_tensor
 


### PR DESCRIPTION
### What does this PR do?

We ran into this while working on an extension on top of verl that adds a custom per-sample field to the batch — a 3D tensor whose ragged dim happens to be the last one. It took a while to track down, because nothing raises: the tensor simply comes back with the wrong width and the tail of the data is silently gone. The fix is small and belongs upstream rather than in our tree, so we would rather contribute it than carry it locally and leave the next person to find it the hard way.

`nested_tensor_from_tensor_list` rebuilds jagged NestedTensors for per-sample rows of 2+ dims via `torch.nested.nested_tensor_from_jagged(values, offsets)`, without passing min/max seqlen. A `to_padded_tensor()` call that does not pass `output_size` then derives the padded width from `values.size(0)`, which is wrong in two different ways depending on the ragged dim:

| `ragged_idx` | `values.size(0)` is | effect |
| --- | --- | --- |
| `== 1` | the sum of the per-sample lengths | over-pads, content preserved |
| `> 1` | the non-ragged dim, unrelated to the lengths | not an upper bound — silently truncates when below the true max seqlen |

Root cause is [pytorch/pytorch#159380](https://github.com/pytorch/pytorch/issues/159380): `to_padded_tensor_default` gates on the raw `_max_seqlen_tensor` cache, so the lazily-computing `_max_seqlen` accessor is never reached. The issue is open, acknowledged by the NestedTensor owner as "clearly wrong", deprioritized, and unfixed on `main`. Their stated workaround is exactly this patch:

> **TL;DR workaround: manually provide min / max sequence length to the `nested_tensor_from_jagged()` constructor.**

Reproducing requires all of: per-sample dim >= 2, shapes varying across samples, a rebuild (`chunk_tensordict`, `index_select_tensor_dict`, `concat_nested_tensors`), and `to_padded_tensor()` without `output_size`. **No in-tree recipe meets the last condition today** — all three engines pad 3D `position_ids` with an explicit `output_size`, and `teacher_logprobs` is never padded — so this is a latent bug in a public helper, not a live regression. Any downstream batch field meeting all four conditions does hit it, including the `partition_tensor_dict` helper proposed in #7097, which calls the same rebuild.

The `sample_dim == 1` early return was already correct: `as_nested_tensor` → `jagged_from_list` computes both values the same way.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [`is:pr is:open max_seqlen`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+max_seqlen), [`is:pr is:open nested tensor`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+nested+tensor), [`is:pr is:open tensordict_utils`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+tensordict_utils). I also enumerated all open PRs and grepped the diffs of the three that touch `verl/utils/tensordict_utils.py` — #6082 (swaps the `_ragged_idx` workaround in `maybe_fix_3d_position_ids` for a tensordict upgrade), #7097 (adds `partition_tensor_dict`), #7137 (different file region) — and none of them mention `max_seqlen`. #6127 and #6149 are the merged PRs that introduced this rebuild path; neither passes the seqlen metadata.
- [x] Format the PR title as `[{modules}] {type}: {description}` — `[trainer]` follows #6127 and #6149, which last touched this function.

### Test

Two regression tests added to `tests/test_protocol_v2_on_cpu.py`, one per symptom. This file is already covered by `cpu_unit_tests.yml` (triggers on `**/*.py`, runs `pytest tests/` with `python_files = *_on_cpu.py`), so no workflow change is needed.

```bash
pytest tests/test_protocol_v2_on_cpu.py -q --asyncio-mode=auto
```

With the fix — `40 passed`. With `verl/utils/tensordict_utils.py` reverted to its pre-patch state and the tests kept:

```
FAILED tests/test_protocol_v2_on_cpu.py::test_chunk_tensordict_3d_nested_padding_width_is_max_not_sum
  AssertionError: expected (8, 33, 16), got (8, 264, 16)      # over-pad: 8*33 = 264

FAILED tests/test_protocol_v2_on_cpu.py::test_chunk_tensordict_3d_nested_ragged_last_dim_does_not_truncate
  AssertionError: expected (3, 4, 6), got (3, 4, 4)           # truncation: K=4 < max len 6

2 failed, 38 passed
```

The other 38 tests pass either way — the existing 3D coverage asserts on `.values()`, `.offsets()` and `_ragged_idx`, none of which this bug touches, which is why it went unnoticed.

Also run: `pre-commit run --files verl/utils/tensordict_utils.py tests/test_protocol_v2_on_cpu.py` — all hooks pass.

### API and Usage Example

No API change. The signature is unchanged, and so are `values`, `offsets` and `_ragged_idx` on the returned tensor. Only the min/max seqlen metadata differs, which changes the result of `to_padded_tensor()` when `output_size` is not supplied:

```python
rows = [torch.arange(4 * n).reshape(4, n) for n in (6, 3, 5)]   # per-sample [C, T], ragged dim last
nt = tu.nested_tensor_from_tensor_list(rows, ragged_idx=2)
chunk = tu.chunk_tensordict(tu.get_tensordict({"x": nt}), chunks=1)[0]

chunk["x"].to_padded_tensor(0).shape
# before: torch.Size([3, 4, 4])   <- width 4 = C, rows of length 5 and 6 truncated
# after:  torch.Size([3, 4, 6])   <- width 6 = max(6, 3, 5)
```

### Design & Code Changes

- Pass `min_seqlen` and `max_seqlen` to `nested_tensor_from_jagged`. Only `max_seqlen` is implicated in the bug; `min_seqlen` is passed so the rebuilt tensor carries the same metadata as the `as_nested_tensor` early return.
- Hoist the per-sample lengths into a `sample_lengths` list and take `min`/`max` over it, rather than over the `lengths` tensor. `lengths` follows `values.device`, so `lengths.max().item()` would add a DtoH sync and a `torch.compile` graph break to a per-micro-batch path — the exact cost pytorch#159380 cites as the reason the lazy computation is avoided upstream.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not applicable: internal helper with no documented surface, and no behavioural contract change beyond restoring the documented one.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Covered by the existing `cpu_unit_tests.yml` job, as described above.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel. Not accessible to me: the verl Slack workspace restricts self-signup to `anyscale.com`, `bytedance.com` and `together.ai` email domains. Happy to have a maintainer kick off CI, or to follow up via the Feishu group.
- [ ] If your PR is related to the `recipe` submodule. Not applicable.

### AI assistance

This change was developed with AI assistance (Claude). I have reviewed every changed line, verified the root-cause analysis against the PyTorch source and pytorch#159380, and run the tests and pre-commit locally with the results shown above.
