### PR TITLE
[misc] chore: fix a non-English error message, a typo and a duplicated docstring step

### DIFF
--- a/verl/checkpoint_engine/nixl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nixl_checkpoint_engine.py
@@ -176,7 +176,7 @@ class ReadableOperation:
 
 class ReadOperation:
     """Encapsulates a read operation from remote agent.
-    1. read medata from remote agent
+    1. read metadata from remote agent
     2. start read transfer operation
     3. wait until read complete
 

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -539,7 +539,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
 
         Flow:
         1. Pre-step processing -> 2. Get batch -> 3. Generate sequences ->
-        4. Compute reward -> 5. Compute log_prob -> 6. Compute reward ->
+        4. Compute reward -> 5. Compute log_prob -> 6. Compute ref log_prob ->
         7. Compute advantage -> 8. Update critic -> 9. Update actor -> 10. Post-step processing
 
         Args:

--- a/verl/experimental/one_step_off_policy/ray_trainer.py
+++ b/verl/experimental/one_step_off_policy/ray_trainer.py
@@ -326,7 +326,7 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
 
         Flow:
         1. Pre-step processing -> 2. Get batch -> 3. Generate sequences ->
-        4. Compute reward -> 5. Compute log_prob -> 6. Compute reward ->
+        4. Compute reward -> 5. Compute log_prob -> 6. Compute ref log_prob ->
         7. Compute advantage -> 8. Update critic -> 9. Update actor -> 10. Post-step processing
 
         Args:

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -344,7 +344,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
 
         Flow:
         1. Pre-step processing -> 2. Get batch -> 3. Generate sequences ->
-        4. Compute reward -> 5. Compute log_prob -> 6. Compute reward ->
+        4. Compute reward -> 5. Compute log_prob -> 6. Compute ref log_prob ->
         7. Compute advantage -> 8. Update critic -> 9. Update actor -> 10. Post-step processing
 
         Args:

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -530,7 +530,7 @@ class RLHFDataset(Dataset):
                 "reason: _read_files_and_tokenize() not called or Parquet file loading failed"
             )
         if self.dataframe is None:
-            raise ValueError("RLHFDataset dataframe 为 None!")
+            raise ValueError("RLHFDataset dataframe is None!")
 
         total_samples = len(self.dataframe)
         print(f"total_samples: {total_samples}")


### PR DESCRIPTION
### What does this PR do?

Three unrelated text-only fixes, no functional change:

- `verl/utils/dataset/rl_dataset.py` — the `ValueError` raised when the dataframe is `None` had a Chinese message (`"RLHFDataset dataframe 为 None!"`); the rest of the codebase raises in English.
- `verl/checkpoint_engine/nixl_checkpoint_engine.py` — `medata` → `metadata`.
- `fit_step` docstrings in `fully_async_policy`, `one_step_off_policy` and `separation` list `Compute reward` twice (as step 4 and step 6). Step 6 is ref log_prob, as the code immediately below each docstring shows.

Happy to split these into separate PRs if preferred.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+typo — no overlapping ones
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Not applicable — comments, a docstring and one exception message. `ruff check` passes.

### API and Usage Example

No API change.

### Design & Code Changes

Text only; see the diff (5 files, 5 lines).
