### PR TITLE
[rollout, perf] fix: cache the generation-prompt delta in incremental tokenization

### DIFF
--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -2018,3 +2018,64 @@ def test_vl_builders_keep_rendering_the_generation_prompt_delta():
     # been checked with the cache.
     assert builder._generation_prompt_delta_cache == {}
     assert builder._generation_prompt_delta_uses == {}
+
+
+class _RecordingGemma4Tokenizer(_RecordingTemplateTokenizer, _Gemma4BoundaryTokenizer):
+    def __init__(self):
+        _RecordingTemplateTokenizer.__init__(self)
+        _Gemma4BoundaryTokenizer.__init__(self)
+
+    def apply_chat_template(
+        self, messages, tokenize=True, add_generation_prompt=True, tools=None, return_dict=False, **kwargs
+    ):
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "add_generation_prompt": add_generation_prompt,
+                "tools": tools,
+                "kwargs": dict(kwargs),
+            }
+        )
+        return _Gemma4BoundaryTokenizer.apply_chat_template(
+            self,
+            messages,
+            tokenize=tokenize,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+            return_dict=return_dict,
+            **kwargs,
+        )
+
+
+def test_gemma4_keeps_its_generation_prompt_render_through_the_cache():
+    tokenizer = _RecordingGemma4Tokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="gemma4")
+    assert isinstance(builder, Gemma4ContinuousTokenBuilder)
+    assert builder.cache_generation_prompt_delta is True
+
+    # Gemma4 renders no generation prompt after a tool response ...
+    tool_final = _tool_loop_history(3)
+    assert builder._tokenize_generation_prompt_delta(tool_final) == []
+    assert builder._generation_prompt_delta_cache[("tool", "")] == []
+
+    # ... and derives it from the last message alone after a user turn; the
+    # cached value is that override's output, not a full-history render.
+    user_final = tool_final + [{"role": "user", "content": "follow-up"}]
+    expected = tokenizer.encode("<assistant>", add_special_tokens=False)
+    assert builder._render_generation_prompt_delta(user_final) == expected
+    assert builder._tokenize_generation_prompt_delta(user_final) == expected
+    assert builder._generation_prompt_delta_cache[("user", "")] == expected
+    assert all(len(call["messages"]) <= 3 for call in tokenizer.calls), (
+        "Gemma4's override renders a bounded pseudo conversation; the cache must not replace it with a full render"
+    )
+
+    # Later uses are served from the cache and stay correct.
+    calls_before = len(tokenizer.calls)
+    for _ in range(20):
+        assert (
+            builder._tokenize_generation_prompt_delta(
+                user_final + [{"role": "assistant", "content": "a"}, user_final[-1]]
+            )
+            == expected
+        )
+    assert len(tokenizer.calls) - calls_before < 20

