### PR TITLE
[reward] fix: remove eval() RCE in prime_math grader (CVE-2026-6878)

### DIFF
--- a/tests/utils/reward_score/test_prime_math_grader_security_on_cpu.py
+++ b/tests/utils/reward_score/test_prime_math_grader_security_on_cpu.py
@@ -26,6 +26,7 @@ pin down that:
 """
 
 import math
+import time
 
 import pytest
 
@@ -134,3 +135,75 @@ class TestLegitimateGradingUnchanged:
     def test_pi_and_fraction_equality(self):
         assert math_equal(r"3\pi", "9.42477796") is True
         assert math_equal("0.5", "0.5") is True
+
+
+class TestResourceBounds:
+    """The evaluator must not turn RCE into a CPU/memory denial of service.
+
+    ``safe_arithmetic_eval`` runs on model-authored text in a long-lived reward worker,
+    and its callers only guard with ``except Exception`` -- which a hang or an OOM does
+    not raise. So an expression that is merely ruinously expensive has to be *rejected*,
+    not merely survived.
+    """
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "9**9**9**9",  # right-associated tower: the classic int-blowup payload
+            "9**9**9",
+            "2**999999999",
+            "10**100000",
+            "(10**1000)**1000",
+        ],
+    )
+    def test_rejects_exponent_blowup(self, expr):
+        with pytest.raises(ValueError):
+            safe_arithmetic_eval(expr)
+
+    def test_exponent_blowup_is_rejected_promptly(self):
+        """Rejection must come from the size check, not from actually computing it."""
+        start = time.monotonic()
+        with pytest.raises(ValueError):
+            safe_arithmetic_eval("9**9**9**9")
+        assert time.monotonic() - start < 1.0
+
+    def test_rejects_oversized_intermediate_from_multiplication(self):
+        """Bounding only ``**`` would leave repeated multiplication as a way through."""
+        with pytest.raises(ValueError):
+            safe_arithmetic_eval("(2**4000) * (2**4000)")
+
+    def test_rejects_overlong_expression(self):
+        with pytest.raises(ValueError):
+            safe_arithmetic_eval("1+" * 20_000 + "1")
+
+    def test_rejects_too_many_nodes(self):
+        with pytest.raises(ValueError):
+            safe_arithmetic_eval("1+" * 9_000 + "1")
+
+    def test_rejects_deep_nesting(self):
+        with pytest.raises(ValueError):
+            safe_arithmetic_eval("-" * 100 + "1")
+
+    def test_bounds_do_not_reject_realistic_answers(self):
+        """The limits must sit far above anything a real answer contains."""
+        assert safe_arithmetic_eval("2**10") == 1024
+        assert safe_arithmetic_eval("2**0.5") == pytest.approx(math.sqrt(2))
+        assert safe_arithmetic_eval("-2**3") == -8
+        assert safe_arithmetic_eval("3.14159*2") == pytest.approx(3.14159 * 2)
+        assert safe_arithmetic_eval("[1, 2, 3, 4, 5, 6, 7, 8, 9]") == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    def test_grader_sinks_survive_a_blowup_payload(self):
+        """Both eval() sinks must reject the payload rather than hang.
+
+        ``handle_pi`` substitutes the numeric pi before evaluating and suppresses any
+        failure, so a rejected expression leaves the substituted *string* in place. That
+        is the intended fallthrough: a non-numeric result simply grades as not correct.
+        """
+        start = time.monotonic()
+
+        result = handle_pi(r"9**9**9**9\pi", math.pi)
+        assert isinstance(result, str)
+        assert result == "9**9**9**9*" + repr(math.pi)
+
+        assert math_equal("[9**9**9**9]", r"\begin{pmatrix}1\end{pmatrix}") is False
+        assert time.monotonic() - start < 2.0

--- a/tests/utils/reward_score/test_prime_math_grader_security_on_cpu.py
+++ b/tests/utils/reward_score/test_prime_math_grader_security_on_cpu.py
@@ -1,0 +1,136 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for CVE-2026-6878 / GHSA-h57c-v2v3-5v3v.
+
+The prime_math grader used ``eval()`` on model-authored answer text in two places
+(``handle_pi`` and the ``math_equal`` matrix branch). Because the reward function runs
+in the reward worker's own process, a single poisoned sample could execute arbitrary
+code and even monkeypatch grading so every later sample scored full reward. These tests
+pin down that:
+
+* the safe evaluator accepts arithmetic / list literals but rejects anything executable,
+* neither sink executes an injected payload,
+* a poisoned sample can no longer forge rewards for later samples, and
+* legitimate arithmetic and list-matrix grading are unchanged.
+"""
+
+import math
+
+import pytest
+
+from verl.utils.reward_score.prime_math.grader import (
+    handle_pi,
+    math_equal,
+    safe_arithmetic_eval,
+)
+
+
+class TestSafeArithmeticEval:
+    def test_accepts_numbers_and_arithmetic(self):
+        assert safe_arithmetic_eval("1*3.14+2") == pytest.approx(1 * 3.14 + 2)
+        assert safe_arithmetic_eval("2**3") == 8
+        assert safe_arithmetic_eval("-5") == -5
+        assert safe_arithmetic_eval("(1 + 2) * 3") == 9
+        assert safe_arithmetic_eval("7 / 2") == pytest.approx(3.5)
+
+    def test_accepts_list_and_tuple_literals(self):
+        assert safe_arithmetic_eval("[1, 2, 3]") == [1, 2, 3]
+        assert safe_arithmetic_eval("[1/2, 3]") == [0.5, 3]
+        assert safe_arithmetic_eval("(1, 2)") == (1, 2)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            'exec("import os")',
+            '__import__("os").system("echo x")',
+            'open("f","w")',
+            "os.system('x')",
+            "[x for x in range(3)]",
+            "lambda: 1",
+            "True",  # bool is not a numeric literal we allow
+        ],
+    )
+    def test_rejects_executable_or_non_numeric(self, expr):
+        with pytest.raises((ValueError, SyntaxError)):
+            safe_arithmetic_eval(expr)
+
+
+class TestHandlePiIsNotExecutable:
+    def test_handle_pi_does_not_execute_payload(self, tmp_path):
+        marker = tmp_path / "pwned.txt"
+        # Valid-syntax payload: `1*math.pi + exec(...)` was a real RCE via eval().
+        payload = r"\pi+" + "exec(" + repr(f"import os as o\no.system('echo x > {marker}')") + ")"
+        result = handle_pi(payload, math.pi)
+        assert not marker.exists(), "handle_pi executed model-authored code"
+        # Non-numeric input falls through unchanged (fail-closed), not raising.
+        assert isinstance(result, str)
+
+    def test_handle_pi_still_evaluates_legit_arithmetic(self):
+        assert handle_pi(r"2\pi", math.pi) == pytest.approx(2 * math.pi)
+        assert handle_pi(r"3\pi+1", math.pi) == pytest.approx(3 * math.pi + 1)
+        assert handle_pi("no pi here", math.pi) == "no pi here"
+
+
+class TestMatrixBranchIsNotExecutable:
+    def test_matrix_branch_does_not_execute_payload(self, tmp_path, monkeypatch):
+        # Use a relative marker with no underscore so the payload survives the
+        # grader's normalize() step and actually reaches the (former) eval() sink,
+        # matching the shape of a real attack.
+        monkeypatch.chdir(tmp_path)
+        marker = tmp_path / "pwned.txt"
+        prediction = '[open("pwned.txt","w").write("x"), 2]'
+        reference = r"\begin{pmatrix}1&2\end{pmatrix}"
+        # Must not raise and must not execute the payload.
+        assert math_equal(prediction, reference) is False
+        assert not marker.exists(), "matrix branch executed model-authored code"
+
+    def test_matrix_branch_still_grades_list_predictions(self):
+        # A list-form prediction still parses and is compared (behavior preserved).
+        assert math_equal(r"[1, 2]", r"\begin{pmatrix}9&9\end{pmatrix}") is False
+
+
+class TestNoRewardForgeryAcrossSamples:
+    def test_payload_cannot_monkeypatch_grade_answer(self, tmp_path):
+        marker = tmp_path / "pwned.txt"
+        from verl.utils.reward_score import prime_math
+
+        original = prime_math.grade_answer
+        try:
+            # A wrong answer is wrong before the attack.
+            assert prime_math.grade_answer("999", "42") is False
+            payload_body = (
+                "import verl.utils.reward_score.prime_math as p\n"
+                "p.grade_answer=lambda *a, **k: True\n"
+                f"import os as o; o.system('echo x > {marker}')"
+            )
+            attack = r"\pi+" + "exec(" + repr(payload_body) + ")"
+            handle_pi(attack, math.pi)
+            # The attack neither ran nor forged later grading.
+            assert not marker.exists()
+            assert prime_math.grade_answer is original
+            assert prime_math.grade_answer("999", "42") is False
+        finally:
+            prime_math.grade_answer = original
+
+
+class TestLegitimateGradingUnchanged:
+    def test_boxed_answers(self):
+        from verl.utils.reward_score.prime_math import compute_score
+
+        assert compute_score(r"The answer is \boxed{42}", "42")[0] is True
+        assert compute_score(r"The answer is \boxed{42}", "7")[0] is False
+
+    def test_pi_and_fraction_equality(self):
+        assert math_equal(r"3\pi", "9.42477796") is True
+        assert math_equal("0.5", "0.5") is True

