### PR TITLE
[fsdp, ckpt] fix: FSDP merger concatenates replicated buffers instead of deduplicating

### DIFF
--- a/tests/model_merger/test_fsdp_merge_replicated_on_cpu.py
+++ b/tests/model_merger/test_fsdp_merge_replicated_on_cpu.py
@@ -1,0 +1,68 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FSDP sharded checkpoints keep replicated entries (buffers, and any parameter
+excluded from wrapping) as plain tensors rather than DTensors: every rank stores
+an identical full copy. The merger must de-duplicate them, not concatenate them.
+"""
+
+import torch
+
+from verl.model_merger.base_model_merger import ModelMergerConfig
+from verl.model_merger.fsdp_model_merger import FSDPModelMerger
+
+WORLD_SIZE = 4
+
+
+def _write_shards(tmp_path, per_rank_state_dict):
+    for rank in range(WORLD_SIZE):
+        torch.save(
+            per_rank_state_dict(rank),
+            tmp_path / f"model_world_size_{WORLD_SIZE}_rank_{rank}.pt",
+        )
+
+
+def _merge(tmp_path):
+    merger = FSDPModelMerger.__new__(FSDPModelMerger)
+    merger.config = ModelMergerConfig(operation="merge", backend="fsdp", local_dir=str(tmp_path))
+    return merger._load_and_merge_state_dicts(
+        world_size=WORLD_SIZE, total_shards=WORLD_SIZE, mesh_shape=(WORLD_SIZE,), mesh_dim_names=("fsdp",)
+    )
+
+
+def test_replicated_entries_are_deduplicated(tmp_path):
+    """A replicated buffer must keep its original shape after merging."""
+    scalar = torch.tensor([0.5], dtype=torch.bfloat16)
+    vector = torch.arange(8, dtype=torch.bfloat16)
+
+    _write_shards(tmp_path, lambda rank: {"layer_scalar": scalar.clone(), "std_scale": vector.clone()})
+
+    merged = _merge(tmp_path)
+
+    assert merged["layer_scalar"].shape == scalar.shape
+    assert merged["std_scale"].shape == vector.shape
+    torch.testing.assert_close(merged["layer_scalar"], scalar)
+    torch.testing.assert_close(merged["std_scale"], vector)
+
+
+def test_mismatched_replicated_shapes_are_rejected(tmp_path):
+    """Shapes differing across ranks mean the entry was not replicated: fail loudly."""
+    _write_shards(tmp_path, lambda rank: {"suspicious": torch.zeros(rank + 1, dtype=torch.bfloat16)})
+
+    try:
+        _merge(tmp_path)
+    except AssertionError as e:
+        assert "suspicious" in str(e)
+    else:
+        raise AssertionError("expected an AssertionError for shapes that differ across ranks")

--- a/verl/model_merger/fsdp_model_merger.py
+++ b/verl/model_merger/fsdp_model_merger.py
@@ -199,7 +199,18 @@ class FSDPModelMerger(BaseModelMerger):
                     # 2-D list, FSDP + TP
                     raise NotImplementedError("FSDP + TP is not supported yet")
             else:
-                state_dict[key] = torch.cat(state_dict[key], dim=0)
+                # Entries that are not DTensors were never sharded by FSDP: buffers (and any
+                # parameter excluded from wrapping) are replicated, so every rank holds an
+                # identical full copy. Concatenating them yields a world_size-times oversized
+                # tensor and a merged checkpoint that cannot be loaded. This mirrors what
+                # _merge_by_placement already does for an explicit Replicate() placement.
+                shards = state_dict[key]
+                ref_shape = shards[0].shape
+                assert all(t.shape == ref_shape for t in shards), (
+                    f"Expected replicated tensor {key} to have the same shape on every rank, "
+                    f"got {[tuple(t.shape) for t in shards]}"
+                )
+                state_dict[key] = shards[0]
 
         return state_dict
 


### PR DESCRIPTION
### What does this PR do?

FSDP sharded checkpoints keep **replicated** entries — buffers, and any parameter excluded from wrapping — as plain tensors rather than `DTensor`s: every rank stores an identical full copy. `FSDPModelMerger._load_and_merge_state_dicts` falls through to `torch.cat(..., dim=0)` for those, producing a `world_size`-times oversized tensor and a merged checkpoint that cannot be loaded.

Concretely, merging an 8-rank checkpoint of `Gemma4ForConditionalGeneration` (a composite vision + audio + language model, which has 32 persistent buffers):

| entry | true shape | after merge |
|---|---|---|
| `model.language_model.layers.{0..29}.layer_scalar` | `[1]` | `[8]` |
| `model.vision_tower.std_scale` | `[1152]` | `[9216]` |
| `model.vision_tower.std_bias` | `[1152]` | `[9216]` |

Verified on a real checkpoint: the set of non-`DTensor` entries in `model_world_size_8_rank_0.pt` is exactly the set of the model's persistent buffers (32 entries, matching names).

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+model_merger+replicated — no results
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

New CPU unit test `tests/model_merger/test_fsdp_merge_replicated_on_cpu.py`, covered by `cpu_unit_tests.yml` (matches `tests/**/test_*_on_cpu.py`), no GPU needed.

On `main` it fails with:

```
>       assert merged["layer_scalar"].shape == scalar.shape
E       assert torch.Size([4]) == torch.Size([1])
```

With this PR both cases pass:

```
tests/model_merger/test_fsdp_merge_replicated_on_cpu.py ..                [100%]
2 passed
```

### API and Usage Example

No API change.

### Design & Code Changes

`_merge_by_placement` already implements the rule for an explicit placement:

```python
if placement.is_replicate():
    return tensors[0]
...
elif placement.is_shard():
    return torch.cat(tensors, dim=placement.dim)
```

So the merger already knows replicated tensors must be de-duplicated rather than concatenated. This PR applies the same rule to the branch that handles entries with no placement information — i.e. the ones that are not `DTensor`s, which are replicated by construction, since FSDP only produces a `DTensor` for what it actually sharded.

- `fsdp_model_merger._load_and_merge_state_dicts`: take `shards[0]` instead of `torch.cat(shards, dim=0)` for non-`DTensor` entries.
- A shape assertion keeps the failure loud (naming the offending key) should a non-`DTensor` entry ever differ across ranks, rather than silently picking rank 0.
- New CPU unit test for both the de-duplication and the mismatch guard.

Note the fix deliberately does *not* compare tensor **contents** to decide whether an entry is replicated: a genuinely sharded tensor can have byte-identical shards (a zero-initialised parameter, for example), and collapsing it would corrupt the very case that works correctly today.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (`ruff check` / `ruff format --check` pass on both files).
- [ ] Add / Update the documentation — not applicable, bug fix with no user-facing API change.
- [x] Add unit or end-to-end test(s) to the CI workflow.
