### PR TITLE
[trainer] feat: add reverse KL top-k distillation loss

### DIFF
--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -276,7 +276,7 @@ Distillation divergence to use. Default: `"k3"`.
 
 Two registered families:
 
-- **Top-k** (`forward_kl_topk`): forward KL using the teacher's top-k logits.
+- **Top-k** (`forward_kl_topk`, `reverse_kl_topk`): distributional KL losses on a truncated support. `forward_kl_topk` uses the teacher's top-k support. `reverse_kl_topk` uses the student's top-k support by default and currently requires full-vocab teacher logprobs; this initial implementation does not expose separate support-specific mode names.
 - **Single-sample KL estimators** (`kl`, `k1`, `abs`, `mse`, `k2`,
   `low_var_kl`, `k3`): per-token Monte Carlo estimators of reverse KL
   computed from the student's `log_probs` and the teacher's single
@@ -286,9 +286,10 @@ Two registered families:
 
 `k` for top-k distillation losses. Default: `32`.
 
-Only used when `loss_mode` requires top-$k$ (e.g. `forward_kl_topk`). Drives both
+Only used when `loss_mode` requires top-$k$. For `forward_kl_topk`, it drives both
 the teacher's `prompt_logprobs` request size and (for vLLM) the engine's
-`max_logprobs` cap.
+`max_logprobs` cap. For `reverse_kl_topk`, it is the student support size by
+default; the teacher request uses the teacher model's full vocabulary size.
 
 ### `distillation.distillation_loss.use_task_rewards` (bool)
 
@@ -665,8 +666,8 @@ rollouts on other samples.
    sampling params with `max_tokens=1` plus `prompt_logprobs=topk` (or `0`),
    so the teacher computes logprobs for the (prompt + response) sequence rather than
    generating new tokens. `topk` is set to `distillation.distillation_loss.topk`
-   when the loss mode requires top-$k$ (e.g. `forward_kl_topk`); otherwise `0`
-   (single-sample logprob only).
+   for `forward_kl_topk`, the teacher model's full vocabulary size for
+   `reverse_kl_topk`, and `0` otherwise (single-sample logprob only).
 
    **Temperature is always forced to `1.0`** regardless of the configured value.
    `prompt_logprobs` is computed via a forward pass over the existing (prompt + response)
