### PR TITLE
[model, vllm] feat: honor Hugging Face revision on student and teacher Hub loads

### DIFF
--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -122,7 +122,16 @@ class RewardLoopWorker:
         if input_tokenizer_path is None:
             input_tokenizer_path = self.config.actor_rollout_ref.model.path
         input_tokenizer_local_path = copy_to_local(input_tokenizer_path)
-        self.input_tokenizer = hf_tokenizer(input_tokenizer_local_path, trust_remote_code=True)
+        tok_kwargs = {"trust_remote_code": True}
+        revision = None
+        model_cfg = self.config.actor_rollout_ref.model
+        if hasattr(model_cfg, "get"):
+            revision = model_cfg.get("revision")
+        else:
+            revision = getattr(model_cfg, "revision", None)
+        if revision and input_tokenizer_path and not str(input_tokenizer_path).startswith("/"):
+            tok_kwargs["revision"] = revision
+        self.input_tokenizer = hf_tokenizer(input_tokenizer_local_path, **tok_kwargs)
         self.reward_model_tokenizer = None
         if self.config.reward.reward_model.enable:
             reward_model_tokenizer_local_path = copy_to_local(self.config.reward.reward_model.model_path)

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -83,6 +83,7 @@ class TeacherModelManager:
             {
                 "_target_": "verl.workers.config.HFModelConfig",
                 "path": teacher_model_config.model_path,
+                "revision": getattr(teacher_model_config, "revision", None),
             }
         )
         name_suffix = (teacher_model_config.key or "").replace("/", "_")

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -85,13 +85,17 @@ def update_model_config(module_config, override_config_kwargs):
             setattr(module_config, key, val)
 
 
-def get_huggingface_actor_config(model_name: str, override_config_kwargs=None, trust_remote_code=False) -> dict:
+def get_huggingface_actor_config(
+    model_name: str, override_config_kwargs=None, trust_remote_code=False, **from_pretrained_kwargs
+) -> dict:
     if override_config_kwargs is None:
         override_config_kwargs = {}
     assert isinstance(override_config_kwargs, dict), (
         f"override_config_kwargs must be a dict, got {type(override_config_kwargs)}"
     )
-    module_config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)
+    module_config = AutoConfig.from_pretrained(
+        model_name, trust_remote_code=trust_remote_code, **from_pretrained_kwargs
+    )
     update_model_config(module_config, override_config_kwargs)
 
     return module_config
@@ -100,17 +104,19 @@ def get_huggingface_actor_config(model_name: str, override_config_kwargs=None, t
 def get_generation_config(
     model: str,
     trust_remote_code: bool = False,
+    **from_pretrained_kwargs,
 ) -> Optional[GenerationConfig]:
     try:
-        return GenerationConfig.from_pretrained(model)
+        return GenerationConfig.from_pretrained(model, **from_pretrained_kwargs)
     except OSError:  # Not found
         try:
             config = get_huggingface_actor_config(
                 model,
                 trust_remote_code=trust_remote_code,
+                **from_pretrained_kwargs,
             )
             return GenerationConfig.from_model_config(config)
-        except OSError:  # Not found
+        except (OSError, ValueError):  # Not found / Hub id without a usable config
             return None
 
 

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -146,6 +146,7 @@ class DistillationTeacherModelConfig(BaseConfig):
 
     key: Optional[str] = None
     model_path: Optional[str] = None
+    revision: Optional[str] = None
     inference: RolloutConfig = field(default_factory=RolloutConfig)
     num_replicas: Optional[int] = 0
 

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -86,6 +86,9 @@ class HFModelConfig(BaseConfig):
     }
 
     path: str = MISSING
+    # Hugging Face revision (commit SHA preferred over a moving branch). Ignored
+    # when `path` is a local directory. Hub ids without this follow `main`.
+    revision: Optional[str] = None
     local_path: Optional[str] = None
     hf_config_path: Optional[str] = None
     local_hf_config_path: Optional[str] = None
@@ -145,6 +148,13 @@ class HFModelConfig(BaseConfig):
 
     mtp: MtpConfig = field(default_factory=MtpConfig)
 
+    def hub_revision_kwargs(self, src: Optional[str] = None) -> dict:
+        """Kwargs for transformers/vLLM Hub loads. Empty for local paths."""
+        loc = src if src is not None else self.path
+        if self.revision and loc and not str(loc).startswith("/"):
+            return {"revision": self.revision}
+        return {}
+
     def __post_init__(self):
         import_external_libs(self.external_lib)
 
@@ -158,8 +168,17 @@ class HFModelConfig(BaseConfig):
         # construct tokenizer
         if self.load_tokenizer:
             self.local_tokenizer_path = copy_to_local(self.tokenizer_path, use_shm=self.use_shm)
