### PR TITLE
[vllm] fix: raise max_num_batched_tokens when chunked prefill is disabled

### DIFF
--- a/tests/workers/rollout/test_chunked_prefill_batched_tokens_on_cpu.py
+++ b/tests/workers/rollout/test_chunked_prefill_batched_tokens_on_cpu.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for vllm max_num_batched_tokens vs max_model_len handling.
+
+Regression guard: with enable_chunked_prefill=False, vllm >= 0.24 raises
+``ValueError`` when ``max_num_batched_tokens < max_model_len``
+(``verify_max_model_len`` in ``vllm/config/scheduler.py``). verl's default
+``max_num_batched_tokens`` (8192) is below every modern model's
+``max_position_embeddings``, so the vLLM HTTP server raises
+``max_num_batched_tokens`` to ``max_model_len`` before engine creation.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.engine.arg_utils import AsyncEngineArgs
+
+from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer
+
+
+def _make_engine_args(
+    max_num_batched_tokens=8192, max_model_len=None, enable_chunked_prefill=False
+) -> AsyncEngineArgs:
+    return AsyncEngineArgs(
+        model="dummy",
+        max_model_len=max_model_len,
+        max_num_batched_tokens=max_num_batched_tokens,
+        enable_chunked_prefill=enable_chunked_prefill,
+        tensor_parallel_size=1,
+        worker_extension_cls="",
+    )
+
+
+def _hf_config(max_position_embeddings=131072):
+    return SimpleNamespace(max_position_embeddings=max_position_embeddings)
+
+
+class TestEnsureMaxNumBatchedTokensValid:
+    def test_chunked_off_raises_when_below_model_len(self):
+        """8192 < max_position_embeddings with chunked off -> raised to model len."""
+        args = _make_engine_args()
+        vLLMHttpServer._ensure_max_num_batched_tokens_valid(args, _hf_config())
+        assert args.max_num_batched_tokens == 131072
+
+    def test_chunked_off_respects_explicit_max_model_len(self):
+        """Explicit max_model_len (2048) already satisfies the check; unchanged."""
+        args = _make_engine_args(max_model_len=2048)
+        vLLMHttpServer._ensure_max_num_batched_tokens_valid(args, _hf_config())
+        assert args.max_num_batched_tokens == 8192
+
+    def test_chunked_off_raised_to_explicit_max_model_len(self):
+        """Explicit max_model_len (131072) becomes the raised target."""
+        args = _make_engine_args(max_num_batched_tokens=16384, max_model_len=131072)
+        vLLMHttpServer._ensure_max_num_batched_tokens_valid(args, _hf_config())
+        assert args.max_num_batched_tokens == 131072
+
+    def test_chunked_on_no_change(self):
+        """Chunked prefill enabled does not trigger the validation, no change."""
+        args = _make_engine_args(enable_chunked_prefill=True)
+        vLLMHttpServer._ensure_max_num_batched_tokens_valid(args, _hf_config())
+        assert args.max_num_batched_tokens == 8192
+
+    def test_skips_when_hf_config_unavailable(self):
+        """Cannot resolve max_model_len without hf_config; leave untouched."""
+        args = _make_engine_args()
+        vLLMHttpServer._ensure_max_num_batched_tokens_valid(args, None)
+        assert args.max_num_batched_tokens == 8192
+
+    def test_none_max_num_batched_tokens_skipped(self):
+        args = _make_engine_args(max_num_batched_tokens=None)
+        vLLMHttpServer._ensure_max_num_batched_tokens_valid(args, _hf_config())
+        assert args.max_num_batched_tokens is None

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -459,6 +459,7 @@ class vLLMHttpServer:
     async def run_server(self, args: argparse.Namespace):
         engine_args = AsyncEngineArgs.from_cli_args(args)
         usage_context = UsageContext.OPENAI_API_SERVER
+        self._ensure_max_num_batched_tokens_valid(engine_args, self.model_config.hf_config)
         vllm_config = engine_args.create_engine_config(usage_context=usage_context)
         vllm_config.parallel_config.data_parallel_master_port = self._dp_master_port
 
@@ -509,6 +510,42 @@ class vLLMHttpServer:
 
         self.engine = engine_client
         self._server_port, self._server_task = await run_uvicorn(app, args, self._server_address)