@@ -709,12 +710,12 @@ Using the `DataProto` produced by the Agent Loop (rollouts + teacher logprobs in
    (`distillation_use_topk=True`), invokes `distillation_ppo_loss` **as a
    logits processor** while the full logits tensor is still in memory; this is
    the `student_logits is not None` branch of `distillation_ppo_loss`. The
-   logits-processor branch dispatches to `compute_forward_kl_topk`, which has a
-   separate implementation per training engine (FSDP and Megatron). Per-token
-   `distillation_losses`, `student_mass`, `teacher_mass`, `overlap_count`, and
-   `overlap_token_advantage` tensors are written back into `model_output` so the
-   full logits can be freed before the final loss step. The overlap tensors are
-   used only for logging.
+   logits-processor branch dispatches to the selected top-$k$ loss, which has a
+   separate implementation per training engine. `reverse_kl_topk` is currently
+   implemented for FSDP/VeOmni only, using the student's top-$k$ support. Per-token
+   `distillation_losses`, `student_mass`, `teacher_mass`, and optional overlap
+   tensors are written back into `model_output` so the full logits can be freed
+   before the final loss step. The overlap tensors are used only for logging.
 
 3. **Final loss.** After the forward, the engine calls the loss function with
    `model_output` (full logits already freed); this is the
@@ -746,7 +747,7 @@ The returned scalar loss is what `engine.train_batch` backpropagates.
 - `verl/experimental/teacher_loop/teacher_model.py` — `MultiTeacherModelManager` and `TeacherModelManager`; spin up teacher inference replicas on the dedicated teacher resource pool and expose per-teacher `LLMServerClient` factories
 - `verl/experimental/teacher_loop/teacher_manager.py` — `AsyncTeacherLLMServerManager`; routes per-sample teacher calls (single- or multi-teacher) and builds teacher sampling params
 - `verl/experimental/agent_loop/agent_loop.py` — `AgentLoopWorker._compute_teacher_logprobs`; per-sample teacher dispatch from `_agent_loop_postprocess`, packs `teacher_logprobs` into the rollout output
-- `verl/trainer/distillation/fsdp/losses.py` — FSDP backend `compute_forward_kl_topk`
+- `verl/trainer/distillation/fsdp/losses.py` — FSDP backend `compute_forward_kl_topk` and `compute_reverse_kl_topk`
 - `verl/trainer/distillation/megatron/losses.py` — Megatron backend `compute_forward_kl_topk`
 - `verl/workers/engine_workers.py` — `ActorRolloutRefWorker.init_model`; binds `distillation_ppo_loss` as the actor's `loss_fn` when distillation is enabled
 - `verl/workers/engine/{fsdp,megatron}/transformer_impl.py` — training-engine forward steps; invoke `distillation_ppo_loss` first as a logits processor (top-$k$ modes) and again as the final loss

--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -276,7 +276,7 @@ Distillation divergence to use. Default: `"k3"`.
 
 Two registered families:
 
-- **Top-k** (`forward_kl_topk`, `reverse_kl_topk`): distributional KL losses on a truncated support. `forward_kl_topk` uses the teacher's top-k support. `reverse_kl_topk` uses the student's top-k support by default and currently requires full-vocab teacher logprobs; this initial implementation does not expose separate support-specific mode names.
+- **Top-k** (`forward_kl_topk`, `reverse_kl_topk`): distributional KL losses on a truncated support. `forward_kl_topk` uses the teacher's top-k support. `reverse_kl_topk` uses the student's top-k support by default and currently requires full-vocab teacher logprobs.
 - **Single-sample KL estimators** (`kl`, `k1`, `abs`, `mse`, `k2`,
   `low_var_kl`, `k3`): per-token Monte Carlo estimators of reverse KL
   computed from the student's `log_probs` and the teacher's single

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -48,7 +48,12 @@ def _get_teacher_sampling_params(
             "on prompt_logprobs (forward pass only). Using temperature=1.0.",
             teacher_model_config.inference.temperature,
         )
-    num_logprobs = distillation_loss_config.topk if distillation_loss_config.loss_settings.use_topk else 0
+    if not distillation_loss_config.loss_settings.use_topk:
+        num_logprobs = 0
+    elif distillation_loss_config.loss_mode == "reverse_kl_topk":
+        num_logprobs = teacher_model_config.get_vocab_size()
+    else:
+        num_logprobs = distillation_loss_config.topk
     return {
         "max_tokens": 1,
         "temperature": 1.0,

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -23,7 +23,10 @@ distillation_loss:
   # Loss function mode for distillation
   loss_mode: k3
 
-  # If distillation loss requires top-k logits, this is the value of k
+  # If distillation loss requires top-k logits, this is the value of k.
+  # For forward_kl_topk, this is the teacher top-k request/support size.
+  # For reverse_kl_topk, this is the student top-k support size by default;
+  # teacher full-vocab logprobs are requested automatically.
   topk: 32
 
   # Whether to include task rewards alongside distillation loss.

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -72,6 +72,15 @@ def kl_divergence(log_q: torch.Tensor, log_p: torch.Tensor) -> torch.Tensor:
     return kld.sum(dim=-1)
 
 
+def reverse_kl_divergence(log_q: torch.Tensor, log_p: torch.Tensor) -> torch.Tensor:
+    """Compute KL(q || p) from log probabilities on a truncated support."""
+    log_p = log_p.float()
+    log_q = log_q.float()
+    q = log_q.exp()
+    kld = q * (log_q - log_p)
+    return kld.sum(dim=-1)
+
+
 def compute_forward_kl_topk(
     student_logits: torch.Tensor,
     teacher_topk_log_probs: torch.Tensor,
@@ -146,4 +155,65 @@ def compute_forward_kl_topk(
         "teacher_mass": teacher_mass,
         "overlap_count": overlap_count,
         "overlap_token_advantage": overlap_token_advantage,
+    }
+
+
+def compute_reverse_kl_topk(
+    student_logits: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute reverse KL on the student's top-k support using full teacher log-probs.
+
+    This first implementation intentionally uses a naive full-vocab teacher
+    log-prob payload. It densifies the teacher log-probs, selects the student
+    top-k support, and gathers the teacher log-probs at those student ids.
+    """
+    assert teacher_topk_log_probs.is_nested and teacher_topk_ids.is_nested
+    teacher_topk_log_probs = teacher_topk_log_probs.values().unsqueeze(0)  # (1, total_nnz, vocab_size)
+    teacher_topk_ids = teacher_topk_ids.values().unsqueeze(0)  # (1, total_nnz, vocab_size)
+
+    if get_ulysses_sequence_parallel_world_size() > 1:
+        teacher_topk_log_probs = slice_input_tensor(teacher_topk_log_probs, dim=1)
+        teacher_topk_ids = slice_input_tensor(teacher_topk_ids, dim=1)
+    assert teacher_topk_log_probs.shape[:2] == teacher_topk_ids.shape[:2] == student_logits.shape[:2]
+
+    loss_config: DistillationLossConfig = config.distillation_loss
+    student_topk = loss_config.topk
+    if student_topk is None:
+        raise ValueError("reverse_kl_topk requires distillation_loss.topk.")
+
+    vocab_size = student_logits.shape[-1]
+    if teacher_topk_ids.shape[-1] < vocab_size:
+        raise ValueError(
+            "reverse_kl_topk currently requires a full-vocab teacher log-prob payload, "
+            f"but got {teacher_topk_ids.shape[-1]} teacher entries for vocab size {vocab_size}."
+        )
+
+    student_log_probs = F.log_softmax(student_logits, dim=-1)
+    student_topk_log_probs, student_topk_ids = torch.topk(student_log_probs, k=student_topk, dim=-1)
+
+    fill_value = torch.finfo(teacher_topk_log_probs.dtype).min
+    teacher_log_probs = torch.full_like(student_log_probs, fill_value)
+    teacher_log_probs.scatter_(dim=-1, index=teacher_topk_ids.long(), src=teacher_topk_log_probs)
+    teacher_log_probs_on_student_topk = torch.gather(teacher_log_probs, dim=-1, index=student_topk_ids)
+
+    student_mass = student_topk_log_probs.exp().sum(dim=-1)
+    teacher_mass = teacher_log_probs_on_student_topk.exp().sum(dim=-1)
+
+    if loss_config.log_prob_min_clamp is not None:
+        student_topk_log_probs = student_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
+        teacher_log_probs_on_student_topk = teacher_log_probs_on_student_topk.clamp_min(loss_config.log_prob_min_clamp)
+
+    distillation_losses = reverse_kl_divergence(
+        log_q=student_topk_log_probs,
+        log_p=teacher_log_probs_on_student_topk,
+    )
+
+    return {
+        "distillation_losses": distillation_losses,
+        "student_mass": student_mass,
+        "teacher_mass": teacher_mass,
     }

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -139,11 +139,27 @@ def compute_topk_loss(
         case "fsdp" | "veomni":
             import verl.trainer.distillation.fsdp.losses as fsdp_losses
 
-            distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
+            match distillation_config.distillation_loss.loss_mode:
+                case "forward_kl_topk":
+                    distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
+                case "reverse_kl_topk":
+                    distillation_loss_fn = fsdp_losses.compute_reverse_kl_topk
+                case _:
+                    raise NotImplementedError(
+                        f"Unsupported top-k distillation loss mode: {distillation_config.distillation_loss.loss_mode}"
+                    )
         case "megatron":
             import verl.trainer.distillation.megatron.losses as megatron_losses
 
-            distillation_loss_fn = megatron_losses.compute_forward_kl_topk
+            match distillation_config.distillation_loss.loss_mode:
+                case "forward_kl_topk":
+                    distillation_loss_fn = megatron_losses.compute_forward_kl_topk
+                case "reverse_kl_topk":
+                    distillation_loss_fn = megatron_losses.compute_reverse_kl_topk
+                case _:
+                    raise NotImplementedError(
+                        f"Unsupported top-k distillation loss mode: {distillation_config.distillation_loss.loss_mode}"
+                    )
         case _:
             raise NotImplementedError(f"Unsupported strategy: {config.strategy=}")
 
@@ -302,7 +318,7 @@ def distillation_loss(
     return distillation_loss, distillation_metrics
 
 
-@register_distillation_loss(DistillationLossSettings(names=["forward_kl_topk"], use_topk=True))  # type: ignore[arg-type]
+@register_distillation_loss(DistillationLossSettings(names=["forward_kl_topk", "reverse_kl_topk"], use_topk=True))  # type: ignore[arg-type]
 def compute_forward_kl_topk(
     config: ActorConfig,
     distillation_config: DistillationConfig,

--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -310,3 +310,13 @@ def compute_forward_kl_topk(
         "overlap_count": overlap_count,
         "overlap_token_advantage": overlap_token_advantage,
     }
+
+
+def compute_reverse_kl_topk(
+    student_logits: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> dict[str, torch.Tensor]:
+    raise NotImplementedError("reverse_kl_topk is currently implemented for fsdp/veomni only.")

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1341,6 +1341,11 @@ class RayPPOTrainer:
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_loss_mode = (
+            self.distillation_config.distillation_loss.loss_mode
+            if is_distillation_enabled(self.config.get("distillation"))
+            else None
+        )
         distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
         if is_distillation_enabled(self.config.get("distillation")):
             distillation_loss_cfg = self.distillation_config.distillation_loss
@@ -1358,6 +1363,7 @@ class RayPPOTrainer:
             batch_td,
             calculate_entropy=calculate_entropy,
             distillation_use_topk=distillation_use_topk,
+            distillation_loss_mode=distillation_loss_mode,
             distillation_only=distillation_only,
             global_batch_size=ppo_mini_batch_size,
             mini_batch_size=ppo_mini_batch_size,

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1743,6 +1743,11 @@ class PPOTrainer(ABC):
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_loss_mode = (
+            self.distillation_config.distillation_loss.loss_mode
+            if is_distillation_enabled(self.config.get("distillation"))
+            else None
+        )
         distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
         if is_distillation_enabled(self.config.get("distillation")):
             distillation_loss_cfg = self.distillation_config.distillation_loss
@@ -1754,6 +1759,7 @@ class PPOTrainer(ABC):
         extra_info = {
             "calculate_entropy": calculate_entropy,
             "distillation_use_topk": distillation_use_topk,
+            "distillation_loss_mode": distillation_loss_mode,
             "distillation_only": distillation_only,
             "global_batch_size": ppo_mini_batch_size,
             "mini_batch_size": ppo_mini_batch_size,

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -49,7 +49,8 @@ class DistillationLossConfig(BaseConfig):
         Whether to incorporate distillation loss as a reward, as done
         by https://thinkingmachines.ai/blog/on-policy-distillation/. Recommended to use loss_mode=k1.
         Otherwise, distillation loss is directly backpropagated as a supervised loss,
-        as in https://arxiv.org/abs/2306.13649. Recommended to use loss_mode=k3 or forward_kl_topk.
+        as in https://arxiv.org/abs/2306.13649. Recommended to use loss_mode=k3, forward_kl_topk, or
+        reverse_kl_topk.
     policy_loss_mode (str):
         Name of the policy loss to use when use_policy_gradient is true.
     clip_ratio (float):
@@ -70,7 +71,7 @@ class DistillationLossConfig(BaseConfig):
     log_prob_min_clamp: Optional[float] = -10.0
 
     # Chunked top-K log-probs (opt-in, avoids [B, T, V] log_softmax buffer
-    # at long context). Only consumed by ``loss_mode='forward_kl_topk'``.
+    # at long context). Consumed by top-k distributional losses.
     # Default ``False`` to preserve short-context performance (chunked path
     # has ~6x time overhead at N=14K, V=152K). Set ``True`` when hitting OOM
     # at long context (>=64K tokens, V=152K) where the baseline path OOMs.
@@ -116,6 +117,12 @@ class DistillationLossConfig(BaseConfig):
                 " token's logprob ∇logπ(a), so the top-k distributional signal (how non-sampled logits "
                 "should move) is largely unused."
             )
+        if self.use_policy_gradient and self.loss_mode == "reverse_kl_topk":
+            raise ValueError(
+                "reverse_kl_topk is a distributional top-k loss and should be used with use_policy_gradient=False."
+            )
+        if self.loss_mode == "reverse_kl_topk" and (self.topk is None or self.topk <= 0):
+            raise ValueError("reverse_kl_topk requires distillation_loss.topk to be a positive integer.")
 
         if not self.use_policy_gradient and self.loss_mode == "k1":
             raise ValueError(
@@ -142,12 +149,13 @@ class DistillationTeacherModelConfig(BaseConfig):
         `num_replicas * per_replica_world_size`.
     """
 
-    _mutable_fields = BaseConfig._mutable_fields | {"num_replicas", "key"}
+    _mutable_fields = BaseConfig._mutable_fields | {"num_replicas", "key", "_vocab_size"}
 
     key: Optional[str] = None
     model_path: Optional[str] = None
     inference: RolloutConfig = field(default_factory=RolloutConfig)
     num_replicas: Optional[int] = 0
+    _vocab_size: Optional[int] = field(default=None, init=False, repr=False)
 
     @property
     def per_replica_world_size(self) -> int:
@@ -168,6 +176,18 @@ class DistillationTeacherModelConfig(BaseConfig):
             raise ValueError("key must be specified for distillation teacher model config.")
         if self.num_replicas is None:
             raise ValueError("num_replicas must be specified for distillation teacher model config.")
+
+    def get_vocab_size(self) -> int:
+        from transformers import AutoConfig
+
+        if self._vocab_size is not None:
+            return self._vocab_size
+        hf_config = AutoConfig.from_pretrained(self.model_path)
+        vocab_size = getattr(hf_config, "vocab_size", None)
+        if vocab_size is None:
+            raise ValueError(f"Teacher model config at {self.model_path!r} does not define vocab_size.")
+        self._vocab_size = int(vocab_size)
+        return self._vocab_size
 
     def validate_and_prepare_for_distillation(self, use_topk: bool, topk: Optional[int]) -> None:
         # Prompt + Response from student are fed into teacher as context
@@ -202,7 +222,7 @@ class DistillationTeacherModelConfig(BaseConfig):
                     max_logprobs = topk
                 if max_logprobs < topk:
                     raise ValueError(
-                        f"VLLM max_logprobs ({max_logprobs}) must be >= distillation_loss topk "
+                        f"VLLM max_logprobs ({max_logprobs}) must be >= requested teacher logprob top-k "
                         f"({topk}) to enable distillation loss computation."
                     )
                 engine_kwargs["vllm"] = vllm_engine_kwargs
@@ -273,9 +293,14 @@ class DistillationConfig(BaseConfig):
         self.teacher_models = self._resolve_teacher_models()
         teacher_world_size_sum = 0
         for teacher_model in self.teacher_models.values():
+            teacher_logprob_topk = (
+                teacher_model.get_vocab_size()
+                if self.distillation_loss.loss_mode == "reverse_kl_topk"
+                else self.distillation_loss.topk
+            )
             teacher_model.validate_and_prepare_for_distillation(
                 use_topk=self.distillation_loss.loss_settings.use_topk,
-                topk=self.distillation_loss.topk,
+                topk=teacher_logprob_topk,
             )
             teacher_world_size_sum += teacher_model.world_size
         total_pool_size = self.n_gpus_per_node * self.nnodes

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -827,6 +827,17 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
         if use_fused_kernels and use_remove_padding:
+            distillation_loss_mode = tu.get_non_tensor_data(
+                data=micro_batch, key="distillation_loss_mode", default=None
+            )
+            distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
+            if distillation_use_topk and distillation_loss_mode is None:
+                raise ValueError("Top-k distillation with fused kernels requires distillation_loss_mode in the batch.")
+            if distillation_loss_mode == "reverse_kl_topk":
+                raise NotImplementedError(
+                    "reverse_kl_topk needs student logits to build the student top-k support. "
+                    "Set actor_rollout_ref.model.use_fused_kernels=False for this loss mode."
+                )
             input_ids_rmpad = model_inputs["input_ids"]
             shift_labels = output_args["input_ids_rmpad_rolled"].unsqueeze(0)
             model_inputs["labels"] = input_ids_rmpad
@@ -837,7 +848,6 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             # chunk_topk_distill_function for fused distillation. TD keys
             # teacher_ids / teacher_logprobs are populated by verl's native
             # distillation pipeline (see verl/trainer/distillation/losses.py).
-            distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
             if distillation_use_topk and "teacher_ids" in micro_batch.keys():
                 if "teacher_logprobs" not in micro_batch.keys():
                     raise ValueError(


### PR DESCRIPTION
### What does this PR do?

Adds a reverse-KL top-k distillation loss for on-policy distillation. The teacher provides full-vocab prompt log-probs, while the student loss is evaluated on the student top-k support.

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=reverse+kl+distillation+topk
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `git diff --check upstream/main...HEAD`
- `PR_TITLE='[trainer] feat: add reverse KL top-k distillation loss' uv run --frozen --all-packages --extra cpu python tests/special_sanity/check_pr_title.py`
- `uv run --frozen --all-packages --extra cpu pytest -q tests/special_sanity/check_device_api_usage.py tests/workers/test_megatron_distillation_only_on_cpu.py tests/workers/test_distillation_topk_symmetry_on_cpu.py` (9 passed)
- Standalone Open-Verl smoke setup was prepared using `examples/on_policy_distillation_trainer/run_qwen3_0.6b_opd_veomni.sh` with a 1-step Qwen3 0.6B/1.7B reverse-KL top-k run.

### API and Usage Example

`distillation.distillation_loss.loss_mode=reverse_kl_topk` with `distillation.distillation_loss.use_policy_gradient=False`.

### Design & Code Changes

- Adds reverse-KL top-k loss metadata and FSDP implementation.
- Requests full-vocab teacher prompt log-probs when reverse-KL top-k needs teacher probabilities on the student top-k support.
- Wires distillation top-k metadata through PPO trainer paths and VeOmni transformer implementation.
- Documents the reverse-KL top-k mode.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [x] Add / Update documentation.
- [x] Add unit or end-to-end test(s), or explain why not feasible.
- [ ] Once ready for CI, request CI in the project channel if required.