### PR TITLE
[vllm] fix: Use dedicated Ray concurrency group for vLLMHttpServer control methods

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -127,6 +127,7 @@ jobs:
             tests/workers/rollout/test_vllm_cli_args_on_cpu.py \
             tests/workers/rollout/test_vision_placeholder_tokens_on_cpu.py \
             tests/workers/rollout/test_vllm_pd_disaggregation_on_cpu.py \
+            tests/workers/rollout/rollout_vllm/test_vllm_control_concurrency_on_cpu.py \
             tests/utils/test_vllm_weight_name_normalization_on_cpu.py::test_update_weights_from_ipc_accumulates_lora_across_buckets \
             tests/utils/test_vllm_weight_name_normalization_on_cpu.py::test_update_weights_from_ipc_standard_loads_per_bucket
       - name: Prepare gsm8k dataset

--- a/tests/utils/test_server_profiler.py
+++ b/tests/utils/test_server_profiler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import json
 import os
 import tempfile
@@ -508,6 +509,7 @@ class TestServerProfilerFunctionality(unittest.IsolatedAsyncioTestCase):
 
         # Mock self object
         mock_self = MagicMock()
+        mock_self._default_asyncio_loop = asyncio.get_running_loop()
         mock_self.node_rank = 0
         mock_self.replica_rank = 3
         mock_self.profiler_controller = mock_profiler
@@ -549,6 +551,7 @@ class TestServerProfilerFunctionality(unittest.IsolatedAsyncioTestCase):
         mock_engine = AsyncMock()
 
         mock_self = MagicMock()
+        mock_self._default_asyncio_loop = asyncio.get_running_loop()
         mock_self.node_rank = 0
         mock_self.profiler_controller = mock_profiler
         mock_self.engine = mock_engine
@@ -574,6 +577,7 @@ class TestServerProfilerFunctionality(unittest.IsolatedAsyncioTestCase):
         mock_engine = AsyncMock()
 
         mock_self = MagicMock()
+        mock_self._default_asyncio_loop = asyncio.get_running_loop()
         mock_self.node_rank = 1  # non-master node, should skip
         mock_self.profiler_controller = mock_profiler
         mock_self.engine = mock_engine
@@ -604,6 +608,7 @@ class TestServerProfilerFunctionality(unittest.IsolatedAsyncioTestCase):
         mock_tokenizer_manager = AsyncMock()
 
         mock_self = MagicMock()
+        mock_self._default_asyncio_loop = asyncio.get_running_loop()
         mock_self.profiler_controller = mock_profiler
         mock_self.tokenizer_manager = mock_tokenizer_manager
         mock_self.replica_rank = 0

--- a/tests/workers/rollout/rollout_vllm/test_submitter_gate_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_submitter_gate_on_cpu.py
@@ -51,6 +51,7 @@ class _FakeEngine:
 
 def _make_server(node_rank: int = 0):
     server = object.__new__(vllm_async_server.vLLMHttpServer)
+    server._default_asyncio_loop = asyncio.get_running_loop()
     server.node_rank = node_rank
     server.engine = _FakeEngine()
     server.engine.server = server

