### PR TITLE
[doc] fix: update rollout load_format docs to dummy/auto/safetensors

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -190,7 +190,7 @@ Actor/Rollout/Reference Policy
       ignore_eos: False
       enforce_eager: True
       free_cache_engine: True
-      load_format: dummy_dtensor
+      load_format: dummy
       tensor_model_parallel_size: 2
       max_num_batched_tokens: 8192
       max_num_seqs: 1024
@@ -423,26 +423,23 @@ Reference model will be enabled when ``actor.use_kl_loss`` or/and ``algorithm.us
   in vLLM generation. Default set to True to disable CUDAGraph.
 
 - ``actor_rollout_ref.rollout.load_format``: Which weight loader to use
-  to load the actor model weights to the rollout model.
+  to load the actor model weights to the rollout model. Default is
+  ``dummy``.
 
-  - ``auto``: Use Megatron weight loader.
-  - ``megatron``: Use Megatron weight loader. Deployed with Megatron
-    backend. The input model ``state_dict()`` is already partitioned
-    along TP dimension and already gathered along PP dimension. This
-    weight loader requires that the Rollout model and Actor model's
-    parameters shape and name should be identical.
-  - ``dtensor``: Default solution when using Huggingface weight loader.
-    Deployed with FSDP backend and the state_dict_type is
-    ``StateDictType.SHARDED_STATE_DICT``. Recommend to use this weight
-    loader
-  - ``hf``: Use Huggingface weight loader. Deployed with FSDP backend
-    and the state_dict_type is ``StateDictType.FULL_STATE_DICT``. This
-    solution doesn't need to rewrite the weight loader for each model
-    implemented in vLLM but it results in larger peak memory usage.
-  - ``dummy_hf``, ``dummy_megatron``, ``dummy_dtensor``: Random
-    initialization.
+  - ``dummy``: Random initialization. Typical for actor/rollout hybrid
+    engine training; real actor weights are synced into the rollout
+    engine after init.
+  - ``auto``: Let the inference engine auto-detect the checkpoint
+    format (usually safetensors, then PyTorch). Used by some non-actor
+    rollouts such as reward-model and distillation teacher.
+  - ``safetensors``: Load weights from safetensors. Use for huge models
+    (set ``use_shm=True``) and for LoRA so vLLM can load the base
+    model.
 
-.. note:: **NOTED**: In this config field, users only need to select from ``dummy_megatron``, ``dummy_dtensor``, ``dummy_hf`` for rollout initialization and our hybrid engine will select the corresponding weight loader (i.e., ``megatron``, ``dtensor``, ``hf``) during actor/rollout weight synchronization.
+.. note:: For actor/rollout initialization, set ``load_format`` to
+  ``dummy`` unless the engine should load a checkpoint from disk
+  (``auto`` or ``safetensors``). Actor/rollout weight synchronization
+  is handled separately by the hybrid engine.
 
 
 Megatron Optimizer and Optimizer Parameter Scheduler


### PR DESCRIPTION
## Summary
- Update `docs/examples/config.rst` so `actor_rollout_ref.rollout.load_format` matches current runtime defaults (`dummy` / `auto` / `safetensors`) instead of the retired `dummy_dtensor` / `dummy_hf` / `dummy_megatron` names.

## Repro
Fetched these files from `verl-project/verl` default branch `main` at `722f96fcd06e37f1a940325ef5dabe15d529cc5c` via the GitHub Contents API (no full clone):

```bash
gh api repos/verl-project/verl/contents/docs/examples/config.rst --jq .content | base64 -d
gh api repos/verl-project/verl/contents/verl/trainer/config/rollout/rollout.yaml --jq .content | base64 -d
gh api repos/verl-project/verl/contents/verl/workers/config/rollout.py --jq .content | base64 -d
gh api repos/verl-project/verl/contents/verl/trainer/config/reward/reward.yaml --jq .content | base64 -d
```

Observed values:

- `docs/examples/config.rst` yaml example: `load_format: dummy_dtensor`
- `docs/examples/config.rst` option list: `dummy_hf`, `dummy_megatron`, `dummy_dtensor` (and a note telling users to pick among those three)
- `verl/trainer/config/rollout/rollout.yaml`: `load_format: dummy` (comments: dummy randomly init; safetensors for huge models)
- `verl/workers/config/rollout.py` `RolloutConfig`: `load_format: str = "dummy"`
- `verl/trainer/config/reward/reward.yaml`: `load_format: auto`
- LoRA docs already require `actor_rollout_ref.rollout.load_format="safetensors"`

This PR changes only the `load_format` example and explanation in `docs/examples/config.rst`.

## Test plan
- [ ] `docs/examples/config.rst` yaml example uses `load_format: dummy`
- [ ] Option list documents `dummy` / `auto` / `safetensors`
- [ ] No remaining `dummy_dtensor` / `dummy_hf` / `dummy_megatron` in `docs/examples/config.rst`
- [ ] Data yaml (`return_raw_chat` / `seed` / `trust_remote_code`) is unchanged