### PR TITLE
[rollout] fix: fall back to a default Continuous Token builder when a required token is missing

### DIFF
--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 
 import pytest
@@ -20,6 +21,7 @@ from verl.utils.tokenizer.continuous_token import (
     ContinuousTokenBuilder,
     DeepSeekContinuousTokenBuilder,
     DeepSeekVL2ContinuousTokenBuilder,
+    FallbackContinuousTokenBuilder,
     Gemma4ContinuousTokenBuilder,
     GLM46VContinuousTokenBuilder,
     GLMContinuousTokenBuilder,
@@ -276,6 +278,26 @@ class _DeepSeekBoundaryTokenizer(_TemplateTokenizer):
         return rendered
 
 
+class _DistillTokenizer(_DeepSeekBoundaryTokenizer):
+    """DeepSeek-R1 distill of Qwen: the root config keeps a Qwen ``model_type`` but the
+    checkpoint ships DeepSeek's tokenizer and chat template, in which ``<|im_end|>``
+    does not exist (renamed to ``<｜end▁of▁sentence｜>``)."""
+
+    name_or_path = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
+    unk_token_id = None
+
+    def __init__(self):
+        super().__init__()
+        self.assistant_id = 2
+
+    def convert_tokens_to_ids(self, token):
+        if token == "<｜end▁of▁sentence｜>":
+            return self.eos_id
+        if token == "<｜Assistant｜>":
+            return self.assistant_id
+        return None
+
+
 class _MissingSpecialTokenTokenizer(_TemplateTokenizer):
     def convert_tokens_to_ids(self, token):
         return None
@@ -468,6 +490,38 @@ def test_unknown_model_with_non_multimodal_processor_uses_default_text_builder(c
     assert isinstance(builder, ContinuousTokenBuilder)
     assert "unknown_text_model" in caplog.text
     assert "default" in caplog.text
+
+
+def test_auto_family_falls_back_to_default_builder_when_a_required_token_is_missing(caplog):
+    tokenizer = _DistillTokenizer()
+    with caplog.at_level(logging.WARNING, logger="verl.utils.tokenizer.continuous_token_wiring"):
+        builder = create_continuous_token_builder(tokenizer, hf_model_type="qwen2")
+
+    assert type(builder) is FallbackContinuousTokenBuilder
+    assert "QwenContinuousTokenBuilder" in caplog.text
+    assert "<|im_end|>" in caplog.text
+    assert "falling back to the default builder" in caplog.text
+
+    # The fallback must also render the distill's DeepSeek-style template: tool
+    # appends splice the synthetic call's arguments in by string concatenation.
+    previous_messages = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_0", "type": "function", "function": {"name": "lookup", "arguments": {"q": "x"}}}
+            ],
+        },
+    ]
+    updated_messages = previous_messages + [{"role": "tool", "content": "answer", "tool_call_id": "call_0"}]
+    incremental = builder.tokenize_non_assistant_incremental_messages(previous_messages, updated_messages)
+    assert incremental == [ord(char) for char in "<tool_output_begin>answer<tool_output_end>"]
+
+
+def test_explicit_family_does_not_fall_back_when_a_required_token_is_missing():
+    with pytest.raises(ValueError, match="required token '<\\|im_end\\|>'"):
+        create_continuous_token_builder(_DistillTokenizer(), model_family="qwen")
 
 
 def test_default_builder_creation_forwards_kwargs():
@@ -665,6 +719,23 @@ def test_deepseek_builder_synthetic_tool_call_arguments_are_a_json_string():
 
     assert [tool_call["id"] for tool_call in synthetic_assistant["tool_calls"]] == ["call_0", "call_1"]
     assert all(tool_call["function"]["arguments"] == "{}" for tool_call in synthetic_assistant["tool_calls"])
