### PR TITLE
[rollout] feat: explicit Continuous Token model_family override with an actionable construction error

### DIFF
--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -276,6 +276,26 @@ class _DeepSeekBoundaryTokenizer(_TemplateTokenizer):
         return rendered
 
 
+class _DistillTokenizer(_DeepSeekBoundaryTokenizer):
+    """DeepSeek-R1 distill of Qwen: the root config keeps a Qwen ``model_type`` but the
+    checkpoint ships DeepSeek's tokenizer and chat template, in which ``<|im_end|>``
+    does not exist (renamed to ``<｜end▁of▁sentence｜>``)."""
+
+    name_or_path = "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"
+    unk_token_id = None
+
+    def __init__(self):
+        super().__init__()
+        self.assistant_id = 2
+
+    def convert_tokens_to_ids(self, token):
+        if token == "<｜end▁of▁sentence｜>":
+            return self.eos_id
+        if token == "<｜Assistant｜>":
+            return self.assistant_id
+        return None
+
+
 class _MissingSpecialTokenTokenizer(_TemplateTokenizer):
     def convert_tokens_to_ids(self, token):
         return None
@@ -468,6 +488,48 @@ def test_unknown_model_with_non_multimodal_processor_uses_default_text_builder(c
     assert isinstance(builder, ContinuousTokenBuilder)
     assert "unknown_text_model" in caplog.text
     assert "default" in caplog.text
+
+
+def test_auto_family_construction_error_points_at_the_model_family_override():
+    with pytest.raises(ValueError) as excinfo:
+        create_continuous_token_builder(_DistillTokenizer(), hf_model_type="qwen2")
+
+    message = str(excinfo.value)
+    assert "required token '<|im_end|>'" in message
+    assert "data.continuous_token.model_family" in message
+    assert "deepseek" in message
+
+
+def test_explicit_model_family_override_selects_the_matching_builder():
+    tokenizer = _DistillTokenizer()
+    builder = create_continuous_token_builder(tokenizer, model_family="deepseek", hf_model_type="qwen2")
+
+    assert type(builder) is DeepSeekContinuousTokenBuilder
+
+    # The selected builder renders the distill's DeepSeek-style template: tool appends
+    # splice the synthetic call's arguments in by string concatenation.
+    previous_messages = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "call_0", "type": "function", "function": {"name": "lookup", "arguments": {"q": "x"}}}
+            ],
+        },
+    ]
+    updated_messages = previous_messages + [{"role": "tool", "content": "answer", "tool_call_id": "call_0"}]
+    incremental = builder.tokenize_non_assistant_incremental_messages(previous_messages, updated_messages)
+    assert incremental == [ord(char) for char in "<tool_output_begin>answer<tool_output_end>"]
+
+
+def test_explicit_family_that_cannot_construct_raises_the_original_error():
+    with pytest.raises(ValueError) as excinfo:
+        create_continuous_token_builder(_DistillTokenizer(), model_family="qwen")
+
+    message = str(excinfo.value)
+    assert "required token '<|im_end|>'" in message
+    assert "model_family" not in message
 
 
 def test_default_builder_creation_forwards_kwargs():

--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -515,10 +515,18 @@ def test_auto_family_construction_error_does_not_assume_deepseek():
     assert "GLMContinuousTokenBuilder" in message
     assert "required token '<|observation|>'" in message
     assert "data.continuous_token.model_family" in message
-    assert "deepseek" not in message
-    # Suggestions are the families that actually construct with this tokenizer, with
-    # the catch-all last rather than presented as a match.
-    assert message.rstrip(".").endswith("default")
+    # No family is recommended without positive evidence. Constructing is not evidence:
+    # the builders that validate nothing accept any tokenizer, so a "these construct"
+    # list would name families nothing supports. The message gives the criterion and
+    # the menu instead -- deepseek appears only as one entry of that menu.
+    assert "model_family=deepseek" not in message
+    assert "match family" not in message
+    assert "do not identify a family" in message
+    assert "chat template" in message
+    # A text run must not be offered VL families; they raise without a processor.
+    assert "qwen3" in message
+    assert "qwenvl" not in message
+    assert "kimivl" not in message
 
 
 def test_explicit_model_family_override_selects_the_matching_builder():

