### PR TITLE
[doc] fix: update Megatron-LM version in install docs to v0.18.0

### DIFF
--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -17,7 +17,7 @@ Choices of Backend Engines
 
 1. Training:
 
-We recommend using the **FSDP / FSDP2** backend to investigate, research and prototype different models, datasets and RL algorithms. For users who pursue better scalability, we recommend the **Megatron-LM** backend. Currently, we support `Megatron-LM v0.13.1 <https://github.com/NVIDIA/Megatron-LM/tree/core_v0.13.1>`_. Both backends are served through the same unified worker layer – see :doc:`Engine Workers<../workers/engine_workers>` for the worker-level API and :doc:`Model Engine<../workers/model_engine>` for the engine-level design.
+We recommend using the **FSDP / FSDP2** backend to investigate, research and prototype different models, datasets and RL algorithms. For users who pursue better scalability, we recommend the **Megatron-LM** backend. Currently, we support `Megatron-LM v0.18.0 <https://github.com/NVIDIA/Megatron-LM/tree/core_v0.18.0>`_. Both backends are served through the same unified worker layer – see :doc:`Engine Workers<../workers/engine_workers>` for the worker-level API and :doc:`Model Engine<../workers/model_engine>` for the engine-level design.
 
 
 2. Inference:


### PR DESCRIPTION
## Summary
- Update `docs/start/install.rst` so the Megatron-LM backend version matches the current `pyproject.toml` pin (`core_v0.18.0`).

## Repro
Fetched both files from `verl-project/verl` default branch `main` at `9c7643648f1e1e109dd30da2da3cf94e1317b229` via the GitHub Contents API (no full clone):

```bash
gh api repos/verl-project/verl/contents/docs/start/install.rst --jq .content | base64 -d
gh api repos/verl-project/verl/contents/pyproject.toml --jq .content | base64 -d
```

Observed version strings:
- `docs/start/install.rst` (Choices of Backend Engines): `Megatron-LM v0.13.1` linking to `core_v0.13.1`
- `pyproject.toml` `[tool.uv.sources]`: `megatron-core = { git = "https://github.com/NVIDIA/Megatron-LM.git", tag = "core_v0.18.0" }`
- The uv note later in the same `install.rst` already cites `core_v0.18.0`

This PR changes only the stale backend-engines sentence.

## Test plan
- [ ] `docs/start/install.rst` no longer mentions `v0.13.1` / `core_v0.13.1`
- [ ] Backend engines link points at `https://github.com/NVIDIA/Megatron-LM/tree/core_v0.18.0`
- [ ] Existing uv note about git-sourced `megatron-core` (`core_v0.18.0`) is unchanged