### PR TITLE
[rollout] fix: resolve the Continuous Token family from tokenizer special tokens for the DeepSeek-R1 distills

### DIFF
--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -33,6 +33,7 @@ from verl.utils.tokenizer.continuous_token import (
 from verl.utils.tokenizer.continuous_token_wiring import (
     CONTINUOUS_TOKEN_BUILDER_FAMILIES,
     ContinuousTokenModelFamily,
+    _family_from_tokenizer_special_tokens,
     create_continuous_token_builder,
     get_continuous_token_builder_class,
     infer_continuous_token_model_family,
@@ -276,6 +277,26 @@ class _DeepSeekBoundaryTokenizer(_TemplateTokenizer):
         return rendered
 
 
+class _DistillTokenizer(_DeepSeekBoundaryTokenizer):
+    """DeepSeek-R1 distill of Qwen: the root config keeps a Qwen ``model_type`` but the
+    checkpoint ships DeepSeek's tokenizer and chat template, in which ``<|im_end|>``
+    does not exist (renamed to ``<｜end▁of▁sentence｜>``)."""
+
+    name_or_path = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
+    unk_token_id = None
+
+    def __init__(self):
+        super().__init__()
+        self.assistant_id = 2
+
+    def convert_tokens_to_ids(self, token):
+        if token == "<｜end▁of▁sentence｜>":
+            return self.eos_id
+        if token == "<｜Assistant｜>":
+            return self.assistant_id
+        return None
+
+
 class _MissingSpecialTokenTokenizer(_TemplateTokenizer):
     def convert_tokens_to_ids(self, token):
         return None
@@ -468,6 +489,48 @@ def test_unknown_model_with_non_multimodal_processor_uses_default_text_builder(c
     assert isinstance(builder, ContinuousTokenBuilder)
     assert "unknown_text_model" in caplog.text
     assert "default" in caplog.text
+
+
+def test_auto_family_resolves_deepseek_from_tokenizer_when_a_required_token_is_missing(caplog):
+    tokenizer = _DistillTokenizer()
+    with caplog.at_level(logging.WARNING, logger="verl.utils.tokenizer.continuous_token_wiring"):
+        builder = create_continuous_token_builder(tokenizer, hf_model_type="qwen2")
+
+    assert type(builder) is DeepSeekContinuousTokenBuilder
+    assert "QwenContinuousTokenBuilder" in caplog.text
+    assert "<|im_end|>" in caplog.text
+    assert "DeepSeekContinuousTokenBuilder" in caplog.text
+
+    # The DeepSeek builder renders the distill's concatenating template: tool appends
+    # splice the synthetic call's arguments in by string concatenation.
+    previous_messages = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_0", "type": "function", "function": {"name": "lookup", "arguments": {"q": "x"}}}
+            ],
+        },
+    ]
+    updated_messages = previous_messages + [{"role": "tool", "content": "answer", "tool_call_id": "call_0"}]
+    incremental = builder.tokenize_non_assistant_incremental_messages(previous_messages, updated_messages)
+    assert incremental == [ord(char) for char in "<tool_output_begin>answer<tool_output_end>"]
+
+
+def test_tokenizer_special_token_key_requires_every_deepseek_marker():
+    # ``<｜end▁of▁sentence｜>`` alone (defined on this fake, ``<｜Assistant｜>`` resolves
+    # to unk) must not identify the family, and the original construction error surfaces.
+    assert _family_from_tokenizer_special_tokens(_DeepSeekBoundaryTokenizer()) is None
+    assert _family_from_tokenizer_special_tokens(_DistillTokenizer()) is ContinuousTokenModelFamily.DEEPSEEK
+
+    with pytest.raises(ValueError, match="required token '<\\|im_end\\|>'"):
+        create_continuous_token_builder(_MissingSpecialTokenTokenizer(), hf_model_type="qwen2")
+
+
+def test_explicit_family_does_not_fall_back_when_a_required_token_is_missing():
+    with pytest.raises(ValueError, match="required token '<\\|im_end\\|>'"):
+        create_continuous_token_builder(_DistillTokenizer(), model_family="qwen")
 
 
 def test_default_builder_creation_forwards_kwargs():