+
+
+def test_fallback_builder_synthetic_tool_call_arguments_are_a_json_string():
+    synthetic_assistant = FallbackContinuousTokenBuilder(_TemplateTokenizer())._synthetic_assistant_for_tools(
+        [{"role": "tool", "content": "out", "tool_call_id": "call_0", "name": "lookup"}]
+    )
+
+    arguments = synthetic_assistant["tool_calls"][0]["function"]["arguments"]
+    assert arguments == "{}"
+    assert json.loads(arguments) == {}
+
+    # The base builder keeps the mapping form: registered templates like Qwen3.5,
+    # MiniMax-M2 and GLM-4.7 render the synthetic arguments with ``.items()``.
+    base_assistant = ContinuousTokenBuilder(_TemplateTokenizer())._synthetic_assistant_for_tools(
+        [{"role": "tool", "content": "out", "tool_call_id": "call_0", "name": "lookup"}]
+    )
+    assert base_assistant["tool_calls"][0]["function"]["arguments"] == {}
 
 
 def test_gpt_oss_builder_formats_tool_responses_with_resolved_tool_name():

--- a/verl/utils/tokenizer/continuous_token.py
+++ b/verl/utils/tokenizer/continuous_token.py
@@ -672,10 +672,19 @@ class Gemma4ContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
+class MissingRequiredTokenError(ValueError):
+    """A special token a model-specific builder depends on is absent from the tokenizer.
+
+    Raised at builder construction. Checkpoints that pair a registered architecture
+    with another vendor's tokenizer hit this — the DeepSeek-R1 distills keep Qwen
+    ``model_type`` values but rename ``<|im_end|>`` away.
+    """
+
+
 def require_token_id(tokenizer: Any, token: str) -> int:
     token_id = tokenizer.convert_tokens_to_ids(token)
     if token_id is None:
-        raise ValueError(f"Tokenizer does not define required token {token!r}")
+        raise MissingRequiredTokenError(f"Tokenizer does not define required token {token!r}")
     if isinstance(token_id, list):
         if len(token_id) != 1:
             raise ValueError(f"Tokenizer returned multiple ids for required token {token!r}: {token_id!r}")
@@ -832,6 +841,27 @@ class DeepSeekContinuousTokenBuilder(ContinuousTokenBuilder):
             appended_token_count=len(appended_token_ids),
             kind="non_assistant",
         )
