### PR TITLE
[fsdp] feat: add Qwen3.5-2B on-policy distillation FSDP script

### DIFF
--- a/examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
@@ -36,7 +36,7 @@ teacher_ep=${TEACHER_EP:-8}
 teacher_gpu_mem_util=${TEACHER_GPU_MEM_UTIL:-0.4}
 
 total_epochs=${TOTAL_EPOCHS:-30}
-save_freq=${SAVE_FREQ:-5}
+save_freq=${SAVE_FREQ:-200}
 test_freq=${TEST_FREQ:-5}
 
 project_name=${PROJECT_NAME:-verl_distill_geo3k}

--- a/examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# On-policy distillation | Qwen3.5-35B-A3B (teacher) -> Qwen3.5-2B (student) | geo3k | vLLM rollout | FSDP2
+# dependency: GPU vllm==0.23.0, transformers==5.9.0
+# dependency: NPU vllm==0.23.0, vllm-ascend==v0.23.0, transformers==5.9.0
+
+set -xeuo pipefail
+
+########################### user-adjustable ###########################
+# DEVICE is auto-detected by probing torch_npu; override only for special cases.
+DEVICE=${DEVICE:-$(python3 -c 'import torch_npu' 2>/dev/null && echo npu || echo gpu)}
+INFER_BACKEND=${INFER_BACKEND:-vllm}
+
+STUDENT_MODEL=${STUDENT_MODEL:-Qwen/Qwen3.5-2B}
+TEACHER_MODEL=${TEACHER_MODEL:-Qwen/Qwen3.5-35B-A3B}
+
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+TEACHER_WORLD_SIZE=${TEACHER_WORLD_SIZE:-8}
+
+distillation_loss_mode=${DISTILLATION_LOSS_MODE:-k1}
+use_policy_gradient=${USE_POLICY_GRADIENT:-True}
+distillation_topk=${DISTILLATION_TOPK:-64}
+
+train_batch_size=${TRAIN_BATCH_SIZE:-128}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-128}
+max_prompt_length=${MAX_PROMPT_LENGTH:-1024}
+max_response_length=${MAX_RESPONSE_LENGTH:-2048}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-24576}
+
+actor_lr=${ACTOR_LR:-1e-6}
+
+rollout_tp=${ROLLOUT_TP:-2}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.4}
+teacher_tp=${TEACHER_TP:-8}
+teacher_ep=${TEACHER_EP:-8}
+teacher_gpu_mem_util=${TEACHER_GPU_MEM_UTIL:-0.4}
+
+total_epochs=${TOTAL_EPOCHS:-30}
+save_freq=${SAVE_FREQ:-5}
+test_freq=${TEST_FREQ:-5}
+
+# Precision alignment determinism (set DETERMINISM=false for perf runs)
+DETERMINISM=${DETERMINISM:-true}
+SEED=${SEED:-42}
+
+project_name=${PROJECT_NAME:-verl_distill_geo3k}
+experiment_name=${EXPERIMENT_NAME:-qwen3_5_2b_from_qwen3_5_35b_geo3k}
+
+TRAIN_FILE=${TRAIN_FILE:-"${HOME}/data/geo3k/train.parquet"}
+VAL_FILE=${VAL_FILE:-"${HOME}/data/geo3k/test.parquet"}
+########################### end user-adjustable ###########################
+
+max_num_tokens=$(( max_prompt_length + max_response_length + 1 ))
+
+########################### device env ###########################
+case "${DEVICE}" in
+    gpu)
+        if [ "${DETERMINISM}" = "true" ]; then
+            export VLLM_ENABLE_V1_MULTIPROCESSING=0
+            export CUBLAS_WORKSPACE_CONFIG=":16:8"
+        fi
+        ;;
+    npu)
+        export HCCL_CONNECT_TIMEOUT=1500
+        export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+        export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+        export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+        export VERL_PLATFORM=huawei
+        export TASK_QUEUE_ENABLE=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_ASCEND_ENABLE_NZ=0
+        export HCCL_BUFFSIZE=610
+        export PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:1024
+        export CUDA_DEVICE_MAX_CONNECTIONS=1
+        if [ "${DETERMINISM}" = "true" ]; then
+            export CLOSE_MATMUL_K_SHIFT=1
+            export ATB_MATMUL_SHUFFLE_K_ENABLE=0
+            export LCCL_DETERMINISTIC=1
+            export ATB_LLM_LCOC_ENABLE=0
+            export VLLM_ENABLE_V1_MULTIPROCESSING=0
+        fi
+        ;;
+    *)
+        echo "Unsupported DEVICE=${DEVICE}. Expected 'gpu' or 'npu'." >&2
+        exit 1
+        ;;
+esac
+
+start_time=$(date +%Y%m%d)_$(date +%H%M%S)
+mkdir -p logs
+
+########################### parameter arrays ###########################
+
+DATA=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+    data.train_files="['${TRAIN_FILE}']"
+    data.val_files="['${VAL_FILE}']"
+    data.train_batch_size=${train_batch_size}
+    data.max_prompt_length=${max_prompt_length}
+    data.max_response_length=${max_response_length}
+    data.filter_overlong_prompts=True
+    data.truncation='error'
+    data.image_key=images
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="${STUDENT_MODEL}"
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.model.enable_gradient_checkpointing=True
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.optim.lr=${actor_lr}
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1
+    actor_rollout_ref.actor.use_dynamic_bsz=False
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.actor.use_torch_compile=False
+    actor_rollout_ref.actor.strategy=fsdp2
+    actor_rollout_ref.actor.fsdp_config.reshard_after_forward=True
+    actor_rollout_ref.actor.fsdp_config.entropy_checkpointing=False
+    actor_rollout_ref.actor.fsdp_config.entropy_from_logits_with_chunking=False
+    actor_rollout_ref.actor.fsdp_config.offload_policy=False
+    actor_rollout_ref.actor.fsdp_config.param_offload=True
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True
+)
+
+REF=(
+    actor_rollout_ref.ref.strategy=fsdp2
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1
+    actor_rollout_ref.ref.fsdp_config.offload_policy=False
+    actor_rollout_ref.ref.fsdp_config.param_offload=True
+    actor_rollout_ref.ref.fsdp_config.reshard_after_forward=True
+    actor_rollout_ref.ref.fsdp_config.entropy_from_logits_with_chunking=False
+    actor_rollout_ref.ref.use_torch_compile=False
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=${INFER_BACKEND}
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${rollout_tp}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${rollout_gpu_mem_util}
+    actor_rollout_ref.rollout.n=1
+    actor_rollout_ref.rollout.max_model_len=${max_num_tokens}
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=False
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.rollout.calculate_log_probs=True
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.logger='["console","tensorboard"]'
+    trainer.project_name=${project_name}
+    trainer.experiment_name=${experiment_name}
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.val_before_train=False
+    trainer.save_freq=${save_freq}
+    trainer.test_freq=${test_freq}
+    trainer.total_epochs=${total_epochs}
+)
+
+EXTRA=(
+    distillation.enabled=True
+    distillation.n_gpus_per_node=${TEACHER_WORLD_SIZE}
+    distillation.nnodes=${NNODES}
+    distillation.teacher_models.teacher_model.model_path="${TEACHER_MODEL}"
+    distillation.teacher_models.teacher_model.inference.tensor_model_parallel_size=${teacher_tp}
+    distillation.teacher_models.teacher_model.inference.expert_parallel_size=${teacher_ep}
+    distillation.teacher_models.teacher_model.inference.name=vllm
+    distillation.teacher_models.teacher_model.inference.gpu_memory_utilization=${teacher_gpu_mem_util}
+    distillation.teacher_models.teacher_model.inference.max_model_len=${max_num_tokens}
+    distillation.distillation_loss.loss_mode=${distillation_loss_mode}
+    distillation.distillation_loss.topk=${distillation_topk}
+    distillation.distillation_loss.use_task_rewards=False
+    distillation.distillation_loss.use_policy_gradient=${use_policy_gradient}
+    distillation.distillation_loss.loss_max_clamp=10.0
+    distillation.distillation_loss.log_prob_min_clamp=-10.0
+)
+
+# NPU VL: disable multimodal processor cache to save memory
+if [ "${DEVICE}" = "npu" ]; then
+    ROLLOUT+=(+actor_rollout_ref.rollout.engine_kwargs.vllm_mm_processor_cache_gb=0)
+fi
+
+########################### determinism (precision alignment) ###########################
+if [ "${DETERMINISM}" = "true" ]; then
+    DATA+=(
+        data.shuffle=False
+        data.validation_shuffle=False
+        data.seed=${SEED}
+    )
+    ACTOR+=(
+        actor_rollout_ref.actor.data_loader_seed=${SEED}
+        actor_rollout_ref.actor.fsdp_config.seed=${SEED}
+        actor_rollout_ref.actor.fsdp_config.full_determinism=True
+    )
+    REF+=(
+        actor_rollout_ref.ref.fsdp_config.seed=${SEED}
+        actor_rollout_ref.ref.fsdp_config.full_determinism=True
+    )
+    ROLLOUT+=(
+        actor_rollout_ref.rollout.seed=${SEED}
+    )
+    EXTRA+=(
+        +distillation.teacher_models.teacher_model.inference.seed=${SEED}
+    )
+fi
+
+########################### launch ###########################
+# uv (set VERL_USE_UV=0 for system python): GPU vllm/sglang × fsdp run the driver and every Ray worker
+# (runtime_env.py_executable) through `uv run` on the matching extras of the committed uv.lock;
+# other backends / NPU fall back to ambient python. Run from the verl repo root.
+LAUNCH=(python3)
+RAY=(ray_kwargs.ray_init.runtime_env.py_executable=null)
+if [ "${VERL_USE_UV:-1}" != 0 ] && [ "${DEVICE}" = gpu ] && { [ "${INFER_BACKEND}" = vllm ] || [ "${INFER_BACKEND}" = sglang ]; }; then
+    LAUNCH=(uv run --frozen --all-packages --extra "${INFER_BACKEND}" --extra fsdp python3)
+    RAY=(ray_kwargs.ray_init.runtime_env.py_executable="uv -v run --frozen --all-packages --extra ${INFER_BACKEND} --extra fsdp")
+fi
+"${LAUNCH[@]}" -m verl.trainer.main_ppo \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${REF[@]}" \
+    "${ROLLOUT[@]}" \
+    "${TRAINER[@]}" \
+    "${EXTRA[@]}" \
+    "${RAY[@]}" \
+    "$@" 2>&1 | tee logs/qwen3_5-2b-opd-35b-${start_time}.log