--- a/tests/utils/test_continuous_token_on_cpu.py
+++ b/tests/utils/test_continuous_token_on_cpu.py
@@ -497,7 +497,28 @@ def test_auto_family_construction_error_points_at_the_model_family_override():
     message = str(excinfo.value)
     assert "required token '<|im_end|>'" in message
     assert "data.continuous_token.model_family" in message
-    assert "deepseek" in message
+    # Named because this tokenizer's special tokens identify the family, not because
+    # the distills are assumed to be the only checkpoints that reach this branch.
+    assert "match family 'deepseek'" in message
+    assert "model_family=deepseek" in message
+
+
+def test_auto_family_construction_error_does_not_assume_deepseek():
+    """Every model-specific builder validates special tokens, so any registered
+    architecture can fail construction. A GLM checkpoint must not be told to set
+    ``deepseek``, which would fail the same way.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        create_continuous_token_builder(_MissingSpecialTokenTokenizer(), hf_model_type="glm4_moe")
+
+    message = str(excinfo.value)
+    assert "GLMContinuousTokenBuilder" in message
+    assert "required token '<|observation|>'" in message
+    assert "data.continuous_token.model_family" in message
+    assert "deepseek" not in message
+    # Suggestions are the families that actually construct with this tokenizer, with
+    # the catch-all last rather than presented as a match.
+    assert message.rstrip(".").endswith("default")
 
 
 def test_explicit_model_family_override_selects_the_matching_builder():

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -238,12 +238,17 @@ class AgentLoopBase(ABC):
         self.data_config = data_config.config
         self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
         self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
+        continuous_token_config = self.data_config.get("continuous_token", None) or {}
         # Continuous Token is the only rollout tokenization path for agent loops.
         # The model family (boundary handling) is inferred by exact lookup of the
         # root Hugging Face config's model_type. Unrecognized models use the
         # default builder (or default VL builder with a multimodal processor).
+        # ``data.continuous_token.model_family`` overrides the inference for
+        # checkpoints whose chat template does not match their architecture
+        # (the DeepSeek-R1 distills of Qwen need ``deepseek``).
         self.continuous_token_builder = create_continuous_token_builder(
             self.tokenizer,
+            model_family=continuous_token_config.get("model_family", "auto") or "auto",
             hf_model_type=hf_model_type,
             chat_template_kwargs=self.apply_chat_template_kwargs,
             mm_processor_kwargs=self.mm_processor_kwargs,

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -542,6 +542,8 @@ data:
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  continuous_token:
+    model_family: auto
   mm_processor_kwargs: {}
 critic:
   optim:

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -486,6 +486,8 @@ data:
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  continuous_token:
+    model_family: auto
   mm_processor_kwargs: {}
 critic:
   optim:

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -527,6 +527,8 @@ data:
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  continuous_token:
+    model_family: auto
   mm_processor_kwargs: {}
 critic:
   optim:

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -504,6 +504,8 @@ data:
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  continuous_token:
+    model_family: auto
   mm_processor_kwargs: {}
 critic:
   optim:

--- a/verl/trainer/config/data/legacy_data.yaml
+++ b/verl/trainer/config/data/legacy_data.yaml
@@ -118,5 +118,16 @@ return_multi_modal_inputs: True
 # Additional kwargs when calling tokenizer.apply_chat_template
 apply_chat_template_kwargs: {}
 
+# Continuous Token boundary handling.
+continuous_token:
+
+  # Builder family override. auto (the default) infers the family by exact lookup of the root
+  # Hugging Face config's model_type. Set a family explicitly when the checkpoint pairs an
+  # architecture with another vendor's tokenizer and chat template, and therefore fails to
+  # construct the inferred builder (the DeepSeek-R1 distills of Qwen need `deepseek`).
+  # Options: the families listed in CONTINUOUS_TOKEN_BUILDER_FAMILIES
+  # (verl/utils/tokenizer/continuous_token_wiring.py), plus auto.
+  model_family: auto
+
 # Additional kwargs passed to multimodal processors/backends.
 mm_processor_kwargs: {}

--- a/verl/utils/tokenizer/continuous_token.py
+++ b/verl/utils/tokenizer/continuous_token.py
@@ -672,10 +672,19 @@ class Gemma4ContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
+class MissingRequiredTokenError(ValueError):
+    """A special token a model-specific builder depends on is absent from the tokenizer.
+
+    Raised at builder construction. Checkpoints that pair a registered architecture
+    with another vendor's tokenizer hit this — the DeepSeek-R1 distills keep Qwen
+    ``model_type`` values but rename ``<|im_end|>`` away.
+    """
+
+
 def require_token_id(tokenizer: Any, token: str) -> int:
     token_id = tokenizer.convert_tokens_to_ids(token)
     if token_id is None:
-        raise ValueError(f"Tokenizer does not define required token {token!r}")
+        raise MissingRequiredTokenError(f"Tokenizer does not define required token {token!r}")
     if isinstance(token_id, list):
         if len(token_id) != 1:
             raise ValueError(f"Tokenizer returned multiple ids for required token {token!r}: {token_id!r}")

--- a/verl/utils/tokenizer/continuous_token_wiring.py
+++ b/verl/utils/tokenizer/continuous_token_wiring.py
@@ -32,6 +32,7 @@ from .continuous_token import (
     KimiVLContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
     MiniMaxVLContinuousTokenBuilder,
+    MissingRequiredTokenError,
     QwenContinuousTokenBuilder,
     QwenVLContinuousTokenBuilder,
     VLContinuousTokenBuilder,
@@ -307,7 +308,25 @@ def create_continuous_token_builder(
             f"Ensure the processor is loaded for vision-language models."
         )
     logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
-    return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+    try:
+        return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+    except MissingRequiredTokenError as exc:
+        if _normalize_model_family(model_family) != ContinuousTokenModelFamily.AUTO:
+            raise
+        # The builder inferred from the architecture cannot work with this tokenizer: the
+        # checkpoint pairs a registered model_type with another vendor's tokenizer and chat
+        # template (the DeepSeek-R1 distills keep Qwen model_type values but rename
+        # ``<|im_end|>`` away). Point the user at the explicit override, since the builder
+        # has to follow the chat template's conversation protocol, not the architecture.
+        raise MissingRequiredTokenError(
+            f"{builder_cls.__name__}, inferred from config.json model_type="
+            f"{_normalize_hf_model_type(hf_model_type)!r}, cannot be constructed: {exc}. The "
+            f"checkpoint pairs this architecture with another vendor's tokenizer and chat "
+            f"template (the DeepSeek-R1 distills of Qwen ship DeepSeek's, which rename "
+            f"<|im_end|> away). Set data.continuous_token.model_family to the family matching "
+            f"the chat template (deepseek for these checkpoints) to select the builder "
+            f"explicitly."
+        ) from exc
 
 
 def _is_multimodal_processor(processor: Any | None) -> bool:

--- a/verl/utils/tokenizer/continuous_token_wiring.py
+++ b/verl/utils/tokenizer/continuous_token_wiring.py
@@ -314,19 +314,109 @@ def create_continuous_token_builder(
         if _normalize_model_family(model_family) != ContinuousTokenModelFamily.AUTO:
             raise
         # The builder inferred from the architecture cannot work with this tokenizer: the
-        # checkpoint pairs a registered model_type with another vendor's tokenizer and chat
-        # template (the DeepSeek-R1 distills keep Qwen model_type values but rename
-        # ``<|im_end|>`` away). Point the user at the explicit override, since the builder
-        # has to follow the chat template's conversation protocol, not the architecture.
+        # checkpoint pairs a registered model_type with a tokenizer and chat template that
+        # builder does not support. Point the user at the explicit override, since the
+        # builder has to follow the chat template's conversation protocol, not the
+        # architecture. Which family to name is derived from this tokenizer rather than
+        # assumed -- every model-specific builder validates special tokens at construction,
+        # so any registered architecture can land here, not only the DeepSeek-R1 distills.
         raise MissingRequiredTokenError(
             f"{builder_cls.__name__}, inferred from config.json model_type="
-            f"{_normalize_hf_model_type(hf_model_type)!r}, cannot be constructed: {exc}. The "
-            f"checkpoint pairs this architecture with another vendor's tokenizer and chat "
-            f"template (the DeepSeek-R1 distills of Qwen ship DeepSeek's, which rename "
-            f"<|im_end|> away). Set data.continuous_token.model_family to the family matching "
-            f"the chat template (deepseek for these checkpoints) to select the builder "
-            f"explicitly."
+            f"{_normalize_hf_model_type(hf_model_type)!r}, cannot be constructed: {exc}. This "
+            f"checkpoint pairs a registered architecture with a tokenizer and chat template "
+            f"that builder does not support. "
+            + _model_family_override_hint(tokenizer, chat_template_kwargs, builder_cls)
         ) from exc
+
+
+def _model_family_override_hint(
+    tokenizer: Any,
+    chat_template_kwargs: dict[str, Any] | None,
+    failed_builder_cls: type[Any],
+) -> str:
+    """Name the family to set, derived from the tokenizer instead of assumed."""
+    suggested = _family_from_tokenizer_special_tokens(tokenizer)
+    if suggested is not None:
+        return (
+            f"This tokenizer's special tokens exactly match family {suggested.value!r}; set "
+            f"data.continuous_token.model_family={suggested.value} to select "
+            f"{get_continuous_token_builder_class(suggested).__name__} explicitly."
+        )
+    candidates = _constructible_text_families(tokenizer, chat_template_kwargs, exclude=failed_builder_cls)
+    if candidates:
+        return (
+            f"Set data.continuous_token.model_family to the family whose builder matches this "
+            f"checkpoint's chat template; these construct with this tokenizer: "
+            f"{', '.join(candidates)}."
+        )
+    return (
+        f"Set data.continuous_token.model_family to the family whose builder matches this "
+        f"checkpoint's chat template. Supported families: {', '.join(CONTINUOUS_TOKEN_BUILDER_FAMILIES)}."
+    )
+
+
+def _constructible_text_families(
+    tokenizer: Any,
+    chat_template_kwargs: dict[str, Any] | None,
+    *,
+    exclude: type[Any],
+) -> list[str]:
+    """Text families whose builder accepts this tokenizer, one name per builder class.
+
+    Only consulted to write the error above. Construction is a special-token lookup with
+    no side effects, so trying every family is cheap and, unlike a fixed suggestion, can
+    never name a family that fails the same way. ``default`` is listed last because it
+    accepts any tokenizer and is therefore the generic answer, not evidence of a match.
+    """
+    candidates: list[str] = []
+    seen_classes: set[type[Any]] = {exclude}
+    for family, builder_cls in _CONTINUOUS_TOKEN_BUILDER_REGISTRY.items():
+        if builder_cls in seen_classes or builder_cls.supports_multimodal():
+            continue
+        try:
+            builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs)
+        except Exception:
+            continue
+        seen_classes.add(builder_cls)
+        candidates.append(family.value)
+    default_family = ContinuousTokenModelFamily.DEFAULT.value
+    if default_family in candidates:
+        candidates.remove(default_family)
+        candidates.append(default_family)
+    return candidates
+
+
+# The DeepSeek chat lineage renames ChatML's ``<|im_end|>`` away and defines these
+# role/eos markers instead. Reusing the builder's own constants keeps the key aligned
+# with what DeepSeekContinuousTokenBuilder validates at construction. This table is the
+# high-confidence path; families absent from it still get a suggestion from
+# ``_constructible_text_families``.
+_DEEPSEEK_TOKENIZER_KEY_TOKENS = (
+    DeepSeekContinuousTokenBuilder._EOS_TOKEN,
+    DeepSeekContinuousTokenBuilder._ASSISTANT_TOKEN,
+)
+_CHATML_IM_END_TOKEN = "<|im_end|>"
+
+
+def _family_from_tokenizer_special_tokens(tokenizer: Any) -> ContinuousTokenModelFamily | None:
+    """Exact special-token key for tokenizers that identify a family themselves.
+
+    Only consulted when the builder inferred from ``model_type`` cannot be constructed,
+    and only to write the error. Matching is exact on token presence; nothing is guessed
+    from repository or tokenizer names.
+    """
+    if all(
+        _tokenizer_defines_token(tokenizer, token) for token in _DEEPSEEK_TOKENIZER_KEY_TOKENS
+    ) and not _tokenizer_defines_token(tokenizer, _CHATML_IM_END_TOKEN):
+        return ContinuousTokenModelFamily.DEEPSEEK
+    return None
+
+
+def _tokenizer_defines_token(tokenizer: Any, token: str) -> bool:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None:
+        return False
+    return token_id != getattr(tokenizer, "unk_token_id", None)
 
 
 def _is_multimodal_processor(processor: Any | None) -> bool:

--- a/verl/utils/tokenizer/continuous_token_wiring.py
+++ b/verl/utils/tokenizer/continuous_token_wiring.py
@@ -252,6 +252,34 @@ def create_continuous_token_builder(
     )
     builder_cls = get_continuous_token_builder_class(resolved_family)
 
+    def _construct(cls: type[Any], *args: Any, **extra: Any) -> Any:
+        """Construct ``cls``, rewriting a missing-token failure into an actionable error.
+
+        Every construction goes through here: a VL builder validates special tokens the
+        same way a text builder does, so a vision checkpoint whose tokenizer does not
+        match its architecture must get the same guidance instead of a bare lookup error.
+        """
+        try:
+            return cls(tokenizer, *args, **extra, **builder_kwargs)
+        except MissingRequiredTokenError as exc:
+            if _normalize_model_family(model_family) != ContinuousTokenModelFamily.AUTO:
+                raise
+            # The builder inferred from the architecture cannot work with this tokenizer:
+            # the checkpoint pairs a registered model_type with a tokenizer and chat
+            # template that builder does not support. Point the user at the explicit
+            # override, since the builder has to follow the chat template's conversation
+            # protocol, not the architecture. Which family to name is derived from this
+            # tokenizer rather than assumed -- every model-specific builder validates
+            # special tokens at construction, so any registered architecture can land
+            # here, not only the DeepSeek-R1 distills.
+            raise MissingRequiredTokenError(
+                f"{cls.__name__}, inferred from config.json model_type="
+                f"{_normalize_hf_model_type(hf_model_type)!r}, cannot be constructed: {exc}. This "
+                f"checkpoint pairs a registered architecture with a tokenizer and chat template "
+                f"that builder does not support. "
+                + _model_family_override_hint(tokenizer, has_multimodal_processor=has_mm_processor)
+            ) from exc
+
     if has_mm_processor:
         # --- Vision-language run ---
         # mm_processor_kwargs is a multimodal-only concern, so (like ``processor``) it
@@ -259,12 +287,11 @@ def create_continuous_token_builder(
         if builder_cls.supports_multimodal():
             # The root model_type identified a model-specific VL family.
             logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
-            return builder_cls(
-                tokenizer,
+            return _construct(
+                builder_cls,
                 processor,
                 chat_template_kwargs=chat_template_kwargs,
                 mm_processor_kwargs=mm_processor_kwargs,
-                **builder_kwargs,
             )
 
         # Inferred a text family, but a multimodal processor is present. Only
@@ -286,12 +313,11 @@ def create_continuous_token_builder(
             resolved_family = upgraded_family
             builder_cls = get_continuous_token_builder_class(resolved_family)
             logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
-            return builder_cls(
-                tokenizer,
+            return _construct(
+                builder_cls,
                 processor,
                 chat_template_kwargs=chat_template_kwargs,
                 mm_processor_kwargs=mm_processor_kwargs,
-                **builder_kwargs,
             )
 
         raise ValueError(
@@ -308,25 +334,7 @@ def create_continuous_token_builder(
             f"Ensure the processor is loaded for vision-language models."
         )
     logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
-    try:
-        return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
-    except MissingRequiredTokenError as exc:
-        if _normalize_model_family(model_family) != ContinuousTokenModelFamily.AUTO:
-            raise
-        # The builder inferred from the architecture cannot work with this tokenizer: the
-        # checkpoint pairs a registered model_type with a tokenizer and chat template that
-        # builder does not support. Point the user at the explicit override, since the
-        # builder has to follow the chat template's conversation protocol, not the
-        # architecture. Which family to name is derived from this tokenizer rather than
-        # assumed -- every model-specific builder validates special tokens at construction,
-        # so any registered architecture can land here, not only the DeepSeek-R1 distills.
-        raise MissingRequiredTokenError(
-            f"{builder_cls.__name__}, inferred from config.json model_type="
-            f"{_normalize_hf_model_type(hf_model_type)!r}, cannot be constructed: {exc}. This "
-            f"checkpoint pairs a registered architecture with a tokenizer and chat template "
-            f"that builder does not support. "
-            + _model_family_override_hint(tokenizer, has_multimodal_processor=has_mm_processor)
-        ) from exc
+    return _construct(builder_cls, chat_template_kwargs=chat_template_kwargs)
 
 
 def _model_family_override_hint(tokenizer: Any, *, has_multimodal_processor: bool) -> str:
@@ -345,11 +353,12 @@ def _model_family_override_hint(tokenizer: Any, *, has_multimodal_processor: boo
             f"data.continuous_token.model_family={suggested.value} to select "
             f"{get_continuous_token_builder_class(suggested).__name__} explicitly."
         )
+    generic = ContinuousTokenModelFamily.VL_DEFAULT if has_multimodal_processor else ContinuousTokenModelFamily.DEFAULT
     return (
         f"This tokenizer's special tokens do not identify a family. Set "
         f"data.continuous_token.model_family to the family whose builder implements this "
         f"checkpoint's chat template -- the conversation protocol, not the architecture -- "
-        f"or to 'default' for plain concatenation. Families available on this path: "
+        f"or to {generic.value!r} for plain concatenation. Families available on this path: "
         f"{', '.join(_families_for_path(has_multimodal_processor=has_multimodal_processor))}."
     )
 

--- a/verl/utils/tokenizer/continuous_token_wiring.py
+++ b/verl/utils/tokenizer/continuous_token_wiring.py
@@ -325,16 +325,19 @@ def create_continuous_token_builder(
             f"{_normalize_hf_model_type(hf_model_type)!r}, cannot be constructed: {exc}. This "
             f"checkpoint pairs a registered architecture with a tokenizer and chat template "
             f"that builder does not support. "
-            + _model_family_override_hint(tokenizer, chat_template_kwargs, builder_cls)
+            + _model_family_override_hint(tokenizer, has_multimodal_processor=has_mm_processor)
         ) from exc
 
 
-def _model_family_override_hint(
-    tokenizer: Any,
-    chat_template_kwargs: dict[str, Any] | None,
-    failed_builder_cls: type[Any],
-) -> str:
-    """Name the family to set, derived from the tokenizer instead of assumed."""
+def _model_family_override_hint(tokenizer: Any, *, has_multimodal_processor: bool) -> str:
+    """Name a family only with positive evidence from this tokenizer.
+
+    Construction succeeding is not evidence: the builders that validate nothing
+    (``default``, and any family whose builder never calls ``require_token_id``)
+    accept every tokenizer, so a "these can be constructed" list would name families
+    nothing supports. When the special tokens do not identify a family, give the knob
+    and the criterion and let the user apply what they know about their checkpoint.
+    """
     suggested = _family_from_tokenizer_special_tokens(tokenizer)
     if suggested is not None:
         return (
@@ -342,55 +345,33 @@ def _model_family_override_hint(
             f"data.continuous_token.model_family={suggested.value} to select "
             f"{get_continuous_token_builder_class(suggested).__name__} explicitly."
         )
-    candidates = _constructible_text_families(tokenizer, chat_template_kwargs, exclude=failed_builder_cls)
-    if candidates:
-        return (
-            f"Set data.continuous_token.model_family to the family whose builder matches this "
-            f"checkpoint's chat template; these construct with this tokenizer: "
-            f"{', '.join(candidates)}."
-        )
     return (
-        f"Set data.continuous_token.model_family to the family whose builder matches this "
-        f"checkpoint's chat template. Supported families: {', '.join(CONTINUOUS_TOKEN_BUILDER_FAMILIES)}."
+        f"This tokenizer's special tokens do not identify a family. Set "
+        f"data.continuous_token.model_family to the family whose builder implements this "
+        f"checkpoint's chat template -- the conversation protocol, not the architecture -- "
+        f"or to 'default' for plain concatenation. Families available on this path: "
+        f"{', '.join(_families_for_path(has_multimodal_processor=has_multimodal_processor))}."
     )
 
 
-def _constructible_text_families(
-    tokenizer: Any,
-    chat_template_kwargs: dict[str, Any] | None,
-    *,
-    exclude: type[Any],
-) -> list[str]:
-    """Text families whose builder accepts this tokenizer, one name per builder class.
+def _families_for_path(*, has_multimodal_processor: bool) -> list[str]:
+    """Families whose builder matches this run, so the menu holds no dead options.
 
-    Only consulted to write the error above. Construction is a special-token lookup with
-    no side effects, so trying every family is cheap and, unlike a fixed suggestion, can
-    never name a family that fails the same way. ``default`` is listed last because it
-    accepts any tokenizer and is therefore the generic answer, not evidence of a match.
+    A VL builder raises without a processor and a text builder raises with one, so
+    listing both halves would offer families that cannot be selected here.
     """
