### PR TITLE
[rollout, vllm] feat: overlap bucketed weight transfer with receiver-side processing

### DIFF
--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -135,7 +135,7 @@ def _sender_fn(zmq_handle, weight_specs, seed, bucket_size_mb, use_shm):
     asyncio.run(sender.async_send_weights(iter(weights)))
 
 
-def _receiver_fn(zmq_handle, use_shm, result_queue):
+def _receiver_fn(zmq_handle, use_shm, result_queue, overlap_bucket_processing=False):
     """Receiver process: receive weights, send back (name, dtype, shape, checksum)."""
     from verl.utils.device import get_device_name
     from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
@@ -145,6 +145,7 @@ def _receiver_fn(zmq_handle, use_shm, result_queue):
         zmq_handle=zmq_handle,
         device=device,
         use_shm=use_shm,
+        overlap_bucket_processing=overlap_bucket_processing,
     )
     received = []
     receiver.receive_weights(
@@ -158,7 +159,7 @@ def _receiver_fn(zmq_handle, use_shm, result_queue):
 # ---------------------------------------------------------------------------
 # Test helper
 # ---------------------------------------------------------------------------
-def _transfer_and_validate(weight_specs, bucket_size_mb, use_shm):
+def _transfer_and_validate(weight_specs, bucket_size_mb, use_shm, overlap_bucket_processing=False):
     """Spawn sender + receiver processes, then validate received tensors."""
     zmq_handle = _unique_zmq_handle()
     seed = 42
@@ -171,7 +172,7 @@ def _transfer_and_validate(weight_specs, bucket_size_mb, use_shm):
     )
     receiver_p = ctx.Process(
         target=_receiver_fn,
-        args=(zmq_handle, use_shm, result_queue),
+        args=(zmq_handle, use_shm, result_queue, overlap_bucket_processing),
     )
 
     # Start sender first (it binds), then receiver (it connects)
@@ -240,6 +241,23 @@ class TestBucketedWeightTransferSHM:
     def test_empty_weights(self):
         _transfer_and_validate([], bucket_size_mb=1, use_shm=True)
 
+    def test_overlap_multiple_buckets(self):
+        # overlap_bucket_processing: receiver acks each bucket before processing
+        # it; received tensors must still be intact (early buffer release).
+        specs = [(f"layer{i}.weight", (128, 128), torch.float32) for i in range(20)]
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=True, overlap_bucket_processing=True)
+
+    def test_overlap_mixed_dtypes(self):
+        specs = [
+            ("fp32_param", (64, 64), torch.float32),
+            ("bf16_param", (64, 64), torch.bfloat16),
+            ("fp16_param", (32, 32), torch.float16),
+        ]
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=True, overlap_bucket_processing=True)
+
+    def test_overlap_empty_weights(self):
+        _transfer_and_validate([], bucket_size_mb=1, use_shm=True, overlap_bucket_processing=True)
+
 
 # ---------------------------------------------------------------------------
 # CUDA IPC tests (CUDA only — IPC is not supported on NPU)
@@ -289,3 +307,17 @@ class TestBucketedWeightTransferIPC:
         specs.append(("lm_head", (1024, 1024), torch.float32))  # 4MB
 
         _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False)
+
+    def test_overlap_multiple_buckets(self):
+        # overlap_bucket_processing on the IPC path stages a private copy of
+        # each bucket before the early ack; received tensors must stay intact.
+        specs = [(f"layer{i}.weight", (128, 128), torch.float32) for i in range(20)]
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False, overlap_bucket_processing=True)
+
+    def test_overlap_large_weight(self):
+        # Oversized weights travel as raw IPC handles; those buckets must fall
+        # back to the late ack even when overlap_bucket_processing is enabled.
+        specs = [("embedding", (1024, 1024), torch.float32)]  # 4MB
+        specs.extend([(f"layer{i}.weight", (128,), torch.bfloat16) for i in range(5)])
+        specs.append(("lm_head", (1024, 1024), torch.float32))  # 4MB
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False, overlap_bucket_processing=True)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -385,6 +385,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -327,6 +327,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -366,6 +366,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -343,6 +343,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -291,6 +291,14 @@ checkpoint_engine:
   # when using Tensor Parallelism (TP) >= 8.
   update_weights_bucket_megabytes: 2048
 