-            self.tokenizer = hf_tokenizer(self.local_tokenizer_path, trust_remote_code=self.trust_remote_code)
-            self.processor = hf_processor(self.local_tokenizer_path, trust_remote_code=self.trust_remote_code)
+            tok_src = self.local_tokenizer_path
+            self.tokenizer = hf_tokenizer(
+                tok_src,
+                trust_remote_code=self.trust_remote_code,
+                **self.hub_revision_kwargs(tok_src),
+            )
+            self.processor = hf_processor(
+                tok_src,
+                trust_remote_code=self.trust_remote_code,
+                **self.hub_revision_kwargs(tok_src),
+            )
 
         # For base models (e.g. Qwen3.5-2b-Base), the processor may not have a chat_template
         # while the tokenizer does. Sync it so that processor.apply_chat_template() works.
@@ -178,7 +197,9 @@ class HFModelConfig(BaseConfig):
 
         self.local_hf_config_path = copy_to_local(self.hf_config_path, use_shm=self.use_shm)
         self.generation_config = get_generation_config(
-            self.local_hf_config_path, trust_remote_code=self.trust_remote_code
+            self.local_hf_config_path,
+            trust_remote_code=self.trust_remote_code,
+            **self.hub_revision_kwargs(self.local_hf_config_path),
         )
 
         # construct hf_config
@@ -188,6 +209,7 @@ class HFModelConfig(BaseConfig):
                 self.local_hf_config_path,
                 trust_remote_code=self.trust_remote_code,
                 attn_implementation=attn_implementation,
+                **self.hub_revision_kwargs(self.local_hf_config_path),
             )
         except ValueError as error:
             lookup_error = error.__cause__ or error.__context__

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -268,11 +268,15 @@ class FSDPEngine(BaseEngine):
             if self.model_config.model_type == "language_model":
                 auto_class = get_hf_auto_model_class(hf_config=self.model_config.hf_config)
 
+                rev_kw = {}
+                if hasattr(self.model_config, "hub_revision_kwargs"):
+                    rev_kw = self.model_config.hub_revision_kwargs(self.model_config.local_path)
                 module = auto_class.from_pretrained(
                     pretrained_model_name_or_path=self.model_config.local_path,
                     torch_dtype=torch_dtype,
                     config=self.model_config.hf_config,
                     trust_remote_code=self.model_config.trust_remote_code,
+                    **rev_kw,
                 )
 
                 # Strip sub-modules listed in _verl_strip_modules (e.g.

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -284,6 +284,16 @@ class vLLMHttpServer:
         # 1. setup vllm serve cli args
         engine_kwargs = self.config.get("engine_kwargs", {}).get(self._get_engine_kwargs_key(), {}) or {}
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
+        mc = getattr(self, "model_config", None)
+        if mc is not None:
+            rev = getattr(mc, "revision", None)
+            if not rev and hasattr(mc, "get"):
+                rev = mc.get("revision")
+            path = getattr(mc, "path", None)
+            if path is None and hasattr(mc, "get"):
+                path = mc.get("path")
+            if rev and path and not str(path).startswith("/"):
+                engine_kwargs.setdefault("revision", rev)
         if self.config.get("limit_images", None):  # support for multi-image data
             engine_kwargs["limit_mm_per_prompt"] = {"image": self.config.get("limit_images")}
 


### PR DESCRIPTION
### What does this PR do?

Hub ids without a pin follow `main`. When a family (e.g. Gemma-4) moves tokenizer / `generation_config` on `main`, student and teacher can load mismatched snapshots and training breaks.

Adds optional `revision` on `HFModelConfig` and teacher model config, and threads it through tokenizer / processor / `AutoConfig` / `generation_config` (ignored for local paths), FSDP `from_pretrained`, vLLM async server `engine_kwargs`, the reward-loop tokenizer, and the teacher vLLM engine.

Search: https://github.com/verl-project/verl/pulls?q=is%3Apr+revision+HuggingFace

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+HFModelConfig+revision
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

CPU-only config plumbing; no new GPU CI. Used in production OPD with `actor_rollout_ref.model.revision: <sha>` and `distillation.teacher_models.*.revision`.

### API and Usage Example

```yaml
actor_rollout_ref.model.path: org/name
+actor_rollout_ref.model.revision: abcdef0123456789
distillation.teacher_models.teacher_model.model_path: org/other
+distillation.teacher_models.teacher_model.revision: fedcba9876543210
```

Local directories ignore `revision`.

### Design & Code Changes

- `HFModelConfig.revision` + `hub_revision_kwargs()`
- `DistillationTeacherModelConfig.revision`
- Pass through FSDP load, vLLM, reward tokenizer

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] pre-commit not run in this environment.
- [x] YAML comments on the new fields.
- [ ] Unit test not added (kwargs plumbing). Can add a CPU test of `hub_revision_kwargs` if useful.
- [ ] Will request CI on Slack after review start.


Made with [Cursor](https://cursor.com)