+
+
+class FallbackContinuousTokenBuilder(ContinuousTokenBuilder):
+    """Default-builder fallback for checkpoints whose inferred builder cannot construct.
+
+    The base class carries the synthetic tool-call arguments as a mapping because
+    registered templates like Qwen3.5, MiniMax-M2 and GLM-4.7 render them with
+    ``.items()``. The checkpoints known to need this fallback (the DeepSeek-R1
+    distills of Qwen) instead splice ``function['arguments']`` into the prompt by
+    string concatenation, so this subclass carries the JSON string form, as
+    ``DeepSeekContinuousTokenBuilder`` does (#7630).
+    """
+
+    def _synthetic_assistant_for_tools(
+        self,
+        tool_messages: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        synthetic_assistant = super()._synthetic_assistant_for_tools(tool_messages)
+        for tool_call in synthetic_assistant["tool_calls"]:
+            tool_call["function"]["arguments"] = "{}"
+        return synthetic_assistant
 
 
 # =============================================================================

--- a/verl/utils/tokenizer/continuous_token_wiring.py
+++ b/verl/utils/tokenizer/continuous_token_wiring.py
@@ -24,6 +24,7 @@ from .continuous_token import (
     ContinuousTokenBuilder,
     DeepSeekContinuousTokenBuilder,
     DeepSeekVL2ContinuousTokenBuilder,
+    FallbackContinuousTokenBuilder,
     Gemma4ContinuousTokenBuilder,
     Gemma4VLContinuousTokenBuilder,
     GLM46VContinuousTokenBuilder,
@@ -32,6 +33,7 @@ from .continuous_token import (
     KimiVLContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
     MiniMaxVLContinuousTokenBuilder,
+    MissingRequiredTokenError,
     QwenContinuousTokenBuilder,
     QwenVLContinuousTokenBuilder,
     VLContinuousTokenBuilder,
@@ -307,7 +309,26 @@ def create_continuous_token_builder(
             f"Ensure the processor is loaded for vision-language models."
         )
     logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
-    return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+    try:
+        return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+    except MissingRequiredTokenError as exc:
+        requested_family = _normalize_model_family(model_family)
+        if requested_family != ContinuousTokenModelFamily.AUTO or builder_cls is ContinuousTokenBuilder:
+            raise
+        # The inferred builder cannot work with this tokenizer: the checkpoint pairs a
+        # registered architecture with another vendor's tokenizer (the DeepSeek-R1
+        # distills keep Qwen model_type values but rename ``<|im_end|>`` away). Give
+        # such checkpoints the treatment an unregistered model_type already gets,
+        # through the fallback subclass whose synthetic tool-call arguments fit
+        # their string-concatenating templates.
+        logger.warning(
+            "%s inferred from config.json model_type=%r cannot be constructed (%s); "
+            "falling back to the default builder (FallbackContinuousTokenBuilder).",
+            builder_cls.__name__,
+            _normalize_hf_model_type(hf_model_type),
+            exc,
+        )
+        return FallbackContinuousTokenBuilder(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
 
 
 def _is_multimodal_processor(processor: Any | None) -> bool:


### PR DESCRIPTION
### What does this PR do?

Fixes #7637: the DeepSeek-R1 distills keep Qwen `model_type` values (`qwen2` / `qwen3`) but ship DeepSeek's tokenizer, in which `<|im_end|>` is renamed to `<｜end▁of▁sentence｜>`. Since #6804 the builder family is an exact `model_type` lookup, so `QwenContinuousTokenBuilder.__init__` raises `Tokenizer does not define required token '<|im_end|>'` in `AgentLoopBase.__init__` before any rollout starts.

With `auto` inference, a builder whose constructor raises for a missing required token now falls back to the default behavior with a warning — the treatment an unregistered `model_type` already gets. The fallback is a dedicated `FallbackContinuousTokenBuilder` that carries the synthetic tool-call arguments as the JSON string form of #7630, because these checkpoints' templates splice `function['arguments']` in by string concatenation. The string form cannot go into the base class: Qwen3.5 / MiniMax-M2 / GLM-4.7 templates render the synthetic arguments as a mapping (`.items()`), which the harness below confirms, so the base class keeps the mapping form and registered families are untouched. An explicitly requested family still raises, and `require_token_id` raises `MissingRequiredTokenError` (a `ValueError` subclass) for the token-absent case so the factory catches exactly that.

Alternative to #7639, which routes these checkpoints to the DeepSeek builder from the tokenizer's own special tokens instead.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+distill+continuous+token
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

- `tests/utils/test_continuous_token_on_cpu.py`: the factory falls back to `FallbackContinuousTokenBuilder` for a distill-style tokenizer and renders its concatenating template; an explicit family still raises; the fallback's synthetic arguments are a JSON string while the base builder keeps the mapping form. On `main` the first of these fails at construction.
- Real tokenizers on upstream `main` (9c76436) vs `main` + this change:
  - the 13-row × 24-case tool-append harness from #7630 / #7636 (Qwen2 / 2.5 / 3 / 3.5, MiniMax-M2, GLM-4.7, Gemma 4, gpt-oss, DeepSeek-V3 / R1 / V3.1 / V3.2-Exp, default): every row byte-identical to `main`. The same harness is what rules out the base-class variant: with string arguments in the base class instead, the Qwen3.5-9B, MiniMax-M2 and GLM-4.7 rows fail all 24 cases (`'str object' has no attribute 'items'`);
  - `create_continuous_token_builder` on the three broken distills: raises on `main`, returns the fallback builder with this change, and the first tool turn matches the template's full-conversation render for all of them (DeepSeek-R1-0528-Qwen3-8B on every turn; the older distills' later turns keep the known `is_output_first` gap tracked in #7636);
  - Qwen3-8B, Qwen2.5-7B-Instruct, DeepSeek-V3.1 and DeepSeek-R1-Distill-Llama-8B select the same builders as `main`.

  Script and raw output: https://github.com/ruiling-smartbear/verl-experiments/blob/main/verl_distill_fix_check_results.txt

### API and Usage Example

No API change.

### Design & Code Changes

- `continuous_token.py`: `MissingRequiredTokenError`; `FallbackContinuousTokenBuilder` (default builder + JSON-string synthetic tool-call arguments).
- `continuous_token_wiring.py`: `create_continuous_token_builder` catches `MissingRequiredTokenError` on the text path and falls back to `FallbackContinuousTokenBuilder` with a warning, only for `auto`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] `ruff check` / `ruff format` pass on the touched files.
- [x] Docs: internal tokenizer utility, no user-facing change.
- [x] Unit tests in `tests/utils/test_continuous_token_on_cpu.py`, covered by the CPU unit-test workflow.
- [ ] CI request in `ci-request` once ready.
