### PR TITLE
[misc] fix: initialize_system_prompt drops the prompt when diff==0 (#6477)

### DIFF
--- a/tests/utils/test_system_prompt_extraction_on_cpu.py
+++ b/tests/utils/test_system_prompt_extraction_on_cpu.py
@@ -1,0 +1,124 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for ``initialize_system_prompt`` / ``extract_system_prompt_and_generation``.
+
+Regression coverage for verl issue #6477: both helpers derive the system-prompt prefix as
+``token1[: -(len(token2) - len(token1))]``, where ``token1``/``token2`` are the token ids for one
+and two probe turns. When the marginal per-turn token count (``diff``) is zero -- e.g. a template
+whose rendering does not grow with extra messages -- Python's ``x[:-0]`` is ``x[:0]`` (empty list),
+not "keep everything", so the whole system prompt was silently dropped. No GPU, network, or model
+download is required: a self-contained Jinja2 template stands in for a real tokenizer.
+"""
+
+import re
+
+from jinja2 import Template
+
+from verl.utils.tokenizer.chat_template import extract_system_prompt_and_generation, initialize_system_prompt
+
+_IM_START, _IM_END, _NL = 1, 2, 3
+_SPECIALS = {"<|im_start|>": _IM_START, "<|im_end|>": _IM_END, "\n": _NL}
+
+# Ordinary ChatML template: system prefix. length grows with every extra turn, so the marginal
+# per-turn probe (`diff`) is non-zero -- this is the common case and must keep working.
+_CHATML_WITH_SYSTEM = (
+    "<|im_start|>system\nYou are helpful<|im_end|>\n"
+    "{% for m in messages %}<|im_start|>{{m['role']}}\n{{m['content']}}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
+
+# Degenerate template that only ever renders the *first* message, ignoring the rest of the list.
+# Rendering one probe turn and rendering two probe turns therefore produce byte-identical output,
+# so `diff == len(token2) - len(token1) == 0` -- exactly the case `x[:-0]` gets wrong.
+_CHATML_FIRST_MESSAGE_ONLY = (
+    "<|im_start|>system\nYou are helpful<|im_end|>\n"
+    "{% set m = messages[0] %}<|im_start|>{{m['role']}}\n{{m['content']}}<|im_end|>\n"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
+
+
+class ChatMLTokenizer:
+    """Deterministic, offline tokenizer mimicking a ChatML ``apply_chat_template``."""
+
+    def __init__(self, template: str):
+        self._template = Template(template)
+        self._vocab: dict[str, int] = {}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        ids: list[int] = []
+        for piece in re.split(r"(<\|im_start\|>|<\|im_end\|>|\n)", text):
+            if piece == "":
+                continue
+            if piece in _SPECIALS:
+                ids.append(_SPECIALS[piece])
+            else:
+                for word in piece.split(" "):
+                    if word:
+                        ids.append(self._vocab.setdefault(word, len(self._vocab) + 100))
+        return ids
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=True, tools=None, **kwargs):
+        text = self._template.render(messages=messages, add_generation_prompt=add_generation_prompt)
+        return self.encode(text) if tokenize else text
+
+
+def test_initialize_system_prompt_normal_template_unaffected():
+    """Sanity check: the common (``diff > 0``) case still returns the real system prompt."""
+    tok = ChatMLTokenizer(_CHATML_WITH_SYSTEM)
+    system_prompt = initialize_system_prompt(tok)
+
+    expected = tok.apply_chat_template([], add_generation_prompt=False)
+    # `[]` is not a valid chat-template input for every tokenizer in production, but this fake one
+    # happily renders just the fixed system preamble, giving the ground-truth prefix to compare.
+    assert system_prompt == expected
+    assert len(system_prompt) > 0
+
+
+def test_initialize_system_prompt_zero_diff_does_not_drop_prompt():
+    """Regression for #6477: a zero marginal turn probe must not silently empty the prompt."""
+    tok = ChatMLTokenizer(_CHATML_FIRST_MESSAGE_ONLY)
+
+    token1 = tok.apply_chat_template([{"role": "user", "content": ""}], add_generation_prompt=False)
+    token2 = tok.apply_chat_template([{"role": "user", "content": ""}] * 2, add_generation_prompt=False)
+    # Confirm the template really does trigger the zero-diff edge case this test targets.
+    assert len(token1) == len(token2) > 0
+
+    system_prompt = initialize_system_prompt(tok)
+
+    # The buggy `token1[:-(len(token2) - len(token1))]` == `token1[:-0]` == `[]` here. The fix must
+    # not throw away every token: with a zero marginal turn probe, the entire probe render is the
+    # only information available, so it must be returned as-is rather than emptied.
+    assert system_prompt != []
+    assert system_prompt == token1
+
+
+def test_extract_system_prompt_and_generation_zero_diff_does_not_drop_prompt():
+    """Same regression, through the sibling helper used by ``MultiTurnSFTDataset``."""
+    tok = ChatMLTokenizer(_CHATML_FIRST_MESSAGE_ONLY)
+    token1 = tok.apply_chat_template([{"role": "user", "content": ""}], add_generation_prompt=False)
+
+    system_prompt, generation_prompt = extract_system_prompt_and_generation(tok)
+
+    assert system_prompt != []
+    assert system_prompt == token1
+    assert generation_prompt == [_IM_START, tok._vocab["assistant"], _NL]
+
+
+def test_extract_system_prompt_and_generation_normal_template_unaffected():
+    tok = ChatMLTokenizer(_CHATML_WITH_SYSTEM)
+    system_prompt, generation_prompt = extract_system_prompt_and_generation(tok)
+
+    expected_system_prompt = tok.apply_chat_template([], add_generation_prompt=False)
+    assert system_prompt == expected_system_prompt
+    assert generation_prompt == [_IM_START, tok._vocab["assistant"], _NL]

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -34,8 +34,14 @@ def initialize_system_prompt(tokenizer, **apply_chat_template_kwargs) -> list[in
             **apply_chat_template_kwargs,
         )
     )