+  # If true, the weight receiver acks each bucket as soon as the shared
+  # transfer buffer is no longer referenced (before the bucket is processed,
+  # e.g. online quantization + load_weights), so the sender can start filling
+  # the next bucket while the current one is being processed. On the IPC path
+  # this stages one private copy of the bucket (one extra bucket of device
+  # memory). Default false preserves the original lock-step behavior.
+  overlap_bucket_processing: false
+
   # Additional keyword arguments to pass to the checkpoint engine constructor
   engine_kwargs: {}
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -133,6 +133,13 @@ class CheckpointEngineConfig(BaseConfig):
     backend: Optional[str] = "naive"
     # Bucket size in MB to transfer multiple weights at one time
     update_weights_bucket_megabytes: int = 2048
+    # If True, the weight receiver acks each bucket as soon as the shared
+    # transfer buffer is no longer referenced (before the bucket is processed,
+    # e.g. online quantization + load_weights), so the sender can start filling
+    # the next bucket while the current one is being processed. On the IPC path
+    # this stages one private copy of the bucket (one extra bucket of device
+    # memory). Default False preserves the original lock-step behavior.
+    overlap_bucket_processing: bool = False
     # Additional keyword arguments for checkpoint engine
     engine_kwargs: dict = field(default_factory=dict)
     # If set, this Python module is imported on every worker process before the

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -244,6 +244,14 @@ class BucketedWeightReceiver:
         zmq_handle: ZMQ IPC socket path (must match sender)
         device: Target device for received tensors
         use_shm: Use shared memory instead of CUDA IPC
+        overlap_bucket_processing: If True, ack each bucket as soon as the
+            shared transfer buffer is no longer referenced — before the bucket
+            is processed (e.g. online quantization + load_weights) — so the
+            sender can start filling the next bucket while the current one is
+            being processed. On the IPC path this stages one private copy of
+            the bucket (one extra bucket of device memory). Buckets that carry
+            raw IPC handles (oversized weights) always use the late ack,
+            because the sender may free the source tensor once acked.
     """
 
     def __init__(
@@ -251,10 +259,12 @@ class BucketedWeightReceiver:
         zmq_handle: str,
         device: torch.device,
         use_shm: bool = False,
+        overlap_bucket_processing: bool = False,
     ):
         self.zmq_handle = zmq_handle
         self.device = device
         self.use_shm = use_shm
+        self.overlap_bucket_processing = overlap_bucket_processing
 
         self.zmq_context = zmq.Context.instance()
         self.socket = None
@@ -265,6 +275,14 @@ class BucketedWeightReceiver:
         """
         Receive weights from sender and process each bucket via callback.
 
+        The ack sent back to the sender after each bucket means "the shared
+        transfer buffer may be overwritten": the sender waits for it before
+        filling the next bucket. With ``overlap_bucket_processing`` enabled,
+        the ack is sent as soon as every tensor of the bucket has been
+        materialized into private memory (independent device copies on the
+        shm path, a staged buffer copy on the IPC path), letting the sender
+        fill bucket i+1 while the callback is still processing bucket i.
+
         Args:
             on_bucket_received: Callback function(weights: list[(name, tensor)],
             is_last: bool) called per bucket. ``is_last`` marks the final bucket
