### PR TITLE
[ckpt, fsdp] fix: FSDP model merger concatenates replicated buffers

### DIFF
--- a/tests/model_merger/test_fsdp_merge_non_dtensor_shards_on_cpu.py
+++ b/tests/model_merger/test_fsdp_merge_non_dtensor_shards_on_cpu.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from verl.model_merger.fsdp_model_merger import merge_non_dtensor_shards
+
+
+def test_replicated_scalar_buffer_is_kept_as_is():
+    # A 0-d buffer replicated by FSDP2: torch.cat would raise on it.
+    shards = [torch.tensor(-6.375) for _ in range(8)]
+    merged = merge_non_dtensor_shards(shards)
+    assert merged.shape == ()
+    assert merged.item() == -6.375
+
+
+def test_replicated_1d_buffer_is_not_concatenated():
+    # A (1,) buffer replicated by FSDP2: concatenating would silently give (8,).
+    shards = [torch.tensor([0.061]) for _ in range(8)]
+    assert merge_non_dtensor_shards(shards).shape == (1,)
+
+
+def test_differing_shards_are_concatenated_on_dim0():
+    shards = [torch.full((2, 3), float(rank)) for rank in range(4)]
+    merged = merge_non_dtensor_shards(shards)
+    assert merged.shape == (8, 3)
+    assert torch.equal(merged[2:4], torch.full((2, 3), 1.0))

--- a/tests/model_merger/test_fsdp_merge_non_dtensor_shards_on_cpu.py
+++ b/tests/model_merger/test_fsdp_merge_non_dtensor_shards_on_cpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 
 from verl.model_merger.fsdp_model_merger import merge_non_dtensor_shards
@@ -20,7 +21,7 @@ from verl.model_merger.fsdp_model_merger import merge_non_dtensor_shards
 def test_replicated_scalar_buffer_is_kept_as_is():
     # A 0-d buffer replicated by FSDP2: torch.cat would raise on it.
     shards = [torch.tensor(-6.375) for _ in range(8)]
-    merged = merge_non_dtensor_shards(shards)
+    merged = merge_non_dtensor_shards("clamp_min", shards)
     assert merged.shape == ()
     assert merged.item() == -6.375
 
@@ -28,11 +29,20 @@ def test_replicated_scalar_buffer_is_kept_as_is():
 def test_replicated_1d_buffer_is_not_concatenated():
     # A (1,) buffer replicated by FSDP2: concatenating would silently give (8,).
     shards = [torch.tensor([0.061]) for _ in range(8)]
-    assert merge_non_dtensor_shards(shards).shape == (1,)
+    assert merge_non_dtensor_shards("layer_scalar", shards).shape == (1,)
 
 
-def test_differing_shards_are_concatenated_on_dim0():
-    shards = [torch.full((2, 3), float(rank)) for rank in range(4)]
-    merged = merge_non_dtensor_shards(shards)
-    assert merged.shape == (8, 3)
-    assert torch.equal(merged[2:4], torch.full((2, 3), 1.0))
+def test_single_rank_checkpoint_returns_the_tensor():
+    # world_size == 1 (the case the old torch.cat fallback was added for): one plain copy.
+    tensor = torch.arange(6.0).reshape(2, 3)
+    assert torch.equal(merge_non_dtensor_shards("weight", [tensor]), tensor)
+
+
+def test_ranks_disagreeing_is_an_error_naming_the_key():
+    same_shape = [torch.full((2, 3), float(rank)) for rank in range(4)]
+    with pytest.raises(ValueError, match="'suspicious'.*rank 1"):
+        merge_non_dtensor_shards("suspicious", same_shape)
+
+    different_shape = [torch.zeros(rank + 1) for rank in range(4)]
+    with pytest.raises(ValueError, match="'ragged'"):
+        merge_non_dtensor_shards("ragged", different_shape)

--- a/verl/model_merger/fsdp_model_merger.py
+++ b/verl/model_merger/fsdp_model_merger.py
@@ -32,16 +32,22 @@ from tqdm import tqdm
 from .base_model_merger import BaseModelMerger
 
 