--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -17,6 +17,7 @@ import logging
 import pytest
 
 from verl.utils.tokenizer.continuous_token import (
+    _GENERATION_PROMPT_DELTA_WARMUP_USES,
     ContinuousTokenBuilder,
     DeepSeekContinuousTokenBuilder,
     DeepSeekVL2ContinuousTokenBuilder,
@@ -29,6 +30,7 @@ from verl.utils.tokenizer.continuous_token import (
     MiniMaxContinuousTokenBuilder,
     QwenContinuousTokenBuilder,
     QwenVLContinuousTokenBuilder,
+    _tools_fingerprint,
 )
 from verl.utils.tokenizer.continuous_token_wiring import (
     CONTINUOUS_TOKEN_BUILDER_FAMILIES,
@@ -1780,3 +1782,239 @@ def test_vl_builder_preserves_explicit_sampling_rate_over_processor_default():
     )
 
     assert builder.mm_processor_kwargs["sampling_rate"] == 24000
+
+
+class _RecordingQwenTokenizer(_RecordingTemplateTokenizer, _QwenBoundaryTokenizer):
+    def __init__(self):
+        _RecordingTemplateTokenizer.__init__(self)
+        _QwenBoundaryTokenizer.__init__(self)
+
+
+def _tool_loop_history(turns):
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "question"},
+    ]
+    for turn in range(turns):
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call-{turn}",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {}},
+                    }
+                ],
+            }
+        )
+        messages.append({"role": "tool", "content": f"result {turn}", "tool_call_id": f"call-{turn}"})
+    return messages
+
+
+def test_qwen_tool_loop_stops_rendering_the_full_history_every_turn():
+    tokenizer = _RecordingQwenTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="qwen3")
+
+    messages = _tool_loop_history(0)
+    for turn in range(40):
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call-{turn}",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {}},
+                    }
+                ],
+            }
+        )
+        previous = list(messages)
+        messages.append({"role": "tool", "content": f"result {turn}", "tool_call_id": f"call-{turn}"})
+        builder.tokenize_non_assistant_incremental_messages(previous, messages)
+
+    # Every render of more than the bounded synthetic prefix is a full-history
+    # render for the generation prompt; with the cache those happen on the
+    # warm-up uses and at powers of two, not on every turn.
+    full_history_renders = sum(1 for call in tokenizer.calls if len(call["messages"]) > 5)
+    assert full_history_renders <= 2 * (_GENERATION_PROMPT_DELTA_WARMUP_USES + 3), (
+        f"{full_history_renders} full-history renders over 40 tool turns; the generation prompt "
+        "should be served from the cache after the warm-up"
+    )
+
+
+def test_default_builder_keeps_full_history_generation_prompt_render():
+    tokenizer = _RecordingTemplateTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="default")
+
+    messages = _tool_loop_history(3)
+    previous = messages[:-1]
+    builder.tokenize_non_assistant_incremental_messages(previous, messages)
+
+    # The fallback must still derive the generation prompt from the full history.
+    assert len(tokenizer.calls[-1]["messages"]) == len(messages)
+    assert tokenizer.calls[-1]["add_generation_prompt"] is True
+
+
+class _HistoryDependentGenerationPromptTokenizer(_TemplateTokenizer):
+    """Renders the generation prompt from the whole history, not the last turn.
+
+    ``changes_after`` renders that make the prompt stable are served first, so a
+    template that only starts drifting later in a rollout is covered too.
+    """
+
+    def __init__(self, changes_after=0):
+        self.changes_after = changes_after
+        self.generation_prompt_renders = 0
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        tools=None,
+        return_dict=False,
+        **kwargs,
+    ):
+        rendered = "".join(f"<{message['role']}>{message.get('content', '')}\n" for message in messages)
+        if add_generation_prompt:
+            self.generation_prompt_renders += 1
+            marker = len(messages) if self.generation_prompt_renders > self.changes_after else 0
+            rendered += f"<assistant turn={marker}>"
+        if tokenize:
+            return self.encode(rendered, add_special_tokens=False)
+        return rendered
+
+
+def _drive_tool_loop(builder, turns):
+    """Append one assistant tool call plus one tool response per turn."""
+    messages = _tool_loop_history(0)
+    for turn in range(turns):
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call-{turn}",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {}},
+                    }
+                ],
+            }
+        )
+        previous = list(messages)
+        messages.append({"role": "tool", "content": f"result {turn}", "tool_call_id": f"call-{turn}"})
+        builder.tokenize_non_assistant_incremental_messages(previous, messages)
+    return messages
+
+
+def test_generation_prompt_delta_cache_stops_rendering_every_turn():
+    tokenizer = _RecordingTemplateTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="default")
+
+    _drive_tool_loop(builder, 32)
+
+    generation_prompt_calls = [call for call in tokenizer.calls if call["add_generation_prompt"]]
+    # 32 turns: warm-up 1..4 plus re-validation at 8, 16 and 32. The assertion
+    # below is deliberately loose; what matters is that it does not grow with
+    # the number of turns.
+    assert len(generation_prompt_calls) <= 10, (
+        f"cached generation prompt still rendered {len(generation_prompt_calls)} times over 32 turns"
+    )
+
+
+def test_generation_prompt_delta_cache_returns_the_rendered_delta():
+    cached_tokenizer = _TemplateTokenizer()
+    uncached_tokenizer = _TemplateTokenizer()
+    cached = create_continuous_token_builder(cached_tokenizer, model_family="default")
+    uncached = create_continuous_token_builder(uncached_tokenizer, model_family="default")
+
+    messages = _tool_loop_history(0)
+    for turn in range(20):
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call-{turn}",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": {}},
+                    }
+                ],
+            }
+        )
+        previous = list(messages)
+        messages.append({"role": "tool", "content": f"result {turn}", "tool_call_id": f"call-{turn}"})
+
+        assert cached.tokenize_non_assistant_incremental_messages(previous, messages) == uncached._tokenize_tool_group(
+            messages[len(previous) :], previous_messages=previous
+        ) + uncached._render_generation_prompt_delta(messages)
+
+
+def test_generation_prompt_delta_cache_falls_back_when_the_template_drifts(caplog):
+    tokenizer = _HistoryDependentGenerationPromptTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="default")
+
+    with caplog.at_level(logging.WARNING):
+        messages = _drive_tool_loop(builder, 6)
+
+    key = builder._generation_prompt_delta_cache_key(messages, None)
+    assert key in builder._generation_prompt_delta_unstable
+    assert key not in builder._generation_prompt_delta_cache
+    assert "rendering it in full from now on" in caplog.text
+    # Once unstable the delta is rendered from the full history again.
+    assert builder._tokenize_generation_prompt_delta(messages) == builder._render_generation_prompt_delta(messages)
+
+
+def test_generation_prompt_delta_cache_catches_drift_after_the_warm_up():
+    # Stable for the four warm-up renders, then history dependent: the drift is
+    # caught by the first re-validation past the warm-up rather than never.
+    tokenizer = _HistoryDependentGenerationPromptTokenizer(changes_after=_GENERATION_PROMPT_DELTA_WARMUP_USES)
+    builder = create_continuous_token_builder(tokenizer, model_family="default")
+
+    messages = _drive_tool_loop(builder, 16)
+
+    key = builder._generation_prompt_delta_cache_key(messages, None)
+    assert key in builder._generation_prompt_delta_unstable
+    assert builder._generation_prompt_delta_uses[key] > _GENERATION_PROMPT_DELTA_WARMUP_USES
+    assert builder._tokenize_generation_prompt_delta(messages) == builder._render_generation_prompt_delta(messages)
+
+
+def test_generation_prompt_delta_cache_separates_roles_and_tools():
+    tokenizer = _TemplateTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="default")
+    tools = [{"type": "function", "function": {"name": "lookup"}}]
+    history = _tool_loop_history(2)
+
+    builder._tokenize_generation_prompt_delta(history)
+    builder._tokenize_generation_prompt_delta(history + [{"role": "user", "content": "follow-up"}])
+    builder._tokenize_generation_prompt_delta(history, tools=tools)
+
+    assert set(builder._generation_prompt_delta_cache) == {
+        ("tool", ""),
+        ("user", ""),
+        ("tool", _tools_fingerprint(tools)),
+    }
+
+
+def test_vl_builders_keep_rendering_the_generation_prompt_delta():
+    builder = create_continuous_token_builder(
+        _MockQwenVLTokenizer(),
+        model_family="qwen25vl",
+        processor=_MockQwenVLProcessor(),
+    )
+    assert builder.cache_generation_prompt_delta is False
+
+    history = _tool_loop_history(2)
+    for _ in range(6):
+        builder._tokenize_generation_prompt_delta(history)
+
+    # Nothing is cached, so nothing can go stale on a template that has not
+    # been checked with the cache.
+    assert builder._generation_prompt_delta_cache == {}
+    assert builder._generation_prompt_delta_uses == {}