-    # get system prompt tokens
-    system_prompt = token1[: -(len(token2) - len(token1))]
+    # get system prompt tokens: token1 is [system-prefix, turn1], token2 is [system-prefix, turn1,
+    # turn2] where turn1 == turn2 (same empty-content probe), so the marginal length `diff` is
+    # exactly one turn's own token count. Slicing via `len(token1) - diff` (rather than the
+    # negative-index form `token1[:-diff]`) also handles `diff == 0` correctly: Python's `x[:-0]`
+    # means `x[:0]` (empty list), not "keep everything", which silently dropped the whole system
+    # prompt whenever a turn probe added zero marginal tokens.
+    diff = len(token2) - len(token1)
+    system_prompt = token1[: len(token1) - diff]
     return system_prompt
 
 
@@ -125,8 +131,10 @@ def extract_system_prompt_and_generation(tokenizer, **apply_chat_template_kwargs
             **apply_chat_template_kwargs,
         )
     )
-    # get system prompt tokens
-    system_prompt = token1[: -(len(token2) - len(token1))]
+    # get system prompt tokens: see the identical derivation (and the `x[:-0]` pitfall it avoids)
+    # in `initialize_system_prompt` above.
+    diff = len(token2) - len(token1)
+    system_prompt = token1[: len(token1) - diff]
     # get generate prompt tokens
     token3 = normalize_token_ids(
         tokenizer.apply_chat_template(


### PR DESCRIPTION
### What does this PR do?

Fixes #6477. `initialize_system_prompt()` and `extract_system_prompt_and_generation()` in `verl/utils/tokenizer/chat_template.py` derive the system-prompt token prefix from two probe renders:

```python
system_prompt = token1[: -(len(token2) - len(token1))]
```

When a chat template's rendering doesn't grow between one probe turn and two identical probe turns (`len(token2) == len(token1)`), this becomes `token1[:-0]`. In Python, `x[:-0]` is `x[:0]` — an empty list, not "keep everything" — so the system prompt is silently dropped to `[]` in that case.

`extract_system_prompt_and_generation()` is the one actually used in production, by `MultiTurnSFTDataset` (`verl/utils/dataset/multiturn_sft_dataset.py`), to compute how many leading tokens to strip from every non-first turn's individually-tokenized `input_ids`. With `system_prompt` wrongly collapsed to `[]`, nothing gets stripped, so every turn after the first is corrupted with a duplicated system-prompt-and-first-turn prefix instead of just its own tokens.

**Fix:** derive the same slice as `token1[: len(token1) - diff]` instead of the negative-index form. This is correct for `diff == 0` (returns the full probe render — there's no turn-specific marginal signal to strip in that case) and is unchanged for the normal `diff > 0` case, with no special-casing needed. Both call sites had the identical bug and are fixed identically.

- [x] Search for similar PRs. Paste at least one query link here: [`is:pr chat_template system_prompt` search](https://github.com/verl-project/verl/pulls?q=is%3Apr+chat_template+system_prompt) — the only related open PRs are for #6500/#6501 (a different bug in the same file, the multi-turn turn-separator token drop) and don't touch this slice. A prior attempt at #6477 itself (#6487) was closed unmerged with no review comment; the bug is still present on current `main` at both call sites.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Added `tests/utils/test_system_prompt_extraction_on_cpu.py` (CPU-only, no GPU/network/model download — a self-contained Jinja2-templated fake tokenizer stands in for a real one, following the existing `tests/utils/test_turn_separator_on_cpu.py` pattern):

- A template that only renders the first message in the list (so rendering 1 vs. 2 probe turns is byte-identical, i.e. `diff == 0`) reproduces the bug for both `initialize_system_prompt` and `extract_system_prompt_and_generation`.
- A normal template (system preamble + growing per-turn content, `diff > 0`) is checked as a non-regression sanity case for both helpers.

Verified red → green manually:
```
$ git stash   # revert the fix, keep the new test
$ uv run --extra cpu pytest -v tests/utils/test_system_prompt_extraction_on_cpu.py
...
FAILED test_initialize_system_prompt_zero_diff_does_not_drop_prompt - assert [] != []
FAILED test_extract_system_prompt_and_generation_zero_diff_does_not_drop_prompt - assert [] != []
2 failed, 2 passed

$ git stash pop   # restore the fix
$ uv run --extra cpu pytest -v tests/utils/test_system_prompt_extraction_on_cpu.py
4 passed
```

Also ran the pre-existing, closely related `tests/utils/test_turn_separator_on_cpu.py` (9 tests) — all still pass, no regression. `tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py` and `tests/utils/dataset/test_rl_dataset_on_cpu.py` fail identically before and after this change in this sandbox (they require locally-cached HF model weights that aren't available offline here) — confirmed by stashing the fix and re-running, so that's a pre-existing environment gap, not a regression from this PR.

Ran `pre-commit run --files verl/utils/tokenizer/chat_template.py tests/utils/test_system_prompt_extraction_on_cpu.py` (ruff, ruff-format, mypy, license/docstring/naming/structure checks): all pass on the changed files.

**Execution-mode note** (pure-Python vs. distributed): this code runs once in the driver process during dataset construction — plain tokenizer/text processing over `apply_chat_template`, before any FSDP/Megatron sharding or Ray/vLLM/SGLang rollout dispatch — and its behavior doesn't depend on the training backend or rollout engine at all. So the CPU unit test exercises the real production code path directly, with no mocking gap to flag.

### API and Usage Example

No API change — same signature and return type (`list[int]`), only the value returned in the previously-buggy `diff == 0` edge case changes (from incorrectly `[]` to the correct full probe token list).

### Design & Code Changes

- `verl/utils/tokenizer/chat_template.py`: in both `initialize_system_prompt()` and `extract_system_prompt_and_generation()`, replace `token1[: -(len(token2) - len(token1))]` with the equivalent-but-`diff==0`-safe `token1[: len(token1) - diff]`.
- `tests/utils/test_system_prompt_extraction_on_cpu.py`: new regression test file.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (see Test section above; ran scoped to the changed files — `pre-commit run --all-files` was not run in full due to an unrelated local-environment false positive from `check-naming-conventions` matching the pip-installed `.venv/` dependency tree, which is `.gitignore`d and not present in this repo's actual CI, which installs via plain `pip install --no-deps -e .` with no `.venv` — the same hook run scoped to just the two changed files passes cleanly).
- [ ] Add / Update the documentation. (Not applicable — internal helper, no public docs reference this slicing detail.)
- [x] Add unit test(s) covering the change (see above).
