### PR TITLE
[algo, worker] feat: per-route teacher system_prompt_by_key

### DIFF
--- a/tests/experimental/teacher_loop/test_teacher_system_prompt_on_cpu.py
+++ b/tests/experimental/teacher_loop/test_teacher_system_prompt_on_cpu.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Edgerunner AI / Bytedance Ltd. and/or its affiliates
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
 """CPU tests for asymmetric teacher system-prompt OPD helpers."""
 
 from __future__ import annotations

--- a/tests/experimental/teacher_loop/test_teacher_system_prompt_on_cpu.py
+++ b/tests/experimental/teacher_loop/test_teacher_system_prompt_on_cpu.py
@@ -132,6 +132,23 @@ class TeacherSystemPromptTests(unittest.TestCase):
         self.assertGreaterEqual(cfg.inference.prompt_length, 1024 + 4096)
         self.assertLessEqual(cfg.inference.prompt_length, 8191)
 
+    def test_system_prompt_by_key_path_and_empty(self):
+        from verl.experimental.teacher_loop.teacher_manager import resolve_teacher_system_prompt_for_sample
+
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "er.txt"
+            path.write_text("ER21", encoding="utf-8")
+            cfg = DistillationTeacherModelConfig(
+                key="default",
+                model_path="dummy",
+                num_replicas=1,
+                system_prompt_by_key={"gold_mil": str(path), "gpqa_if_tqa": ""},
+            )
+            self.assertEqual(resolve_teacher_system_prompt_for_sample(cfg, "gold_mil"), "ER21")
+            self.assertIsNone(resolve_teacher_system_prompt_for_sample(cfg, "gpqa_if_tqa"))
+            with self.assertRaisesRegex(ValueError, "No system_prompt_by_key"):
+                resolve_teacher_system_prompt_for_sample(cfg, "unknown")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/experimental/teacher_loop/test_teacher_system_prompt_on_cpu.py
+++ b/tests/experimental/teacher_loop/test_teacher_system_prompt_on_cpu.py
@@ -1,0 +1,137 @@
+# Copyright 2025 Edgerunner AI / Bytedance Ltd. and/or its affiliates
+"""CPU tests for asymmetric teacher system-prompt OPD helpers."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+from verl.experimental.teacher_loop.teacher_manager import (
+    align_teacher_outputs_to_student,
+    inject_system_message,
+    resolve_teacher_system_prompt,
+)
+from verl.workers.config.distillation import DistillationTeacherModelConfig
+from verl.workers.config.rollout import RolloutConfig
+
+
+class TeacherSystemPromptTests(unittest.TestCase):
+    def test_inject_system_message_prepends_when_missing(self):
+        msgs = [{"role": "user", "content": "hi"}]
+        out = inject_system_message(msgs, "SYS")
+        self.assertEqual(out[0], {"role": "system", "content": "SYS"})
+        self.assertEqual(out[1], {"role": "user", "content": "hi"})
+        self.assertEqual(msgs[0]["role"], "user")
+
+    def test_inject_system_message_replaces_existing_system(self):
+        msgs = [{"role": "system", "content": "old"}, {"role": "user", "content": "hi"}]
+        out = inject_system_message(msgs, "NEW")
+        self.assertEqual(out[0]["content"], "NEW")
+        self.assertEqual(msgs[0]["content"], "old")
+
+    def test_resolve_teacher_system_prompt_inline_and_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            cfg = DistillationTeacherModelConfig(
+                key="default",
+                model_path="dummy",
+                num_replicas=1,
+                inference=RolloutConfig(),
+                system_prompt="  inline  ",
+                system_prompt_path=str(Path(td) / "ignored.txt"),
+            )
+            self.assertEqual(resolve_teacher_system_prompt(cfg), "  inline  ")
+
+            path = Path(td) / "sys.txt"
+            path.write_text("from-file", encoding="utf-8")
+            cfg2 = DistillationTeacherModelConfig(
+                key="default",
+                model_path="dummy",
+                num_replicas=1,
+                inference=RolloutConfig(),
+                system_prompt=None,
+                system_prompt_path=str(path),
+            )
+            self.assertEqual(resolve_teacher_system_prompt(cfg2), "from-file")
+
+        cfg3 = DistillationTeacherModelConfig(
+            key="default",
+            model_path="dummy",
+            num_replicas=1,
+            inference=RolloutConfig(),
+        )
+        self.assertIsNone(resolve_teacher_system_prompt(cfg3))
+
+    def test_align_identity_passthrough(self):
+        n, m = 4, 3
+        ids = torch.arange(n + m, dtype=torch.int32).unsqueeze(-1).expand(-1, 2).contiguous()
+        lps = torch.arange(n + m, dtype=torch.float32).unsqueeze(-1).expand(-1, 2).contiguous() * 0.1
+        out_ids, out_lps = align_teacher_outputs_to_student(
+            ids,
+            lps,
+            student_prompt_len=n,
+            student_response_len=m,
+            teacher_prompt_len=n,
+            pad_token_id=0,
+        )
+        self.assertTrue(torch.equal(out_ids, ids))
+        self.assertTrue(torch.equal(out_lps, lps))
+
+    def test_align_asymmetric_preserves_left_shift_response_window(self):
+        n, m, t = 5, 4, 9
+        teacher_ids = torch.arange(t + m, dtype=torch.int32).unsqueeze(-1)
+        teacher_lps = (torch.arange(t + m, dtype=torch.float32) + 100.0).unsqueeze(-1)
+
+        aligned_ids, aligned_lps = align_teacher_outputs_to_student(
+            teacher_ids,
+            teacher_lps,
+            student_prompt_len=n,
+            student_response_len=m,
+            teacher_prompt_len=t,
+            pad_token_id=7,
+        )
+        self.assertEqual(aligned_ids.shape[0], n + m)
+        self.assertEqual(aligned_lps.shape[0], n + m)
+        self.assertTrue(torch.equal(aligned_lps[n - 1 : n + m - 1], teacher_lps[t - 1 : t + m - 1]))
+        self.assertTrue(torch.equal(aligned_ids[n - 1 : n + m - 1], teacher_ids[t - 1 : t + m - 1]))
+        self.assertTrue(torch.all(aligned_ids[: n - 1] == 7))
+        self.assertTrue(torch.all(aligned_lps[: n - 1] == 0))
+
+    def test_align_rejects_length_mismatch(self):
+        ids = torch.zeros(10, 1, dtype=torch.int32)
+        lps = torch.zeros(10, 1)
+        with self.assertRaisesRegex(ValueError, "teacher output length"):
+            align_teacher_outputs_to_student(
+                ids,
+                lps,
+                student_prompt_len=3,
+                student_response_len=4,
+                teacher_prompt_len=5,
+                pad_token_id=0,
+            )
+
+    def test_validate_and_prepare_reserves_system_budget(self):
+        inf = RolloutConfig(
+            name="vllm",
+            prompt_length=1024,
+            response_length=4096,
+            max_model_len=8192,
+            engine_kwargs={"vllm": {}},
+        )
+        cfg = DistillationTeacherModelConfig(
+            key="default",
+            model_path="dummy",
+            num_replicas=1,
+            inference=inf,
+            system_prompt="x" * 2000,
+        )
+        cfg.validate_and_prepare_for_distillation(use_topk=False, topk=None)
+        self.assertEqual(cfg.inference.response_length, 1)
+        self.assertGreaterEqual(cfg.inference.prompt_length, 1024 + 4096)
+        self.assertLessEqual(cfg.inference.prompt_length, 8191)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -1006,7 +1006,15 @@ class AgentLoopWorker:
         validate: bool,
         sample_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
-        """Compute teacher logprobs for single sample."""
+        """Compute teacher logprobs for single sample.
+
+        Default (same-tokenizer OPD): score ``prompt_ids + response_ids`` as-is.
+
+        When the routed teacher has ``system_prompt`` / ``system_prompt_path`` set,
+        rebuild the teacher prefix from ``raw_prompt`` with that system turn injected,
+        append the same ``response_ids``, score that longer sequence, then remap the
+        teacher logprobs onto the student sequence layout for the distillation loss.
+        """
         if self.distillation_enabled and not validate:
             routing_key = None
             if sample_kwargs is not None:
@@ -1014,14 +1022,109 @@ class AgentLoopWorker:
                 if routing_value is not None:
                     # Non-tensor batch values arrive as 0-d numpy objects / arrays; normalize to Python.
                     routing_key = routing_value.item() if hasattr(routing_value, "item") else routing_value
+
+            sequence_ids = list(prompt_ids) + list(response_ids)
+            teacher_prompt_len = len(prompt_ids)
+            system_prompt = self._get_teacher_system_prompt(routing_key)
+            if system_prompt is not None:
+                sequence_ids, teacher_prompt_len = self._build_teacher_sequence_with_system(
+                    output=output,
+                    sample_kwargs=sample_kwargs,
+                    response_ids=response_ids,
+                    system_prompt=system_prompt,
+                )
+
             teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(
-                sequence_ids=prompt_ids + response_ids,
+                sequence_ids=sequence_ids,
                 multi_modal_data=output.multi_modal_data,
                 mm_processor_kwargs=output.mm_processor_kwargs,
                 routing_key=routing_key,
             )
+            if system_prompt is not None:
+                from verl.experimental.teacher_loop.teacher_manager import align_teacher_outputs_to_student
+
+                pad_token_id = self.tokenizer.pad_token_id
+                if pad_token_id is None:
+                    pad_token_id = 0
+                teacher_ids, teacher_logprobs = align_teacher_outputs_to_student(
+                    teacher_ids,
+                    teacher_logprobs,
+                    student_prompt_len=len(prompt_ids),
+                    student_response_len=len(response_ids),
+                    teacher_prompt_len=teacher_prompt_len,
+                    pad_token_id=int(pad_token_id),
+                )
             output.extra_fields["teacher_ids"] = teacher_ids
             output.extra_fields["teacher_logprobs"] = teacher_logprobs
+
+    def _get_teacher_system_prompt(self, routing_key: Optional[str]) -> Optional[str]:
+        from verl.experimental.teacher_loop.teacher_manager import resolve_teacher_system_prompt
+
+        teacher_key = self.teacher_server_manager._resolve_teacher_key(routing_key)
+        return resolve_teacher_system_prompt(self.teacher_server_manager.teacher_model_configs[teacher_key])
+
+    def _build_teacher_sequence_with_system(
+        self,
+        output: AgentLoopOutput,
+        sample_kwargs: Optional[dict[str, Any]],
+        response_ids: list[int],
+        system_prompt: str,
+    ) -> tuple[list[int], int]:
+        """Re-template raw messages with a teacher system prompt; append student response ids."""
+        from verl.experimental.teacher_loop.teacher_manager import inject_system_message
+        from verl.utils.tokenizer.chat_template import apply_chat_template
+        from verl.utils.tokenizer.tokenizer import normalize_token_ids
+
+        multi_modal_data = output.multi_modal_data or {}
+        if multi_modal_data.get("images") or multi_modal_data.get("videos") or multi_modal_data.get("audios"):
+            raise NotImplementedError(
+                "Teacher system_prompt / system_prompt_path is not supported for multimodal samples."
+            )
+
+        raw_prompt = output.extra_fields.get("raw_prompt") if output.extra_fields else None
+        if raw_prompt is None and sample_kwargs is not None:
+            raw_prompt = sample_kwargs.get("raw_prompt")
+        if raw_prompt is None:
+            raise ValueError(
+                "Teacher system_prompt is set but raw_prompt is missing from the sample; "
+                "cannot rebuild the teacher chat template."
+            )
+
+        # Dataset / TransferQueue may wrap messages as numpy object arrays.
+        if hasattr(raw_prompt, "tolist"):
+            raw_prompt = raw_prompt.tolist()
+        messages = [dict(m) for m in list(raw_prompt)]
+        teacher_messages = inject_system_message(messages, system_prompt)
+
+        apply_chat_template_kwargs = dict(self.config.data.get("apply_chat_template_kwargs", {}) or {})
+        tokenized = apply_chat_template(
+            self.tokenizer,
+            teacher_messages,
+            tools=None,
+            add_generation_prompt=True,
+            tokenize=True,
+            **apply_chat_template_kwargs,
+        )
+        teacher_prompt_ids = normalize_token_ids(tokenized)
+        if not teacher_prompt_ids:
+            raise ValueError("Teacher prompt tokenization produced an empty sequence.")
+
+        max_model_len = None
+        # Single-teacher configs expose max_model_len on the one teacher; multi-teacher
+        # uses the routed config's inference.max_model_len via the manager when needed.
+        try:
+            any_teacher = next(iter(self.teacher_server_manager.teacher_model_configs.values()))
+            max_model_len = any_teacher.inference.max_model_len
+        except StopIteration:
+            max_model_len = None
+        total_len = len(teacher_prompt_ids) + len(response_ids)
+        if max_model_len is not None and total_len > max_model_len:
+            raise ValueError(
+                "Teacher sequence with system prompt exceeds inference.max_model_len: "
+                f"teacher_prompt_len={len(teacher_prompt_ids)}, response_len={len(response_ids)}, "
+                f"total={total_len}, max_model_len={max_model_len}."
+            )
+        return list(teacher_prompt_ids) + list(response_ids), len(teacher_prompt_ids)
 
     def _postprocess(
         self,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -1058,10 +1058,13 @@ class AgentLoopWorker:
             output.extra_fields["teacher_logprobs"] = teacher_logprobs
 
     def _get_teacher_system_prompt(self, routing_key: Optional[str]) -> Optional[str]:
-        from verl.experimental.teacher_loop.teacher_manager import resolve_teacher_system_prompt
+        from verl.experimental.teacher_loop.teacher_manager import resolve_teacher_system_prompt_for_sample
 
         teacher_key = self.teacher_server_manager._resolve_teacher_key(routing_key)
-        return resolve_teacher_system_prompt(self.teacher_server_manager.teacher_model_configs[teacher_key])
+        return resolve_teacher_system_prompt_for_sample(
+            self.teacher_server_manager.teacher_model_configs[teacher_key],
+            routing_key,
+        )
 
     def _build_teacher_sequence_with_system(
         self,

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -32,6 +32,113 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
 
+def resolve_teacher_system_prompt(teacher_model_config: DistillationTeacherModelConfig) -> Optional[str]:
+    """Return the teacher-only system prompt text, or None when unset.
+
+    ``system_prompt`` wins over ``system_prompt_path``. Empty / whitespace-only
+    values are treated as unset so Hydra ``""`` overrides stay no-ops.
+    """
+    text = teacher_model_config.system_prompt
+    if text is not None and str(text).strip():
+        return str(text)
+    path = teacher_model_config.system_prompt_path
+    if path is None or not str(path).strip():
+        return None
+    path = os.path.expanduser(str(path))
+    if not os.path.isfile(path):
+        raise FileNotFoundError(
+            f"distillation teacher system_prompt_path not found: {path!r}"
+        )
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    if not text.strip():
+        raise ValueError(f"distillation teacher system_prompt_path is empty: {path!r}")
+    return text
+
+
+def inject_system_message(messages: list[dict], system_prompt: str) -> list[dict]:
+    """Return a copy of ``messages`` with ``system_prompt`` as the leading system turn.
+
+    If the conversation already starts with a system/developer turn, that turn's
+    content is replaced (teacher-only context should not stack on a student system
+    message that the teacher never saw during student rollout).
+    """
+    if not system_prompt:
+        raise ValueError("system_prompt must be non-empty")
+    msgs = [dict(m) for m in messages]
+    if msgs and msgs[0].get("role") in ("system", "developer"):
+        msgs[0] = {"role": "system", "content": system_prompt}
+    else:
+        msgs = [{"role": "system", "content": system_prompt}] + msgs
+    return msgs
+
+
+def align_teacher_outputs_to_student(
+    teacher_ids: torch.Tensor,
+    teacher_logprobs: torch.Tensor,
+    *,
+    student_prompt_len: int,
+    student_response_len: int,
+    teacher_prompt_len: int,
+    pad_token_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Remap teacher prompt_logprobs onto the student sequence layout.
+
+    Native OPD feeds student ``prompt_ids + response_ids`` to the teacher. When the
+    teacher is scored on a *different* prompt prefix (e.g. an injected system turn)
+    of length ``teacher_prompt_len``, the response token ids are still shared, but
+    the full teacher tensor is longer/shorter than the student sequence.
+
+    Downstream ``no_padding_2_padding`` left-shifts by one and slices the response
+    using *student* prompt/response lengths. Combined with vLLM
+    ``extract_prompt_logprobs`` (drop first, append trailing zeros), response token
+    ``j`` is read from index ``prompt_len - 1 + j``. Copy that window from the
+    teacher tensor onto a student-length tensor so loss alignment is unchanged.
+    """
+    if student_prompt_len < 1:
+        raise ValueError(f"student_prompt_len must be >= 1, got {student_prompt_len}")
+    if student_response_len < 1:
+        raise ValueError(f"student_response_len must be >= 1, got {student_response_len}")
+    if teacher_prompt_len < 1:
+        raise ValueError(f"teacher_prompt_len must be >= 1, got {teacher_prompt_len}")
+
+    expected_teacher_len = teacher_prompt_len + student_response_len
+    if teacher_ids.shape[0] != expected_teacher_len or teacher_logprobs.shape[0] != expected_teacher_len:
+        raise ValueError(
+            "teacher output length must equal teacher_prompt_len + student_response_len: "
+            f"got ids={tuple(teacher_ids.shape)} logprobs={tuple(teacher_logprobs.shape)} "
+            f"expected_len={expected_teacher_len} "
+            f"({teacher_prompt_len=}, {student_response_len=})"
+        )
+
+    # Identity layout: keep the original tensors (including prompt-side logprobs).
+    if teacher_prompt_len == student_prompt_len:
+        return teacher_ids, teacher_logprobs
+
+    student_len = student_prompt_len + student_response_len
+    # Window of length student_response_len that survives left-shift response slicing.
+    src = slice(teacher_prompt_len - 1, teacher_prompt_len + student_response_len - 1)
+    dst = slice(student_prompt_len - 1, student_prompt_len + student_response_len - 1)
+
+    if teacher_ids.ndim == 1:
+        aligned_ids = torch.full((student_len,), pad_token_id, dtype=teacher_ids.dtype)
+        aligned_logprobs = torch.zeros(student_len, dtype=teacher_logprobs.dtype)
+    else:
+        aligned_ids = torch.full(
+            (student_len, *teacher_ids.shape[1:]),
+            pad_token_id,
+            dtype=teacher_ids.dtype,
+        )
+        aligned_logprobs = torch.zeros(
+            (student_len, *teacher_logprobs.shape[1:]),
+            dtype=teacher_logprobs.dtype,
+        )
+
+    aligned_ids[dst] = teacher_ids[src]
+    aligned_logprobs[dst] = teacher_logprobs[src]
+    return aligned_ids, aligned_logprobs
+
+
 def _get_teacher_sampling_params(
     teacher_model_config: DistillationTeacherModelConfig,
     distillation_loss_config: DistillationLossConfig,

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -44,16 +44,47 @@ def resolve_teacher_system_prompt(teacher_model_config: DistillationTeacherModel
     path = teacher_model_config.system_prompt_path
     if path is None or not str(path).strip():
         return None
-    path = os.path.expanduser(str(path))
-    if not os.path.isfile(path):
-        raise FileNotFoundError(
-            f"distillation teacher system_prompt_path not found: {path!r}"
-        )
-    with open(path, encoding="utf-8") as f:
-        text = f.read()
-    if not text.strip():
-        raise ValueError(f"distillation teacher system_prompt_path is empty: {path!r}")
-    return text
+    return _load_system_prompt_spec(str(path))
+
+
+def _load_system_prompt_spec(spec: str) -> str:
+    path = os.path.expanduser(spec)
+    if os.path.isfile(path):
+        with open(path, encoding="utf-8") as f:
+            text = f.read()
+        if not text.strip():
+            raise ValueError(f"distillation teacher system prompt file is empty: {path!r}")
+        return text
+    if "/" in spec or spec.endswith(".txt"):
+        raise FileNotFoundError(f"distillation teacher system_prompt_path not found: {path!r}")
+    if not spec.strip():
+        raise ValueError("distillation teacher system prompt is empty")
+    return spec
+
+
+def resolve_teacher_system_prompt_for_sample(
+    teacher_model_config: DistillationTeacherModelConfig,
+    routing_key: Optional[str] = None,
+) -> Optional[str]:
+    """System prompt for one sample. Honors ``system_prompt_by_key`` when set."""
+    by_key = teacher_model_config.system_prompt_by_key
+    if by_key:
+        mapping = dict(by_key)
+        if routing_key is None:
+            raise ValueError(
+                "system_prompt_by_key is set but the sample has no routing key "
+                f"(distillation.teacher_key). Configured keys: {sorted(mapping)}"
+            )
+        if routing_key not in mapping:
+            raise ValueError(
+                f"No system_prompt_by_key entry for routing key {routing_key!r}. "
+                f"Configured keys: {sorted(mapping)}"
+            )
+        spec = mapping[routing_key]
+        if spec is None or not str(spec).strip():
+            return None
+        return _load_system_prompt_spec(str(spec))
+    return resolve_teacher_system_prompt(teacher_model_config)
 
 
 def inject_system_message(messages: list[dict], system_prompt: str) -> list[dict]:

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -84,6 +84,11 @@ teacher_models:
     key: null
     model_path: null
     num_replicas: 0
+    # Optional teacher-only system prompt (asymmetric / privileged-context OPD).
+    # When set, the teacher re-templates raw_prompt with this system turn and scores
+    # the student's response tokens under that longer prefix. Student rollout is unchanged.
+    system_prompt: null
+    system_prompt_path: null
     inference:
       _target_: verl.workers.config.RolloutConfig
       name: ${oc.select:actor_rollout_ref.rollout.name}

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -89,6 +89,9 @@ teacher_models:
     # the student's response tokens under that longer prefix. Student rollout is unchanged.
     system_prompt: null
     system_prompt_path: null
+    # Optional map of routing-key -> prompt text or file path (empty string = no system turn).
+    # When set, every sample must have distillation.teacher_key in this map.
+    system_prompt_by_key: null
     inference:
       _target_: verl.workers.config.RolloutConfig
       name: ${oc.select:actor_rollout_ref.rollout.name}

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -140,6 +140,14 @@ class DistillationTeacherModelConfig(BaseConfig):
         inference.tensor_model_parallel_size * inference.pipeline_model_parallel_size),
         so the teacher's total GPU footprint is
         `num_replicas * per_replica_world_size`.
+    system_prompt (str, optional):
+        Teacher-only system prompt text. When set, the teacher scores the student's
+        response tokens under a re-templated prompt that injects this system turn,
+        while the student rollout stays unchanged (asymmetric / privileged-context OPD).
+        Takes precedence over ``system_prompt_path``.
+    system_prompt_path (str, optional):
+        Path to a UTF-8 text file containing the teacher-only system prompt. Used when
+        ``system_prompt`` is unset. Prefer this for long prompts (Hydra-friendly).
     """
 
     _mutable_fields = BaseConfig._mutable_fields | {"num_replicas", "key"}
@@ -148,6 +156,8 @@ class DistillationTeacherModelConfig(BaseConfig):
     model_path: Optional[str] = None
     inference: RolloutConfig = field(default_factory=RolloutConfig)
     num_replicas: Optional[int] = 0
+    system_prompt: Optional[str] = None
+    system_prompt_path: Optional[str] = None
 
     @property
     def per_replica_world_size(self) -> int:
@@ -170,18 +180,35 @@ class DistillationTeacherModelConfig(BaseConfig):
             raise ValueError("num_replicas must be specified for distillation teacher model config.")
 
     def validate_and_prepare_for_distillation(self, use_topk: bool, topk: Optional[int]) -> None:
-        # Prompt + Response from student are fed into teacher as context
+        # Prompt + Response from student are fed into teacher as context. When a
+        # teacher-only system prompt is configured, the teacher prefix can be longer
+        # than the student prompt; reserve headroom via a conservative char estimate
+        # (exact length is checked when scoring each sample).
         max_model_len = self.inference.max_model_len
         student_prompt_length = self.inference.prompt_length
         student_response_length = self.inference.response_length
-        required_context_len = student_prompt_length + student_response_length + 1
+        system_token_budget = 0
+        if self.system_prompt and str(self.system_prompt).strip():
+            system_token_budget = max(256, len(str(self.system_prompt)) // 2)
+        elif self.system_prompt_path and str(self.system_prompt_path).strip():
+            path = os.path.expanduser(str(self.system_prompt_path))
+            if os.path.isfile(path):
+                with open(path, encoding="utf-8") as f:
+                    system_token_budget = max(256, len(f.read()) // 2)
+            else:
+                # Path may be resolved later relative to the job cwd; keep a floor.
+                system_token_budget = 2048
+        required_context_len = student_prompt_length + student_response_length + 1 + system_token_budget
         if max_model_len is not None and required_context_len > max_model_len:
             raise ValueError(
-                "Distillation teacher inference requires room for the student prompt, the full student "
-                f"response, and one generated token, but got {student_prompt_length=}, "
-                f"{student_response_length=}, {required_context_len=}, {max_model_len=}."
+                "Distillation teacher inference requires room for the (possibly system-augmented) "
+                "prompt, the full student response, and one generated token, but got "
+                f"{student_prompt_length=}, {student_response_length=}, {system_token_budget=}, "
+                f"{required_context_len=}, {max_model_len=}."
             )
-        self.inference.prompt_length = self.inference.prompt_length + self.inference.response_length
+        self.inference.prompt_length = student_prompt_length + student_response_length + system_token_budget
+        if max_model_len is not None:
+            self.inference.prompt_length = min(self.inference.prompt_length, max_model_len - 1)
         self.inference.response_length = 1
         self._validate_topk_logprobs(use_topk=use_topk, topk=topk)
 

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -148,9 +148,17 @@ class DistillationTeacherModelConfig(BaseConfig):
     system_prompt_path (str, optional):
         Path to a UTF-8 text file containing the teacher-only system prompt. Used when
         ``system_prompt`` is unset. Prefer this for long prompts (Hydra-friendly).
+    system_prompt_by_key (dict, optional):
+        Per-sample teacher system prompts for a *single* loaded teacher. Keys must
+        match ``sample[distillation.teacher_key]`` (typically ``data_source``). A
+        value is either a filesystem path or inline text; empty/null means no
+        system turn for that key. When this map is non-empty it replaces
+        ``system_prompt`` / ``system_prompt_path`` for scoring. Use this when the
+        same teacher weights should see an optional privileged prompt depending
+        on the mix, without launching a second replica.
     """
 
-    _mutable_fields = BaseConfig._mutable_fields | {"num_replicas", "key"}
+    _mutable_fields = BaseConfig._mutable_fields | {"num_replicas", "key", "system_prompt_by_key"}
 
     key: Optional[str] = None
     model_path: Optional[str] = None
@@ -158,6 +166,7 @@ class DistillationTeacherModelConfig(BaseConfig):
     num_replicas: Optional[int] = 0
     system_prompt: Optional[str] = None
     system_prompt_path: Optional[str] = None
+    system_prompt_by_key: Optional[dict] = None
 
     @property
     def per_replica_world_size(self) -> int:
@@ -170,6 +179,35 @@ class DistillationTeacherModelConfig(BaseConfig):
     @property
     def world_size(self) -> int:
         return self.num_replicas * self.per_replica_world_size
+
+    def _system_prompt_specs(self) -> list[str]:
+        specs: list[str] = []
+        by_key = self.system_prompt_by_key or {}
+        try:
+            values = dict(by_key).values()
+        except Exception:
+            values = []
+        for v in values:
+            if v is not None and str(v).strip():
+                specs.append(str(v))
+        if specs:
+            return specs
+        if self.system_prompt and str(self.system_prompt).strip():
+            specs.append(str(self.system_prompt))
+        elif self.system_prompt_path and str(self.system_prompt_path).strip():
+            specs.append(str(self.system_prompt_path))
+        return specs
+
+    @staticmethod
+    def _system_token_budget_for_spec(spec: str) -> int:
+        path = os.path.expanduser(spec)
+        if os.path.isfile(path):
+            with open(path, encoding="utf-8") as f:
+                return max(256, len(f.read()) // 2)
+        if "/" in spec or spec.endswith(".txt"):
+            # Path may be resolved later relative to the job cwd; keep a floor.
+            return 2048
+        return max(256, len(spec) // 2)
 
     def check_configured(self):
         if self.model_path is None:
@@ -188,16 +226,8 @@ class DistillationTeacherModelConfig(BaseConfig):
         student_prompt_length = self.inference.prompt_length
         student_response_length = self.inference.response_length
         system_token_budget = 0
-        if self.system_prompt and str(self.system_prompt).strip():
-            system_token_budget = max(256, len(str(self.system_prompt)) // 2)
-        elif self.system_prompt_path and str(self.system_prompt_path).strip():
-            path = os.path.expanduser(str(self.system_prompt_path))
-            if os.path.isfile(path):
-                with open(path, encoding="utf-8") as f:
-                    system_token_budget = max(256, len(f.read()) // 2)
-            else:
-                # Path may be resolved later relative to the job cwd; keep a floor.
-                system_token_budget = 2048
+        for spec in self._system_prompt_specs():
+            system_token_budget = max(system_token_budget, self._system_token_budget_for_spec(spec))
         required_context_len = student_prompt_length + student_response_length + 1 + system_token_budget
         if max_model_len is not None and required_context_len > max_model_len:
             raise ValueError(


### PR DESCRIPTION
### What does this PR do?

**Depends on https://github.com/verl-project/verl/pull/7659** (teacher-only `system_prompt`). This branch is stacked on that one; GitHub will show both commits until 7659 merges.

Same teacher replica, different system turns by routing key (e.g. gold military + ER-style prompt, GPQA/IF/TQA with an empty system turn). Avoids a second vLLM teacher pool.

```yaml
+distillation.teacher_models.teacher_model.system_prompt_by_key.gold_mil: configs/prompts/teacher_sys.txt
+distillation.teacher_models.teacher_model.system_prompt_by_key.gpqa_if_tqa: ""
```

Empty string means no system turn. Every sample must have `distillation.teacher_key` in the map.

Search: https://github.com/verl-project/verl/pulls?q=is%3Apr+system_prompt_by_key

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+teacher+system_prompt
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Extends `tests/experimental/teacher_loop/test_teacher_system_prompt_on_cpu.py` for by-key path vs empty vs missing key.

### API and Usage Example

See yaml above. `system_prompt_by_key` takes precedence over a global `system_prompt` / `system_prompt_path`.

### Design & Code Changes

- `resolve_teacher_system_prompt_for_sample` in `teacher_manager.py`
- Agent loop passes the sample routing key
- `DistillationTeacherModelConfig.system_prompt_by_key` + yaml comment

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] pre-commit not run in this environment.
- [x] YAML comments.
- [x] CPU unit test extended.
- [ ] Will request CI on Slack after 7659 / review start.


Made with [Cursor](https://cursor.com)