--- a/verl/utils/reward_score/prime_math/grader.py
+++ b/verl/utils/reward_score/prime_math/grader.py
@@ -92,8 +92,10 @@ This logic is largely copied from the Hendrycks' MATH release (math_equivalence)
 - https://github.com/openai/prm800k
 """
 
+import ast
 import contextlib
 import math
+import operator
 import re
 from math import isclose
 
@@ -147,6 +149,54 @@ def handle_base(x) -> str:
     return x
 
 
+# Allowlist of AST nodes for the safe evaluator below. Everything else
+# (Name, Call, Attribute, Subscript, comprehensions, ...) is rejected.
+_SAFE_BINOPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+_SAFE_UNARYOPS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+
+
+def safe_arithmetic_eval(expr: str):
+    """Safely evaluate an arithmetic / list / tuple expression over numeric literals.
+
+    This is the security-hardened replacement for ``eval()`` in the math grader. The
+    grader compares model-authored answer text, so ``eval()`` here is arbitrary code
+    execution driven by the policy's own output (CVE-2026-6878 / GHSA-h57c-v2v3-5v3v):
+    a single poisoned sample can run code in the reward worker and even monkeypatch
+    grading so every later sample scores full reward.
+
+    Only numeric constants, unary ``+``/``-``, binary ``+ - * / // % **``, parentheses,
+    and list/tuple literals of those are permitted. Any function call, name, attribute
+    access, or other construct raises ``ValueError``, so answer text can never execute
+    code. This is an allowlist, not a denylist, so obfuscation tricks (e.g. ``chr(95)``)
+    cannot bypass it.
+    """
+
+    def _eval(node):
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, int | float | complex) and not isinstance(node.value, bool):
+                return node.value
+            raise ValueError(f"disallowed constant: {node.value!r}")
+        if isinstance(node, ast.BinOp) and type(node.op) in _SAFE_BINOPS:
+            return _SAFE_BINOPS[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and type(node.op) in _SAFE_UNARYOPS:
+            return _SAFE_UNARYOPS[type(node.op)](_eval(node.operand))
+        if isinstance(node, ast.List):
+            return [_eval(elt) for elt in node.elts]
+        if isinstance(node, ast.Tuple):
+            return tuple(_eval(elt) for elt in node.elts)
+        raise ValueError(f"disallowed expression: {type(node).__name__}")
+
+    return _eval(ast.parse(expr, mode="eval").body)
+
+
 def handle_pi(string, pi):
     if isinstance(string, str) and "\\pi" in string:
         # Find the first occurrence of "\pi"
@@ -164,9 +214,11 @@ def handle_pi(string, pi):
             # Find the next occurrence of "\pi"
             idx = string.find("\\pi", idx + 1)
 
-        # Evaluate the expression using eval() function
+        # Evaluate the substituted arithmetic expression safely (see
+        # safe_arithmetic_eval). On any failure the original string is kept, which
+        # makes a non-numeric answer fall through to a not-correct comparison.
         with contextlib.suppress(Exception):
-            string = eval(string)
+            string = safe_arithmetic_eval(string)
 
     return string
 
@@ -296,9 +348,15 @@ def math_equal(
         except Exception:
             pass
     elif r"\begin{pmatrix}" in reference and prediction.startswith("[") and prediction.endswith("]"):
-        if isinstance(eval(prediction), list):
+        # Parse the bracketed prediction as a list literal without eval(): the
+        # prediction is model-authored text (CVE-2026-6878). safe_arithmetic_eval
+        # accepts list/tuple/number literals and rejects anything executable.
+        try:
+            pred_matrix = safe_arithmetic_eval(prediction)
+        except Exception:
+            pred_matrix = None
+        if isinstance(pred_matrix, list):
             try:
-                pred_matrix = eval(prediction)
                 # ref_matrix_items = reference.split()[1:-1:2]
                 ref_matrix_items = (
                     reference.removeprefix(r"\\begin{pmatrix}")

--- a/verl/utils/reward_score/prime_math/grader.py
+++ b/verl/utils/reward_score/prime_math/grader.py
@@ -149,6 +149,44 @@ def handle_base(x) -> str:
     return x
 
 
+# Resource bounds for the safe evaluator. Refusing code execution is not sufficient on
+# its own: the grader runs on model-authored text inside a long-lived reward worker, so
+# an expression that merely takes forever is still a denial of service -- and unlike a
+# rejected expression, a hang is not something the callers' ``except Exception`` can
+# recover from. Python integers are arbitrary precision, so a right-associated tower such
+# as ``9**9**9**9`` would try to build an astronomically large number before returning.
+# Bound the input, the tree, and the size of every intermediate value.
+_MAX_EXPR_CHARS = 10_000
+_MAX_AST_NODES = 10_000
+_MAX_AST_DEPTH = 50
+_MAX_POW_EXPONENT = 1024
+_MAX_INT_BITS = 4096
+
+
+def _check_int_size(value):
+    """Reject an integer too large to keep manipulating cheaply."""
+    if isinstance(value, int) and not isinstance(value, bool) and value.bit_length() > _MAX_INT_BITS:
+        raise ValueError("intermediate value is too large")
+    return value
+
+
+def _safe_pow(base, exponent):
+    """``operator.pow`` with the result size bounded *before* the result is computed.
+
+    Checking afterwards would be too late: the cost of ``a ** b`` is paid during the
+    call, so the projected size has to be rejected up front.
+    """
+    if isinstance(base, complex) or isinstance(exponent, complex):
+        raise ValueError("complex exponentiation is not supported")
+    if abs(exponent) > _MAX_POW_EXPONENT:
+        raise ValueError(f"exponent is too large: {exponent!r}")
+    if isinstance(base, int) and isinstance(exponent, int) and exponent > 0:
+        # `a ** b` occupies roughly `b * log2(|a|)` bits; refuse before allocating it.
+        if base.bit_length() * exponent > _MAX_INT_BITS:
+            raise ValueError("exponentiation result is too large")
+    return operator.pow(base, exponent)
+
+
 # Allowlist of AST nodes for the safe evaluator below. Everything else
 # (Name, Call, Attribute, Subscript, comprehensions, ...) is rejected.
 _SAFE_BINOPS = {
@@ -158,7 +196,7 @@ _SAFE_BINOPS = {
     ast.Div: operator.truediv,
     ast.FloorDiv: operator.floordiv,
     ast.Mod: operator.mod,
-    ast.Pow: operator.pow,
+    ast.Pow: _safe_pow,
 }
 _SAFE_UNARYOPS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
 
@@ -177,21 +215,39 @@ def safe_arithmetic_eval(expr: str):
     access, or other construct raises ``ValueError``, so answer text can never execute
     code. This is an allowlist, not a denylist, so obfuscation tricks (e.g. ``chr(95)``)
     cannot bypass it.
+
+    Evaluation is also bounded, so the security boundary does not simply move from remote
+    code execution to resource exhaustion: the input length, node count, nesting depth,
+    exponent magnitude, and the size of every intermediate integer are all capped, and
+    exceeding any of them raises ``ValueError`` rather than burning the reward worker.
     """
 