@@ -272,36 +290,29 @@ class BucketedWeightReceiver:
             (e.g. vLLM ``add_lora``, which takes one adapter dict per call) can
             defer their finalization until the whole adapter has arrived.
         """
-        # Overlap mode: ack each bucket as soon as the shared buffer is no
-        # longer referenced, so the sender can start refilling it (gather +
-        # copy of bucket i+1) while this side is still processing bucket i
-        # (e.g. online quantization + load_weights).
-        # - shm path: every tensor is already a fresh device copy (``.to``),
-        #   so the shared buffer is free once those copies complete — ack right
-        #   after them, no staging needed.
-        # - IPC path: received tensors are views into the sender's device
-        #   buffer, so stage a private copy first (one extra device copy and
-        #   one bucket of device memory).
-        # Buckets that carry raw IPC handles (oversized weights) always use the
-        # late ack, because the sender may free the source tensor once acked.
-        early_ack = os.getenv("VERL_WEIGHT_SYNC_OVERLAP", "1") == "1"
         staging = None
         try:
             self._init_socket()
             self._init_buffer()
-            if early_ack and not self.use_shm:
+            if self.overlap_bucket_processing and not self.use_shm:
+                # IPC path: received tensors are views into the sender's device
+                # buffer, so stage a private copy before releasing the buffer.
                 staging = torch.empty_like(self.buffer)
-                logger.info("BucketedWeightReceiver: overlap mode enabled (early ack + staged bucket)")
+                logger.info("BucketedWeightReceiver: overlap_bucket_processing enabled (early ack + staged bucket)")
 
             # receive bucket and update weights
             while True:
                 metadata = self.socket.recv_pyobj()
-                weights, tensor = [], None
                 bucket_meta = metadata["bucket_meta"]
-                can_early_ack = early_ack and all(meta["handle"] is None for meta in bucket_meta.values())
+                # Buckets that carry raw IPC handles (oversized weights) always
+                # use the late ack: the sender may free the source tensor once acked.
+                early_ack = self.overlap_bucket_processing and all(
+                    meta["handle"] is None for meta in bucket_meta.values()
+                )
+                weights, tensor = [], None
                 src = self.buffer
                 acked = False
-                if can_early_ack and not self.use_shm:
+                if early_ack and not self.use_shm:
                     staging.copy_(self.buffer, non_blocking=True)
                     # Wait for the copy to finish before acking: the sender starts
                     # overwriting the shared buffer right after it gets the ack.
@@ -320,7 +331,7 @@ class BucketedWeightReceiver:
                     if self.use_shm:
                         tensor = tensor.to(self.device)
                     weights.append((name, tensor))
-                if can_early_ack and self.use_shm:
+                if early_ack and self.use_shm:
                     # All tensors above are independent device copies; the shm
                     # buffer is no longer referenced once the copies complete.
                     get_torch_device().synchronize()
@@ -338,7 +349,6 @@ class BucketedWeightReceiver:
                 if is_last:
                     break
             del staging
-            staging = None
         finally:
             self._cleanup()
 

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -272,32 +272,73 @@ class BucketedWeightReceiver:
             (e.g. vLLM ``add_lora``, which takes one adapter dict per call) can
             defer their finalization until the whole adapter has arrived.
         """
+        # Overlap mode: ack each bucket as soon as the shared buffer is no
+        # longer referenced, so the sender can start refilling it (gather +
+        # copy of bucket i+1) while this side is still processing bucket i
+        # (e.g. online quantization + load_weights).
+        # - shm path: every tensor is already a fresh device copy (``.to``),
+        #   so the shared buffer is free once those copies complete — ack right
+        #   after them, no staging needed.
+        # - IPC path: received tensors are views into the sender's device
+        #   buffer, so stage a private copy first (one extra device copy and
+        #   one bucket of device memory).
+        # Buckets that carry raw IPC handles (oversized weights) always use the
+        # late ack, because the sender may free the source tensor once acked.
+        early_ack = os.getenv("VERL_WEIGHT_SYNC_OVERLAP", "1") == "1"
+        staging = None
         try:
             self._init_socket()
             self._init_buffer()
+            if early_ack and not self.use_shm:
+                staging = torch.empty_like(self.buffer)
+                logger.info("BucketedWeightReceiver: overlap mode enabled (early ack + staged bucket)")
 
             # receive bucket and update weights
             while True:
                 metadata = self.socket.recv_pyobj()
                 weights, tensor = [], None
-                for name, meta in metadata["bucket_meta"].items():
+                bucket_meta = metadata["bucket_meta"]
+                can_early_ack = early_ack and all(meta["handle"] is None for meta in bucket_meta.values())
+                src = self.buffer
+                acked = False
+                if can_early_ack and not self.use_shm:
+                    staging.copy_(self.buffer, non_blocking=True)
+                    # Wait for the copy to finish before acking: the sender starts
+                    # overwriting the shared buffer right after it gets the ack.
+                    get_torch_device().synchronize()
+                    self.socket.send(b"")
+                    acked = True
+                    src = staging
+                for name, meta in bucket_meta.items():
                     shape, dtype, offset, handle = meta["shape"], meta["dtype"], meta["offset"], meta["handle"]
                     if handle is not None:
                         tensor = rebuild_ipc(handle, self.device.index)
                         weights.append((name, tensor))
                         continue
                     size = dtype.itemsize * shape.numel()
