### PR TITLE
[data, trainer] fix: preserve NeoProto storage configuration

### DIFF
--- a/docs/advance/neoproto_integration.md
+++ b/docs/advance/neoproto_integration.md
@@ -2,9 +2,10 @@
 
 Last updated: 08/19/2026.
 
-NeoProto is the default and only data path for the V0 `RayPPOTrainer`. Batch
+NeoProto is the default data representation for the V0 `RayPPOTrainer`. Batch
 payloads stay in a storage engine while the driver manipulates schemas,
-references, and index views. There is no runtime classic/NeoProto selector.
+references, and index views. There is no runtime classic/NeoProto selector;
+storage selection remains independent and defaults to the Ray object store.
 
 ## Public compatibility API
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -34,7 +34,6 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
 from verl import DataProto
-from verl.experimental.neoproto.storage import DefaultStorageEngine, set_default_storage_engine
 from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
 from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup, ResourcePoolManager
 from verl.single_controller.ray.base import create_colocated_worker_cls
@@ -330,9 +329,8 @@ class RayPPOTrainer:
         self.tokenizer = tokenizer
         self.processor = processor
         self.config = config
-        # NeoProto is the single trainer data path. ``DataProto`` is its
-        # backward-compatible public API, not a runtime-selectable alternative.
-        set_default_storage_engine(DefaultStorageEngine())
+        # ``DataProto`` is the NeoProto-backed public API. Storage remains
+        # independently selectable and defaults to the Ray object store.
         if os.environ.get("NEO_BRIDGE_FULL_MATERIALIZE", "0") != "0":
             raise RuntimeError("The NeoProto-only trainer forbids NEO_BRIDGE_FULL_MATERIALIZE")
 

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -637,14 +637,12 @@ def patch_valuehead_model(model) -> None:
 def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_code):
     from transformers import AutoModelForCausalLM, AutoModelForTokenClassification
 
-    attn_implementation = getattr(model_config, "_attn_implementation", None) or "flash_attention_2"
-
     try:
         model = AutoModelForTokenClassification.from_pretrained(
             pretrained_model_name_or_path=local_path,
             torch_dtype=torch_dtype,
             config=model_config,
-            attn_implementation=attn_implementation,
+            attn_implementation="flash_attention_2",
             trust_remote_code=trust_remote_code,
         )
         return model
@@ -666,7 +664,7 @@ def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_cod
         pretrained_model_name_or_path=local_path,
         torch_dtype=torch_dtype,
         config=model_config,
-        attn_implementation=attn_implementation,
+        attn_implementation="flash_attention_2",
         trust_remote_code=trust_remote_code,
     )
     # vlm models


### PR DESCRIPTION

  ### What does this PR do?

  Follow-up to #7557.

  This PR stops `RayPPOTrainer` from overwriting the configured NeoProto storage engine. Ray object store remains the default, while custom storage engines are preserved.

  It also reverts an unrelated value-head attention change from #7557.

  This does not duplicate an open PR: [search query](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+NeoProto+storage).

  ### Checklist Before Starting

  - [x] Search for similar PRs.
  - [x] Format the PR title correctly.

  ### Test

  - `pytest -q tests/experimental/neoproto/test_neoproto.py tests/experimental/neoproto/test_neo_plane.py`
    - 41 passed, 1 skipped
  - `pre-commit run --all-files`
    - Passed in a clean checkout
  - Single-node 8-GPU NeoProto E2E completed successfully with these runtime changes.

  ### API and Usage Example

  No API changes.

  ### Design & Code Changes

  - Preserve explicitly configured storage engines.
  - Revert the unrelated model attention change.
  - Clarify the storage behavior in the documentation.

  ### Checklist Before Submitting

  - [x] Apply pre-commit checks.
  - [x] Update documentation.
  - [x] Existing NeoProto tests cover the changed path
  - [ ] Request CI when ready.