-    candidates: list[str] = []
-    seen_classes: set[type[Any]] = {exclude}
-    for family, builder_cls in _CONTINUOUS_TOKEN_BUILDER_REGISTRY.items():
-        if builder_cls in seen_classes or builder_cls.supports_multimodal():
-            continue
-        try:
-            builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs)
-        except Exception:
-            continue
-        seen_classes.add(builder_cls)
-        candidates.append(family.value)
-    default_family = ContinuousTokenModelFamily.DEFAULT.value
-    if default_family in candidates:
-        candidates.remove(default_family)
-        candidates.append(default_family)
-    return candidates
+    return [
+        family.value
+        for family, builder_cls in _CONTINUOUS_TOKEN_BUILDER_REGISTRY.items()
+        if builder_cls.supports_multimodal() == has_multimodal_processor
+    ]
 
 
 # The DeepSeek chat lineage renames ChatML's ``<|im_end|>`` away and defines these
 # role/eos markers instead. Reusing the builder's own constants keeps the key aligned
-# with what DeepSeekContinuousTokenBuilder validates at construction. This table is the
-# high-confidence path; families absent from it still get a suggestion from
-# ``_constructible_text_families``.
+# with what DeepSeekContinuousTokenBuilder validates at construction. A tokenizer that
+# matches no entry gets no family named for it: this table is the only positive evidence
+# available here, and guessing without it is what the suggestion is meant to avoid.
 _DEEPSEEK_TOKENIZER_KEY_TOKENS = (
     DeepSeekContinuousTokenBuilder._EOS_TOKEN,
     DeepSeekContinuousTokenBuilder._ASSISTANT_TOKEN,


### PR DESCRIPTION
### What does this PR do?

For #7637, this implements the explicit-override option (option 3 there): the DeepSeek-R1 distills keep Qwen `model_type` values (`qwen2` / `qwen3`) but ship DeepSeek's tokenizer and chat template, in which `<|im_end|>` is renamed away, so since #6804 `QwenContinuousTokenBuilder.__init__` raises `Tokenizer does not define required token '<|im_end|>'` in `AgentLoopBase.__init__` before any rollout starts — and no configuration can route around it, because #6804 removed `data.continuous_token`.

This restores `data.continuous_token.model_family` only (not the removed `enable` toggle): `auto`, the default, keeps #6804's exact `model_type` inference for everything, and an explicit family selects the builder matching the checkpoint's chat template — the builder has to follow the template's conversation protocol, and when a checkpoint's architecture and template disagree, the user states the protocol. When the auto-inferred builder cannot be constructed because a required token is missing, the error now names the override and the family these checkpoints need instead of only naming the missing token, so the failure is self-explaining. An explicitly requested family that cannot construct still raises the original error.

Alternative to #7638 / #7639, which route these checkpoints automatically instead of asking for configuration; this override composes with either if automatic routing is wanted on top.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+continuous+token+model_family
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

- `tests/utils/test_continuous_token_on_cpu.py`: the auto-path construction error names `data.continuous_token.model_family` and the needed family; `model_family="deepseek"` selects the DeepSeek builder for a distill-style tokenizer and renders its concatenating template; an explicit family that cannot construct raises the original error unchanged.
- Hydra: `ppo_trainer` composes with the restored key, `data.continuous_token.model_family=deepseek` overrides to the value; the four `_generated_ppo_*.yaml` files are regenerated with `scripts/generate_trainer_config.sh`.
- Real tokenizers on upstream `main` (9c76436) vs `main` + this change:
  - the 13-row × 24-case tool-append harness from #7630 / #7636: every row byte-identical to `main` (no successful path changes);
  - the three broken distills under `auto`: still fail, now with the error pointing at the override; with `model_family=deepseek` they construct `DeepSeekContinuousTokenBuilder` and the first tool turn matches the template's full-conversation render (DeepSeek-R1-0528-Qwen3-8B on every turn; the older distills' later turns keep the known `is_output_first` gap tracked in #7636);
  - Qwen3-8B, DeepSeek-V3.1 and DeepSeek-R1-Distill-Llama-8B select the same builders as `main` under `auto`.

  Script and raw output: https://github.com/ruiling-smartbear/verl-experiments/blob/main/verl_family_config_check_results.txt

### API and Usage Example

```yaml
data:
  continuous_token:
    model_family: deepseek  # e.g. for DeepSeek-R1-Distill-Qwen-* / DeepSeek-R1-0528-Qwen3-8B
```

Default `auto` is unchanged behavior for every checkpoint that works today.

### Design & Code Changes

- `verl/trainer/config/data/legacy_data.yaml` (+ regenerated `_generated_ppo_*.yaml`): `data.continuous_token.model_family`, default `auto`.
- `agent_loop.py`: reads the key and passes it to `create_continuous_token_builder` (whose `model_family` parameter already existed).
- `continuous_token.py`: `MissingRequiredTokenError` (a `ValueError` subclass) for the token-absent case.
- `continuous_token_wiring.py`: under `auto`, a construction failure for a missing required token is re-raised with the override guidance.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] `ruff check` / `ruff format` pass on the touched files.
- [x] Docs: the config key is documented in `legacy_data.yaml`.
- [x] Unit tests in `tests/utils/test_continuous_token_on_cpu.py`, covered by the CPU unit-test workflow.
- [ ] CI request in `ci-request` once ready.
