### PR TITLE
[model, fsdp] fix: Gemma-4 FSDP2 shared_kv_states and text-only post-backward

### DIFF
--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -324,6 +324,82 @@ def apply_monkey_patch(
     if use_prefix_grouper:
         apply_prefix_grouper_patch()
 
+    # Gemma-4 cross-layer KV-sharing under FSDP2 MixedPrecisionPolicy
+    # (cast_forward_inputs=True). FSDP2's _apply_to_tensors reconstructs plain dicts
+    # per layer, so anchor writes are invisible to sharer layers -> KeyError
+    # 'sliding_attention' in compute_log_prob. Seed a non-dict holder instead.
+    if getattr(model.config, "model_type", None) == "gemma4":
+        try:
+            import functools
+            from transformers.models.gemma4 import modeling_gemma4 as _g4
+
+            class _KVStates:
+                __slots__ = ("_d",)
+
+                def __init__(self, initial=None):
+                    self._d = dict(initial) if initial else {}
+
+                def __getitem__(self, key):
+                    return self._d[key]
+
+                def __setitem__(self, key, value):
+                    self._d[key] = value
+
+                def __contains__(self, key):
+                    return key in self._d
+
+                def get(self, key, default=None):
+                    return self._d.get(key, default)
+
+                def pop(self, key, *args):
+                    return self._d.pop(key, *args)
+
+            TextModel = getattr(_g4, "Gemma4TextModel", None)
+            if TextModel is not None and not getattr(TextModel.forward, "_gemma4_kvshare_patched", False):
+                _orig = TextModel.forward
+
+                @functools.wraps(_orig)
+                def _forward(self, *args, **kwargs):
+                    skv = kwargs.get("shared_kv_states")
+                    if skv is None:
+                        kwargs["shared_kv_states"] = _KVStates()
+                    elif type(skv) is dict:
+                        kwargs["shared_kv_states"] = _KVStates(skv)
+                    return _orig(self, *args, **kwargs)
+
+                _forward._gemma4_kvshare_patched = True
+                TextModel.forward = _forward
+                print("Monkey patch Gemma4 shared_kv_states as a non-dict leaf. ")
+        except Exception as _e:  # noqa: BLE001
+            import warnings as _w
+
+            _w.warn(f"gemma4 kvshare patch failed: {_e}")
+
+        # Text-only batches never run the vision tower; FSDP2 still post-backwards
+        # those units and crashes on lazily-missing `_unsharded_param` (same bug
+        # NeMo AutoModel guards). Skip the no-grad upcast when the field is absent.
+        try:
+            from torch.distributed.fsdp._fully_shard._fsdp_param import FSDPParam as _FSDPParam
+
+            _orig_acc = _FSDPParam.to_accumulated_grad_if_needed
+            if not getattr(_orig_acc, "_gemma4_fsdp_grad_guarded", False):
+
+                def _guarded_to_accumulated_grad_if_needed(self):
+                    try:
+                        return _orig_acc(self)
+                    except AttributeError as exc:
+                        if "_unsharded_param" not in str(exc) or hasattr(self, "_unsharded_param"):
+                            raise
+                        return None
+
+                _guarded_to_accumulated_grad_if_needed._gemma4_fsdp_grad_guarded = True
+                _FSDPParam.to_accumulated_grad_if_needed = _guarded_to_accumulated_grad_if_needed
+                print("Monkey patch FSDPParam.to_accumulated_grad_if_needed for Gemma4 text-only. ")
+        except Exception as _e:  # noqa: BLE001
+            import warnings as _w
+
+            _w.warn(f"gemma4 FSDP accumulated-grad guard failed: {_e}")
+
     """Replace _flash_attention_forward to _ulysses_flash_attention_forward"""
     module = sys.modules[model.__module__]
 


### PR DESCRIPTION
### What does this PR do?

Gemma-4 training under FSDP2 MixedPrecisionPolicy (`cast_forward_inputs=True`) fails in two ways:

1. Cross-layer KV sharing uses a `dict` for `shared_kv_states`. FSDP2 `_apply_to_tensors` reconstructs a **new** dict per layer, so later layers never see the sliding-attention keys written by the anchor layer (`KeyError: 'sliding_attention'` in `compute_log_prob`). This wraps the dict in a small non-dict holder so FSDP2 treats it as a leaf.
2. Text-only batches never run the vision tower; FSDP2 still post-backwards those units and crashes on missing `_unsharded_param`. Same guard pattern as NeMo AutoModel: skip the no-grad upcast when that field is absent.

Non-DTensor replica merge for Gemma-4 `layer_scalar` is **already on main** (`merge_non_dtensor_shards`); not included here.

Search: https://github.com/verl-project/verl/pulls?q=is%3Apr+gemma4+fsdp

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+gemma4+FSDP2
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Cannot be covered by CPU CI (needs Gemma-4 + FSDP2 GPU). Validated on H100 same-family OPD (Gemma-4.1 E4B student, FSDP2, vLLM rollout).

### API and Usage Example

No config/API change. `apply_monkey_patch` enables the Gemma-4 path when `model.config.model_type == "gemma4"`.

### Design & Code Changes

- Patch `Gemma4TextModel.forward` to seed `shared_kv_states` as a non-dict mapping.
- Guard `FSDPParam.to_accumulated_grad_if_needed` against missing `_unsharded_param`.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] pre-commit not run in this environment.
- [ ] Docs: none (internal FSDP2 workaround).
- [ ] GPU unit test not added; needs Gemma-4 weights + FSDP2.
- [ ] Will request CI on Slack after review start.


Made with [Cursor](https://cursor.com)