--- a/tests/workers/rollout/rollout_vllm/test_vllm_control_concurrency_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_control_concurrency_on_cpu.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test that the _control_method decorator used by vLLMHttpServer schedules
+control methods on a dedicated concurrency group to prevent deadlock.
+
+Usage:
+    pytest tests/workers/rollout/rollout_vllm/test_vllm_control_concurrency_on_cpu.py -v
+"""
+
+import asyncio
+import sys
+
+import pytest
+
+ray = pytest.importorskip("ray")
+ray_cloudpickle = pytest.importorskip("ray.cloudpickle")
+pytest.importorskip("vllm")
+
+from verl.workers.rollout.replica import CONTROL_METHOD_CONCURRENCY  # noqa: E402
+from verl.workers.rollout.vllm_rollout.vllm_async_server import _control_method  # noqa: E402
+
+GENERATE_CONCURRENCY = 8
+RAY_TIMEOUT = 30
+
+
+class _FakeHttpServer:
+    def __init__(self):
+        # Required by _control_method.
+        self._default_asyncio_loop = asyncio.get_running_loop()
+
+        self._num_enqueued_generations = 0
+        self._all_generations_enqueued = asyncio.Event()
+        self._release_generations = asyncio.Event()
+
+    @_control_method
+    async def release_generations(self):
+        await self._all_generations_enqueued.wait()
+
+        assert asyncio.get_running_loop() is self._default_asyncio_loop
+        self._release_generations.set()
+
+    async def generate(self):
+        assert asyncio.get_running_loop() is self._default_asyncio_loop
+
+        self._num_enqueued_generations += 1
+        if self._num_enqueued_generations == GENERATE_CONCURRENCY:
+            self._all_generations_enqueued.set()
+
+        await self._release_generations.wait()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def serialize_test_module_by_value():
+    """Tells Ray to serialize helpers in this file (e.g. _FakeHttpServer) by
+    value to avoid import errors in the actor process."""
+
+    test_module = sys.modules[__name__]
+    ray_cloudpickle.register_pickle_by_value(test_module)
+    yield
+    ray_cloudpickle.unregister_pickle_by_value(test_module)
+
+
+def test_control_rpc_is_not_starved_by_generate():
+    """Test the _control_method decorator using _FakeHttpServer."""
+
+    server = None
+
+    try:
+        server_actor_class = ray.remote(
+            concurrency_groups={"control": CONTROL_METHOD_CONCURRENCY},
+        )(_FakeHttpServer)
+        server = server_actor_class.options(max_concurrency=GENERATE_CONCURRENCY).remote()
+
+        # Saturate server with GENERATE_CONCURRENCY requests.
+        generation_refs = [server.generate.remote() for _ in range(GENERATE_CONCURRENCY)]
+
+        # Verify that release_generations() is not blocked and that it runs on the
+        # default asyncio loop.
+        ray.get(server.release_generations.remote(), timeout=RAY_TIMEOUT)
+
+        # Verify all generation_refs are fulfilled.
+        ray.get(generation_refs, timeout=RAY_TIMEOUT)
+
+    finally:
+        if server is not None:
+            ray.kill(server)

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -257,6 +257,10 @@ class RolloutReplica(ABC):
     def max_concurrency(self) -> int:
         # 1000 is Ray's default max_concurrency for async execution.
         # Add some margin to account for control method call.
+        # TODO: The vLLMReplica subclass uses separate concurrency groups for
+        # control and generate methods to avoid deadlocks, and so does not use
+        # this method. Other rollout replica subclasses should migrate to
+        # vLLMReplica's approach.
         return max(1000, self.config.max_num_seqs + CONTROL_METHOD_CONCURRENCY)
 
     def rollout_worker_use_gpu(self) -> bool:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import argparse
 import asyncio
+import functools
 import inspect
 import json
 import logging
@@ -53,7 +54,12 @@ from verl.utils.tokenizer import normalize_token_ids
 from verl.utils.tracking import RLInsightLogger
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
-from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
+from verl.workers.rollout.replica import (
+    CONTROL_METHOD_CONCURRENCY,
+    RolloutMode,
+    RolloutReplica,
+    TokenOutput,
+)
 from verl.workers.rollout.utils import (
     get_max_position_embeddings,
     get_vision_placeholder_token_ids,
@@ -82,6 +88,28 @@ if os.getenv("VERL_USE_GPT_OSS", "0") == "1":
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
+
+
+def _control_method(server_method):
+    """Decorator used inside vLLMHttpServer to mark control methods that should
+    be scheduled on their own concurrency group but submit work to the default
+    asyncio loop.
+
+    See comment on `vLLMHttpServer._default_asyncio_loop`."""
+
+    server_method = ray.method(concurrency_group="control")(server_method)
+
+    @functools.wraps(server_method)
+    async def wrapper(self, *args, **kwargs):
+        if asyncio.get_running_loop() is self._default_asyncio_loop:
+            return await server_method(self, *args, **kwargs)
+        future = asyncio.run_coroutine_threadsafe(
+            server_method(self, *args, **kwargs),
+            self._default_asyncio_loop,
+        )
+        return await asyncio.wrap_future(future)
+
+    return wrapper
 
 
 class vLLMHttpServer:
@@ -217,6 +245,17 @@ class vLLMHttpServer:
 
         self._post_init(cuda_visible_devices)
 
+        # Ray associates actors with a capped number of async tasks that can be
+        # running. To avoid deadlocks, we use separate 'concurrency groups' for
+        # control messages and generate() requests. Each concurrency group is
+        # backed by a different CPU thread and asyncio event loop. To ensure
+        # thread safety, we require that any code that reads or writes
+        # vLLMHttpServer's state executes on default_asyncio_loop. Methods
+        # annotated with `concurrency_group="..."` run on non-default asyncio
+        # loops, so they should enqueue work onto _default_asyncio_loop. The
+        # _control_method decorator ensures this for control methods.
+        self._default_asyncio_loop = asyncio.get_running_loop()
+
     def get_master_address(self):
         """Get master address and port for data parallel.
         Returns:
@@ -244,6 +283,7 @@ class vLLMHttpServer:
             self.model_config.lora_rank > 0 or self.model_config.lora.get("rank", 0) > 0
         ) and not self.model_config.lora.get("merge", False)
 
+    @_control_method
     async def collective_rpc(
         self,
         method: str | Callable,
@@ -258,6 +298,7 @@ class vLLMHttpServer:
             kwargs=kwargs,
         )
 
+    @_control_method
     async def set_pd_peer(
         self,
         decode_peers: list,
@@ -567,6 +608,8 @@ class vLLMHttpServer:
     ) -> TokenOutput:
         """Generate sequence with token-in-token-out.
 
+        This consumes slots on the default Ray concurrency group.
+
         Args:
             kv_transfer_params: vLLM KV-transfer payload for PD requests.
         """
@@ -830,6 +873,7 @@ class vLLMHttpServer:
             kv_transfer_params=decode_kv_params,
         )
 
+    @_control_method
     async def wake_up(self, tags: list[str] | None = None):
         if self.node_rank != 0:
             return
@@ -851,6 +895,7 @@ class vLLMHttpServer:
         elif self.rollout_mode == RolloutMode.STANDALONE:
             logger.info("skip wake_up in standalone mode")
 
+    @_control_method
     async def sleep(self):
         if self.node_rank != 0 or not self.config.free_cache_engine:
             return
@@ -862,6 +907,7 @@ class vLLMHttpServer:
         elif self.rollout_mode == RolloutMode.STANDALONE:
             logger.info("skip sleep in standalone mode")
 
+    @_control_method
     async def clear_kv_cache(self):
         if self.node_rank == 0:
             # reset_connector=True drops any attached external KV store
@@ -873,6 +919,7 @@ class vLLMHttpServer:
             await self.engine.reset_mm_cache()
             await self.engine.reset_encoder_cache()
 
+    @_control_method
     async def release_kv_cache(self):
         """Free the kv_cache pool for the duration of a weight sync."""
         # TODO: use the real release_kv_cache() method after vllm supports it (vllm#44890/46438)
@@ -883,6 +930,7 @@ class vLLMHttpServer:
         await self.engine.sleep(level=self._resolve_sleep_level())
         await self.engine.wake_up(tags=["weights"])
 
+    @_control_method
     async def resume_kv_cache(self):
         """Restore kv_cache GPU memory after a weight sync. Counterpart to release_kv_cache()."""
         if self.node_rank != 0 or not self.config.free_cache_engine:
@@ -900,12 +948,14 @@ class vLLMHttpServer:
             and self.profiler_controller.is_discrete_mode()
         )
 
+    @_control_method
     async def start_profile(self, **kwargs):
         if self.node_rank != 0:
             return
         if self._should_profile():
             await self.engine.start_profile(**kwargs)
 
+    @_control_method
     async def stop_profile(self):
         if self.node_rank != 0:
             return