--- a/examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
@@ -39,10 +39,6 @@ total_epochs=${TOTAL_EPOCHS:-30}
 save_freq=${SAVE_FREQ:-5}
 test_freq=${TEST_FREQ:-5}
 
-# Precision alignment determinism (set DETERMINISM=false for perf runs)
-DETERMINISM=${DETERMINISM:-true}
-SEED=${SEED:-42}
-
 project_name=${PROJECT_NAME:-verl_distill_geo3k}
 experiment_name=${EXPERIMENT_NAME:-qwen3_5_2b_from_qwen3_5_35b_geo3k}
 
@@ -55,10 +51,6 @@ max_num_tokens=$(( max_prompt_length + max_response_length + 1 ))
 ########################### device env ###########################
 case "${DEVICE}" in
     gpu)
-        if [ "${DETERMINISM}" = "true" ]; then
-            export VLLM_ENABLE_V1_MULTIPROCESSING=0
-            export CUBLAS_WORKSPACE_CONFIG=":16:8"
-        fi
         ;;
     npu)
         export HCCL_CONNECT_TIMEOUT=1500
@@ -72,13 +64,6 @@ case "${DEVICE}" in
         export HCCL_BUFFSIZE=610
         export PYTORCH_NPU_ALLOC_CONF=max_split_size_mb:1024
         export CUDA_DEVICE_MAX_CONNECTIONS=1
