### PR TITLE
[doc] fix: point legacy model merger docs at scripts/legacy_model_merger.py

### DIFF
--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -290,7 +290,7 @@ Convert FSDP and Megatron Checkpoints to HuggingFace Format Model
 -----------------------------------------------------------------
 
 We provide a tool to convert the FSDP and Megatron checkpoints to HuggingFace format model.
-The tool is located in ``verl/model_merger``. For older versions of verl that don't include fsdp_config.json in checkpoints, you can use the legacy model merger located at ``verl/scripts/legacy_model_merger.py``.
+The tool is located in ``verl/model_merger``. For older versions of verl that don't include fsdp_config.json in checkpoints, you can use the legacy model merger located at ``scripts/legacy_model_merger.py``.
 
 The script supports two main sub-commands: `merge` (to convert and save checkpoints) and `test` (to validate merged checkpoints against a reference model).
 The arguments for the `merge` sub-command are as follows:


### PR DESCRIPTION
## Summary

Checkpoint docs still point at a ghost path for the legacy model merger.

**Reproduce (main `722f96fcd06e37f1a940325ef5dabe15d529cc5c`):**

Docs (`docs/advance/checkpoint.rst`):

> The tool is located in `verl/model_merger`. For older versions of verl that don't include fsdp_config.json in checkpoints, you can use the legacy model merger located at `verl/scripts/legacy_model_merger.py`.

That documented path 404s on main:
- `verl/scripts/legacy_model_merger.py` → 404
- current script: `scripts/legacy_model_merger.py` (exists; its own docstring uses `python scripts/legacy_model_merger.py`)
- current merger module: `verl/model_merger` (`python -m verl.model_merger`) — already documented correctly in the same section

This PR only rewrites the dead path to `scripts/legacy_model_merger.py`.

## Test plan

- [x] Confirmed `verl/scripts/legacy_model_merger.py` 404s on main
- [x] Confirmed `scripts/legacy_model_merger.py` and `verl/model_merger` exist on main
- [x] No other docs still use `verl/scripts/legacy_model_merger.py`