-    def _eval(node):
+    if len(expr) > _MAX_EXPR_CHARS:
+        raise ValueError("expression is too long")
+
+    remaining_nodes = _MAX_AST_NODES
+
+    def _eval(node, depth=0):
+        nonlocal remaining_nodes
+        remaining_nodes -= 1
+        if remaining_nodes < 0:
+            raise ValueError("expression has too many nodes")
+        if depth > _MAX_AST_DEPTH:
+            raise ValueError("expression is nested too deeply")
+
         if isinstance(node, ast.Constant):
             if isinstance(node.value, int | float | complex) and not isinstance(node.value, bool):
-                return node.value
+                return _check_int_size(node.value)
             raise ValueError(f"disallowed constant: {node.value!r}")
         if isinstance(node, ast.BinOp) and type(node.op) in _SAFE_BINOPS:
-            return _SAFE_BINOPS[type(node.op)](_eval(node.left), _eval(node.right))
+            left, right = _eval(node.left, depth + 1), _eval(node.right, depth + 1)
+            return _check_int_size(_SAFE_BINOPS[type(node.op)](left, right))
         if isinstance(node, ast.UnaryOp) and type(node.op) in _SAFE_UNARYOPS:
-            return _SAFE_UNARYOPS[type(node.op)](_eval(node.operand))
+            return _check_int_size(_SAFE_UNARYOPS[type(node.op)](_eval(node.operand, depth + 1)))
         if isinstance(node, ast.List):
