### PR TITLE
[distillation] fix: Disable detokenization for teacher prompt_logprobs

### DIFF
--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -53,6 +53,7 @@ def _get_teacher_sampling_params(
         "max_tokens": 1,
         "temperature": 1.0,
         "prompt_logprobs": num_logprobs,
+        "detokenize": False,
     }
 
 


### PR DESCRIPTION
## Motivation

The distillation teacher path requests `prompt_logprobs=topk` from vLLM to score the student sequence. vLLM's `LogprobsProcessor` **detokenizes every prompt-logprob candidate** — it calls `tokenizer.decode([id])` once per id over `num_prompt_tokens × num_prompt_logprobs` ids and runs verification per position 
(`vllm/tokenizers/detokenizer_utils.py::convert_ids_list_to_tokens`, `vllm/v1/engine/logprobs.py::_update_prompt_logprobs`).

For distillation we consume **only** the numeric logprobs and token ids — the decoded strings are never read, so this is pure wasted work.
 It also runs **synchronously on the AsyncLLM engine event loop**, so under concurrent requests it serializes: a newly arrived request cannot enter the engine until the loop finishes decoding earlier ones, turning a per-request cost into an engine-wide stall.

## Change

`verl/experimental/teacher_loop/teacher_manager.py::_get_teacher_sampling_params`:

```diff
     num_logprobs = distillation_loss_config.topk if distillation_loss_config.loss_settings.use_topk else 0
     return {
         "max_tokens": 1,
         "temperature": teacher_model_config.inference.temperature,
         "prompt_logprobs": num_logprobs,
+        "detokenize": False,
     }
```

## Why it's safe (no change to consumers)

The only consumer of the teacher output is `extract_prompt_logprobs` (`verl/workers/rollout/vllm_rollout/utils.py`), which reads `token_logprob.logprob`, `token_logprob.rank`, and the integer token id — **never** `.decoded_token`. 

With `detokenize=False`, vLLM's `OutputProcessor.from_new_request` sets `tokenizer=None` for the `LogprobsProcessor` (`vllm/v1/engine/output_processor.py`), which skips `convert_ids_list_to_tokens` and `_verify_tokens` while returning **identical** `logprob`/`rank`/`token_id` values. 

Loss values are unchanged (verified). Unconditional `detokenize=False` is correct because this codepath is used *only* for teacher logprob scoring, whose output never contains decoded strings.

## Evidence — microbenchmark of the exact affected function

`LogprobsProcessor._update_prompt_logprobs`, `num_prompt_logprobs=128`, vocab ≈ 150k, timed with tokenizer set (before) vs `tokenizer=None` (after):

| prompt_len | BEFORE `detokenize=True` | AFTER `detokenize=False` | speedup |
|---:|---:|---:|---:|
| 2000  | 1382.7 ms | 438.2 ms | **3.2×** |
| 8000  | 5906.9 ms | 2069.1 ms | **2.9×** |
| 16000 | 10947.8 ms | 4471.9 ms | **2.4×** |
| 24000 | 18293.5 ms | 6220.8 ms | **2.9×** |

Per-request post-processing drops 2.4–3.2× (e.g. a 24k-token prompt: **18.3 s → 6.2 s**), removing 0.9–12 s of synchronous event-loop work per request, with identical numeric logprobs. Gains scale with prompt length and `topk`.

## Notes
- Verified on vLLM 0.22.1 (v1 engine); `detokenize` is a standard `SamplingParams` field and `prompt_logprobs` values are unaffected.