### PR TITLE
[model] fix: import AutoModelForCausalLMWithValueHead from trl.experimental.ppo in utils/model.py

### DIFF
--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -608,7 +608,10 @@ def patch_valuehead_model(model) -> None:
     from types import MethodType
 
     from transformers import PreTrainedModel
-    from trl import AutoModelForCausalLMWithValueHead
+    try:
+        from trl.experimental.ppo import AutoModelForCausalLMWithValueHead  # type: ignore
+    except ImportError:
+        from trl import AutoModelForCausalLMWithValueHead  # type: ignore
 
     def tie_weights(self: "AutoModelForCausalLMWithValueHead") -> None:
         if isinstance(self.pretrained_model, PreTrainedModel):
@@ -654,7 +657,10 @@ def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_cod
 
     assert is_trl_available()
 
-    from trl import AutoModelForCausalLMWithValueHead
+    try:
+        from trl.experimental.ppo import AutoModelForCausalLMWithValueHead  # type: ignore
+    except ImportError:
+        from trl import AutoModelForCausalLMWithValueHead  # type: ignore
 
     if type(model_config) in AutoModelForVision2Seq._model_mapping.keys():
         module_class = AutoModelForVision2Seq


### PR DESCRIPTION
Fixes #5690

## Motivation

Fixes the remaining gap of [#5690](https://github.com/verl-project/verl/issues/5690)
(`verl cannot import name 'AutoModelForCausalLMWithValueHead' from 'trl'`).

PR [#6539](https://github.com/verl-project/verl/pull/6539) fixed the import for
`trl >= 0.29` only in `verl/models/transformers/monkey_patch.py`, but the same
top-level import still exists in **two places** in `verl/utils/model.py`, which
are hit when the FSDP engine loads a value-head critic
(`verl/workers/engine/fsdp/transformer_impl.py:272` -> `load_valuehead_model`):

- `verl/utils/model.py:611` (`patch_valuehead_model`)
- `verl/utils/model.py:657` (`load_valuehead_model`)

With `trl >= 0.29` (e.g. the latest `trl==1.12.0`, which removed the top-level
class in huggingface/trl#5044), PPO/RLHF training with a value-head critic on
the FSDP engine crashes with `ImportError`. This also blocks trl dependency
bumps (see closed dependabot PR #7478).

Verified on `trl==1.12.0`:

```
>>> from trl import AutoModelForCausalLMWithValueHead
ImportError: cannot import name 'AutoModelForCausalLMWithValueHead' from 'trl'
>>> from trl.experimental.ppo import AutoModelForCausalLMWithValueHead
OK  # trl.experimental.ppo.modeling_value_head.AutoModelForCausalLMWithValueHead
```

## Change

Mirror the existing pattern in `verl/models/transformers/monkey_patch.py:351-353`
at both sites in `verl/utils/model.py`:

```python
try:
    from trl.experimental.ppo import AutoModelForCausalLMWithValueHead  # type: ignore
except ImportError:
    from trl import AutoModelForCausalLMWithValueHead  # type: ignore
```

- `trl >= 0.29` (experimental path exists): uses `trl.experimental.ppo`.
- `trl < 0.29` (e.g. the fsdp/megatron extra pin `trl==0.27.0`): experimental
  import fails and falls back to the top-level import — unchanged behavior.

## Why this is not duplicating an existing PR

Checked `gh pr list --repo verl-project/verl --state open --search "trl"` and
`--search "valuehead OR value_head OR AutoModelForCausalLMWithValueHead"`:
no open PR touches `verl/utils/model.py` imports. #6539 (merged) covered only
`monkey_patch.py`; this PR completes the same fix for the FSDP valuehead path
that #6539 missed.

## Tests

- `pip install trl==1.12.0` in a scratch env; both import paths verified as
  above (top-level fails, `trl.experimental.ppo` works).
- Existing CPU unit tests unaffected:
  `python -m pytest tests/workers/rollout/test_chunked_prefill_batched_tokens_on_cpu.py -v` (6 passed)
  and the wider CPU suite (`cpu_tests_tf510.log`: 613 passed) were used as a
  regression baseline on this machine.
- (Optional, pending reviewer preference) a unit test asserting the import
  resolves under both trl layouts via `sys.modules` stubbing.

## AI assistance disclosure

Prepared with AI assistance (draft + verification). The submitting human has
reviewed the design, will review every changed line, and has run the
verification commands above before submitting.