### PR TITLE
[rollout] fix: DeepSeek tool outputs after the first tool turn follow the template

### DIFF
--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 
 import pytest
@@ -269,6 +270,54 @@ class _DeepSeekBoundaryTokenizer(_TemplateTokenizer):
                 rendered += "<assistant>" + message.get("content", "") + calls + "<eos>"
             else:
                 rendered += f"<{role}>{message.get('content', '')}\n"
+        if add_generation_prompt and not last_was_tool:
+            rendered += "<assistant>"
+        if tokenize:
+            return self.encode(rendered, add_special_tokens=False)
+        return rendered
+
+
+class _DeepSeekOutputsBlockTokenizer(_DeepSeekBoundaryTokenizer):
+    name_or_path = "deepseek-ai/DeepSeek-V3"
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        tools=None,
+        return_dict=False,
+        **kwargs,
+    ):
+        """DeepSeek-V3 / R1 style tool outputs: one ``is_output_first`` flag for the whole
+        conversation, so only the first tool output opens an outputs block and later ones
+        start with a newline; a trailing tool message closes the block.
+        """
+        rendered = ""
+        last_was_tool = False
+        output_first = True
+        for message in messages:
+            role = message.get("role")
+            if role == "tool":
+                opener = "<tool_outputs_begin>" if output_first else "\n"
+                output_first = False
+                rendered += f"{opener}<tool_output_begin>{message.get('content', '')}<tool_output_end>"
+                last_was_tool = True
+                continue
+            if last_was_tool:
+                rendered += "<tool_outputs_end>"
+            last_was_tool = False
+            if role == "assistant" and message.get("tool_calls"):
+                calls = ""
+                for tool_call in message["tool_calls"]:
+                    function = tool_call["function"]
+                    calls += "<tool_call_begin>" + function["name"] + "<tool_sep>" + function["arguments"]
+                    calls += "<tool_call_end>"
+                rendered += "<assistant>" + message.get("content", "") + calls + "<eos>"
+            else:
+                rendered += f"<{role}>{message.get('content', '')}\n"
+        if last_was_tool:
+            rendered += "<tool_outputs_end>"
         if add_generation_prompt and not last_was_tool:
             rendered += "<assistant>"
         if tokenize:
@@ -665,6 +714,70 @@ def test_deepseek_builder_synthetic_tool_call_arguments_are_a_json_string():
 
     assert [tool_call["id"] for tool_call in synthetic_assistant["tool_calls"]] == ["call_0", "call_1"]
     assert all(tool_call["function"]["arguments"] == "{}" for tool_call in synthetic_assistant["tool_calls"])
+
+
+def _deepseek_tool_call_turn(call_id: str, arguments) -> dict:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": call_id, "type": "function", "function": {"name": "lookup", "arguments": arguments}}],
+    }
+
+
+def test_deepseek_builder_opens_the_outputs_block_on_the_first_tool_turn():
+    builder = create_continuous_token_builder(_DeepSeekOutputsBlockTokenizer(), model_family="deepseek")
+    previous_messages = [{"role": "user", "content": "question"}, _deepseek_tool_call_turn("call_0", {"q": "x"})]
+    updated_messages = previous_messages + [{"role": "tool", "content": "first", "tool_call_id": "call_0"}]
+
+    incremental = builder.tokenize_non_assistant_incremental_messages(previous_messages, updated_messages)
+
+    expected = "<tool_outputs_begin><tool_output_begin>first<tool_output_end><tool_outputs_end>"
+    assert incremental == [ord(char) for char in expected]
+
+
+def test_deepseek_builder_renders_later_tool_turns_like_the_full_conversation():
+    tokenizer = _DeepSeekOutputsBlockTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="deepseek")
+    previous_messages = [
+        {"role": "user", "content": "question"},
+        _deepseek_tool_call_turn("call_0", {"q": "x"}),
+        {"role": "tool", "content": "first", "tool_call_id": "call_0"},
+        _deepseek_tool_call_turn("call_1", {"q": "y"}),
+    ]
+    tool_messages = [
+        {"role": "tool", "content": "second", "tool_call_id": "call_1"},
+        {"role": "tool", "content": "third", "tool_call_id": "call_1"},
+    ]
+
+    incremental = builder.tokenize_non_assistant_incremental_messages(
+        previous_messages, previous_messages + tool_messages
+    )
+
+    # The conversation already holds a tool output, so the template is past its first
+    # outputs block: no <tool_outputs_begin>, a newline before each output instead.
+    expected = (
+        "\n<tool_output_begin>second<tool_output_end>\n<tool_output_begin>third<tool_output_end><tool_outputs_end>"
+    )
+    assert incremental == [ord(char) for char in expected]
+
+    # Same tokens the template produces for the whole conversation (rendered with the
+    # JSON-string arguments this template family can splice in).
+    def with_string_arguments(messages):
+        rendered = []
+        for message in messages:
+            message = dict(message)
+            if message.get("tool_calls"):
+                message["tool_calls"] = [
+                    {**call, "function": {**call["function"], "arguments": json.dumps(call["function"]["arguments"])}}
+                    for call in message["tool_calls"]
+                ]
+            rendered.append(message)
+        return rendered
+
+    full = tokenizer.apply_chat_template(with_string_arguments(previous_messages + tool_messages))
+    prefix = tokenizer.apply_chat_template(with_string_arguments(previous_messages), add_generation_prompt=False)
+    assert full[: len(prefix)] == prefix
+    assert incremental == full[len(prefix) :]
 
 
 def test_gpt_oss_builder_formats_tool_responses_with_resolved_tool_name():

