### PR TITLE
[rollout] fix: DeepSeek continuous token builder cannot render tool appends

### DIFF
--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -226,6 +226,56 @@ class _Gemma4BoundaryTokenizer(_TemplateTokenizer):
         return rendered
 
 
+class _DeepSeekBoundaryTokenizer(_TemplateTokenizer):
+    name_or_path = "deepseek-ai/DeepSeek-V3.1"
+    unk_token_id = 0
+
+    def __init__(self):
+        self.eos_id = 1
+
+    def convert_tokens_to_ids(self, token):
+        if token == "<｜end▁of▁sentence｜>":
+            return self.eos_id
+        return self.unk_token_id
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        tools=None,
+        return_dict=False,
+        **kwargs,
+    ):
+        """Minimal DeepSeek-style renderer: tool calls are spliced in by string
+        concatenation like the real R1 / V3.1 / V3.2 templates (a mapping raises
+        TypeError there), and no generation prompt follows a tool message.
+        """
+        rendered = ""
+        last_was_tool = False
+        for message in messages:
+            role = message.get("role")
+            if role == "tool":
+                rendered += f"<tool_output_begin>{message.get('content', '')}<tool_output_end>"
+                last_was_tool = True
+                continue
+            last_was_tool = False
+            if role == "assistant" and message.get("tool_calls"):
+                calls = ""
+                for tool_call in message["tool_calls"]:
+                    function = tool_call["function"]
+                    calls += "<tool_call_begin>" + function["name"] + "<tool_sep>" + function["arguments"]
+                    calls += "<tool_call_end>"
+                rendered += "<assistant>" + message.get("content", "") + calls + "<eos>"
+            else:
+                rendered += f"<{role}>{message.get('content', '')}\n"
+        if add_generation_prompt and not last_was_tool:
+            rendered += "<assistant>"
+        if tokenize:
+            return self.encode(rendered, add_special_tokens=False)
+        return rendered
+
+
 class _MissingSpecialTokenTokenizer(_TemplateTokenizer):
     def convert_tokens_to_ids(self, token):
         return None
@@ -574,6 +624,47 @@ def test_gemma4_builder_formats_tool_response_by_position_with_warning(caplog):
     expected = '<|tool_response>response:lookup{value:<|"|>answer<|"|>}<tool_response|>'
     assert token_ids == [ord(char) for char in expected]
     assert "resolving a tool response name by position" in caplog.text
+
+
+def test_deepseek_builder_renders_tool_appends_through_string_concatenating_template():
+    tokenizer = _DeepSeekBoundaryTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="deepseek")
+    previous_messages = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_0", "type": "function", "function": {"name": "lookup", "arguments": {"q": "x"}}}
+            ],
+        },
+    ]
+    updated_messages = previous_messages + [{"role": "tool", "content": "answer", "tool_call_id": "call_0"}]
+
+    # The base synthetic tool call carries a mapping, which this template family cannot splice in.
+    with pytest.raises(TypeError):
+        ContinuousTokenBuilder(tokenizer).tokenize_non_assistant_incremental_messages(
+            previous_messages, updated_messages
+        )
+
+    assert isinstance(builder, DeepSeekContinuousTokenBuilder)
+    incremental = builder.tokenize_non_assistant_incremental_messages(previous_messages, updated_messages)
+
+    # Only the tool output: DeepSeek templates add no generation prompt after a tool message.
+    assert incremental == [ord(char) for char in "<tool_output_begin>answer<tool_output_end>"]
+
+
+def test_deepseek_builder_synthetic_tool_call_arguments_are_a_json_string():
+    builder = DeepSeekContinuousTokenBuilder(_DeepSeekBoundaryTokenizer())
+    tool_messages = [
+        {"role": "tool", "content": "first", "tool_call_id": "call_0"},
+        {"role": "tool", "content": "second", "tool_call_id": "call_1"},
+    ]
+
+    synthetic_assistant = builder._synthetic_assistant_for_tools(tool_messages)
+
+    assert [tool_call["id"] for tool_call in synthetic_assistant["tool_calls"]] == ["call_0", "call_1"]
+    assert all(tool_call["function"]["arguments"] == "{}" for tool_call in synthetic_assistant["tool_calls"])
 
 
 def test_gpt_oss_builder_formats_tool_responses_with_resolved_tool_name():

--- a/verl/utils/tokenizer/continuous_token.py
+++ b/verl/utils/tokenizer/continuous_token.py
@@ -771,6 +771,19 @@ class DeepSeekContinuousTokenBuilder(ContinuousTokenBuilder):
             return None
         return int(token_id)
 