-def merge_non_dtensor_shards(shards: list[torch.Tensor]) -> torch.Tensor:
-    """Merge the per-rank copies of a plain (non-DTensor) tensor.
+def merge_non_dtensor_shards(key: str, shards: list[torch.Tensor]) -> torch.Tensor:
+    """Return the single copy of a plain (non-DTensor) checkpoint entry.
 
-    FSDP2 replicates buffers instead of sharding them, so identical copies are returned
-    as-is (concatenating them would be wrong, and fails outright for 0-d tensors).
-    Shards that differ across ranks are concatenated on dim 0 as before.
+    FSDP only produces DTensors for what it actually shards; plain tensors are buffers and
+    unwrapped parameters, replicated in full on every rank (or the whole tensor when
+    world_size == 1). Concatenating them would give a world_size-times oversized tensor
+    and fails outright for 0-d tensors, so keep one copy and fail loudly if the ranks
+    disagree, which would mean the checkpoint is malformed.
     """
-    if all(torch.equal(shards[0], shard) for shard in shards[1:]):
-        return shards[0]
-    return torch.cat(shards, dim=0)
+    for rank, shard in enumerate(shards[1:], start=1):
+        if shard.shape != shards[0].shape or not torch.equal(shard, shards[0]):
+            raise ValueError(
+                f"Non-DTensor entry {key!r} differs between rank 0 and rank {rank}; "
+                "expected a replicated buffer/parameter identical on every rank"
+            )
+    return shards[0]
 
 
 class FSDPModelMerger(BaseModelMerger):
@@ -211,7 +217,7 @@ class FSDPModelMerger(BaseModelMerger):
                     # 2-D list, FSDP + TP
                     raise NotImplementedError("FSDP + TP is not supported yet")
             else:
-                state_dict[key] = merge_non_dtensor_shards(state_dict[key])
+                state_dict[key] = merge_non_dtensor_shards(key, state_dict[key])
 
         return state_dict
 

--- a/verl/model_merger/fsdp_model_merger.py
+++ b/verl/model_merger/fsdp_model_merger.py
@@ -32,6 +32,18 @@ from tqdm import tqdm
 from .base_model_merger import BaseModelMerger
 
 
+def merge_non_dtensor_shards(shards: list[torch.Tensor]) -> torch.Tensor:
+    """Merge the per-rank copies of a plain (non-DTensor) tensor.
+
+    FSDP2 replicates buffers instead of sharding them, so identical copies are returned
+    as-is (concatenating them would be wrong, and fails outright for 0-d tensors).
+    Shards that differ across ranks are concatenated on dim 0 as before.
+    """
+    if all(torch.equal(shards[0], shard) for shard in shards[1:]):
+        return shards[0]
+    return torch.cat(shards, dim=0)
+
+
 class FSDPModelMerger(BaseModelMerger):
     """
     Model merger for FSDP (Fully Sharded Data Parallel) checkpoints.
@@ -199,7 +211,7 @@ class FSDPModelMerger(BaseModelMerger):
                     # 2-D list, FSDP + TP
                     raise NotImplementedError("FSDP + TP is not supported yet")
             else:
-                state_dict[key] = torch.cat(state_dict[key], dim=0)
+                state_dict[key] = merge_non_dtensor_shards(state_dict[key])
 
         return state_dict
 


### PR DESCRIPTION
### What does this PR do?

FSDPModelMerger treats every non-DTensor entry in a rank's checkpoint as a row-shard and torch.cat(dim=0)s it across ranks. FSDP2 never shards buffers, so each rank holds an identical copy, and merging a model with persistent buffers goes wrong in two ways:

  - 0-d buffers crash the merge: RuntimeError: zero-dimensional tensor (at position 0) cannot be concatenated
  The error this had yielded is: 
```bash
File "verl/model_merger/fsdp_model_merger.py", line 202, in _load_and_merge_state_dicts
      state_dict[key] = torch.cat(state_dict[key], dim=0)
  RuntimeError: zero-dimensional tensor (at position 0) cannot be concatenated
```
  - ≥1-d buffers are silently corrupted: a (1,) buffer becomes (8,) on 8 ranks, producing an HF checkpoint with wrong-shaped tensors.

This happened during conversion of `google/gemma-4-E4B-it` FSDP2 checkpoints