--- a/verl/utils/tokenizer/continuous_token.py
+++ b/verl/utils/tokenizer/continuous_token.py
@@ -25,6 +25,7 @@ from .tokenizer import build_multimodal_processor_inputs, normalize_token_ids
 _SUPPORTED_APPEND_ROLES = frozenset({"tool", "user", "system"})
 _SYNTHETIC_SYSTEM_MESSAGE: dict[str, Any] = {"role": "system", "content": "continuous token synthetic system"}
 _SYNTHETIC_USER_MESSAGE: dict[str, Any] = {"role": "user", "content": "continuous token synthetic user"}
+_SYNTHETIC_TOOL_OUTPUT: str = "continuous token synthetic tool output"
 _ASSISTANT_REASONING_CONTENT: str = "reasoning"
 _DUMMY_TOOL_NAME = "continuous_token_tool"
 MergeKind = Literal["assistant", "non_assistant"]
@@ -821,6 +822,41 @@ class DeepSeekContinuousTokenBuilder(ContinuousTokenBuilder):
         for tool_call in synthetic_assistant["tool_calls"]:
             tool_call["function"]["arguments"] = "{}"
         return synthetic_assistant
+
+    def _tokenize_tool_group(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        previous_messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = False,
+    ) -> list[int]:
+        if not any(message.get("role") == "tool" for message in previous_messages):
+            return super()._tokenize_tool_group(
+                tool_messages,
+                previous_messages=previous_messages,
+                tools=tools,
+                add_generation_prompt=add_generation_prompt,
+            )
+        # The V3 / R1 templates keep one ``is_output_first`` flag for the whole
+        # conversation: the first tool output opens with <｜tool▁outputs▁begin｜>,
+        # every later one starts with a newline instead. Once the conversation has
+        # seen a tool output, render behind a prefix that already contains one tool
+        # exchange so the template is in the later-turn state for the appended group.
+        earlier_tool_message = {"role": "tool", "content": _SYNTHETIC_TOOL_OUTPUT}
+        synthetic_prefix = [
+            _SYNTHETIC_SYSTEM_MESSAGE,
+            _SYNTHETIC_USER_MESSAGE,
+            self._synthetic_assistant_for_tools([earlier_tool_message]),
+            earlier_tool_message,
+            self._synthetic_assistant_for_tools(tool_messages),
+        ]
+        return self.render_delta_token_id(
+            synthetic_prefix,
+            tool_messages,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+        )
 
     def _merge_non_assistant_token_ids(
         self, runtime_token_ids: list[int], appended_token_ids: list[int]


### PR DESCRIPTION
### What does this PR do?

The DeepSeek-V3 and R1 chat templates keep a single `is_output_first` flag for the whole conversation: the first tool output opens with `<｜tool▁outputs▁begin｜>`, every later one starts with a newline instead (R1: no newline). `DeepSeekContinuousTokenBuilder` renders every tool group behind the same three-message synthetic prefix, so from the second tool turn on it emits the first-turn form and drifts from what the template writes for the full conversation. Noticed while checking #7628 / #7630 (https://github.com/verl-project/verl/pull/7628#issuecomment-5474456502, last bullet).

Once `previous_messages` contain a tool message, the group is rendered behind a prefix that already holds one synthetic tool exchange, which puts the template in its later-turn state; the suffix diff then yields what the template would have written. The first tool turn is unchanged, and so are V3.1 / V3.2, whose templates have no such flag — the output is derived by rendering the template, not by hard-coding a form, so templates that re-open the block per turn (DeepSeek-R1-0528-Qwen3-8B does) keep re-opening it.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+deepseek+continuous+token
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

- `tests/utils/test_continuous_token_on_cpu.py`: 2 new CPU tests with a V3-style fake template (`is_output_first` for the whole conversation): the first tool turn opens the block, later turns render exactly the template's full-conversation suffix. On `main` the second test fails.
- Real tokenizers, upstream `main` (f97625b) vs `main` + this change, the same 24-case harness as #7630 (system prompt on/off × 0 / 10 / 50 prior tool turns × 1 or 2 parallel calls × `enable_thinking`), compared with the template's full-conversation render as the reference:

| model | this PR == full-history render | `main` == full-history render |
|---|---|---|
| DeepSeek-V3 | 24/24 | 8/24 (only the cases with no prior tool turn) |
| DeepSeek-R1 | 24/24 | 8/24 |
| DeepSeek-V3.1 | 24/24 | 24/24 |
| DeepSeek-V3.2-Exp | 24/24 | 24/24 |
| Qwen2 / 2.5 / 3 / 3.5, MiniMax-M2, GLM-4.7, Gemma 4, gpt-oss, default | unchanged, 24/24 identical to `main` | |

  Script and raw output: https://github.com/ruiling-smartbear/verl-experiments/blob/main/generation_prompt_fold_experiment.md#tokenizer-level-check-of-the-prefix-change

### API and Usage Example

No API change.

### Design & Code Changes

- `DeepSeekContinuousTokenBuilder._tokenize_tool_group`: base behaviour when no tool message precedes the group; otherwise a five-message synthetic prefix (system, user, tool-call turn, tool output, tool-call turn) in front of the appended group.
- `_SYNTHETIC_TOOL_OUTPUT` constant for the earlier synthetic exchange.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] `ruff check` / `ruff format` pass on the touched files.
- [x] Docs: internal tokenizer utility, no user-facing change.
- [x] Unit tests in `tests/utils/test_continuous_token_on_cpu.py`, covered by the CPU unit-test workflow.
- [ ] CI request in `ci-request` once ready.