### PR TITLE
[fsdp] fix: param_offload frees nothing with fsdp_size=1 (NO_SHARD)

### DIFF
--- a/tests/special_distributed/run_all.sh
+++ b/tests/special_distributed/run_all.sh
@@ -25,3 +25,6 @@ torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_cp
 # Regression for colocated FSDP2 full-parameter model transfers. It locks in
 # PyTorch's implicit pinned allocation for non-blocking D2H Module.to().
 torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_pinned_model_transfer.py
+# Regression for FSDP1 param_offload under an unsharded strategy (fsdp_size=1).
+# Only needs 2 ranks to build the one-rank shard group that degrades to NO_SHARD.
+torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp1_no_shard_offload.py

--- a/tests/special_distributed/test_fsdp1_no_shard_offload.py
+++ b/tests/special_distributed/test_fsdp1_no_shard_offload.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for FSDP1 parameter offload under an unsharded strategy.
+
+``fsdp_size=1`` builds a one-rank shard group, which degrades FSDP1 to
+``NO_SHARD``. Combined with verl's default ``use_orig_params=False``, the
+per-parameter views registered on the wrapped modules keep pointing at the
+pre-move flat-parameter storage: ``FlatParamHandle.flat_param_to()`` only
+refreshes those views when ``use_orig_params=True``. The stale views hold a
+reference to the old device allocation, so ``offload_fsdp_model_to_cpu`` frees
+nothing and the following ``load_fsdp_model_to_gpu`` allocates a second copy.
+
+The offload must be exercised **before any forward pass**: FSDP's pre-forward
+unshard re-points the views itself, which hides the leak.
+
+Launch:
+    torchrun --nproc-per-node=2 --standalone \
+        tests/special_distributed/test_fsdp1_no_shard_offload.py
+"""
+
+import torch
+import torch.distributed
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import MixedPrecision
+from transformers import AutoModelForCausalLM, Qwen2Config
+
+from verl.utils.device import get_device_name, get_torch_device
+from verl.utils.distributed import initialize_global_process_group
+from verl.utils.fsdp_utils import load_fsdp_model_to_gpu, offload_fsdp_model_to_cpu
+from verl.workers.engine.fsdp.utils import create_device_mesh, get_sharding_strategy
+
+
+def _build_no_shard_fsdp1_model(world_size):
+    config = Qwen2Config(
+        num_hidden_layers=4,
+        hidden_size=1024,
+        intermediate_size=2048,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+        vocab_size=2048,
+    )
+    model = AutoModelForCausalLM.from_config(config=config, torch_dtype=torch.float32)
+    model = model.to(get_device_name())
+    device_mesh = create_device_mesh(world_size=world_size, fsdp_size=1)
+    return FSDP(
+        model,
+        device_mesh=device_mesh,
+        sharding_strategy=get_sharding_strategy(device_mesh),
+        mixed_precision=MixedPrecision(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            buffer_dtype=torch.float32,
+        ),
+        use_orig_params=False,
+        device_id=get_torch_device().current_device(),
+    )
+
+
+def main():
+    if not get_torch_device().is_available():
+        print("skipped: accelerator unavailable")
+        return
+    assert get_torch_device().device_count() >= 2, "test requires at least 2 devices"
+
+    _local_rank, rank, world_size = initialize_global_process_group()
+    device_type = get_device_name()
+
+    model = _build_no_shard_fsdp1_model(world_size)
+
+    # Keep the reference copy on the host: a device-side clone would itself be counted
+    # by memory_allocated() and mask the very allocation this test measures.
+    num_params_before = sum(1 for _ in model.parameters())
+    expected = [param.detach().to("cpu", copy=True) for param in model.parameters()]
+
+    get_torch_device().synchronize()
+    alloc_before = get_torch_device().memory_allocated()
+
+    # Before any forward: FSDP's pre-forward unshard would re-point the views itself.
+    offload_fsdp_model_to_cpu(model)
+    get_torch_device().synchronize()
+    alloc_offloaded = get_torch_device().memory_allocated()
+
+    handles = model._all_handles
+    assert handles, "expected at least one FlatParamHandle"
+    for handle in handles:
+        assert not handle.uses_sharded_strategy, (
+            f"expected an unsharded strategy from fsdp_size=1, got {handle._sharding_strategy}"
+        )
+
+    assert alloc_offloaded < 0.1 * alloc_before, (
+        f"offload_fsdp_model_to_cpu freed almost nothing: {alloc_before} -> {alloc_offloaded} "
+        f"bytes allocated ({alloc_offloaded / max(alloc_before, 1):.1%} still resident on device)"
+    )
+    for name, param in model.named_parameters():
+        assert param.device.type == "cpu", f"{name} still on {param.device} after offload"
+
+    load_fsdp_model_to_gpu(model)
+    get_torch_device().synchronize()
+    alloc_reloaded = get_torch_device().memory_allocated()
+
+    assert alloc_reloaded <= 1.1 * alloc_before, (
+        f"load_fsdp_model_to_gpu double-allocated: {alloc_before} -> {alloc_reloaded} bytes "
+        f"allocated ({alloc_reloaded / max(alloc_before, 1):.2f}x the pre-offload footprint)"
+    )
+
+    params = list(model.parameters())
+    assert len(params) == num_params_before, (
+        f"parameter count changed across the round trip: {num_params_before} -> {len(params)}"
+    )
+    for param, want in zip(params, expected, strict=True):
+        assert param.device.type == device_type, f"expected {device_type}, got {param.device}"
+        torch.testing.assert_close(param.detach().cpu(), want, atol=0.0, rtol=0.0)
+
+    torch.distributed.barrier()
+    torch.distributed.destroy_process_group()
+    if rank == 0:
+        print("test_fsdp1_no_shard_offload passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -166,6 +166,29 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
 
 
 @torch.no_grad()
+def _refresh_unsharded_views_after_move(handle):
+    """Re-point a handle's per-parameter views at the moved flat-parameter storage.
+
+    ``FlatParamHandle.flat_param_to()`` only refreshes the per-parameter views when
+    ``use_orig_params=True``. With ``use_orig_params=False`` (verl's default) and an
+    unsharded strategy -- which ``fsdp_size=1`` yields, because a 1-rank shard group
+    degrades to ``NO_SHARD`` -- the original views keep pointing at the pre-move
+    storage. That keeps the old device allocation alive, so the offload frees nothing
+    and the following reload allocates a second copy.
+
+    ``as_params=False`` matches how FSDP registers the views at rest for
+    ``use_orig_params=False``, so the flat parameter stays the only registered
+    ``nn.Parameter`` and ``model.parameters()`` (and the optimizer param groups) are
+    unchanged.
+    """
+    if handle._use_orig_params:
+        return  # flat_param_to() already refreshed the views
+    if handle.uses_sharded_strategy:
+        return  # sharded strategies rebuild the views on the next unshard
+    handle._use_unsharded_views(as_params=False)
+
+
+@torch.no_grad()
 def offload_fsdp_model_to_cpu(model: FSDP, empty_cache: bool = True):
     if fsdp_version(model) == 2 or fsdp_version(model) == 0:
         offload_fsdp2_model_to_cpu(model, empty_cache)
@@ -188,6 +211,7 @@ def offload_fsdp_model_to_cpu(model: FSDP, empty_cache: bool = True):
         # the following still keeps id(._local_shard) != id(.data)
         flat_param._local_shard = flat_param.data
         assert id(flat_param._local_shard) != id(flat_param.data)
+        _refresh_unsharded_views_after_move(handle)
     if empty_cache:
         get_torch_device().empty_cache()
 
@@ -229,6 +253,7 @@ def load_fsdp_model_to_gpu(model: FSDP):
         handle.flat_param_to(torch.device(f"{get_device_name()}:{device_id}"), non_blocking=True)
         # the following still keeps id(._local_shard) != id(.data)
         flat_param._local_shard = flat_param.data
+        _refresh_unsharded_views_after_move(handle)
 
 
 @torch.no_grad()


### PR DESCRIPTION
### What does this PR do?

Fixes `param_offload` silently freeing no device memory when the actor is built with
`fsdp_size=1` (FSDP1). `fsdp_size=1` produces a 2-D `(ddp, fsdp)` mesh whose 1-rank shard
group degrades to `NO_SHARD`; combined with `use_orig_params=False` (the default),
`FlatParamHandle.flat_param_to()` moves the flat-parameter storage but does not refresh the
per-parameter views — those are only refreshed when `use_orig_params=True`. The stale views
keep the pre-move device allocation alive, so `offload_fsdp_model_to_cpu` frees nothing and
the following `load_fsdp_model_to_gpu` allocates a *second* copy.

The failure is silent: the assert added for the sharded path passes, and
`After offload model/optimizer/grad during init` is not printed at the default
`VERL_LOGGING_LEVEL=WARN`. The symptom only surfaces downstream — with a colocated vLLM
rollout the engine reads the still-occupied memory during KV-cache sizing and refuses to
start:

```
ValueError: Free memory on device cuda:0 (31.33/47.4 GiB) on startup is less than
desired GPU memory utilization (0.85, 40.29 GiB).
```

`FULL_SHARD` (`fsdp_size>1`) is unaffected and its code path is byte-for-byte unchanged.

### Checklist Before Starting

- [x] Search for similar PRs:
  [`is:open param_offload OR fsdp_size OR NO_SHARD`](https://github.com/verl-project/verl/issues?q=is%3Aopen+param_offload+OR+fsdp_size+OR+NO_SHARD)
- [x] PR title formatted as `[{modules}] {type}: {description}`

**Not a duplicate.** Searched open PRs for `param_offload`, `fsdp_size`, `NO_SHARD`,
`use_orig_params`, `offload_fsdp_model_to_cpu` and `flat_param`. The nearest hits are
#7182 (make the *ref model* `CPUOffload` configurable — FSDP2, a config choice, not a
leak), #4696/#4726 (param offloading in `get_actor_weights_info`, under `recipe/`) and
#5125 (host memory retained after `state_dict()` on rank 0). None of them touch
`FlatParamHandle` view refresh after `flat_param_to` — verified with
`gh pr diff <n> | grep -E "_use_unsharded_views|flat_param_to|uses_sharded_strategy"`,
which matches 0 lines in each.

**Relationship to #7493 / #7494.** #7493 reports a *separate* bug in the same
configuration: on FSDP1 with `world_size > 1`, `fsdp_size=1` produces a degenerate
`(N, 1)` mesh whose shard group has one rank, so the gradient all-reduce becomes a no-op.
Its fix (#7494) was closed unmerged and `get_sharding_strategy` is unchanged on `main`, so
that issue is still open in practice. This PR does **not** fix or depend on it — the view
leak is in `flat_param_to` bookkeeping and is orthogonal to the process-group selection.

Note also that the leak is **not limited to `fsdp_size=1`**. Any FSDP1 run whose strategy
resolves to an unsharded one hits it, including a plain single-GPU run
(`world_size == 1`), where FSDP clamps to `NO_SHARD` regardless of `fsdp_size` and
`param_offload` is a legitimate, commonly-used setting.

### AI assistance

This change was developed with AI assistance (Claude). I reviewed every changed line,
ran the tests below myself, and can defend the change end-to-end. The AI assistance is
also recorded as a `Co-authored-by:` trailer on the commit.

### Test

Adds `tests/special_distributed/test_fsdp1_no_shard_offload.py` (2 GPUs), mirroring the
existing `test_fsdp2_pinned_model_transfer.py`. It builds an FSDP1 model through verl's own
`create_device_mesh(world_size, fsdp_size=1)` / `get_sharding_strategy(...)`, asserts the
handles really are `NO_SHARD`, then checks that the offload frees the device and that the
reload restores — rather than doubles — the footprint.

**The test offloads before the first forward, and that matters.** After a forward the views
point at the bf16 `_mp_shard` which FSDP frees post-forward, so nothing fp32 is pinned and
the bug does not reproduce. Pre-forward is also what `FSDPEngine` actually does — it offloads
right after model construction, and that is the allocation vLLM's KV-cache sizing reads.

Measured with a 735M-param model, `use_orig_params=False`, 2 GPUs:

| `fsdp_size` | strategy | state | variant | allocated before → after |
|---|---|---|---|---|
| 1 | NO_SHARD | init (pre-forward) | before this PR | 2.7387 GB → **2.7387 GB** (0% freed) |
| 1 | NO_SHARD | init (pre-forward) | with this PR | 2.7387 GB → **0.0000 GB** |
| 1 | NO_SHARD | post-forward | either | 2.8076 → 0.0690 GB (identical) |
| 2 | FULL_SHARD | any | before this PR | already correct, unchanged |

The reload also compounds without the fix: the offload→load round trip left **5.4773 GB**,
roughly 2× the model, because the stale views keep the original allocation alive while the
reload allocates a fresh one. With the fix it returns to 2.7387 GB.

The test was verified to fail without the fix. On pristine upstream it reports:

```
AssertionError: offload_fsdp_model_to_cpu freed almost nothing:
               184636416 -> 184636416 bytes allocated (100.0% still resident on device)
```

byte-for-byte identical before and after, on both ranks. With the fix applied it passes. A
variant with `fsdp_size=2` (NO_SHARD assertion inverted) confirms the `uses_sharded_strategy`
early-return leaves the sharded path untouched.

End-to-end, Qwen3-4B / GRPO / 2 GPUs / `fsdp_size=1` / `param_offload=True`
(`VERL_LOGGING_LEVEL=DEBUG` to surface the line):

```
                                          before        after
After FSDP,                             15.02 GB      15.02 GB
After offload ... during init            15.02 GB       0.00 GB
```

which lets the colocated vLLM engine start at `gpu_memory_utilization=0.85`. Post-round-trip
forward is bit-identical (`max|logit diff| = 0`) and `len(list(model.parameters()))` is
unchanged.

**Commands run:**

```bash
# regression test, 2 GPUs -- fails on main, passes with this PR
torchrun --nproc-per-node=2 --standalone \
    tests/special_distributed/test_fsdp1_no_shard_offload.py

# lint / sanity
ruff check verl/utils/fsdp_utils.py tests/special_distributed/test_fsdp1_no_shard_offload.py
ruff format --check verl/utils/fsdp_utils.py tests/special_distributed/test_fsdp1_no_shard_offload.py
python3 tests/special_sanity/check_license.py --directories .
python3 tests/special_sanity/check_device_api_usage.py --directory ./verl
python3 tests/special_sanity/check_docstrings.py
python3 tests/special_sanity/validate_structure.py
```

All lint/sanity checks pass. The regression test is wired into
`tests/special_distributed/run_all.sh`, which `model.yml` already runs and already lists
in its `paths`.

### API and Usage Example

No API change. Existing configs are unaffected; `fsdp_size=1` with `param_offload=True` now
behaves as documented.

```bash
actor_rollout_ref.actor.fsdp_config.fsdp_size=1 \
actor_rollout_ref.actor.fsdp_config.param_offload=True \
actor_rollout_ref.rollout.gpu_memory_utilization=0.85
```

### Design & Code Changes

- `verl/utils/fsdp_utils.py`: add `_refresh_unsharded_views_after_move(handle)` and call it
  after the move in both `offload_fsdp_model_to_cpu` and `load_fsdp_model_to_gpu`.
  - Guarded by `handle._use_orig_params` (already handled by `flat_param_to`) and
    `handle.uses_sharded_strategy` (sharded strategies rebuild views on the next unshard), so
    only the unsharded + `use_orig_params=False` case changes behaviour.
  - `as_params=False` matches FSDP's at-rest registration for `use_orig_params=False`, so the
    flat parameter remains the only registered `nn.Parameter` and `model.parameters()` /
    optimizer param groups are unchanged.
- `tests/special_distributed/test_fsdp1_no_shard_offload.py`: new 2-GPU regression test.

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [ ] Apply pre-commit checks
- [x] Add / update documentation — n/a (no user-facing API change)
- [x] Add unit or end-to-end test(s)
- [ ] Send a message in the `ci-request` channel
