### PR TITLE
[BREAKING][perf] feat: overlap bucketed weight transfer with receiver-side processing

### DIFF
--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -135,7 +135,7 @@ def _sender_fn(zmq_handle, weight_specs, seed, bucket_size_mb, use_shm):
     asyncio.run(sender.async_send_weights(iter(weights)))
 
 
-def _receiver_fn(zmq_handle, use_shm, result_queue):
+def _receiver_fn(zmq_handle, use_shm, result_queue, overlap_bucket_processing=False):
     """Receiver process: receive weights, send back (name, dtype, shape, checksum)."""
     from verl.utils.device import get_device_name
     from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
@@ -145,6 +145,7 @@ def _receiver_fn(zmq_handle, use_shm, result_queue):
         zmq_handle=zmq_handle,
         device=device,
         use_shm=use_shm,
+        overlap_bucket_processing=overlap_bucket_processing,
     )
     received = []
     receiver.receive_weights(
@@ -158,7 +159,7 @@ def _receiver_fn(zmq_handle, use_shm, result_queue):
 # ---------------------------------------------------------------------------
 # Test helper
 # ---------------------------------------------------------------------------
-def _transfer_and_validate(weight_specs, bucket_size_mb, use_shm):
+def _transfer_and_validate(weight_specs, bucket_size_mb, use_shm, overlap_bucket_processing=False):
     """Spawn sender + receiver processes, then validate received tensors."""
     zmq_handle = _unique_zmq_handle()
     seed = 42
@@ -171,7 +172,7 @@ def _transfer_and_validate(weight_specs, bucket_size_mb, use_shm):
     )
     receiver_p = ctx.Process(
         target=_receiver_fn,
-        args=(zmq_handle, use_shm, result_queue),
+        args=(zmq_handle, use_shm, result_queue, overlap_bucket_processing),
     )
 
     # Start sender first (it binds), then receiver (it connects)
@@ -240,6 +241,23 @@ class TestBucketedWeightTransferSHM:
     def test_empty_weights(self):
         _transfer_and_validate([], bucket_size_mb=1, use_shm=True)
 
+    def test_overlap_multiple_buckets(self):
+        # overlap_bucket_processing: receiver acks each bucket before processing
+        # it; received tensors must still be intact (early buffer release).
+        specs = [(f"layer{i}.weight", (128, 128), torch.float32) for i in range(20)]
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=True, overlap_bucket_processing=True)
+
+    def test_overlap_mixed_dtypes(self):
+        specs = [
+            ("fp32_param", (64, 64), torch.float32),
+            ("bf16_param", (64, 64), torch.bfloat16),
+            ("fp16_param", (32, 32), torch.float16),
+        ]
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=True, overlap_bucket_processing=True)
+
+    def test_overlap_empty_weights(self):
+        _transfer_and_validate([], bucket_size_mb=1, use_shm=True, overlap_bucket_processing=True)
+
 
 # ---------------------------------------------------------------------------
 # CUDA IPC tests (CUDA only — IPC is not supported on NPU)
@@ -289,3 +307,17 @@ class TestBucketedWeightTransferIPC:
         specs.append(("lm_head", (1024, 1024), torch.float32))  # 4MB
 
         _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False)
+
+    def test_overlap_multiple_buckets(self):
+        # overlap_bucket_processing on the IPC path stages a private copy of
+        # each bucket before the early ack; received tensors must stay intact.
+        specs = [(f"layer{i}.weight", (128, 128), torch.float32) for i in range(20)]
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False, overlap_bucket_processing=True)
+
+    def test_overlap_large_weight(self):
+        # Oversized weights travel as raw IPC handles; those buckets must fall
+        # back to the late ack even when overlap_bucket_processing is enabled.
+        specs = [("embedding", (1024, 1024), torch.float32)]  # 4MB
+        specs.extend([(f"layer{i}.weight", (128,), torch.bfloat16) for i in range(5)])
+        specs.append(("lm_head", (1024, 1024), torch.float32))  # 4MB
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False, overlap_bucket_processing=True)