-        if [ "${DETERMINISM}" = "true" ]; then
-            export CLOSE_MATMUL_K_SHIFT=1
-            export ATB_MATMUL_SHUFFLE_K_ENABLE=0
-            export LCCL_DETERMINISTIC=1
-            export ATB_LLM_LCOC_ENABLE=0
-            export VLLM_ENABLE_V1_MULTIPROCESSING=0
-        fi
         ;;
     *)
         echo "Unsupported DEVICE=${DEVICE}. Expected 'gpu' or 'npu'." >&2
@@ -184,37 +169,13 @@ if [ "${DEVICE}" = "npu" ]; then
     ROLLOUT+=(+actor_rollout_ref.rollout.engine_kwargs.vllm_mm_processor_cache_gb=0)
 fi
 
-########################### determinism (precision alignment) ###########################
-if [ "${DETERMINISM}" = "true" ]; then
-    DATA+=(
-        data.shuffle=False
-        data.validation_shuffle=False
-        data.seed=${SEED}
-    )
-    ACTOR+=(
-        actor_rollout_ref.actor.data_loader_seed=${SEED}
-        actor_rollout_ref.actor.fsdp_config.seed=${SEED}
-        actor_rollout_ref.actor.fsdp_config.full_determinism=True
-    )
-    REF+=(
-        actor_rollout_ref.ref.fsdp_config.seed=${SEED}
-        actor_rollout_ref.ref.fsdp_config.full_determinism=True
-    )
-    ROLLOUT+=(
-        actor_rollout_ref.rollout.seed=${SEED}
-    )
-    EXTRA+=(
-        +distillation.teacher_models.teacher_model.inference.seed=${SEED}
-    )
-fi
-
 ########################### launch ###########################
 # uv (set VERL_USE_UV=0 for system python): GPU vllm/sglang × fsdp run the driver and every Ray worker
 # (runtime_env.py_executable) through `uv run` on the matching extras of the committed uv.lock;
 # other backends / NPU fall back to ambient python. Run from the verl repo root.
 LAUNCH=(python3)
 RAY=(ray_kwargs.ray_init.runtime_env.py_executable=null)