+
+    @staticmethod
+    def _ensure_max_num_batched_tokens_valid(engine_args: AsyncEngineArgs, hf_config=None) -> None:
+        """Keep ``max_num_batched_tokens`` >= ``max_model_len`` when chunked prefill is disabled.
+
+        vllm >= 0.24 rejects ``max_num_batched_tokens < max_model_len`` when
+        ``enable_chunked_prefill`` is False (see ``verify_max_model_len`` in
+        ``vllm/config/scheduler.py``). verl's default ``max_num_batched_tokens``
+        (8192) is below every modern model's ``max_position_embeddings``, so
+        honoring an explicit ``enable_chunked_prefill=False`` would crash at
+        startup. This raises ``max_num_batched_tokens`` to the effective
+        ``max_model_len`` (the scheduler's real batch limit under chunked-off)
+        instead.
+
+        Args:
+            engine_args: vLLM engine args (mutated in place when adjusted).
+            hf_config: HF config used to resolve ``max_model_len`` when it is
+                ``None`` (the model's ``max_position_embeddings``).
+        """
+        if engine_args.enable_chunked_prefill is not False or engine_args.max_num_batched_tokens is None:
+            return
+        if engine_args.max_model_len is None:
+            if hf_config is None:
+                return
+            eff_max_model_len = get_max_position_embeddings(hf_config)
+        else:
+            eff_max_model_len = engine_args.max_model_len
+        if engine_args.max_num_batched_tokens < eff_max_model_len:
+            logger.warning(
+                "max_num_batched_tokens (%d) < max_model_len (%d) with enable_chunked_prefill=False; "
+                "raising max_num_batched_tokens to max_model_len to satisfy vllm >= 0.24 validation. "
+                "Set actor_rollout_ref.rollout.max_num_batched_tokens explicitly to control this value.",
+                engine_args.max_num_batched_tokens,
+                eff_max_model_len,
+            )
+            engine_args.max_num_batched_tokens = eff_max_model_len
 
     async def run_headless(self, args: argparse.Namespace):
         """Run headless server in a separate thread."""


### PR DESCRIPTION
## Motivation

Fixes #7624. `enable_chunked_prefill=False` crashes vLLM startup on verl main
with the vllm 0.24 pin:

```
ValidationError: 1 validation error for SchedulerConfig
  Value error, max_num_batched_tokens (8192) is smaller than max_model_len (131072). ...
```

Root cause chain: #7508 made an explicit `False` for `Optional[bool]` engine
args actually reach the engine (previously it was silently dropped); vLLM >=
0.24 then rejects `max_num_batched_tokens < max_model_len` when chunked
prefill is disabled (`verify_max_model_len` in `vllm/config/scheduler.py`).
verl's default `max_num_batched_tokens` (8192) is below every modern model's
`max_position_embeddings` (e.g. 131072 for Llama-3.2-1B), so any official
example with `enable_chunked_prefill=False` (13 scripts under `examples/`)
aborts at rollout-engine startup. #7558/#7584 worked around this for the
Ascend NPU scripts by deleting the flag, but the GPU scripts (and users who
legitimately disable chunked prefill) remain broken.

## Change

In `verl/workers/rollout/vllm_rollout/vllm_async_server.py`, before
`create_engine_config`, raise `max_num_batched_tokens` to the effective
`max_model_len` (explicit value, or the model's `max_position_embeddings`
resolved via the existing `get_max_position_embeddings` helper) when chunked
prefill is explicitly disabled, with a warning. This matches vLLM's own error
guidance ("increase max_num_batched_tokens or decrease max_model_len") and is
a no-op in every other configuration:

- `enable_chunked_prefill` is not explicitly `False` -> unchanged;
- `max_num_batched_tokens is None` -> unchanged;
- `max_num_batched_tokens >= max_model_len` -> unchanged.

New CPU unit tests added: `tests/workers/rollout/test_chunked_prefill_batched_tokens_on_cpu.py`
(explicit/None max_model_len, chunked-on, unavailable hf_config, None tokens).

## Why this is not duplicating an existing PR

Checked `gh pr list --repo verl-project/verl --state open --search
"max_num_batched_tokens"` and `--search "chunked prefill"`; no open PR/issue
covers this (the only related merged PRs are #7508 which introduced the
regression, and #7558/#7584 which remove the flag from NPU scripts only).
This fix keeps the flag working for GPU users instead of dropping it.

## Tests

- `python -m pytest tests/workers/rollout/test_chunked_prefill_batched_tokens_on_cpu.py -v`
  -> 6 passed
- End-to-end on this machine (vllm 0.24.0, Llama-3.2-1B-Instruct):
  `AsyncEngineArgs(max_num_batched_tokens=8192, enable_chunked_prefill=False).create_engine_config()`
  raises `ValidationError` before the fix and succeeds after applying
  `_ensure_max_num_batched_tokens_valid` (max_num_batched_tokens 8192 -> 131072).
- 8-GPU GRPO smoke run (`enable_chunked_prefill=False`, Llama-3.2-1B, GSM8K):
  training progressed normally (14/233 steps, then externally interrupted);
  the same config crashed at vLLM startup before the fix.

## AI assistance disclosure

Prepared with AI assistance (draft + code + verification). The submitting
human reviewed every changed line and ran the tests listed above.
