### PR TITLE
[megatron,worker] fix: offload actor parameters after disaggregated weight sync

### DIFF
--- a/tests/checkpoint_engine/test_global_steps_on_cpu.py
+++ b/tests/checkpoint_engine/test_global_steps_on_cpu.py
@@ -60,6 +60,7 @@ def test_actor_worker_passes_global_steps_to_checkpoint_engine_send():
     checkpoint_engine = _FakeCheckpointEngine()
     worker = ActorRolloutRefWorker.__new__(ActorRolloutRefWorker)
     worker.config = SimpleNamespace(
+        actor=SimpleNamespace(strategy="fsdp"),
         rollout=SimpleNamespace(
             checkpoint_engine=SimpleNamespace(backend="modelexpress"),
         ),

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -723,6 +723,14 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         assert "actor" in self.role, "save_checkpoint only support actor role"
         self.actor.save_checkpoint(local_path, hdfs_path, global_step, max_ckpt_to_keep)
 
+    def _offload_actor_after_weight_sync(self, metrics: dict | None) -> dict:
+        """Return Megatron actor parameters to CPU after checkpoint-engine weight sync."""
+        engine = self.actor.engine
+        if self.config.actor.strategy != "megatron" or not engine.is_param_offload_enabled:
+            return metrics or {}
+        engine.to("cpu", model=True, optimizer=False, grad=False)
+        return metrics or {}
+
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
     async def update_weights(self, global_steps: int = None, mode: str = "auto"):
         """Update weights from trainer to rollout.
@@ -759,10 +767,10 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 # the delta engine owns the sync state machine (seed vs steady,
                 # snapshot prime), so it drives the training engine itself.
                 metrics = await self.checkpoint_engine.send_weights(self.actor.engine, global_steps=global_steps)
-                return metrics or {}
+                return self._offload_actor_after_weight_sync(metrics)
             per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
             metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
-            return metrics or {}
+            return self._offload_actor_after_weight_sync(metrics)
 
         set_expandable_segments(False)
         aggressive_empty_cache(force_sync=True)


### PR DESCRIPTION


### What does this PR do?

This PR fixes Megatron actor parameters remaining on GPU after update_weights() in disaggregated mode with a non-naive checkpoint backend. It moves the parameters back to CPU after weight synchronization when parameter offloading is enabled. No API or configuration changes are introduced.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [megatron_update_query](https://github.com/verl-project/verl/pulls?q=megatron+offload+actor+weights+)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