-                    tensor = self.buffer[offset : offset + size].view(dtype=dtype).view(shape)
+                    tensor = src[offset : offset + size].view(dtype=dtype).view(shape)
                     if self.use_shm:
                         tensor = tensor.to(self.device)
                     weights.append((name, tensor))
+                if can_early_ack and self.use_shm:
+                    # All tensors above are independent device copies; the shm
+                    # buffer is no longer referenced once the copies complete.
+                    get_torch_device().synchronize()
+                    self.socket.send(b"")
+                    acked = True
                 is_last = metadata["is_last"]
                 on_bucket_received(weights, is_last)
                 get_torch_device().synchronize()
-                self.socket.send(b"")
-                del weights, tensor
+                if not acked:
+                    self.socket.send(b"")
+                # Drop every local reference to the shared buffer: on the shm
+                # path a lingering view keeps the memoryview exported and
+                # _cleanup's shm.close() fails with BufferError.
+                del weights, tensor, src
                 if is_last:
                     break
+            del staging
+            staging = None
         finally:
             self._cleanup()
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -18,7 +18,6 @@ import os
 import platform
 import signal
 import threading
-import time
 from collections.abc import Mapping
 from types import MethodType
 from typing import Any, Literal, Optional, get_args
@@ -26,7 +25,7 @@ from typing import Any, Literal, Optional, get_args
 import torch
 from vllm.outputs import RequestOutput
 
-from verl.utils.device import get_device_name, get_torch_device, is_npu_available
+from verl.utils.device import get_device_name, is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack, resolve_weight_name
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches, is_fp8_model, load_quanted_weights
@@ -230,11 +229,15 @@ class vLLMColocateWorkerExtension:
             # patch weight loader to support MoE model
             patch_vllm_moe_model_weight_loader(model)
 
-    def update_weights_from_ipc(self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False):
+    def update_weights_from_ipc(
+        self,
+        peft_config: dict = None,
+        base_sync_done=False,
+        use_shm: bool = False,
+        overlap_bucket_processing: bool = False,
+    ):
         """Update the weights of the rollout model."""
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
-
-        t_start = time.time()
 
         if self.device is None:
             # vLLM workers may leave self.device unset on non-CUDA platforms (e.g. NPU);
@@ -281,12 +284,11 @@ class vLLMColocateWorkerExtension:
                 patch_vllm_moe_model_weight_loader(model)
 
         # =========================== step 2: receive weights and update ===========================
-        get_torch_device().synchronize()
-        t_prepared = time.time()
         receiver = BucketedWeightReceiver(
             zmq_handle=self._get_zmq_handle(),
             device=self.device,
             use_shm=use_shm,
+            overlap_bucket_processing=overlap_bucket_processing,
         )
         # LoRA adapters need a single complete tensor dict per ``add_lora``, but
         # the bucketed transport may split one across buckets. Accumulate and
@@ -313,8 +315,6 @@ class vLLMColocateWorkerExtension:
             )
 
         receiver.receive_weights(on_bucket_received=on_bucket_received)
-        get_torch_device().synchronize()
-        t_received = time.time()
 
         # =========================== step 3: process weights after loading ===========================
         if self._is_qat_model:
@@ -342,17 +342,6 @@ class vLLMColocateWorkerExtension:
 
             for model, model_config in self._iter_all_models_with_config():
                 process_weights_after_loading(model, model_config, self.device)
