### PR TITLE
[doc] fix: update broken external links

### DIFF
--- a/docs/advance/fully_async.md
+++ b/docs/advance/fully_async.md
@@ -172,7 +172,7 @@ https://github.com/ArronHZG/verl-community/blob/main/docs/fully_async_policy_rev
 
   During the training process, we observed that metrics and response lengths may become unstable in the later
   stages of training. To mitigate this issue, we can use
-  the [Rollout Importance Sampling](https://verl.readthedocs.io/en/latest/advance/rollout_is.html)
+  the [Rollout Importance Sampling](https://verl.readthedocs.io/en/latest/algo/rollout_corr.html)
   technique for importance sampling. To utilize Rollout Importance Sampling, we need to compute log_prob using
   the training engine, which requires enabling this switch.
   Additionally, when `algorithm.rollout_correction.bypass_mode=False` and Rollout Importance Sampling are enabled under

--- a/docs/advance/grafana_prometheus.md
+++ b/docs/advance/grafana_prometheus.md
@@ -180,8 +180,8 @@ After task execution, log in to Grafana to view and customize monitoring dashboa
 **Available Dashboards:**
 
 - [vLLM Grafana Dashboard style 1](https://github.com/ArronHZG/verl-community/blob/main/docs/grafana/vllm_grafana.json)
-- [vLLM Grafana Dashboard style 2](https://github.com/vllm-project/vllm/blob/main/examples/online_serving/dashboards/grafana/performance_statistics.json)
-- [vLLM Grafana Dashboard style 2](https://github.com/vllm-project/vllm/blob/main/examples/online_serving/dashboards/grafana/query_statistics.json)
+- [vLLM Grafana Dashboard style 2](https://github.com/vllm-project/vllm/blob/main/examples/observability/dashboards/grafana/performance_statistics.json)
+- [vLLM Grafana Dashboard style 2](https://github.com/vllm-project/vllm/blob/main/examples/observability/dashboards/grafana/query_statistics.json)
 - [SGLang Grafana Dashboard](https://github.com/sgl-project/sglang/blob/main/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json)
 
 ## Additional Resources

--- a/docs/advance/rl_insight.md
+++ b/docs/advance/rl_insight.md
@@ -158,4 +158,4 @@ For more RL-Insight server installation details, see the [RL-Insight server inst
 ## Related documentation
 
 - [Agent Loop protocol](https://github.com/verl-project/rl-insight/blob/main/docs/monitor/agent_loop_protocol.md)
-- [Uni-Agent RL-Insight instrumentation guide](https://github.com/verl-project/uni-agent/blob/rlinsight/docs/source/concepts/rl-insight-integration.md)
+- [Uni-Agent RL-Insight instrumentation guide](https://github.com/verl-project/uni-agent/blob/main/docs/source/concepts/rl-insight-integration.md)

--- a/docs/algo/dapo.md
+++ b/docs/algo/dapo.md
@@ -4,7 +4,7 @@ Last updated: 06/19/2025.
 
 > Open-Source Algorithm Implementation & Expriement Running: [Yuxuan Tong](https://tongyx361.github.io/), [Guangming Sheng](https://hk.linkedin.com/in/guangming-sheng-b50640211)
 
-🏠 [Homepage](https://dapo-sia.github.io/) | 📝 [Paper@arXiv](https://arxiv.org/abs/2503.14476) | 🤗 [Datasets&Models@HF](https://huggingface.co/collections/BytedTsinghua-SIA/dapo-67d7f1517ee33c8aed059da0) | 🐱 [Code@GitHub](https://github.com/verl-project/verl-recipe/tree/main/dapo/recipe/dapo) | 🐱 [Repo@GitHub](https://github.com/BytedTsinghua-SIA/DAPO)
+🏠 [Homepage](https://dapo-sia.github.io/) | 📝 [Paper@arXiv](https://arxiv.org/abs/2503.14476) | 🤗 [Datasets&Models@HF](https://huggingface.co/collections/BytedTsinghua-SIA/dapo-67d7f1517ee33c8aed059da0) | 🐱 [Code@GitHub](https://github.com/verl-project/verl-recipe/tree/main/dapo) | 🐱 [Repo@GitHub](https://github.com/BytedTsinghua-SIA/DAPO)
 
 > We propose the **D**ecoupled Clip and Dynamic s**A**mpling **P**olicy **O**ptimization (DAPO) algorithm. By making our work publicly available, we provide the broader research community and society with practical access to scalable reinforcement learning, enabling all to benefit from these advancements. Our system is based on the awesome [verl](https://github.com/verl-project/verl) framework. Thanks for their great work! Applying DAPO training to Qwen2.5-32B base model proves to outperform the previous state-of-the-art DeepSeek-R1-Zero-Qwen-32B on AIME 2024, achieving **50%** accuracy with **50%** less training steps.
 >

--- a/docs/ascend_tutorial/zh/dev_guide/model_dev/transfer_to_npu_guide.md
+++ b/docs/ascend_tutorial/zh/dev_guide/model_dev/transfer_to_npu_guide.md
@@ -29,7 +29,7 @@ VeRL 框架采用推理引擎、训练引擎与权重同步桥接（Checkpoint E
 
 VeRL 推理引擎采用分层架构设计，通过抽象接口与工厂模式，实现 vllm、sglang 等多种主流推理后端的灵活支持。在完成 GPU 向 NPU 的迁移适配过程中，推理引擎适配推荐按以下流程操作：
 
-在 NPU 上跑通 VeRL 整网链路前，建议参考 [vllm-ascend](https://github.com/vllm-project/vllm-ascend/tree/main/docs/source/tutorials/models)、[sglang](https://github.com/sgl-project/sglang/blob/main/docs_new/docs/basic_usage) 官方模型部署教程，优先调通**单实例推理链路**，完整验证模型加载与初始化、Tokenizer 加载正常、单轮 / 批量生成、停止词终止、长上下文推理等**基础推理功能**，前置底层推理引擎稳定可用后，再接入 VeRL 训练流程。
+在 NPU 上跑通 VeRL 整网链路前，建议参考 [vllm-ascend](https://github.com/vllm-project/vllm-ascend/tree/main/docs/source/tutorials/models)、[sglang](https://github.com/sgl-project/sglang/tree/main/docs/docs/basic_usage) 官方模型部署教程，优先调通**单实例推理链路**，完整验证模型加载与初始化、Tokenizer 加载正常、单轮 / 批量生成、停止词终止、长上下文推理等**基础推理功能**，前置底层推理引擎稳定可用后，再接入 VeRL 训练流程。
 
 ### 2.2 训练引擎选择与适配
 

--- a/docs/ascend_tutorial/zh/get_start/quick_start.rst
+++ b/docs/ascend_tutorial/zh/get_start/quick_start.rst
@@ -144,7 +144,7 @@ vLLM 后端脚本转换为 SGLang
 
    # 可选
    # 使能推理 EP，详细使用方法见：
-   # https://github.com/sgl-project/sgl-kernel-npu/blob/main/python/deep_ep/README_CN.md
+   # https://github.com/sgl-project/sgl-kernel-npu/blob/main/python/deep_ep/README.md
    ++actor_rollout_ref.rollout.engine_kwargs.sglang.deepep_mode="auto" \
    ++actor_rollout_ref.rollout.engine_kwargs.sglang.moe_a2a_backend="deepep" \
 

--- a/docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst
+++ b/docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst
@@ -4,7 +4,7 @@
 Last updated: 06/06/2026.
 
 .. _Qwen3-30B: https://github.com/verl-project/verl/blob/release/v0.7.1/examples/grpo_trainer/run_qwen3moe-30b_grpo_megatron_vllm_npu.sh
-.. _doclink: https://github.com/verl-project/verl/blob/c98cb8cc/docs/ascend_tutorial/examples/ascend_vllm_best_pratice.rst
+.. _doclink: https://github.com/verl-project/verl/blob/main/docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst
 引言
 ----------------------------------
 

--- a/docs/data/transfer_queue.md
+++ b/docs/data/transfer_queue.md
@@ -75,7 +75,7 @@ Currently, we support the following storage backends:
 - SimpleStorage: A basic CPU memory storage with minimal data format constraints and ease of use.
 - [Yuanrong](https://gitee.com/openeuler/yuanrong-datasystem) ([usage guide](docs/storage_backends/openyuanrong_datasystem.md), beta, [#PR107](https://github.com/TransferQueue/TransferQueue/pull/107), [#PR96](https://github.com/TransferQueue/TransferQueue/pull/96)): An Ascend native data system that provides hierarchical storage interfaces including HBM/DRAM/SSD.
 - [MooncakeStore](https://github.com/kvcache-ai/Mooncake) (beta, [#PR162](https://github.com/TransferQueue/TransferQueue/pull/162)): A high-performance, KV-based hierarchical storage that supports RDMA transport between GPU and DRAM.
-- [RayRDT](https://docs.ray.io/en/master/ray-core/direct-transport.html) (alpha, [#PR167](https://github.com/TransferQueue/TransferQueue/pull/167)): Ray's new feature that allows Ray to store and pass objects directly between Ray actors.
+- [RayRDT](https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html) (alpha, [#PR167](https://github.com/TransferQueue/TransferQueue/pull/167)): Ray's new feature that allows Ray to store and pass objects directly between Ray actors.
 
 Among them, `SimpleStorageUnit` serves as our default storage backend, coordinated by the `AsyncSimpleStorageManager` class. Each storage unit can be deployed on a separate node, allowing for distributed data management.
 
@@ -160,7 +160,7 @@ We have experimentally implemented a **standardized, fully-streamed distributed*
 
 By leveraging the `RankAwareSampler` and `StreamingDataLoader` interfaces, we achieve a **streamlined micro-batch-level producer-consumer pipeline**. This design eliminates the need to manually determine data dispatching logic across varying parallelism strategies—a typical complexity in the single-controller paradigm—thereby greatly simplifying framework design. 
 
-Please refer to our [Roadmap](https://github.com/Ascend/TransferQueue/issues/1) and [tutorials/05_streaming_dataloader.py](https://github.com/Ascend/TransferQueue/blob/main/tutorial/05_streaming_dataloader.py) for more details.
+Please refer to our [Roadmap](https://github.com/Ascend/TransferQueue/issues/1) and [tutorials/06_streaming_dataloader.py](https://github.com/Ascend/TransferQueue/blob/main/tutorial/06_streaming_dataloader.py) for more details.
 
 <p align="center">
   <img src="https://github.com/TransferQueue/community_doc/blob/main/docs/tq_streaming_dataloader.png?raw=true" width="70%">

--- a/docs/examples/ppo_code_architecture.rst
+++ b/docs/examples/ppo_code_architecture.rst
@@ -33,7 +33,7 @@ function based on the datasets (or applications) utilized in PPO
 training.
 
 For example, we already provide reward functions for `GSM8k <https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/gsm8k.py>`_ 
-and `MATH <https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/math.py>`_
+and `MATH <https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/math_reward.py>`_
 datasets in the ``_select_rm_score_fn``. In the ``RewardManager``, we
 will compute the reward score based on the data_source to select
 corresponding reward functions. For some RLHF datasets (e.g.,

--- a/docs/low_precision/fp8.md
+++ b/docs/low_precision/fp8.md
@@ -10,7 +10,7 @@ verl supports two FP8 modes for accelerating RL training:
 | **FP8 End-to-End** | FP8 (Megatron) | FP8 (vLLM) |
 
 > [!TIP]
-> For ready-to-run scripts, see the [low-precision recipe directory](https://github.com/verl-project/verl-recipe/low_precision).
+> For ready-to-run scripts, see the [low-precision recipe directory](https://github.com/verl-project/verl-recipe/tree/main/low_precision).
 
 ---
 

--- a/docs/perf/device_tuning.rst
+++ b/docs/perf/device_tuning.rst
@@ -165,7 +165,7 @@ a PR and include a screenshot from Wandb or other verifiable evidence.
       - \
       - fsdp
       - vllm0.8.2
-      - `qwen2-14b_grpo_4_h800_fsdp_vllm <https://github.com/verl-project/verl/blob/2239fd0ff7210c80ad63e20581924d1f66167429/examples/tuning/14b/qwen2-14b_grpo_4_h800_fsdp_vllm.sh>`_
+      - `qwen2-14b_grpo_4_h800_fsdp_vllm <https://github.com/verl-project/verl/blob/2239fd0ff7210c80ad63e20581924d1f66167429/examples/tuning/14b/qwen2_14b_grpo_4_h800_fsdp_vllm.sh>`_
       - `Xiangyongan <xiangyongan@bytedance.com>`_
     * - MIN
       - Qwen2.5-14B

--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -60,7 +60,7 @@ Below are key factors for tuning vLLM-based rollout. Before tuning, we recommend
   Must to set ``enforce_eager=False`` to use ``cudagraph_capture_sizes``.
 
 More tuning details such as dealing with Preemption and Chunked-prefill
-can be found in `vLLM official tuning guide <https://docs.vllm.ai/en/latest/performance/optimization.html>`_ 
+can be found in `vLLM official tuning guide <https://docs.vllm.ai/en/latest/configuration/optimization/>`_ 
 
 For optimal performance, we recommend using vLLM v0.8.3 or later. See https://github.com/verl-project/verl/blob/main/docs/README_vllm0.8.md for details.
 

--- a/docs/preparation/reward_function.rst
+++ b/docs/preparation/reward_function.rst
@@ -49,7 +49,7 @@ We already pre-implemented some reward functions in `reward_score directory <htt
   use string matching to compare with the ground truth. If completely
   correct, score 1 point; if the format is correct, score 0.1 points; if
   the format is incorrect, score 0 points.
-- In the `MATH example <https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/math.py>`_, we follow
+- In the `MATH example <https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/math_reward.py>`_, we follow
   the implementation in `lm-evaluation-harness repository <https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/hendrycks_math/utils.py>`_.
 
 Customized

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -164,7 +164,7 @@ Other backends
 
 Ascend NPU, AMD ROCm, aarch64 GPUs, and ``trtllm`` are outside the uv
 workflow. Use the standalone Dockerfiles instead — for example
-``docker/ascend/`` (Ascend), ``docker/Dockerfile.rocm`` (AMD), or
+``docker/ascend/`` (Ascend), ``docker/rocm/Dockerfile.rocm`` (AMD), or
 ``docker/Dockerfile.stable.trtllm`` (TensorRT-LLM).
 
 Upgrade or modify dependencies
@@ -370,13 +370,13 @@ Install with AMD GPUs - ROCM kernel support
 When you run on AMD GPUs (MI300) with ROCM platform, you cannot use the previous quickstart to run verl. You should follow the following steps to build a docker and run it.
 If you encounter any issues in using AMD GPUs running verl, feel free to contact me - `Yusheng Su <https://yushengsu-thu.github.io/>`_.
 
-Find the docker for AMD ROCm: `docker/Dockerfile.rocm <https://github.com/verl-project/verl/blob/main/docker/Dockerfile.rocm>`_
+Find the docker for AMD ROCm: `docker/rocm/Dockerfile.rocm <https://github.com/verl-project/verl/blob/main/docker/rocm/Dockerfile.rocm>`_
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 .. code-block:: bash
 
     #  Build the docker in the repo dir:
-    # docker build -f docker/Dockerfile.rocm -t verl-rocm:03.04.2015 .
+    # docker build -f docker/rocm/Dockerfile.rocm -t verl-rocm:03.04.2015 .
     # docker images # you can find your built docker
     FROM rocm/vllm:rocm6.2_mi300_ubuntu20.04_py3.9_vllm_0.6.4
 

--- a/docs/start/multinode.rst
+++ b/docs/start/multinode.rst
@@ -579,7 +579,7 @@ slurm_script.sh
     ### Project
     CONTAINER_NAME="multinode_verl_training"
     IMG="verl.rocm"
-    DOCKERFILE="docker/Dockerfile.rocm"
+    DOCKERFILE="docker/rocm/Dockerfile.rocm"
     # echo $PWD
     verl_workdir="${HOME}/projects/verl_upstream"
     export TRANSFORMERS_CACHE="${HOME}/.cache/huggingface"

--- a/docs/workers/model_engine.rst
+++ b/docs/workers/model_engine.rst
@@ -111,7 +111,7 @@ Add a new backend
    ``transformer_impl.py``. If you want to implement a non-transformer
    model, please contact us in advance.
 -  Add the engine config to the GSM8k SFT trainer script:
-   https://github.com/verl-project/verl/blob/main/tests/special_e2e/sft/run_sft_engine_gsm8k.sh
+   https://github.com/verl-project/verl/blob/main/tests/special_e2e/sft/run_sft_engine.sh
 -  Invoke the tests with your backend:
    https://github.com/verl-project/verl/blob/main/tests/special_e2e/sft/test_sft_engine_all.sh.
    This test script will run various backends and various


### PR DESCRIPTION
### What does this PR do?

Scanned all 758 external URLs across `docs/` and fixed 15 categories of broken links whose new locations were confirmed (16 files). Every replacement URL has been verified with HTTP 200.

## Fixed links (before → after)

### 1. uni-agent branch merged and deleted
`docs/advance/rl_insight.md:161`
- Before: `https://github.com/verl-project/uni-agent/blob/rlinsight/docs/source/concepts/rl-insight-integration.md`
- After: `https://github.com/verl-project/uni-agent/blob/main/docs/source/concepts/rl-insight-integration.md`
- Reason: the `rlinsight` branch was merged into `main` and deleted

### 2. TransferQueue tutorial renumbered
`docs/data/transfer_queue.md:163`
- Before: `https://github.com/Ascend/TransferQueue/blob/main/tutorial/05_streaming_dataloader.py`
- After: `https://github.com/Ascend/TransferQueue/blob/main/tutorial/06_streaming_dataloader.py`
- Reason: the tutorial directory was renumbered to 01–06

### 3. Ray direct-transport docs restructured into a directory
`docs/data/transfer_queue.md:78`
- Before: `https://docs.ray.io/en/master/ray-core/direct-transport.html`
- After: `https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html`
- Reason: Ray docs reorganization moved the page into the `direct-transport/` section

### 4. sgl-kernel-npu README renamed
`docs/ascend_tutorial/zh/get_start/quick_start.rst:147`
- Before: `https://github.com/sgl-project/sgl-kernel-npu/blob/main/python/deep_ep/README_CN.md`
- After: `https://github.com/sgl-project/sgl-kernel-npu/blob/main/python/deep_ep/README.md`
- Reason: the Chinese README was merged into the main README

### 5. sglang docs directory renamed
`docs/ascend_tutorial/zh/dev_guide/model_dev/transfer_to_npu_guide.md:32`
- Before: `https://github.com/sgl-project/sglang/blob/main/docs_new/docs/basic_usage`
- After: `https://github.com/sgl-project/sglang/tree/main/docs/docs/basic_usage`
- Reason: `docs_new/` was renamed to `docs/`

### 6. verl-recipe low_precision became a directory
`docs/low_precision/fp8.md:13`
- Before: `https://github.com/verl-project/verl-recipe/low_precision`
- After: `https://github.com/verl-project/verl-recipe/tree/main/low_precision`
- Reason: `low_precision` is now a top-level directory and requires a tree URL

### 7. verl-recipe dapo directory flattened (homepage link)
`docs/algo/dapo.md:7`
- Before: `https://github.com/verl-project/verl-recipe/tree/main/dapo/recipe/dapo`
- After: `https://github.com/verl-project/verl-recipe/tree/main/dapo`
- Reason: the directory structure was flattened; `dapo/` now lives at the repository root
- Note: lines 173/175 of the same file reference the same URL but involve the semantics of the now-missing `recipe/dapo` branch, so they were not blindly changed — see "Needs decision" below

### 8. tuning script filename typo (hyphen → underscore)
`docs/perf/device_tuning.rst:168`
- Before: `.../verl/blob/2239fd0.../examples/tuning/14b/qwen2-14b_grpo_4_h800_fsdp_vllm.sh`
- After: `.../verl/blob/2239fd0.../examples/tuning/14b/qwen2_14b_grpo_4_h800_fsdp_vllm.sh`
- Reason: the original link mistyped `qwen2_14b` as `qwen2-14b` (the actual filename at that commit uses an underscore)

### 9. Dockerfile.rocm moved into the rocm/ subdirectory
`docs/start/install.rst:167,373,379`, `docs/start/multinode.rst:582`
- Before: `docker/Dockerfile.rocm`
- After: `docker/rocm/Dockerfile.rocm`
- Reason: the file moved into `docker/rocm/`; in addition to the link, 3 path references in prose and code blocks were updated for consistency

### 10. SFT test script renamed
`docs/workers/model_engine.rst:114`
- Before: `https://github.com/verl-project/verl/blob/main/tests/special_e2e/sft/run_sft_engine_gsm8k.sh`
- After: `https://github.com/verl-project/verl/blob/main/tests/special_e2e/sft/run_sft_engine.sh`
- Reason: the gsm8k-specific script was renamed to the generic `run_sft_engine.sh`

### 11. reward score math.py renamed
`docs/preparation/reward_function.rst:52`, `docs/examples/ppo_code_architecture.rst:36`
- Before: `https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/math.py`
- After: `https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/math_reward.py`
- Reason: commit f346f96d renamed `math.py` to `math_reward.py`

### 12. vLLM Grafana dashboard JSONs moved (2 links)
`docs/advance/grafana_prometheus.md:183,184`
- Before: `https://github.com/vllm-project/vllm/blob/main/examples/online_serving/dashboards/grafana/{performance,query}_statistics.json`
- After: `https://github.com/vllm-project/vllm/blob/main/examples/observability/dashboards/grafana/{performance,query}_statistics.json`
- Reason: the dashboards moved from `online_serving/` to `observability/`

### 13. vLLM optimization docs reorganized
`docs/perf/perf_tuning.rst:63`
- Before: `https://docs.vllm.ai/en/latest/performance/optimization.html`
- After: `https://docs.vllm.ai/en/latest/configuration/optimization/`
- Reason: vLLM docs reorganization; the new page still covers Preemption / Chunked Prefill

### 14. verl docs site rollout_is page migrated
`docs/advance/fully_async.md:175`
- Before: `https://verl.readthedocs.io/en/latest/advance/rollout_is.html`
- After: `https://verl.readthedocs.io/en/latest/algo/rollout_corr.html`
- Reason: the feature doc was renamed to Rollout Correction and moved to the `algo/` namespace

### 15. ascend vLLM best practices historical reference is invalid
`docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst:7`
- Before: `https://github.com/verl-project/verl/blob/c98cb8cc/docs/ascend_tutorial/examples/ascend_vllm_best_pratice.rst`
- After: `https://github.com/verl-project/verl/blob/main/docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst`
- Reason: the file did not exist at commit `c98cb8cc` (only the sglang version existed then), and the path contains a typo (`pratice`); updated to point to the current main version
- Note: the sglang `c98cb8cc` link on line 8 of the same file is valid and was left untouched

## Needs decision (deleted resources / missing branches, not fixed)

The following broken links have no direct replacement and require maintainer decisions:

### A. verl-data experiment logs (7 links)
- Location: `docs/algo/baseline.md`, `docs/algo/grpo.md`, `docs/algo/ppo.md`
- Broken links: `https://github.com/eric-haibin-lin/verl-data/blob/experiments/gsm8k/Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-bsz64_*.log` (7 links)
- Status: the `experiments` branch still exists, but these `bsz64_*-lorarank32-score*.log` files were deleted; the remaining logs are from other experiments (bsz256 naming, deepseek, gemma, etc.)
- Options: (1) ask the author to re-upload; (2) link to the closest existing experiment logs; (3) remove these comparison links

### B. Images in the aoshen524 fork (3 images, 4 references)
- Location: `docs/start/multinode.rst:458,485,502,509`
- Broken links: `https://github.com/aoshen524/verl/blob/main/docs/start/{c7098b75...,4ddad743...,6e83c910...}.png?raw=true`
- Status: the entire `aoshen524/verl` fork repository has been deleted
- Options: (1) re-host the images in the verl repo or an official data repo; (2) retake the screenshots

### C. Author's personal site offline
- Location: `docs/start/ray_debug_tutorial.rst:9`
- Broken link: `https://aoshen524.github.io/`
- Status: the author's GitHub Pages site returns 404
- Options: (1) link to their GitHub profile; (2) remove the author link

### D. recipe/dapo branch references in the dapo.md FAQ (2 links)
- Location: `docs/algo/dapo.md:173,175`
- Broken link: `https://github.com/verl-project/verl-recipe/tree/main/dapo/recipe/dapo`
- Status: verl-recipe no longer has a `recipe/dapo` branch (remaining branches: main, wuxibin/*), and the directory was flattened; the FAQ entry itself is outdated
- Options: (1) rewrite or remove the FAQ entry; (2) restore the historical branch and update the link

### E. ubecc author's about page
- Location: `docs/workers/sglang_worker.rst:8`
- Broken link: `https://ubecc.github.io/about/`
- Status: the about page returns 404, but the site root `https://ubecc.github.io/` works
- Options: (1) link to the site root; (2) link to the GitHub profile

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