@@ -922,13 +972,16 @@ class vLLMHttpServer:
                 self.profiler_keep_global_ranks,
             )
 
+    @_control_method
     async def set_global_steps(self, global_steps: int):
         """Set the global steps of the model weights."""
         self.global_steps = global_steps
 
+    @_control_method
     async def wait_for_requests_to_drain(self):
         await self.engine.wait_for_requests_to_drain()
 
+    @_control_method
     async def abort_all_requests(self, reset_prefix_cache: bool = True) -> dict[str, Any]:
         """Abort all ongoing generation requests.
 
@@ -992,6 +1045,7 @@ class vLLMHttpServer:
             logger.exception("Error aborting requests")
             raise
 
+    @_control_method
     async def resume_generation(self):
         """Resume generation after abort_all_requests (pause_generation)."""
         # Before the node_rank guard: every server in the replica closed the gate, so every
@@ -1002,6 +1056,7 @@ class vLLMHttpServer:
             return
         await self.engine.resume_generation()
 
+    @_control_method
     async def abort_request(self, request_id: str, reset_prefix_cache: bool = True) -> dict[str, Any]:
         """Abort a specific generation request.
 
@@ -1290,7 +1345,15 @@ class vLLMReplica(RolloutReplica):
         super().__init__(
             replica_rank, config, model_config, gpus_per_node, is_reward_model, is_teacher_model, name_suffix
         )
-        self.server_class = ray.remote(vLLMHttpServer)
+        self.server_class = ray.remote(
+            concurrency_groups={"control": CONTROL_METHOD_CONCURRENCY},
+        )(vLLMHttpServer)
+
+    @property
+    def max_concurrency(self) -> int:
+        # Control calls have their own concurrency group, so this only caps
+        # methods in Ray's default group, primarily generate().
+        return max(1000, self.config.max_num_seqs)
 
     async def launch_servers(self):
         """Launch http server in each node."""


### PR DESCRIPTION
### What does this PR do?

This PR prevents vLLM rollout control RPCs from being starved by `generate()` calls.

Ray limits the number of concurrent calls admitted to an async actor. During highly asynchronous rollouts, generation calls can occupy every slot in the vLLM server's default concurrency group. Control calls such as `wake_up()` and `abort_all_requests()` then cannot start, which can deadlock rollout transitions and weight synchronization.

The fix gives vLLM control-plane methods a separate Ray concurrency group while leaving `generate()` in the default group. Ray runs named concurrency groups on separate threads and asyncio loops, so the new control-method wrapper `_control_method` forwards the actual method body to the server's default loop to preserve thread-safe access to server and vLLM state.

### Checklist Before Starting

- [x] Search for similar PRs. Query: "vLLM concurrency group"
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

- Added CPU-only unit test `test_vllm_control_concurrency_on_cpu.py` which verifies control methods are not blocked after saturating `vLLMHttpServer` with `generate()` requests.
    - The new test is included in the vLLM CPU test workflow.
- Verified that this E2E test deadlocks without this fix and does not deadlock with it: https://gist.github.com/rao-ashish/d186729e83434b2e4b5425647abec735

### API and Usage Example

There are no user-facing API or configuration changes.

### Design & Code Changes

- Adds a 16-slot `control` concurrency group to `vLLMHttpServer`.
- Marks vLLM management methods as control-plane RPCs while keeping `generate()` in Ray's default group.
- Executes control-method bodies on the server's original asyncio loop, preserving thread-safe access to shared server and engine state.
- Removes the control-slot margin from vLLM's default-group concurrency limit because control calls now have independent capacity. Other rollout backends retain their existing behavior.
- Adds CPU-only metadata and runtime regression coverage and includes it in CI.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). N/A: this is an internal scheduling fix with no user-facing API.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in the [ci-request channel](https://verl-project.slack.com/archives/C091TCESWB1) in the [verl Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). If unavailable, try the [Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).
- [x] If this PR is related to the `recipe` submodule, update its reference with `git submodule update --remote` or `cd recipe && git pull origin main`. N/A.