-            return [_eval(elt) for elt in node.elts]
+            return [_eval(elt, depth + 1) for elt in node.elts]
         if isinstance(node, ast.Tuple):
-            return tuple(_eval(elt) for elt in node.elts)
+            return tuple(_eval(elt, depth + 1) for elt in node.elts)
         raise ValueError(f"disallowed expression: {type(node).__name__}")
 
     return _eval(ast.parse(expr, mode="eval").body)


### PR DESCRIPTION
### What does this PR do?

Fixes #7603. Removes the `eval()` remote-code-execution sinks in the `prime_math` reward grader (CVE-2026-6878 / GHSA-h57c-v2v3-5v3v), which is still present on `main`.

`verl/utils/reward_score/prime_math/grader.py` passed model-authored answer text to Python `eval()` in two places, both reached from `default_compute_score` for every `numina_*` data source:

- `handle_pi` — `eval()` of the answer string after `\pi` substitution
- `math_equal` matrix branch — `eval(prediction)` (one call was **unguarded**)

Because rule-based rewards run in the reward worker's own process, this is arbitrary code execution driven by the policy's own output. Worse, a single poisoned sample can monkeypatch `grade_answer` so that **every later sample in the same worker scores full reward** — persistent reward forgery that silently corrupts training curves, checkpoint selection, and eval numbers.