--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -156,6 +156,30 @@ def _receiver_fn(zmq_handle, use_shm, result_queue, overlap_bucket_processing=Fa
     result_queue.put(summaries)
 
 
+def _receiver_fn_raising(zmq_handle, use_shm, result_queue, overlap_bucket_processing=False):
+    """Receiver whose bucket callback raises; reports the exception type escaping receive_weights."""
+    from verl.utils.device import get_device_name
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
+
+    device = torch.device(f"{get_device_name()}:0")
+    receiver = BucketedWeightReceiver(
+        zmq_handle=zmq_handle,
+        device=device,
+        use_shm=use_shm,
+        overlap_bucket_processing=overlap_bucket_processing,
+    )
+
+    def _boom(weights, is_last):
+        raise RuntimeError("callback boom")
+
+    try:
+        receiver.receive_weights(on_bucket_received=_boom)
+    except BaseException as e:
+        result_queue.put(type(e).__name__)
+        return
+    result_queue.put("no-exception")
+
+
 # ---------------------------------------------------------------------------
 # Test helper
 # ---------------------------------------------------------------------------
@@ -240,6 +264,33 @@ class TestBucketedWeightTransferSHM:
 
     def test_empty_weights(self):
         _transfer_and_validate([], bucket_size_mb=1, use_shm=True)
+
+    def test_callback_exception_not_masked_by_cleanup(self):
+        # Regression: an exception raised by on_bucket_received must propagate
+        # as-is. Local references to the shared buffer that survive into
+        # _cleanup keep the shm memoryview exported, so shm.close() raises
+        # BufferError and masks the original exception.
+        for overlap in (False, True):
+            zmq_handle = _unique_zmq_handle()
+            ctx = mp.get_context("spawn")
+            result_queue = ctx.Queue()
+            specs = [("layer.weight", (32, 16), torch.float32)]
+            sender_p = ctx.Process(target=_sender_fn, args=(zmq_handle, specs, 42, 1, True))
+            receiver_p = ctx.Process(target=_receiver_fn_raising, args=(zmq_handle, True, result_queue, overlap))
+            sender_p.start()
+            receiver_p.start()
+            receiver_p.join(timeout=PROCESS_TIMEOUT)
+            # The receiver never acks the first bucket, so the sender is still
+            # blocked in socket.recv(); it is no longer needed for this test.
+            sender_p.terminate()
+            sender_p.join(timeout=PROCESS_TIMEOUT)
+            assert receiver_p.exitcode == 0, (
+                f"Receiver process failed with exit code {receiver_p.exitcode} (overlap={overlap})"
+            )
+            exc_type = result_queue.get(timeout=5)
+            assert exc_type == "RuntimeError", (
+                f"callback exception was masked by cleanup (overlap={overlap}): got {exc_type}"
+            )
 
     def test_overlap_multiple_buckets(self):
         # overlap_bucket_processing: receiver acks each bucket before processing

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -381,6 +381,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -325,6 +325,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -366,6 +366,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -343,6 +343,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.CheckpointEngineConfig
       backend: naive
       update_weights_bucket_megabytes: 2048
+      overlap_bucket_processing: false
       engine_kwargs: {}
       custom_backend_module: null
     trace:

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -291,6 +291,14 @@ checkpoint_engine:
   # when using Tensor Parallelism (TP) >= 8.
   update_weights_bucket_megabytes: 2048
 
+  # If true, the weight receiver acks each bucket as soon as the shared
+  # transfer buffer is no longer referenced (before the bucket is processed,
+  # e.g. online quantization + load_weights), so the sender can start filling
+  # the next bucket while the current one is being processed. On the IPC path
+  # this stages one private copy of the bucket (one extra bucket of device
+  # memory). Default false preserves the original lock-step behavior.
+  overlap_bucket_processing: false
+
   # Additional keyword arguments to pass to the checkpoint engine constructor
   engine_kwargs: {}
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -133,6 +133,13 @@ class CheckpointEngineConfig(BaseConfig):
     backend: Optional[str] = "naive"
     # Bucket size in MB to transfer multiple weights at one time
     update_weights_bucket_megabytes: int = 2048
+    # If True, the weight receiver acks each bucket as soon as the shared
+    # transfer buffer is no longer referenced (before the bucket is processed,
+    # e.g. online quantization + load_weights), so the sender can start filling
+    # the next bucket while the current one is being processed. On the IPC path
+    # this stages one private copy of the bucket (one extra bucket of device
+    # memory). Default False preserves the original lock-step behavior.
+    overlap_bucket_processing: bool = False
     # Additional keyword arguments for checkpoint engine
     engine_kwargs: dict = field(default_factory=dict)
     # If set, this Python module is imported on every worker process before the

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -244,6 +244,14 @@ class BucketedWeightReceiver:
         zmq_handle: ZMQ IPC socket path (must match sender)
         device: Target device for received tensors
         use_shm: Use shared memory instead of CUDA IPC
+        overlap_bucket_processing: If True, ack each bucket as soon as the
+            shared transfer buffer is no longer referenced — before the bucket
+            is processed (e.g. online quantization + load_weights) — so the
+            sender can start filling the next bucket while the current one is
+            being processed. On the IPC path this stages one private copy of
+            the bucket (one extra bucket of device memory). Buckets that carry
+            raw IPC handles (oversized weights) always use the late ack,
+            because the sender may free the source tensor once acked.
     """
 
     def __init__(
@@ -251,10 +259,12 @@ class BucketedWeightReceiver:
         zmq_handle: str,
         device: torch.device,
         use_shm: bool = False,
+        overlap_bucket_processing: bool = False,
     ):
         self.zmq_handle = zmq_handle
         self.device = device
         self.use_shm = use_shm
+        self.overlap_bucket_processing = overlap_bucket_processing
 
         self.zmq_context = zmq.Context.instance()
         self.socket = None
@@ -265,6 +275,14 @@ class BucketedWeightReceiver:
         """
         Receive weights from sender and process each bucket via callback.
 
+        The ack sent back to the sender after each bucket means "the shared
+        transfer buffer may be overwritten": the sender waits for it before
+        filling the next bucket. With ``overlap_bucket_processing`` enabled,
+        the ack is sent as soon as every tensor of the bucket has been
+        materialized into private memory (independent device copies on the
+        shm path, a staged buffer copy on the IPC path), letting the sender
+        fill bucket i+1 while the callback is still processing bucket i.
+
         Args:
             on_bucket_received: Callback function(weights: list[(name, tensor)],
             is_last: bool) called per bucket. ``is_last`` marks the final bucket
@@ -272,36 +290,29 @@ class BucketedWeightReceiver:
             (e.g. vLLM ``add_lora``, which takes one adapter dict per call) can
             defer their finalization until the whole adapter has arrived.
         """
-        # Overlap mode: ack each bucket as soon as the shared buffer is no
-        # longer referenced, so the sender can start refilling it (gather +
-        # copy of bucket i+1) while this side is still processing bucket i
-        # (e.g. online quantization + load_weights).
-        # - shm path: every tensor is already a fresh device copy (``.to``),
-        #   so the shared buffer is free once those copies complete — ack right
-        #   after them, no staging needed.
-        # - IPC path: received tensors are views into the sender's device
-        #   buffer, so stage a private copy first (one extra device copy and
-        #   one bucket of device memory).
-        # Buckets that carry raw IPC handles (oversized weights) always use the
-        # late ack, because the sender may free the source tensor once acked.
-        early_ack = os.getenv("VERL_WEIGHT_SYNC_OVERLAP", "1") == "1"
         staging = None
         try:
             self._init_socket()
             self._init_buffer()
-            if early_ack and not self.use_shm:
+            if self.overlap_bucket_processing and not self.use_shm:
+                # IPC path: received tensors are views into the sender's device
+                # buffer, so stage a private copy before releasing the buffer.
                 staging = torch.empty_like(self.buffer)
-                logger.info("BucketedWeightReceiver: overlap mode enabled (early ack + staged bucket)")
+                logger.info("BucketedWeightReceiver: overlap_bucket_processing enabled (early ack + staged bucket)")
 
             # receive bucket and update weights
             while True:
                 metadata = self.socket.recv_pyobj()
-                weights, tensor = [], None
                 bucket_meta = metadata["bucket_meta"]
-                can_early_ack = early_ack and all(meta["handle"] is None for meta in bucket_meta.values())
+                # Buckets that carry raw IPC handles (oversized weights) always
+                # use the late ack: the sender may free the source tensor once acked.
+                early_ack = self.overlap_bucket_processing and all(
+                    meta["handle"] is None for meta in bucket_meta.values()
+                )
+                weights, tensor = [], None
                 src = self.buffer
                 acked = False
-                if can_early_ack and not self.use_shm:
+                if early_ack and not self.use_shm:
                     staging.copy_(self.buffer, non_blocking=True)
                     # Wait for the copy to finish before acking: the sender starts
                     # overwriting the shared buffer right after it gets the ack.
@@ -320,7 +331,7 @@ class BucketedWeightReceiver:
                     if self.use_shm:
                         tensor = tensor.to(self.device)
                     weights.append((name, tensor))
-                if can_early_ack and self.use_shm:
+                if early_ack and self.use_shm:
                     # All tensors above are independent device copies; the shm
                     # buffer is no longer referenced once the copies complete.
                     get_torch_device().synchronize()
@@ -338,7 +349,6 @@ class BucketedWeightReceiver:
                 if is_last:
                     break
             del staging
-            staging = None
         finally:
             self._cleanup()
 

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -290,7 +290,12 @@ class BucketedWeightReceiver:
             (e.g. vLLM ``add_lora``, which takes one adapter dict per call) can
             defer their finalization until the whole adapter has arrived.
         """
+        # Keep these names bound for the whole call so the finally block can
+        # always release them (see below).
         staging = None
+        weights: list[tuple[str, torch.Tensor]] = []
+        tensor = None
+        src = None
         try:
             self._init_socket()
             self._init_buffer()
@@ -342,14 +347,22 @@ class BucketedWeightReceiver:
                 get_torch_device().synchronize()
                 if not acked:
                     self.socket.send(b"")
-                # Drop every local reference to the shared buffer: on the shm
-                # path a lingering view keeps the memoryview exported and
-                # _cleanup's shm.close() fails with BufferError.
-                del weights, tensor, src
+                # Release this bucket's references promptly: the next recv may
+                # block while the sender refills the shared buffer. Rebinding
+                # (rather than `del`) keeps the names bound for the finally.
+                weights, tensor = [], None
+                src = None
                 if is_last:
                     break
             del staging
         finally:
+            # Drop every local reference to the shared buffer *before* cleanup:
+            # a lingering view keeps the shm memoryview exported, and
+            # _cleanup's shm.close() then raises BufferError — on the exception
+            # path that would mask the original exception (and skip unlink).
+            # (staging is a private device tensor, it never exports the shm
+            # buffer, so it does not need to be released here.)
+            del weights, tensor, src
             self._cleanup()
 
     def _init_socket(self):

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -272,32 +272,73 @@ class BucketedWeightReceiver:
             (e.g. vLLM ``add_lora``, which takes one adapter dict per call) can
             defer their finalization until the whole adapter has arrived.
         """
+        # Overlap mode: ack each bucket as soon as the shared buffer is no
+        # longer referenced, so the sender can start refilling it (gather +
+        # copy of bucket i+1) while this side is still processing bucket i
+        # (e.g. online quantization + load_weights).
+        # - shm path: every tensor is already a fresh device copy (``.to``),
+        #   so the shared buffer is free once those copies complete — ack right
+        #   after them, no staging needed.
+        # - IPC path: received tensors are views into the sender's device
+        #   buffer, so stage a private copy first (one extra device copy and
+        #   one bucket of device memory).
+        # Buckets that carry raw IPC handles (oversized weights) always use the
+        # late ack, because the sender may free the source tensor once acked.
+        early_ack = os.getenv("VERL_WEIGHT_SYNC_OVERLAP", "1") == "1"
+        staging = None
         try:
             self._init_socket()
             self._init_buffer()
+            if early_ack and not self.use_shm:
+                staging = torch.empty_like(self.buffer)
+                logger.info("BucketedWeightReceiver: overlap mode enabled (early ack + staged bucket)")
 
             # receive bucket and update weights
             while True:
                 metadata = self.socket.recv_pyobj()
                 weights, tensor = [], None
-                for name, meta in metadata["bucket_meta"].items():
+                bucket_meta = metadata["bucket_meta"]
+                can_early_ack = early_ack and all(meta["handle"] is None for meta in bucket_meta.values())
+                src = self.buffer
+                acked = False
+                if can_early_ack and not self.use_shm:
+                    staging.copy_(self.buffer, non_blocking=True)
+                    # Wait for the copy to finish before acking: the sender starts
+                    # overwriting the shared buffer right after it gets the ack.
+                    get_torch_device().synchronize()
+                    self.socket.send(b"")
+                    acked = True
+                    src = staging
+                for name, meta in bucket_meta.items():
                     shape, dtype, offset, handle = meta["shape"], meta["dtype"], meta["offset"], meta["handle"]
                     if handle is not None:
                         tensor = rebuild_ipc(handle, self.device.index)
                         weights.append((name, tensor))
                         continue
                     size = dtype.itemsize * shape.numel()
-                    tensor = self.buffer[offset : offset + size].view(dtype=dtype).view(shape)
+                    tensor = src[offset : offset + size].view(dtype=dtype).view(shape)
                     if self.use_shm:
                         tensor = tensor.to(self.device)
                     weights.append((name, tensor))
+                if can_early_ack and self.use_shm:
+                    # All tensors above are independent device copies; the shm
+                    # buffer is no longer referenced once the copies complete.
+                    get_torch_device().synchronize()
+                    self.socket.send(b"")
+                    acked = True
                 is_last = metadata["is_last"]
                 on_bucket_received(weights, is_last)
                 get_torch_device().synchronize()
-                self.socket.send(b"")
-                del weights, tensor
+                if not acked:
+                    self.socket.send(b"")
+                # Drop every local reference to the shared buffer: on the shm
+                # path a lingering view keeps the memoryview exported and
+                # _cleanup's shm.close() fails with BufferError.
+                del weights, tensor, src
                 if is_last:
                     break
+            del staging
+            staging = None
         finally:
             self._cleanup()
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -20,7 +20,6 @@ import os
 import platform
 import signal
 import threading
-import time
 from collections.abc import Mapping
 from types import MethodType
 from typing import Any, Literal, Optional, get_args
@@ -28,7 +27,7 @@ from typing import Any, Literal, Optional, get_args
 import torch
 from vllm.outputs import RequestOutput
 
-from verl.utils.device import get_device_name, get_torch_device, is_npu_available
+from verl.utils.device import get_device_name, is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack, resolve_weight_name
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches, is_fp8_model, load_quanted_weights
@@ -232,11 +231,15 @@ class vLLMColocateWorkerExtension:
             # patch weight loader to support MoE model
             patch_vllm_moe_model_weight_loader(model)
 
-    def update_weights_from_ipc(self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False):
+    def update_weights_from_ipc(
+        self,
+        peft_config: dict = None,
+        base_sync_done=False,
+        use_shm: bool = False,
+        overlap_bucket_processing: bool = False,
+    ):
         """Update the weights of the rollout model."""
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
-
-        t_start = time.time()
 
         if self.device is None:
             # vLLM workers may leave self.device unset on non-CUDA platforms (e.g. NPU);
@@ -283,12 +286,11 @@ class vLLMColocateWorkerExtension:
                 patch_vllm_moe_model_weight_loader(model)
 
         # =========================== step 2: receive weights and update ===========================
-        get_torch_device().synchronize()
-        t_prepared = time.time()
         receiver = BucketedWeightReceiver(
             zmq_handle=self._get_zmq_handle(),
             device=self.device,
             use_shm=use_shm,
+            overlap_bucket_processing=overlap_bucket_processing,
         )
         # LoRA adapters need a single complete tensor dict per ``add_lora``, but
         # the bucketed transport may split one across buckets. Accumulate and
@@ -315,8 +317,6 @@ class vLLMColocateWorkerExtension:
             )
 
         receiver.receive_weights(on_bucket_received=on_bucket_received)
-        get_torch_device().synchronize()
-        t_received = time.time()
 
         # =========================== step 3: process weights after loading ===========================
         if self._is_qat_model:
@@ -344,17 +344,6 @@ class vLLMColocateWorkerExtension:
 
             for model, model_config in self._iter_all_models_with_config():
                 process_weights_after_loading(model, model_config, self.device)
-
-        get_torch_device().synchronize()
-        t_done = time.time()
-        if self.local_rank == 0:
-            logger.warning(
-                "update_weights_from_ipc timing: prepare=%.2fs receive=%.2fs finalize=%.2fs total=%.2fs",
-                t_prepared - t_start,
-                t_received - t_prepared,
-                t_done - t_received,
-                t_done - t_start,
-            )
 
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):
         """Apply buffer updates to the main model and any synced MTP drafter.

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -20,6 +20,7 @@ import os
 import platform
 import signal
 import threading
+import time
 from collections.abc import Mapping
 from types import MethodType
 from typing import Any, Literal, Optional, get_args
@@ -27,7 +28,7 @@ from typing import Any, Literal, Optional, get_args
 import torch
 from vllm.outputs import RequestOutput
 
-from verl.utils.device import get_device_name, is_npu_available
+from verl.utils.device import get_device_name, get_torch_device, is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack, resolve_weight_name
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches, is_fp8_model, load_quanted_weights
@@ -235,6 +236,8 @@ class vLLMColocateWorkerExtension:
         """Update the weights of the rollout model."""
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
 
+        t_start = time.time()
+
         if self.device is None:
             # vLLM workers may leave self.device unset on non-CUDA platforms (e.g. NPU);
             # fall back to the worker's local rank on the current accelerator.
@@ -280,6 +283,8 @@ class vLLMColocateWorkerExtension:
                 patch_vllm_moe_model_weight_loader(model)
 
         # =========================== step 2: receive weights and update ===========================
+        get_torch_device().synchronize()
+        t_prepared = time.time()
         receiver = BucketedWeightReceiver(
             zmq_handle=self._get_zmq_handle(),
             device=self.device,
@@ -310,6 +315,8 @@ class vLLMColocateWorkerExtension:
             )
 
         receiver.receive_weights(on_bucket_received=on_bucket_received)
+        get_torch_device().synchronize()
+        t_received = time.time()
 
         # =========================== step 3: process weights after loading ===========================
         if self._is_qat_model:
@@ -337,6 +344,17 @@ class vLLMColocateWorkerExtension:
 
             for model, model_config in self._iter_all_models_with_config():
                 process_weights_after_loading(model, model_config, self.device)
+
+        get_torch_device().synchronize()
+        t_done = time.time()
+        if self.local_rank == 0:
+            logger.warning(
+                "update_weights_from_ipc timing: prepare=%.2fs receive=%.2fs finalize=%.2fs total=%.2fs",
+                t_prepared - t_start,
+                t_received - t_prepared,
+                t_done - t_received,
+                t_done - t_start,
+            )
 
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):
         """Apply buffer updates to the main model and any synced MTP drafter.

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -222,7 +222,11 @@ class ServerAdapter(BaseRollout):
         future = await self._execute_method(
             "update_weights_from_ipc",
             non_block=True,
-            kwargs={**kwargs, "use_shm": self.use_shm},
+            kwargs={
+                **kwargs,
+                "use_shm": self.use_shm,
+                "overlap_bucket_processing": self.config.checkpoint_engine.overlap_bucket_processing,
+            },
         )
 
         bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes


### PR DESCRIPTION
### What does this PR do?

Bucketed vLLM weight sync is currently lock-step: the sender waits for each bucket's ACK until the receiver finishes `load_weights`, including online quantization for FP8/MXFP8 models.

This PR adds an opt-in `checkpoint_engine.overlap_bucket_processing` flag (default: `false`). When enabled, the receiver ACKs once the shared transfer buffer can be safely reused, allowing the sender to fill bucket *i+1* while the receiver processes bucket *i*.

- SHM: ACK after the existing H2D copies complete; no additional staging copy or allocation.
- IPC: copy into a private staging bucket before ACK.
- Oversized weights using raw IPC handles keep the original late ACK.

Enable it with:

```text
actor_rollout_ref.rollout.checkpoint_engine.overlap_bucket_processing=true
```

Related: #5619 implements overlap with a double transfer buffer. Current PR keeps the single-buffer wire format and only changes receiver-side ACK timing.

### Checklist Before Starting

- [x] Search for similar PRs: #5619 uses a materially different double-buffer approach.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

End-to-end validation on 8x Ascend 950DT with Qwen3.5-35B-A3B GRPO (8 steps per group, step 1 excluded):

| rollout | overlap | gen (s)| update_weights | step |
|---|:---:|:---:|:---:|:---:|
| BF16 | off | 50.76 |57.49s | 313.94s |
| BF16 | on | 50.18 |53.47s | 320.49s |
| MXFP8 | off | 43.41 |59.56s | 310.18s |
| MXFP8 | on | 43.50 |53.51s | 305.49s |

With overlap enabled, BF16 and MXFP8 weight updates both converge to ~53.5s; MXFP8 + overlap is 4.7% faster end-to-end than BF16 + overlap. Rewards were unchanged within run-to-run noise.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): all hooks pass.
- [x] Add / Update the documentation: the new option is documented in config comments.
- [x] Add unit or end-to-end tests to cover the change.
- [ ] Request CI in the `ci-request` Slack/Feishu channel when the PR leaves draft.
- [ ] Update the `recipe` submodule if needed: not applicable; `recipe` is unchanged.

### AI assistance

Codex assisted with the implementation and PR preparation. I reviewed every changed line and ran the tests reported above.
