### PR TITLE
[doc] fix: align rollout max_num_seqs default docs with 256

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -193,7 +193,7 @@ Actor/Rollout/Reference Policy
       load_format: dummy_dtensor
       tensor_model_parallel_size: 2
       max_num_batched_tokens: 8192
-      max_num_seqs: 1024
+      max_num_seqs: 256
       log_prob_micro_batch_size: null # will be deprecated, use log_prob_micro_batch_size_per_gpu
       log_prob_micro_batch_size_per_gpu: 16
       log_prob_use_dynamic_bsz: ${actor_rollout_ref.actor.use_dynamic_bsz}


### PR DESCRIPTION
## Summary
- Update `docs/examples/config.rst` so `actor_rollout_ref.rollout.max_num_seqs` matches the current runtime default (`256`) instead of the stale `1024`.

## Repro
Fetched these files from `verl-project/verl` default branch `main` at `722f96fcd06e37f1a940325ef5dabe15d529cc5c` via the GitHub Contents API (no full clone):

```bash
gh api repos/verl-project/verl/contents/docs/examples/config.rst --jq .content | base64 -d
gh api repos/verl-project/verl/contents/verl/trainer/config/rollout/rollout.yaml --jq .content | base64 -d
```

Observed values:

- `docs/examples/config.rst` yaml example: `max_num_seqs: 1024`
- `verl/trainer/config/rollout/rollout.yaml`:
  ```
  # max length of sequences
  max_num_seqs: 256
  ```

Reward and distillation configs still default to `max_num_seqs: 1024` (`verl/trainer/config/reward/reward.yaml`, `verl/trainer/config/distillation/distillation.yaml`), so those values are left unchanged. This PR changes only the actor/rollout example default in `docs/examples/config.rst`. `load_format` and `enforce_eager` in the same file are left unchanged.

## Test plan
- [ ] `docs/examples/config.rst` yaml example uses `max_num_seqs: 256`
- [ ] No other `max_num_seqs` lines in `docs/examples/config.rst` were edited
- [ ] `load_format: dummy_dtensor` in the same file is unchanged
- [ ] `enforce_eager: True` in the same file is unchanged (covered by a separate PR)