I reproduced all of this on current `main`: both sinks execute injected code, and a wrong answer flips from `False` to `True` after one payload runs.

### Test

New CPU test: `tests/utils/reward_score/test_prime_math_grader_security_on_cpu.py` (matches the `*_on_cpu.py` glob, runs in `cpu_unit_tests.yml`).

- Verified it **fails on the pre-fix code** (payloads execute, marker files are written) and **passes after** the fix (16 passed).
- Confirmed no behavioral regression: the repo's own three `prime_math` grading cases (matrix / fraction / symbolic) still grade `True`, and a 23-case legitimate-behavior baseline (arithmetic, `\pi` expressions, list-matrix, fractions, boxed answers) is byte-for-byte identical before and after.
- `pre-commit run ruff` and `ruff-format` pass on both files.

### API and Usage Example

No public API change. Internal `eval()` is replaced by a new module-level helper `safe_arithmetic_eval` in the same file.

```python
from verl.utils.reward_score.prime_math.grader import safe_arithmetic_eval

safe_arithmetic_eval("1*3.14 + 2")   # 5.14
safe_arithmetic_eval("[1/2, 3]")     # [0.5, 3]
safe_arithmetic_eval('exec("...")')  # raises ValueError — never executes
```

### Design & Code Changes

- Add `safe_arithmetic_eval(expr)` — an allowlist AST evaluator permitting only numeric constants, unary `+`/`-`, binary `+ - * / // % **`, and list/tuple literals of those. Any `Call`, `Name`, `Attribute`, subscript, comprehension, etc. raises `ValueError`. An **allowlist** (not the existing `should_allow_eval` denylist) cannot be bypassed by obfuscation such as `chr(95)`, which the issue's PoC uses.
- `handle_pi`: `eval` → `safe_arithmetic_eval`, still under `contextlib.suppress`, so a non-numeric answer falls through to a not-correct comparison (fail-closed), preserving current output for legit inputs.
- `math_equal` matrix branch: parse the bracketed prediction once via `safe_arithmetic_eval` inside a `try`, removing the previously **unguarded** `eval`.

Deeper isolation (running rule-based reward functions in a subprocess that does not share module state, so a payload cannot patch grading for later samples) is a larger architectural change and is left as follow-up; this PR closes the code-execution and reward-forgery vectors themselves.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+prime_math+eval — none open for this.
- [x] PR title format `[reward] fix: ...` (passes `check_pr_title.py`).

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (ruff / ruff-format pass on the changed files).
- [ ] Update documentation — n/a (internal security fix, no API change).
- [x] Add unit test(s) to CI (`test_prime_math_grader_security_on_cpu.py`).


---

AI assistance was used to prepare this change (per [`AGENTS.md`](https://github.com/verl-project/verl/blob/main/AGENTS.md)). Every changed line was reviewed by me before submitting, and the tests listed above were run locally with the results shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