--- a/verl/utils/tokenizer/continuous_token.py
+++ b/verl/utils/tokenizer/continuous_token.py
@@ -672,10 +672,19 @@ class Gemma4ContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
+class MissingRequiredTokenError(ValueError):
+    """A special token a model-specific builder depends on is absent from the tokenizer.
+
+    Raised at builder construction. Checkpoints that pair a registered architecture
+    with another vendor's tokenizer hit this — the DeepSeek-R1 distills keep Qwen
+    ``model_type`` values but rename ``<|im_end|>`` away.
+    """
+
+
 def require_token_id(tokenizer: Any, token: str) -> int:
     token_id = tokenizer.convert_tokens_to_ids(token)
     if token_id is None:
-        raise ValueError(f"Tokenizer does not define required token {token!r}")
+        raise MissingRequiredTokenError(f"Tokenizer does not define required token {token!r}")
     if isinstance(token_id, list):
         if len(token_id) != 1:
             raise ValueError(f"Tokenizer returned multiple ids for required token {token!r}: {token_id!r}")

--- a/verl/utils/tokenizer/continuous_token_wiring.py
+++ b/verl/utils/tokenizer/continuous_token_wiring.py
@@ -32,6 +32,7 @@ from .continuous_token import (
     KimiVLContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
     MiniMaxVLContinuousTokenBuilder,
+    MissingRequiredTokenError,
     QwenContinuousTokenBuilder,
     QwenVLContinuousTokenBuilder,
     VLContinuousTokenBuilder,
@@ -307,7 +308,61 @@ def create_continuous_token_builder(
             f"Ensure the processor is loaded for vision-language models."
         )
     logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
-    return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+    try:
+        return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+    except MissingRequiredTokenError as exc:
+        if _normalize_model_family(model_family) != ContinuousTokenModelFamily.AUTO:
+            raise
+        # The inferred builder cannot work with this tokenizer: the checkpoint pairs a
+        # registered architecture with another vendor's tokenizer. Fall back to an exact
+        # special-token lookup on the tokenizer itself, which identifies such
+        # checkpoints (the DeepSeek-R1 distills keep Qwen model_type values but ship
+        # DeepSeek's tokenizer and chat template).
+        token_family = _family_from_tokenizer_special_tokens(tokenizer)
+        if token_family is None:
+            raise
+        token_builder_cls = get_continuous_token_builder_class(token_family)
+        logger.warning(
+            "%s inferred from config.json model_type=%r cannot be constructed (%s); "
+            "the tokenizer's special tokens exactly match family %s, using %s instead.",
+            builder_cls.__name__,
+            _normalize_hf_model_type(hf_model_type),
+            exc,
+            token_family,
+            token_builder_cls.__name__,
+        )
+        return token_builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+
+
+# The DeepSeek chat lineage renames ChatML's ``<|im_end|>`` away and defines these
+# role/eos markers instead. Reusing the builder's own constants keeps the key aligned
+# with what DeepSeekContinuousTokenBuilder validates at construction.
+_DEEPSEEK_TOKENIZER_KEY_TOKENS = (
+    DeepSeekContinuousTokenBuilder._EOS_TOKEN,
+    DeepSeekContinuousTokenBuilder._ASSISTANT_TOKEN,
+)
+_CHATML_IM_END_TOKEN = "<|im_end|>"
+
+
+def _family_from_tokenizer_special_tokens(tokenizer: Any) -> ContinuousTokenModelFamily | None:
+    """Exact special-token key for tokenizers that identify a family themselves.
+
+    Only consulted when the builder inferred from ``model_type`` cannot be
+    constructed. Matching is exact on token presence; nothing is guessed from
+    repository or tokenizer names.
+    """
+    if all(
+        _tokenizer_defines_token(tokenizer, token) for token in _DEEPSEEK_TOKENIZER_KEY_TOKENS
+    ) and not _tokenizer_defines_token(tokenizer, _CHATML_IM_END_TOKEN):
+        return ContinuousTokenModelFamily.DEEPSEEK
+    return None
+
+
+def _tokenizer_defines_token(tokenizer: Any, token: str) -> bool:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None:
+        return False
+    return token_id != getattr(tokenizer, "unk_token_id", None)
 
 
 def _is_multimodal_processor(processor: Any | None) -> bool:


### PR DESCRIPTION
### What does this PR do?

Fixes #7637: the DeepSeek-R1 distills keep Qwen `model_type` values (`qwen2` / `qwen3`) but ship DeepSeek's tokenizer, in which `<|im_end|>` is renamed to `<｜end▁of▁sentence｜>`. Since #6804 the builder family is an exact `model_type` lookup, so `QwenContinuousTokenBuilder.__init__` raises `Tokenizer does not define required token '<|im_end|>'` in `AgentLoopBase.__init__` before any rollout starts.

When the builder inferred with `auto` cannot be constructed because a required token is missing, the factory now consults an exact special-token key on the tokenizer itself: `<｜end▁of▁sentence｜>` and `<｜Assistant｜>` defined and `<|im_end|>` not defined selects the DeepSeek builder, so #7630 (and #7636 once merged) apply to these checkpoints directly. Any other tokenizer re-raises, an explicitly requested family still raises, and nothing is guessed from repository or tokenizer names — matching stays exact, in the spirit of #6804. `require_token_id` raises `MissingRequiredTokenError` (a `ValueError` subclass) for the token-absent case so the factory catches exactly that.

Alternative to #7638, which falls back to the default builder instead.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+distill+continuous+token
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

- `tests/utils/test_continuous_token_on_cpu.py`: the factory resolves the DeepSeek builder for a distill-style tokenizer and renders its concatenating template; the key requires every marker (a tokenizer with fewer re-raises the original error); an explicit family still raises. On `main` the first of these fails at construction.
- Real tokenizers on upstream `main` (9c76436) vs `main` + this change:
  - the 13-row × 24-case tool-append harness from #7630 / #7636 (Qwen2 / 2.5 / 3 / 3.5, MiniMax-M2, GLM-4.7, Gemma 4, gpt-oss, DeepSeek-V3 / R1 / V3.1 / V3.2-Exp, default): every row byte-identical to `main`;
  - `create_continuous_token_builder` on the three broken distills: raises on `main`, returns `DeepSeekContinuousTokenBuilder` with this change, and the first tool turn matches the template's full-conversation render for all of them (DeepSeek-R1-0528-Qwen3-8B on every turn; the older distills' later turns keep the known `is_output_first` gap tracked in #7636);
  - the special-token key fires for exactly the three broken distills: Qwen3-8B / Qwen2.5-7B-Instruct define `<|im_end|>`, DeepSeek-V3.1 / R1 construct from `model_type` before the key is consulted, DeepSeek-R1-Distill-Llama-8B keeps the default builder (`llama` is unregistered, so construction never fails).

  Script and raw output: https://github.com/ruiling-smartbear/verl-experiments/blob/main/verl_distill_fix_check_results.txt

### API and Usage Example

No API change.

### Design & Code Changes

- `continuous_token.py`: `MissingRequiredTokenError`.
- `continuous_token_wiring.py`: `_family_from_tokenizer_special_tokens` (key tokens reuse `DeepSeekContinuousTokenBuilder`'s own constants); `create_continuous_token_builder` consults it only after a `MissingRequiredTokenError` under `auto`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] `ruff check` / `ruff format` pass on the touched files.
- [x] Docs: internal tokenizer utility, no user-facing change.
- [x] Unit tests in `tests/utils/test_continuous_token_on_cpu.py`, covered by the CPU unit-test workflow.
- [ ] CI request in `ci-request` once ready.
