### PR TITLE
[doc] fix: update Megatron-LM version in install docs to v0.18.0

### DIFF
--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -17,7 +17,7 @@ Choices of Backend Engines
 
 1. Training:
 
-We recommend using the **FSDP / FSDP2** backend to investigate, research and prototype different models, datasets and RL algorithms. For users who pursue better scalability, we recommend the **Megatron-LM** backend. Currently, we support `Megatron-LM v0.13.1 <https://github.com/NVIDIA/Megatron-LM/tree/core_v0.13.1>`_. Both backends are served through the same unified worker layer – see :doc:`Engine Workers<../workers/engine_workers>` for the worker-level API and :doc:`Model Engine<../workers/model_engine>` for the engine-level design.
+We recommend using the **FSDP / FSDP2** backend to investigate, research and prototype different models, datasets and RL algorithms. For users who pursue better scalability, we recommend the **Megatron-LM** backend. Currently, we support `Megatron-LM v0.18.0 <https://github.com/NVIDIA/Megatron-LM/tree/core_v0.18.0>`_. Both backends are served through the same unified worker layer – see :doc:`Engine Workers<../workers/engine_workers>` for the worker-level API and :doc:`Model Engine<../workers/model_engine>` for the engine-level design.
 
 
 2. Inference:


### PR DESCRIPTION
### What does this PR do?

Update the supported Megatron-LM version in `docs/start/install.rst` from v0.13.1 / `core_v0.13.1` to v0.18.0 / `core_v0.18.0`.

The same file already documents git-sourced `megatron-core` (`core_v0.18.0`), and `pyproject.toml` pins `megatron-core` 0.18.0 / tag `core_v0.18.0`. This change makes the backend-support sentence match those pins.

### Checklist Before Starting

- [x] Search for similar PRs. Query: [Megatron-LM install docs version](https://github.com/verl-project/verl/pulls?q=is%3Apr+Megatron-LM+install+v0.18.0)
- [x] Format the PR title as `[{modules}] {type}: {description}`.
  - PR title: `[doc] fix: update Megatron-LM version in install docs to v0.18.0`
- This change does not introduce a breaking API or configuration change.

### Test

Docs-only change. Verified on upstream `main` HEAD that:

- `docs/start/install.rst` no longer claims Megatron-LM v0.13.1 / `core_v0.13.1`.
- The linked tag is `core_v0.18.0`.
- This matches `pyproject.toml` `megatron-core` 0.18.0 / `core_v0.18.0`.

### API and Usage Example

This PR does not change any public API or configuration.

### Design & Code Changes

Single-line docs update in `docs/start/install.rst`:

- `Megatron-LM v0.13.1` / `core_v0.13.1` → `Megatron-LM v0.18.0` / `core_v0.18.0`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Documentation update is included (`docs/start/install.rst`).
- [x] Unit / CI tests are not applicable because this is a docs version-string fix.
- [x] Recipe submodule update is not applicable to this change.