### PR TITLE
[trainer] fix: dump reward_extra_info in v1 train rollout JSONL

### DIFF
--- a/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_trainer_base_on_cpu.py
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import numpy as np
+import torch
 from omegaconf import OmegaConf
+from transfer_queue import KVBatchMeta
 
 from verl.trainer.ppo.v1.replay_buffer import ReplayBuffer, ReplayBufferAsync
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer
@@ -163,3 +169,72 @@ def test_builtin_filter_groups_warns_when_total_generation_limit_is_configured()
         "use max_inflight_gen_batches to bound concurrent Sync DAPO generation.",
         10,
     )
+
+
+def _dumped_rollout(keys: list[str], reward_extra_infos: list[dict | None]) -> dict:
+    """Run ``_log_rollout_data`` over a stubbed TransferQueue read and return the kwargs it passed
+    to ``_dump_generations``. The stub honours ``select_fields`` like the real queue, so a field the
+    trainer stops requesting is a field it stops receiving.
+    """
+    n = len(keys)
+    data = {
+        "uid": np.array(keys, dtype=object),
+        "prompts": torch.nested.nested_tensor([[10 + i] for i in range(n)], layout=torch.jagged),
+        "responses": torch.nested.nested_tensor([[20 + i] for i in range(n)], layout=torch.jagged),
+        "rm_scores": torch.arange(n, dtype=torch.float32).unsqueeze(1),
+        "reward_model": np.array([{"ground_truth": f"gt{i}"} for i in range(n)], dtype=object),
+        "extra_fields": np.array(
+            [{} if extra is None else {"reward_extra_info": extra} for extra in reward_extra_infos], dtype=object
+        ),
+    }
+
+    def kv_batch_get(keys, partition_id, select_fields):
+        return {field: data[field] for field in select_fields}
+
+    trainer = _StubTrainer.__new__(_StubTrainer)
+    # Decode ids to their digits so dumped text stays traceable to its sample.
+    trainer.tokenizer = SimpleNamespace(pad_token_id=0, decode=lambda ids, skip_special_tokens=True: str(int(ids[0])))
+    batch = KVBatchMeta(keys=list(keys), tags=[{} for _ in keys], partition_id="train")
+
+    with (
+        patch("verl.trainer.ppo.v1.trainer_base.tq.kv_batch_get", side_effect=kv_batch_get),
+        patch.object(_StubTrainer, "_dump_generations") as dump_generations,
+    ):
+        trainer._log_rollout_data(batch, {}, "/dev/null/never-written")
+
+    return dump_generations.call_args.kwargs
+
+
+def test_rollout_dump_carries_reward_extra_info_sorted_by_uid():
+    dumped = _dumped_rollout(["u1_0_0", "u0_0_0"], [{"acc": 1.0}, {"acc": 0.0}])
+
+    assert dumped["reward_extra_infos_dict"] == {"acc": [0.0, 1.0], "uid": ["u0_0_0", "u1_0_0"]}
+    assert dumped["gts"] == ["gt1", "gt0"]
+    assert dumped["scores"] == [1.0, 0.0]
+    assert dumped["outputs"] == ["21", "20"]
+
+
+def test_rollout_dump_pads_reward_extra_info_keys_missing_from_some_samples():
+    dumped = _dumped_rollout(["u0_0_0", "u1_0_0", "u2_0_0"], [{"acc": 1.0}, None, {"acc": 0.0, "pred": "x"}])
+
+    assert dumped["reward_extra_infos_dict"] == {
+        "acc": [1.0, None, 0.0],
+        "pred": [None, None, "x"],
+        "uid": ["u0_0_0", "u1_0_0", "u2_0_0"],
+    }
+
+
+def test_generation_dump_writes_sparse_and_exotic_values(tmp_path):
+    PPOTrainer._write_generations(
+        inputs=["p"],
+        outputs=["o"],
+        gts=["g"],
+        scores=[1.0],
+        reward_extra_infos_dict={"acc": [None], "stamp": [datetime.date(2026, 8, 27)]},
+        dump_path=str(tmp_path),
+        global_steps=3,
+    )
+
+    row = json.loads((tmp_path / "3.jsonl").read_text())
+    assert row["acc"] is None
+    assert row["stamp"] == "2026-08-27"

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1173,7 +1173,9 @@ class PPOTrainer(ABC):
                 return bool(obj)
             elif hasattr(obj, "tolist"):
                 return obj.tolist()
-            raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+            # A generation dump is a debug artifact: stringify exotic values (datetime, Decimal,
+            # set, ...) rather than raising, which would kill the training run.
+            return str(obj)
 
         with open(filename, "w") as f:
             for i in range(n):
