### PR TITLE
[reward] fix: DisRM returns reward_extra_info so async scoring does not KeyError

### DIFF
--- a/docs/advance/reward_loop.rst
+++ b/docs/advance/reward_loop.rst
@@ -200,7 +200,7 @@ Model-Base Reward
          }
          output = await self._post_request(payloads, "classify")
          rm_score = output["data"][-1]["probs"][-1]
-         return {"reward_score": rm_score}
+         return {"reward_score": rm_score, "reward_extra_info": {}}
 
 pass the question and the model rollout as inputs to the reward model and obtain a reward score. This is also the standard practice for most DisRM.
 

--- a/tests/experimental/reward_loop/test_disrm_reward_contract_on_cpu.py
+++ b/tests/experimental/reward_loop/test_disrm_reward_contract_on_cpu.py
@@ -1,0 +1,105 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for the standalone DisRM result contract (issue #7368).
+
+``RewardLoopWorker.compute_score_disrm`` used to return only ``{"reward_score": ...}``.
+The async consumer ``AgentLoopWorker._compute_score`` reads ``result["reward_extra_info"]``
+unconditionally, so standalone DisRM scoring raised ``KeyError: 'reward_extra_info'`` for
+every trajectory and no training batch was produced. These tests pin the two-field
+contract at the producer and end-to-end through the real consumer indexing.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import torch
+
+from verl.experimental.reward_loop.reward_loop import RewardLoopWorker
+
+
+def _make_worker(engine_name: str) -> RewardLoopWorker:
+    worker = object.__new__(RewardLoopWorker)
+    worker.config = SimpleNamespace(
+        reward=SimpleNamespace(
+            reward_model=SimpleNamespace(
+                rollout=SimpleNamespace(name=engine_name),
+                model_path="dummy-reward-model",
+            )
+        )
+    )
+    worker._preprocess_reward_inputs = AsyncMock(return_value="reward prompt")
+    return worker
+
+
+@pytest.mark.parametrize(
+    ("engine_name", "response", "expected_score", "expected_endpoint"),
+    [
+        ("vllm", {"data": [{"probs": [0.125, 0.875]}]}, 0.875, "classify"),
+        ("sglang", {"data": [{"embedding": [0.25, 0.75]}]}, 0.75, "v1/embeddings"),
+    ],
+)
+def test_compute_score_disrm_returns_two_field_contract(engine_name, response, expected_score, expected_endpoint):
+    worker = _make_worker(engine_name)
+    worker._post_request = AsyncMock(return_value=response)
+
+    result = asyncio.run(worker.compute_score_disrm(data=object()))
+
+    # Both fields required by the reward-manager contract must be present.
+    assert result == {"reward_score": expected_score, "reward_extra_info": {}}
+    worker._post_request.assert_awaited_once()
+    assert worker._post_request.await_args.args[1] == expected_endpoint
+
+
+def test_disrm_result_survives_agent_loop_consumer_indexing():
+    """End-to-end: the real consumer that used to KeyError now completes scoring."""
+    from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics, AgentLoopOutput, AgentLoopWorker
+
+    class _RemoteMethod:
+        def __init__(self, worker):
+            self.worker = worker
+
+        def remote(self, data):
+            return self.worker.compute_score_disrm(data)
+
+    class _RewardWorkerHandle:
+        def __init__(self, worker):
+            self.compute_score = _RemoteMethod(worker)
+
+    async def _run():
+        producer = _make_worker("vllm")
+        producer._post_request = AsyncMock(return_value={"data": [{"probs": [0.125, 0.875]}]})
+
+        consumer = object.__new__(AgentLoopWorker)
+        consumer.reward_loop_worker_handles = [_RewardWorkerHandle(producer)]
+        consumer._compute_multi_modal_inputs = lambda output, input_ids: {}
+        consumer._compute_position_ids = lambda input_ids, attention_mask, mm, mm_processor_kwargs=None: torch.arange(
+            input_ids.shape[-1], dtype=torch.long
+        ).unsqueeze(0)
+        consumer._get_mm_processor_kwargs = lambda audio_data=None: {}
+
+        output = AgentLoopOutput(
+            prompt_ids=[1, 2],
+            response_ids=[3],
+            response_mask=[1],
+            metrics=AgentLoopMetrics(),
+            extra_fields={},
+        )
+        # Must not raise KeyError('reward_extra_info').
+        await consumer._compute_score([output], kwargs={})
+        assert output.reward_score == pytest.approx(0.875)
+        assert output.extra_fields["reward_extra_info"] == {}
+
+    asyncio.run(_run())

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -267,7 +267,12 @@ class RewardLoopWorker:
         else:
             raise NotImplementedError(f"RewardLoopManager does not support {engine_name}")
 
-        return {"reward_score": rm_score}
+        # Return both fields required by the reward-manager result contract. The async
+        # consumer (AgentLoopWorker._compute_score) reads result["reward_extra_info"]
+        # unconditionally, so a DisRM, which has no extra metrics, must still return an
+        # empty dict here or async scoring raises KeyError and no training batch is
+        # produced (see issue #7368).
+        return {"reward_score": rm_score, "reward_extra_info": {}}
 
 
 class RewardLoopManager:


### PR DESCRIPTION
### What does this PR do?

Fixes #7368. Standalone DisRM scoring (`reward.reward_model.enable_resource_pool=True`) deterministically crashes every async AgentLoop trajectory with `KeyError: 'reward_extra_info'`, so training cannot advance.

`RewardLoopWorker.compute_score_disrm` returned only `{"reward_score": rm_score}`, but the async consumer `AgentLoopWorker._compute_score` follows the common reward-manager contract and reads `result["reward_extra_info"]` unconditionally (`agent_loop.py:998`). DisRM is the only built-in producer that violated the two-field contract. Colocated DisRM scoring is unaffected because it defensively uses `output.get("reward_extra_info", {})`.

This PR makes the DisRM producer return an empty `reward_extra_info` dict (a DisRM has no extra metrics on this path), matching every other reward manager, and updates the matching example in `docs/advance/reward_loop.rst`. The consumer's strict indexing is intentionally left intact so it still validates malformed custom reward-manager results.

I verified the bug is still present on `main` (producer `reward_loop.py:270` returns one field; consumer `agent_loop.py:998` reads the missing key).

> Note: a previous PR (#7389) proposed the same one-line fix but was **closed by its own author, unmerged** (no maintainer objection). This revives it with an added end-to-end regression test.

### Test

New CPU test `tests/experimental/reward_loop/test_disrm_reward_contract_on_cpu.py`:

- Producer unit test for both the vLLM (`classify`) and SGLang (`v1/embeddings`) response formats.
- End-to-end test that drives the real `AgentLoopWorker._compute_score` path which previously raised at `agent_loop.py:998`.

All three **fail on the pre-fix code** (the integration test hits the exact `KeyError`) and **pass after** the fix. `pre-commit run ruff` / `ruff-format` pass.

### API and Usage Example

No public API change. The DisRM result now includes the field the consumer already requires:

```python
# RewardLoopWorker.compute_score_disrm
return {"reward_score": rm_score, "reward_extra_info": {}}
```

### Design & Code Changes

- `verl/experimental/reward_loop/reward_loop.py`: return `{"reward_score": rm_score, "reward_extra_info": {}}` from `compute_score_disrm`, with a comment pointing at the consumer contract.
- `docs/advance/reward_loop.rst`: update the DisRM example to the two-field return.
- `tests/experimental/reward_loop/test_disrm_reward_contract_on_cpu.py`: new regression test.

### Checklist Before Starting

- [x] Search for similar PRs: #7389 (same fix, author-closed unmerged), #7151 and #7271 are related but distinct.
- [x] PR title format `[reward] fix: ...` (passes `check_pr_title.py`).

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (ruff / ruff-format pass on changed files).
- [x] Update the documentation (`docs/advance/reward_loop.rst`).
- [x] Add unit / e2e test(s) to CI (`test_disrm_reward_contract_on_cpu.py`).


---

AI assistance was used to prepare this change (per [`AGENTS.md`](https://github.com/verl-project/verl/blob/main/AGENTS.md)). Every changed line was reviewed by me before submitting, and the tests listed above were run locally with the results shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