--- a/verl/utils/tokenizer/continuous_token.py
+++ b/verl/utils/tokenizer/continuous_token.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -28,9 +29,28 @@ _SYNTHETIC_USER_MESSAGE: dict[str, Any] = {"role": "user", "content": "continuou
 _ASSISTANT_REASONING_CONTENT: str = "reasoning"
 _DUMMY_TOOL_NAME = "continuous_token_tool"
 MergeKind = Literal["assistant", "non_assistant"]
+# (role of the final message, tool schema fingerprint)
+_GenerationPromptCacheKey = tuple[str | None, str]
+# Uses that always re-render the generation-prompt delta before the cache is
+# trusted; after them re-validation is exponentially spaced.
+_GENERATION_PROMPT_DELTA_WARMUP_USES = 4
 
 
 logger = logging.getLogger(__name__)
+
+
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and value & (value - 1) == 0
+
+
+def _tools_fingerprint(tools: list[dict[str, Any]] | None) -> str:
+    """Stable text for a tool schema list, cheap next to a chat-template render."""
+    if not tools:
+        return ""
+    try:
+        return json.dumps(tools, sort_keys=True, default=repr)
+    except (TypeError, ValueError):
+        return repr(tools)
 
 
 @dataclass(frozen=True)
@@ -68,12 +88,15 @@ class ContinuousTokenBuilder:
         Model-specific builders should subclass this class and keep the runtime
         API contracts above stable. Chat template specific behavior belongs in hooks
         such as ``_tokenize_tool_group``, ``_tokenize_single_non_tool``,
-        ``_tokenize_generation_prompt_delta``, and ``_merge_non_assistant_token_ids``.
+        ``_render_generation_prompt_delta``, and ``_merge_non_assistant_token_ids``.
         ``render_delta_token_id`` is the shared suffix-diff helper those hooks can
         reuse.
     """
 
     allowed_append_roles: frozenset[str] = _SUPPORTED_APPEND_ROLES
+    # Builders whose renders have not been checked with the cache keep rendering
+    # the generation-prompt delta on every call.
+    cache_generation_prompt_delta: bool = True
 
     def __init__(
         self,
@@ -87,6 +110,10 @@ class ContinuousTokenBuilder:
         # layer so a text builder never carries multimodal parameters it cannot use.
         self.tokenizer = tokenizer
         self.chat_template_kwargs = chat_template_kwargs or {}
+        # Generation-prompt delta cache; see ``_tokenize_generation_prompt_delta``.
+        self._generation_prompt_delta_cache: dict[_GenerationPromptCacheKey, list[int]] = {}
+        self._generation_prompt_delta_uses: dict[_GenerationPromptCacheKey, int] = {}
+        self._generation_prompt_delta_unstable: set[_GenerationPromptCacheKey] = set()
         if allowed_append_roles is not None:
             allowed_roles = frozenset(allowed_append_roles)
             unknown_roles = allowed_roles - _SUPPORTED_APPEND_ROLES
@@ -248,7 +275,80 @@ class ContinuousTokenBuilder:
         *,
         tools: list[dict[str, Any]] | None = None,
     ) -> list[int]:
-        """Tokenize the tokens added only by ``add_generation_prompt=True``."""
+        """Tokenize the tokens added only by ``add_generation_prompt=True``.
+
+        The delta is cached per (final message role, tools). Every one of the
+        first ``_GENERATION_PROMPT_DELTA_WARMUP_USES`` uses re-renders and
+        compares, and after that re-validation happens at exponentially spaced
+        uses, so a rollout pays for O(log n) renders instead of one per turn.
+        On the first disagreement the key is marked unstable and every later
+        turn renders in full, which keeps templates that derive the generation
+        prompt from more than the last message correct.
+        """
+        if not self.cache_generation_prompt_delta:
+            return self._render_generation_prompt_delta(updated_messages, tools=tools)
+        key = self._generation_prompt_delta_cache_key(updated_messages, tools)
+        if key in self._generation_prompt_delta_unstable:
+            return self._render_generation_prompt_delta(updated_messages, tools=tools)
+
+        uses = self._generation_prompt_delta_uses.get(key, 0) + 1
+        self._generation_prompt_delta_uses[key] = uses
+        cached = self._generation_prompt_delta_cache.get(key)
+        if cached is not None and not self._should_revalidate_generation_prompt_delta(uses):
+            return list(cached)
+
+        rendered = self._render_generation_prompt_delta(updated_messages, tools=tools)
+        if cached is not None and rendered != cached:
+            self._generation_prompt_delta_unstable.add(key)
+            self._generation_prompt_delta_cache.pop(key, None)
+            logger.warning(
+                "Continuous Token generation-prompt delta changed for %r after %d uses; "
+                "this chat template renders it from more than the last message, "
+                "rendering it in full from now on",
+                key[0],
+                uses,
+            )
+            return rendered
+        self._generation_prompt_delta_cache[key] = list(rendered)
+        return rendered
+
+    def _should_revalidate_generation_prompt_delta(self, uses: int) -> bool:
+        """Re-render on the warm-up uses, then at exponentially spaced ones.
+
+        The warm-up catches templates whose generation prompt starts moving as
+        soon as the history grows; the exponential tail keeps catching later
+        drift at a cost that vanishes over a long rollout.
+        """
+        return uses <= _GENERATION_PROMPT_DELTA_WARMUP_USES or _is_power_of_two(uses)
+
+    def _generation_prompt_delta_cache_key(
+        self,
+        updated_messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> _GenerationPromptCacheKey:
+        """Cache key for the generation-prompt delta.
+
+        The role of the final message and the tool schemas are the inputs a
+        chat template is expected to derive the generation prompt from;
+        anything beyond them is caught by re-validation rather than by the key.
+        """
+        role = updated_messages[-1].get("role") if updated_messages else None
+        return role, _tools_fingerprint(tools)
+
+    def _render_generation_prompt_delta(
+        self,
+        updated_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        """Render the generation-prompt delta, uncached.
+
+        The base implementation renders the full history because some chat
+        templates derive the generation prompt from more than the last message.
+        Builders with template-specific behaviour override this hook (see
+        :class:`Gemma4ContinuousTokenBuilder`); the cache in
+        ``_tokenize_generation_prompt_delta`` wraps whichever is in place.
+        """
         return self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools)
 
     def _iter_append_groups(self, appended_messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
@@ -581,7 +681,7 @@ class Gemma4ContinuousTokenBuilder(ContinuousTokenBuilder):
             tools=tools,
         )
 
-    def _tokenize_generation_prompt_delta(
+    def _render_generation_prompt_delta(
         self,
         updated_messages: list[dict[str, Any]],
         *,
@@ -797,6 +897,10 @@ class VLContinuousTokenMixin:
     via Python MRO so that boundary handling like Qwen's newline insertion or
     GLM's observation/user trim still applies through ``_merge_non_assistant_token_ids``.
     """
+
+    # Processor-backed renders have not been checked with the cache yet; VL
+    # builders keep rendering the generation-prompt delta on every call.
+    cache_generation_prompt_delta = False
 
     def __init__(
         self,


### PR DESCRIPTION
### What does this PR do?

Fixes #7617. `tokenize_non_assistant_incremental_messages()` rendered the full conversation twice after every appended tool/user/system group, only to obtain the tokens that `add_generation_prompt=True` adds. Over a long tool loop that is a quadratic amount of chat-template rendering; the issue measured it at ~34% of rollout wall time on a 200-turn Qwen3.5-9B agent loop.

Following the discussion on the issue (@gxlvera, @wuxibin89): the generation-prompt delta is now **cached on the builder by default**, keyed by the role of the final message and the tool schemas, and filled by the existing full-history render. Builders keep template-specific behaviour through an override hook.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+generation+prompt+delta+tokeniz
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

- `tests/utils/test_continuous_token_on_cpu.py`: 128 passed (119 existing + 9 new: a Qwen tool loop no longer renders the full history every turn, the cached delta equals the rendered one turn by turn, a template whose generation prompt drifts is detected and falls back, drift after the warm-up is still caught, roles and tool schemas get separate entries, the default builder still renders the full history on first use, VL builders stay uncached, Gemma4's own last-message render is what the cache serves).
- Real tokenizers, this branch vs `main`, 100-turn tool loops with 800-char tool results through the public incremental API — token ids identical on every turn:

| builder | model | main | this PR | last-turn cost |
|---|---|---|---|---|
| qwen3 | Qwen3-8B | 6.31s | 0.19s | 147 ms -> 1.5 ms |
| qwen35 | Qwen3.5-9B | 6.16s | 0.25s | 117 ms -> 1.9 ms |
| glm47 | GLM-4.7 | 4.50s | 0.30s | 91 ms -> 1.4 ms |
| minimaxm2 | MiniMax-M2 | 4.94s | 0.31s | 98 ms -> 1.4 ms |
| gptoss | gpt-oss-20b | 5.55s | 0.22s | 111 ms -> 0.3 ms |
| deepseek | DeepSeek-V3 | 4.80s | 0.22s | 96 ms -> 0.7 ms |
| default | Qwen3-8B | 6.14s | 0.35s | 112 ms -> 1.6 ms |

  Tokenization only, CPU. Rollout-level numbers are the issue's, not mine.
- The cache key has to include the final role: DeepSeek-V3.2-Exp emits `<｜Assistant｜></think>` after a user turn and nothing after a tool output. Keyed on (role, tools), every template measured is stable over 20 turns.

### API and Usage Example

No API change.

### Design & Code Changes

- `ContinuousTokenBuilder._tokenize_generation_prompt_delta`: cache keyed by `(final message role, tools fingerprint)`. The first 4 uses of a key re-render and compare, then re-validation happens at powers of two (8, 16, 32, ...). One disagreement marks the key unstable and it renders in full for the rest of the rollout, with a warning. O(log n) full renders per rollout instead of O(n).
- `_render_generation_prompt_delta`: the uncached renderer, which is the override hook for template-specific behaviour. Base = full-history render; `Gemma4ContinuousTokenBuilder` keeps its existing last-message render there.
- `cache_generation_prompt_delta` class flag: `VLContinuousTokenMixin` sets it to `False`, so processor-backed builders keep today's behaviour until someone checks them.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] `ruff check` / `ruff format` pass on the touched files.
- [x] Docs: no user-facing change (internal tokenizer utility).
- [x] Unit tests added to `tests/utils/test_continuous_token_on_cpu.py`, covered by the CPU unit-test workflow.
- [ ] CI request in `ci-request` once ready.