@@ -1220,7 +1222,7 @@ class PPOTrainer(ABC):
     def _log_rollout_data(self, batch: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout data from TransferQueue and dump sorted by uid."""
         with marked_timer("dump_rollout_generations", timing_raw, color="green"):
-            fields = ["uid", "prompts", "responses", "rm_scores", "reward_model"]
+            fields = ["uid", "prompts", "responses", "rm_scores", "reward_model", "extra_fields"]
             data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
             data["prompts"] = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
             data["responses"] = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
@@ -1235,6 +1237,22 @@ class PPOTrainer(ABC):
                 gts = [item.get("ground_truth", None) for item in reward_model.tolist()]
             else:
                 gts = [None] * len(uids)
+
+            # Mirror ``_validate``'s unpack of ``extra_fields["reward_extra_info"]`` so the train
+            # rollout dump carries the per-sample extras the reward function attaches. Without this
+            # the dump only holds input / output / gts / score / uid.
+            reward_extra_infos_dict: dict[str, list] = {}
+            extra_fields_list = data.pop("extra_fields", None)
+            if extra_fields_list is not None:
+                for pos, extra_field in enumerate(extra_fields_list.tolist()):
+                    reward_extra_info = (
+                        extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
+                    )
+                    for key in reward_extra_info:
+                        if key not in reward_extra_infos_dict:
+                            reward_extra_infos_dict[key] = [None] * pos
+                    for key in reward_extra_infos_dict:
+                        reward_extra_infos_dict[key].append(reward_extra_info.get(key))
 
             # Sort by uid key ({sample}_{rollout}_{output})
             sort_keys = []
@@ -1251,7 +1269,8 @@ class PPOTrainer(ABC):
             gts = [gts[i] for i in sorted_indices]
             scores = [scores[i] for i in sorted_indices]
 
-            reward_extra_infos_dict = {"uid": [batch.keys[i] for i in sorted_indices]}
+            reward_extra_infos_dict = {k: [v[i] for i in sorted_indices] for k, v in reward_extra_infos_dict.items()}
+            reward_extra_infos_dict["uid"] = [batch.keys[i] for i in sorted_indices]
 
             self._dump_generations(
                 inputs=inputs,


### PR DESCRIPTION
### What does this PR do?

Restores the reward-function extra columns (`acc`, `pred`, ...) in the V1 trainer's train rollout dump, and stops a single unserializable value in that dump from killing a training run.

**The gap.** The v0 trainer feeds its train rollout dump the reward function's extra info: `ray_trainer` extracts `reward_extra_infos_dict` alongside the reward tensor (`ray_trainer.py:1568`) and passes it to `_log_rollout_data` (`:1724`), so `trainer.rollout_data_dir` JSONL carries per-sample keys such as `acc` or `pred`. The V1 trainer drops them — `PPOTrainer._log_rollout_data` fetched only `uid / prompts / responses / rm_scores / reward_model` from TransferQueue, where the extras live under `extra_fields["reward_extra_info"]` rather than in `non_tensor_batch`. The dump therefore held just `input`, `output`, `gts`, `score` and `uid`.

It is the same producer over two transports, so flipping one flag loses the columns: `AgentLoopWorker._postprocess` flattens `AgentLoopOutput.extra_fields["reward_extra_info"]` into `non_tensor_batch` for v0 (`agent_loop.py:1076-1080`), while `AgentLoopWorkerTQ` stores that same dict verbatim into TransferQueue for V1 (`agent_loop_tq.py:194`). Since #6823 made `trainer.use_v1` the default, an unchanged reward function with an unchanged `trainer.rollout_data_dir` produces a narrower dump than before. `_validate` already unpacks the same sub-dict for the validation dump (#6024), so train and val also disagreed within V1.

To be precise about the framing: this is not a regression inside V1's own history. `_log_rollout_data` arrived in #6024 already lacking the unpack, in the same commit that added the `_validate` side. The loss surfaced when the default flipped in #6823.

**Second change — JSON encoding.** Routing arbitrary reward values into the train dump makes `json_encode_default`'s terminal `raise TypeError` reachable there, and `_dump_generations` re-raises into the training loop, so a reward function returning a `datetime`, `Decimal` or `set` would terminate the run over a debug column. `trainer.rollout_data_dir` and `trainer.validation_data_dir` are independently gated, so users who set only `rollout_data_dir` had no prior exposure to this. Such values are now stringified, mirroring `ray_trainer`'s `default=str` (#6062); issue #4924 is the same failure class on the v0 path. The change is scoped to per-value encoding, so genuine I/O errors (disk full, read-only dir) still propagate exactly as #6324 intended.

**Scope.** This covers the default agent-loop reward path. In colocated-reward mode (`reward.reward_model.enable=true` with `enable_resource_pool=false`) `_compute_reward_colocate` writes extras as top-level TransferQueue fields rather than under `extra_fields` (`trainer_base.py:1479-1481`), so they are still not picked up; `_validate` has the same gap, so train/val parity holds either way. Left for a separate change.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [`reward_extra_info`](https://github.com/verl-project/verl/pulls?q=is%3Apr+reward_extra_info), [`_log_rollout_data`](https://github.com/verl-project/verl/pulls?q=is%3Apr+_log_rollout_data), [`rollout_data_dir`](https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout_data_dir)
- [x] Format the PR title as `[{modules}] {type}: {description}`

**Why this does not duplicate an open PR.** No open PR touches `verl/trainer/ppo/v1/trainer_base.py::_log_rollout_data` or V1's `json_encode_default`. The nearest neighbours: #7151 fixes sparse `reward_extra_info` *assembly* in `agent_loop.py` / `reward_loop.py` / `reward_extra_info.py` — complementary and mergeable in either order, and the V1 path bypasses the code it rewrites since `AgentLoopWorkerTQ` overrides `_agent_loop_postprocess`; #6845 targets `process_validation_metrics` (`metric_utils`), which this dump path never reaches; #5810 fixes JSON serialization in v0's `ray_trainer.py` only; #5793 / #3957 / #4698 add reward extras to *metrics*, not dumps. Happy to reuse #7151's `assemble_reward_extra_info` helper if that lands first.

### Test

Added to `tests/trainer/ppo/v1/test_trainer_base_on_cpu.py`, so `cpu_unit_tests.yml` picks them up automatically via its `python_files = *_on_cpu.py` collection.

```bash
PYTHONPATH=$PWD python -m pytest tests/trainer/ppo/v1/test_trainer_base_on_cpu.py -q
# 10 passed, 25 warnings in 4.07s

pre-commit run --all-files --show-diff-on-failure
# all 14 hooks Passed, no files modified
```

Three new tests, and I verified each one actually fails when its target regresses by re-running the suite against a mutated `trainer_base.py`:

| Mutation | Caught by |
| --- | --- |
| Drop `"extra_fields"` from `select_fields` | `test_rollout_dump_carries_reward_extra_info_sorted_by_uid`, `test_rollout_dump_pads_reward_extra_info_keys_missing_from_some_samples` |
| `return str(obj)` reverted to `raise TypeError` | `test_generation_dump_writes_sparse_and_exotic_values` |
| Extras not reindexed by `sorted_indices` | `test_rollout_dump_carries_reward_extra_info_sorted_by_uid` |
| Drop the `[None] * pos` back-fill | `test_rollout_dump_pads_reward_extra_info_keys_missing_from_some_samples` |

I also probed the pinned TransferQueue directly to confirm the new `select_fields` entry cannot break an existing run: with a key that has no `extra_fields`, and with a batch where only some keys have it, `kv_batch_get` does not raise — `BatchMeta.select_fields` drops names absent from the schema, so the `data.pop("extra_fields", None)` guard falls back to exactly the pre-change output.

### API and Usage Example

No API, config or CLI change. With `trainer.rollout_data_dir` set and a reward function returning extra info, each JSONL line gains those keys:

```diff
- {"input": "...", "output": "...", "gts": "...", "score": 0.5, "step": 12, "uid": "abc_0_0"}
+ {"input": "...", "output": "...", "gts": "...", "score": 0.5, "step": 12, "acc": 1.0, "pred": "42", "uid": "abc_0_0"}
```

Keys returned for only some samples are filled with `null` for the rest, which `_write_generations` already tolerates via its `len(v) == n` guard.

### Design & Code Changes

- `_log_rollout_data`: add `"extra_fields"` to the TransferQueue `select_fields`, and fold `extra_fields["reward_extra_info"]` into `reward_extra_infos_dict` before it is reindexed by the uid sort. Mirrors the `_validate` unpack; kept inline rather than factored into a shared helper, since `_validate` accumulates across batches and feeds `process_validation_metrics`, and reworking that risks the sparse-key behaviour tracked in #6830.
- Keys first seen part-way through a batch are back-filled with `None` so every column stays length `n` and index-aligned with `inputs` / `outputs` / `gts` / `scores`.
- `json_encode_default`: replace the terminal `raise TypeError` with `return str(obj)`. The numpy and `.tolist()` branches are untouched, so numeric columns keep the native typing added by #6167 rather than reverting to v0's stringified numbers.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not applicable: no config, API or CLI surface changes, and `trainer.rollout_data_dir` is already documented.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel. Not accessible to me: the `verl` Slack workspace restricts self-signup to the `anyscale.com`, `bytedance.com` and `together.ai` email domains, so a request here has to stand in for that step.
- [ ] If your PR is related to the `recipe` submodule ... Not applicable.

### AI assistance

This change was developed with AI assistance (Claude). I have reviewed every changed line and run the tests and pre-commit locally with the results shown above.