-
-        get_torch_device().synchronize()
-        t_done = time.time()
-        if self.local_rank == 0:
-            logger.warning(
-                "update_weights_from_ipc timing: prepare=%.2fs receive=%.2fs finalize=%.2fs total=%.2fs",
-                t_prepared - t_start,
-                t_received - t_prepared,
-                t_done - t_received,
-                t_done - t_start,
-            )
 
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):
         """Apply buffer updates to the main model and any synced MTP drafter.

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -18,6 +18,7 @@ import os
 import platform
 import signal
 import threading
+import time
 from collections.abc import Mapping
 from types import MethodType
 from typing import Any, Literal, Optional, get_args
@@ -25,7 +26,7 @@ from typing import Any, Literal, Optional, get_args
 import torch
 from vllm.outputs import RequestOutput
 
-from verl.utils.device import get_device_name, is_npu_available
+from verl.utils.device import get_device_name, get_torch_device, is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack, resolve_weight_name
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches, is_fp8_model, load_quanted_weights
@@ -233,6 +234,8 @@ class vLLMColocateWorkerExtension:
         """Update the weights of the rollout model."""
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
 
+        t_start = time.time()
+
         if self.device is None:
             # vLLM workers may leave self.device unset on non-CUDA platforms (e.g. NPU);
             # fall back to the worker's local rank on the current accelerator.
@@ -278,6 +281,8 @@ class vLLMColocateWorkerExtension:
                 patch_vllm_moe_model_weight_loader(model)
 
         # =========================== step 2: receive weights and update ===========================
+        get_torch_device().synchronize()
+        t_prepared = time.time()
         receiver = BucketedWeightReceiver(
             zmq_handle=self._get_zmq_handle(),
             device=self.device,
@@ -308,6 +313,8 @@ class vLLMColocateWorkerExtension:
             )
 
         receiver.receive_weights(on_bucket_received=on_bucket_received)
+        get_torch_device().synchronize()
+        t_received = time.time()
 
         # =========================== step 3: process weights after loading ===========================
         if self._is_qat_model:
@@ -335,6 +342,17 @@ class vLLMColocateWorkerExtension:
 
             for model, model_config in self._iter_all_models_with_config():
                 process_weights_after_loading(model, model_config, self.device)
+
+        get_torch_device().synchronize()
+        t_done = time.time()
+        if self.local_rank == 0:
+            logger.warning(
+                "update_weights_from_ipc timing: prepare=%.2fs receive=%.2fs finalize=%.2fs total=%.2fs",
+                t_prepared - t_start,
+                t_received - t_prepared,
+                t_done - t_received,
+                t_done - t_start,
+            )
 
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):
         """Apply buffer updates to the main model and any synced MTP drafter.

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -222,7 +222,11 @@ class ServerAdapter(BaseRollout):
         future = await self._execute_method(
             "update_weights_from_ipc",
             non_block=True,
-            kwargs={**kwargs, "use_shm": self.use_shm},
+            kwargs={
+                **kwargs,
+                "use_shm": self.use_shm,
+                "overlap_bucket_processing": self.config.checkpoint_engine.overlap_bucket_processing,
+            },
         )
 
         bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes


### PR DESCRIPTION
### What does this PR do?

Bucketed weight sync (`BucketedWeightSender`/`BucketedWeightReceiver`) is strictly lock-step: the sender blocks on each bucket's ack while the receiver processes the bucket (H2D copies, then `load_weights` — plus online quantization in FP8/MXFP8 RL refit setups). Receiver-side processing therefore adds its full latency to every training step.

The ack's only real meaning is "the shared transfer buffer may be overwritten" — the receiver does not need to finish *processing* the bucket first. This PR adds an opt-in `actor_rollout_ref.rollout.checkpoint_engine.overlap_bucket_processing` (default `false`, preserving current behavior): when enabled, the receiver acks each bucket as soon as the shared buffer is no longer referenced, so the sender fills bucket i+1 while the receiver is still processing bucket i (depth-1 pipeline, zero protocol change, sender untouched).

- **shm path**: every tensor is already an independent device copy after `.to(device)`; ack right after those copies complete. No extra copy, no extra memory.
- **IPC path**: received tensors are views into the sender's device buffer, so the bucket is first staged into a private buffer (one extra bucket of device memory), then acked.
- Buckets carrying raw IPC handles (oversized weights via `_direct_send_large_weight`) always use the late ack: the sender may free the source tensor once acked.