-if [ "${VERL_USE_UV:-1}" != 0 ] && [ "${DEVICE}" = gpu ] && { [ "${INFER_BACKEND}" = vllm ] || [ "${INFER_BACKEND}" = sglang ]; }; then
+if [ "${VERL_USE_UV:-1}" != 0 ] && [ "${DEVICE:-gpu}" = gpu ] && { [ "${INFER_BACKEND}" = vllm ] || [ "${INFER_BACKEND}" = sglang ]; }; then
     LAUNCH=(uv run --frozen --all-packages --extra "${INFER_BACKEND}" --extra fsdp python3)
     RAY=(ray_kwargs.ray_init.runtime_env.py_executable="uv -v run --frozen --all-packages --extra ${INFER_BACKEND} --extra fsdp")
 fi


### PR DESCRIPTION
### What does this PR do?

Add `examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh` for on-policy distillation from Qwen3.5-35B-A3B (teacher) to Qwen3.5-2B (student) on geo3k. The script unifies GPU and NPU into a single entry point with auto-detected `DEVICE`.

Key features:
- Auto-detects `DEVICE` (GPU/NPU) via `torch_npu` probe, with `case` branching for platform-specific env vars
- Uses `uv run` launch on GPU, ambient python on NPU
- Verified on both H100 and Ascend 910B

### Checklist Before Starting

- Search for similar PRs:  
  https://github.com/verl-project/verl/pulls?q=is%3Apr+qwen3_5_2b+opd  
  https://github.com/verl-project/verl/pull/6638 (Qwen3.5-4B OPD FSDP script)
- This is not a duplicate of #6638: that PR targets the Qwen3.5-4B student, while this PR adds and validates the Qwen3.5-2B student configuration.

### Test

Static checks on the latest commit:

```bash
bash -n examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
python tests/special_sanity/check_uv_gpu_only.py
python tests/special_sanity/check_example_naming.py
```

All passed.

400-step long runs:

- GPU: 8x H100, with 4 GPUs for student/rollout and 4 GPUs for teacher
- NPU: 8x Ascend 910B cards / 16 dies, with 8 dies for student/rollout and 8 dies for teacher

The `critic/rewards/mean` curves align across GPU and NPU:

<img width="595" height="337" alt="image" src="https://github.com/user-attachments/assets/83b53ffa-60fe-4452-a4e2-65020556ea7e" />

### API and Usage Example

```bash
# Train on GPU (8 GPUs: 4 student/rollout + 4 teacher)
NGPUS_PER_NODE=4 \
TEACHER_WORLD_SIZE=4 \
TEACHER_TP=4 \
TEACHER_EP=4 \
bash examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh

# Train on NPU (8 cards / 16 dies: 8 student/rollout + 8 teacher)
DEVICE=npu \
bash examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh
```
### Design & Code Changes

- `examples/on_policy_distillation_trainer/run_qwen3_5_2b_fsdp.sh` — unified GPU/NPU OPD script

AI assistance was used to review and refine this change.

### Checklist Before Submitting

- Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md)
- Apply pre-commit checks
- Request CI in [ci-request](https://verl-project.slack.com/archives/C091TCESWB1)