### PR TITLE
[doc] fix: align rollout enforce_eager default docs with False

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -188,7 +188,7 @@ Actor/Rollout/Reference Policy
       dtype: bfloat16 # should align with FSDP
       gpu_memory_utilization: 0.5
       ignore_eos: False
-      enforce_eager: True
+      enforce_eager: False
       free_cache_engine: True
       load_format: dummy_dtensor
       tensor_model_parallel_size: 2
@@ -419,8 +419,8 @@ Reference model will be enabled when ``actor.use_kl_loss`` or/and ``algorithm.us
   for vllm v0.5.4 and v0.6.3, we need to disable the usage of CUDAGraph
   (set ``enforce_eager`` to True.)
 
-- ``actor_rollout_ref.rollout.enforce_eager``: Whether to use CUDAGraph
-  in vLLM generation. Default set to True to disable CUDAGraph.
+- ``actor_rollout_ref.rollout.enforce_eager``: Whether to disable CUDAGraph
+  in vLLM generation. Default is False for best performance.
 
 - ``actor_rollout_ref.rollout.load_format``: Which weight loader to use
   to load the actor model weights to the rollout model.


### PR DESCRIPTION
## Summary
- Update `docs/examples/config.rst` so `actor_rollout_ref.rollout.enforce_eager` matches the current runtime default (`False`) instead of the stale `True`.

## Repro
Fetched these files from `verl-project/verl` default branch `main` at `722f96fcd06e37f1a940325ef5dabe15d529cc5c` via the GitHub Contents API (no full clone):

```bash
gh api repos/verl-project/verl/contents/docs/examples/config.rst --jq .content | base64 -d
gh api repos/verl-project/verl/contents/verl/trainer/config/rollout/rollout.yaml --jq .content | base64 -d
gh api repos/verl-project/verl/contents/verl/workers/config/rollout.py --jq .content | base64 -d
```

Observed values:

- `docs/examples/config.rst` yaml example: `enforce_eager: True`
- `docs/examples/config.rst` field docs: `Default set to True to disable CUDAGraph.`
- `verl/trainer/config/rollout/rollout.yaml`:
  ```
  # Whether to disable CUDA graph. Default False to best performance.
  enforce_eager: False
  ```
- `verl/workers/config/rollout.py` `RolloutConfig`: `enforce_eager: bool = False`

This PR changes only the `enforce_eager` example value and default wording in `docs/examples/config.rst`. `load_format` is left unchanged.

## Test plan
- [ ] `docs/examples/config.rst` yaml example uses `enforce_eager: False`
- [ ] Field docs say the default is False (disable CUDAGraph is opt-in)
- [ ] `load_format: dummy_dtensor` in the same file is unchanged
- [ ] free_cache_engine note that old vLLM may still need `enforce_eager` True is unchanged