**Relation to #5619 (duplicate-work check)**: #5619 reaches the same pipeline depth via double buffering — 2x transfer buffer, a protocol change carrying `start_offset`, 23 files including checkpoint-engine backend refactors, plus a large-weight slicing feature — and has been a stale draft blocked on #5378 since 2026-03. This PR is a materially different, minimal approach: single buffer, no protocol change, zero extra memory on the shm path (the Ascend path), 6 core files + regenerated configs. It hides receiver-side *processing* (which dominates in online-quantization refits); #5619 additionally hides H2D materialization, which we measured as a small residual (~1s/step of ~46s). #7366 is orthogonal (error surfacing).

Search queries used for the duplicate check:
- https://github.com/verl-project/verl/pulls?q=is%3Apr+bucketed+weight+transfer
- https://github.com/verl-project/verl/pulls?q=is%3Apr+overlap+weight+sync

### Test

**Unit tests** (new cases cover overlap on the shm path, and on the IPC path incl. the raw-handle late-ack fallback):

```
python -m pytest tests/utils/test_bucketed_weight_transfer.py -q
# 9 passed, 9 skipped (IPC cases skipped on Ascend NPU: is_support_ipc()=False)
```

**End-to-end** (8x Ascend 950DT, Qwen3.5-35B-A3B GRPO, vllm-ascend W8A8_MXFP8 online quantization in the receiver; 16 prompts x 5 samples x ~1.8k tokens per step, 8 steps per group, step>=2 means):

| group | gen (s) | update_weights (s) | step (s) |
|---|---|---|---|
| bf16, overlap off | 50.76 | 57.49 | 313.94 |
| bf16, overlap on | 50.18 | 53.47 | 320.49 |
| MXFP8, overlap off | 43.41 | 59.56 | 310.18 |
| MXFP8, overlap on | 43.50 | 53.51 | 305.49 |

- With overlap on, both precisions converge to the same ~53.5s floor — receiver-side processing (incl. the online-quantization overhead) is fully hidden (+0.04s); the remainder is sender-side (gather + buffer fill).
- Online-quant refit overhead: +2.1s/step without overlap -> +0.04s with overlap.
- MXFP8+overlap vs bf16+overlap: **-15.0s/step (-4.7%) net win** end-to-end.

Earlier validation at batch=8 (same mechanism, env-var prototype):

| update_weights | bf16 | MXFP8 | delta |
|---|---|---|---|
| no overlap | 46.77s | 55.31s | +8.54s |
| overlap | 45.15s | 46.04s | +0.89s |

Rewards across all groups agree within noise (0.22-0.24).

### API and Usage Example

```yaml
actor_rollout_ref:
  rollout:
    checkpoint_engine:
      overlap_bucket_processing: true   # default: false (current lock-step behavior)
```

### Design & Code Changes

- `verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py` — `BucketedWeightReceiver(overlap_bucket_processing=...)`; the ack contract ("shared buffer may be overwritten") is documented in `receive_weights`; shm path acks after H2D copies, IPC path stages a private copy, raw-handle buckets keep the late ack.
- `verl/workers/config/rollout.py` + `verl/trainer/config/rollout/rollout.yaml` (+ regenerated `_generated_*.yaml`) — new `overlap_bucket_processing` config field, default `false`.
- `verl/workers/rollout/vllm_rollout/vllm_rollout.py` + `utils.py` — plumb the flag from config to the receiver.
- `tests/utils/test_bucketed_weight_transfer.py` — 5 new overlap cases (3 shm, 2 IPC incl. raw-handle fallback).

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] `pre-commit run` on all changed files: all hooks pass (ruff, ruff format, mypy, generated-config check, license, etc.).
- [x] Documentation: the new field is documented in `rollout.yaml` comments and the `CheckpointEngineConfig` docstring.
- [x] Unit tests added to `tests/utils/test_bucketed_weight_transfer.py` (already covered by CI); the IPC-path cases exercise on CUDA runners (skipped on NPU).
- [ ] CI request in the `ci-request` Slack channel — will do once the PR leaves draft.

### AI-assistance disclosure (per AGENTS.md)

This change was developed with AI assistance (Codex). The submitting human (@zjchenn) has reviewed the changed lines and can defend the design. All test commands above were actually run on the stated hardware; results are quoted verbatim. This is not a duplicate of #5619: different mechanism (single-buffer early-ack vs double-buffer), no protocol change, no extra buffer memory on the shm path, and #5619 has been stalled since 2026-03 (blocked on #5378).
