### PR TITLE
[fully_async] fix: parameter sync with partial_rollout crashes the rollouter

### DIFF
--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
+import ray
 import torch
 
 from verl import DataProto
@@ -441,11 +442,37 @@ def task_exception_handler(task: asyncio.Task):
     """Handle task exceptions and log them"""
     try:
         task.result()
-    except asyncio.CancelledError:
-        pass  # Task was cancelled, this is expected
+    except (asyncio.CancelledError, ray.exceptions.TaskCancelledError):
+        # Task was cancelled, this is expected. Ray surfaces the cancellation of a
+        # remote task as ray.exceptions.TaskCancelledError rather than
+        # asyncio.CancelledError, so both must be exempted here.
+        pass
     except Exception as e:
         print(f"Task {task.get_name()} failed with exception: {e}")
         raise e
+
+
+async def await_task_ignore_cancel(task: asyncio.Task) -> None:
+    """Await a task taken from an ``asyncio.wait(..., FIRST_COMPLETED)`` result set,
+    swallowing cancellation instead of letting it propagate into the caller.
+
+    Same exemption as :func:`task_exception_handler`, and for the same reason: when
+    ``partial_rollout`` is enabled, a parameter sync interrupts in-flight rollout
+    generation tasks, and re-awaiting such a task raises
+    ``ray.exceptions.TaskCancelledError`` (not ``asyncio.CancelledError``). The
+    coroutines that drain ``done_tasks`` do not wrap that ``await`` in a try/except,
+    so without this a routine parameter sync escapes as an uncaught exception and
+    takes down the whole Rollouter actor over what is meant to be a transparent
+    interruption.
+
+    Note this only prevents the crash: the cancelled sample is dropped, not
+    resubmitted. Making ``partial_rollout`` actually resume the interrupted sample
+    is a separate, larger change.
+    """
+    try:
+        await task
+    except (asyncio.CancelledError, ray.exceptions.TaskCancelledError) as e:
+        print(f"Task {task.get_name()} cancelled ({type(e).__name__}); sample dropped")
 
 
 def safe_create_task(coro, name: str, task_set: set = None):

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -27,6 +27,7 @@ from omegaconf import DictConfig, open_dict
 from verl.experimental.agent_loop.agent_loop import AgentLoopManager
 from verl.experimental.fully_async_policy.detach_utils import (
     RolloutSample,
+    await_task_ignore_cancel,
     prepare_single_generation_data,
     safe_create_task,
 )
@@ -927,7 +928,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                             async with self.lock:
                                 for task in actual_done:
                                     self.active_tasks.discard(task)
-                                    await task
+                                    await await_task_ignore_cancel(task)
                                 self._record_active_count()
                         if resume_future in done:
                             print(
@@ -962,7 +963,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                                 self.active_tasks, return_when=asyncio.FIRST_COMPLETED
                             )
                             for task in done_tasks:
-                                await task
+                                await await_task_ignore_cancel(task)
                             self._record_active_count()
                 break
 
@@ -974,7 +975,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                             self.active_tasks, return_when=asyncio.FIRST_COMPLETED
                         )
                         for task in done_tasks:
-                            await task
+                            await await_task_ignore_cancel(task)
                         self._record_active_count()
 
             # Submit single sample processing


### PR DESCRIPTION
### What does this PR do?

With `async_training.partial_rollout=True`, a parameter sync interrupts in-flight rollout generation tasks. Re-awaiting such a task in `FullyAsyncRollouter._processor_worker` raises `ray.exceptions.TaskCancelledError`, which nothing catches, so a routine parameter sync escapes as an uncaught exception and takes down the whole Rollouter actor — over an interruption that is meant to be transparent.

This PR exempts Ray's cancellation exception alongside `asyncio.CancelledError`, both in the existing `task_exception_handler` and at the three `await task` sites that drain `asyncio.wait(...)` results.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+TaskCancelledError — no results
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

No new test. Reproducing the crash needs a multi-GPU fully-async run with `partial_rollout` enabled and a parameter sync landing while samples are in flight, which the current CI does not cover. Encountered in practice in fully-async runs with `partial_rollout=True`.

The change is a strict widening of an exception exemption the module already applies, so it cannot alter behaviour on any path that does not raise `TaskCancelledError`.

### API and Usage Example

No API change.

### Design & Code Changes

`FullyAsyncRollouter._processor_worker` drains completed tasks with this shape, at three sites (lines 930 / 965 / 977), none of them wrapped in a `try`/`except`:

```python
done_tasks, self.active_tasks = await asyncio.wait(self.active_tasks, return_when=asyncio.FIRST_COMPLETED)
for task in done_tasks:
    await task          # re-await to surface the task's exception
```

When the task was cancelled by Ray, this `await` raises `ray.exceptions.TaskCancelledError`, not `asyncio.CancelledError`.

The module already treats cancellation as benign — `task_exception_handler` catches `asyncio.CancelledError` with the comment *"Task was cancelled, this is expected"*. This PR does not introduce a new policy; it completes the existing one for the exception type Ray actually raises.

- `detach_utils.task_exception_handler`: exempt `ray.exceptions.TaskCancelledError` as well.
- `detach_utils.await_task_ignore_cancel`: new helper that awaits a task and swallows both cancellation types, logging the dropped sample.
- `fully_async_rollouter`: use the helper at the three drain sites.

Scope note: this prevents the crash only. The cancelled sample is dropped, not resubmitted — making `partial_rollout` actually resume an interrupted sample is a separate, larger change.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (`ruff check` / `ruff format --check` pass on both changed files).
- [ ] Add / Update the documentation — not applicable, no user-facing behaviour change.
- [ ] Add unit or end-to-end test(s) to the CI workflow — see Test section: the failure needs a multi-GPU fully-async run with an in-flight parameter sync, which the current CI does not cover.
