### PR TITLE
[ci] fix: pin ROCm e2e CI containers to a single NUMA node

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
@@ -109,6 +109,8 @@ jobs:
         --shm-size 2048g
         --ulimit memlock=-1
         --ulimit stack=67108864
+        --cpuset-cpus 0-31
+        --cpuset-mems 0
         -v /data/models:/root/models
         -v /data/data:/root/data
     env:
@@ -200,6 +202,8 @@ jobs:
         --shm-size 2048g
         --ulimit memlock=-1
         --ulimit stack=67108864
+        --cpuset-cpus 0-31
+        --cpuset-mems 0
         -v /data/models:/root/models
         -v /data/data:/root/data
     env:


### PR DESCRIPTION
### What does this PR do?

Fixes the ROCm MI300 e2e CI (`e2e_ppo_trainer_megatron_vllm_rocm.yml`) timing out, by pinning both job containers to a single NUMA node.

The ROCm runners sit in a rocm7.14 QEMU VM that exposes 160 vCPUs spread over two NUMA nodes (node0 = CPUs 0-79, node1 = CPUs 80-159). With the container free to schedule on all of them, the host-side launch path regresses badly: process and thread bootstrap fans out across both nodes, and the resulting cross-node traffic dominates the job wall clock. The jobs end up spending most of their time in startup rather than in the workloads, and hit the 60-minute timeout.

This is a host-side / virtualization issue, not a verl issue — the training scripts themselves are unaffected. Constraining the containers to 32 CPUs on NUMA node 0 keeps launch node-local, which removes the overhead and brings both jobs comfortably back inside their existing timeouts.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+rocm+ci
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

CI-only change; the ROCm workflow itself is the test. The CPU pinning was validated on the same rocm7.14 MI300 VM before being applied here.

### API and Usage Example

No API change. Only the `container.options` of the two ROCm jobs are touched. No GPU count, parallelism config, or timeout is modified.

### Design & Code Changes

`.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml` — add to `container.options` of both `e2e_ppo_trainer_fsdp_vllm_rocm` and `e2e_ppo_trainer_megatron-moe-expert-parallel_rocm`:

```
--cpuset-cpus 0-31
--cpuset-mems 0
```

`--cpuset-cpus 0-31` restricts the container to 32 CPUs, all of which belong to NUMA node 0, and `--cpuset-mems 0` pins its memory allocation to the same node so CPU and memory locality stay consistent.

Note that `options` is a YAML folded scalar (`>-`), so each option goes on its own line with no trailing backslash — a `\` there would survive folding and be passed to `docker create` as a literal argument.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: this PR only reconfigures existing CI jobs.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel in the `verl` Slack workspace.
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit.
