### PR TITLE
[fully_async] fix: do not overwrite an agent_name provided by the dataset

### DIFF
--- a/tests/experimental/fully_async_policy/test_prepare_generation_data_on_cpu.py
+++ b/tests/experimental/fully_async_policy/test_prepare_generation_data_on_cpu.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The dataset may select an agent loop per sample via an ``agent_name`` column;
+``AgentLoopWorker.generate_sequences`` only fills in a default when that column is
+absent. The fully-async generation path must not overwrite a caller-provided value.
+"""
+
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+
+from verl.experimental.fully_async_policy.detach_utils import prepare_single_generation_data
+
+
+def _config(multi_turn_enable: bool):
+    return OmegaConf.create({"actor_rollout_ref": {"rollout": {"n": 1, "multi_turn": {"enable": multi_turn_enable}}}})
+
+
+def _batch_dict(agent_name=None):
+    batch_dict = {"input_ids": torch.zeros(1, 4, dtype=torch.long)}
+    if agent_name is not None:
+        batch_dict["agent_name"] = np.array([agent_name], dtype=object)
+    return batch_dict
+
+
+def test_dataset_agent_name_is_preserved():
+    out = prepare_single_generation_data(_batch_dict("my_custom_agent"), _config(multi_turn_enable=False))
+    assert list(out.non_tensor_batch["agent_name"]) == ["my_custom_agent"]
+
+
+def test_default_is_applied_when_absent():
+    out = prepare_single_generation_data(_batch_dict(), _config(multi_turn_enable=False))
+    assert list(out.non_tensor_batch["agent_name"]) == ["single_turn_agent"]
+
+
+def test_multi_turn_path_leaves_column_untouched():
+    out = prepare_single_generation_data(_batch_dict("my_custom_agent"), _config(multi_turn_enable=True))
+    assert list(out.non_tensor_batch["agent_name"]) == ["my_custom_agent"]

--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -62,8 +62,12 @@ def prepare_single_generation_data(batch_dict, config) -> DataProto:
             non_tensor_batch_keys=existing_non_tensor_keys,
         )
 
-    # Setting selected agent, that supports partial
-    if not config.actor_rollout_ref.rollout.multi_turn.enable:
+    # Setting selected agent, that supports partial.
+    # Only fill in the default: the dataset may select an agent loop per sample, and
+    # AgentLoopWorker.generate_sequences applies its own default the same way (it fills
+    # config.agent.default_agent_loop only when the column is absent). Overwriting an
+    # agent_name the dataset provided silently discards the caller's agent loop.
+    if not config.actor_rollout_ref.rollout.multi_turn.enable and "agent_name" not in full_batch.non_tensor_batch:
         full_batch.non_tensor_batch["agent_name"] = np.array(["single_turn_agent"] * len(full_batch), dtype=object)
 
     # Add global step count to generated data


### PR DESCRIPTION
### What does this PR do?

The dataset may select an agent loop per sample through an `agent_name` column. `AgentLoopWorker.generate_sequences` honours that and fills in `config.agent.default_agent_loop` only when the column is absent:

```python
if "agent_name" not in batch.non_tensor_batch:
    default_agent_loop = config.agent.default_agent_loop
    batch.non_tensor_batch["agent_name"] = np.array([default_agent_loop] * len(batch), dtype=object)
```

`prepare_single_generation_data` on the fully-async path overwrites the column unconditionally whenever `multi_turn` is disabled, so an `agent_name` the dataset provided is silently discarded and the run falls back to `single_turn_agent`.

This PR applies the default only when the column is missing, matching the `AgentLoopWorker` behaviour.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+agent_name — no results
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

New CPU unit test `tests/experimental/fully_async_policy/test_prepare_generation_data_on_cpu.py`, covered by `cpu_unit_tests.yml`, no GPU needed. Three cases: a dataset-provided `agent_name` is preserved, the default is still applied when absent, and the multi-turn path is unchanged.

On `main` the first case fails:

```
>       assert list(out.non_tensor_batch["agent_name"]) == ["my_custom_agent"]
E       AssertionError: assert ['single_turn_agent'] == ['my_custom_agent']
```

With this PR all three pass.

### API and Usage Example

No API change. A dataset that does not carry an `agent_name` column behaves exactly as before.

### Design & Code Changes

- `detach_utils.prepare_single_generation_data`: guard the assignment with `and "agent_name" not in full_batch.non_tensor_batch`.
- New CPU unit test as described above.