+    def _synthetic_assistant_for_tools(
+        self,
+        tool_messages: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        # The R1 / V3.1 / V3.2 templates splice ``tool['function']['arguments']`` into
+        # the prompt by string concatenation, so a mapping raises TypeError there. The
+        # synthetic tool call only exists to be diffed away; carry its arguments as the
+        # JSON string those templates expect.
+        synthetic_assistant = super()._synthetic_assistant_for_tools(tool_messages)
+        for tool_call in synthetic_assistant["tool_calls"]:
+            tool_call["function"]["arguments"] = "{}"
+        return synthetic_assistant
+
     def _merge_non_assistant_token_ids(
         self, runtime_token_ids: list[int], appended_token_ids: list[int]
     ) -> MergeResult:


### PR DESCRIPTION
### What does this PR do?

`ContinuousTokenBuilder._tokenize_tool_group()` renders a tool group behind a synthetic assistant message whose tool calls carry `"arguments": {}`. The DeepSeek R1, V3.1 and V3.2 chat templates splice `tool['function']['arguments']` into the prompt by string concatenation, so with `DeepSeekContinuousTokenBuilder` every tool append raises `TypeError` on that concatenation. DeepSeek-V3 is the only one of the family that gets through, and only because its template renders `tool_calls` when `content is none`, which the synthetic message never is.

Found while checking #7628 on the DeepSeek family (https://github.com/verl-project/verl/pull/7628#issuecomment-5474456502). The fix is a one-method override: the DeepSeek builder carries the synthetic arguments as the JSON string `"{}"`. The message only exists to be diffed away, so the emitted tokens do not change. #7628 is what makes this sufficient: the history, with the harness's own dict `arguments` from `OpenAIFunctionCallSchema`, is no longer re-rendered on a tool append.

The base builder is left alone; Qwen-style templates run `arguments` through `tojson` and expect a mapping.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+deepseek+continuous+token
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

- `tests/utils/test_continuous_token_on_cpu.py`: 124 passed (122 existing + 2 new). The new DeepSeek-shaped fake template concatenates arguments like the real ones; on `main` the new test fails with the same `TypeError`.
- Real tokenizers (tokenizer files only, transformers 5.16.1), upstream `main` @3dab856 vs `main` with this patch, token ids from `tokenize_non_assistant_incremental_messages` on `tool_agent_loop`-shaped trajectories, 24 cases per row (system prompt on/off × 0 / 10 / 50 prior tool turns × 1 or 2 parallel calls × `enable_thinking` default / False):

| model | harness `arguments` | `main` | this PR |
|---|---|---|---|
| DeepSeek-V3 | dict, json | 24/24 render | 24/24, identical to `main` |
| DeepSeek-R1 | dict, json | 0/24 (`TypeError`) | 24/24 render |
| DeepSeek-V3.1 | dict, json | 0/24 | 24/24 |
| DeepSeek-V3.2-Exp | dict, json | 0/24 | 24/24 |
| Qwen2 / 2.5 / 3 / 3.5, MiniMax-M2, GLM-4.7, Gemma 4, gpt-oss, default builder | dict | – | 24/24 identical to `main` |

  With JSON-string arguments the naive full-history suffix diff is available as an independent reference: the fixed output matches it 24/24 on V3.1 and V3.2-Exp. On V3 and R1 it matches on the cases without prior tool turns; those two templates keep a conversation-global `is_output_first` flag that no bounded render can see, which is pre-existing and unchanged here.

  Script and raw output: https://github.com/ruiling-smartbear/verl-experiments/blob/main/generation_prompt_fold_experiment.md#the-fix-checked

### API and Usage Example

No API change.

### Design & Code Changes

- `DeepSeekContinuousTokenBuilder._synthetic_assistant_for_tools`: the base message with `arguments` replaced by `"{}"`.
- Tests: `_DeepSeekBoundaryTokenizer`, a minimal string-concatenating renderer with no generation prompt after a tool message; one test for the tool append through `create_continuous_token_builder(..., model_family="deepseek")` (and the base builder raising on the same template), one for the synthetic message itself.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] `ruff check` / `ruff format` pass on the touched files.
- [x] Docs: internal tokenizer utility, no user-facing change.
- [x] Unit tests in `tests/utils/test_continuous_token_on_cpu.py`, covered by the CPU unit-test workflow.
- [ ] CI request in `ci-request` once ready.