### PR TITLE
[rollout] fix: make GlobalRequestLoadBalancer full_determinism cross-process reproducible

### DIFF
--- a/tests/workers/rollout/test_router_on_cpu.py
+++ b/tests/workers/rollout/test_router_on_cpu.py
@@ -377,3 +377,78 @@ class TestGetRouterHandlePrecedence:
 
         status = ray.get(manager.global_load_balancer.get_status.remote())
         assert status["active_servers"] == 2
+
+
+class TestFullDeterminismRouting:
+    """Validate that GlobalRequestLoadBalancer full_determinism routing is
+    cross-process reproducible (independent of PYTHONHASHSEED) and invariant
+    to server dictionary insertion order."""
+
+    def test_full_determinism_insertion_order_invariant(self):
+        """Routing under full_determinism must not depend on dictionary insertion order."""
+        servers_order1 = {"s0": "h0", "s1": "h1", "s2": "h2", "s3": "h3"}
+        servers_order2 = {"s3": "h3", "s1": "h1", "s0": "h0", "s2": "h2"}
+        servers_order3 = {"s2": "h2", "s0": "h0", "s3": "h3", "s1": "h1"}
+
+        lb1 = GlobalRequestLoadBalancer(servers=servers_order1, full_determinism=True)
+        lb2 = GlobalRequestLoadBalancer(servers=servers_order2, full_determinism=True)
+        lb3 = GlobalRequestLoadBalancer(servers=servers_order3, full_determinism=True)
+
+        for i in range(50):
+            req_id = f"det-{i}"
+            s1, _ = lb1.acquire_server(req_id)
+            s2, _ = lb2.acquire_server(req_id)
+            s3, _ = lb3.acquire_server(req_id)
+            assert s1 == s2 == s3, f"Mismatch for {req_id}: {s1} vs {s2} vs {s3}"
+
+    def test_full_determinism_cross_process_reproducibility(self):
+        """Different Python processes with different PYTHONHASHSEED must compute
+        identical server assignments for the same request IDs."""
+        import json
+        import subprocess
+        import sys
+
+        code = """
+import json
+import sys
+from verl.workers.rollout.router import GlobalRequestLoadBalancer
+
+servers = {"s0": None, "s1": None, "s2": None, "s3": None}
+lb = GlobalRequestLoadBalancer(servers=servers, full_determinism=True)
+results = [lb.acquire_server(f"det-{i}")[0] for i in range(30)]
+print(json.dumps(results))
+"""
+        seeds = ["0", "42", "12345", "random"]
+        all_results = []
+        for seed in seeds:
+            env = {"PYTHONPATH": ".", "PYTHONHASHSEED": seed}
+            res = subprocess.run(
+                [sys.executable, "-c", code],
+                capture_output=True,
+                text=True,
+                check=True,
+                env=env,
+            )
+            all_results.append(json.loads(res.stdout.strip()))
+
+        baseline = all_results[0]
+        for idx, (seed, r) in enumerate(zip(seeds, all_results, strict=True)):
+            assert r == baseline, f"Process with PYTHONHASHSEED={seed} produced divergent routing: {r} != {baseline}"
+
+    def test_full_determinism_sticky_session_and_clear(self):
+        """Sticky session returns the cached server, and clear_sticky_cache re-routes deterministically."""
+        servers = {"s0": "h0", "s1": "h1", "s2": "h2"}
+        lb = GlobalRequestLoadBalancer(servers=servers, full_determinism=True)
+
+        s_first, _ = lb.acquire_server("det-0")
+        s_second, _ = lb.acquire_server("det-0")
+        assert s_first == s_second
+        assert lb.get_inflight_count(s_first) == 2
+
+        lb.release_server(s_first)
+        lb.release_server(s_first)
+        assert lb.get_inflight_count(s_first) == 0
+
+        lb.clear_sticky_cache()
+        s_third, _ = lb.acquire_server("det-0")
+        assert s_third == s_first

--- a/verl/workers/rollout/router.py
+++ b/verl/workers/rollout/router.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import random
+import zlib
 from typing import Any, Protocol
 
 import ray
@@ -147,8 +148,9 @@ class GlobalRequestLoadBalancer:
     - **Least-loaded Selection**: When no sticky session exists, selects the
       server with the fewest in-flight requests.
     - **Deterministic Routing**: When ``full_determinism=True``, routes every
-      request by ``hash(request_id) % len(servers)`` over the full pool so the
-      same request always routes to the same replica across runs.
+      request by a stable platform-independent hash (``zlib.crc32``) over sorted
+      server IDs so the same request always routes to the same replica across
+      processes and runs.
     - **Dynamic Server Management**: Supports add/remove servers at runtime
       for hybrid scaling.
     """
@@ -192,9 +194,12 @@ class GlobalRequestLoadBalancer:
 
         if self._full_determinism:
             # Full-hash routing: same request_id always lands on the same replica
-            # across runs. Least-loaded selection depends on async arrival timing,
-            # which varies run-to-run, so it is bypassed entirely here.
-            server_id = list(self._servers)[hash(request_id) % len(self._servers)]
+            # across runs and across processes. Least-loaded selection depends on async
+            # arrival timing, which varies run-to-run, so it is bypassed entirely here.
+            # Using sorted server keys and crc32 ensures platform and process independence
+            # without relying on PYTHONHASHSEED or dict insertion order.
+            sorted_servers = sorted(self._servers.keys())
+            server_id = sorted_servers[zlib.crc32(request_id.encode("utf-8")) % len(sorted_servers)]
         else:
             min_count = min(self._inflight_requests.values())
             candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]


### PR DESCRIPTION
### What does this PR do?

Fixes #7666.

Under `full_determinism=True`, `GlobalRequestLoadBalancer` in `verl/workers/rollout/router.py` previously routed requests via `list(self._servers)[hash(request_id) % len(self._servers)]`.

This caused non-deterministic request-to-replica distribution across runs and worker processes due to:
1. Python's built-in `hash(str)` utilizing a process-randomized seed (`PYTHONHASHSEED`), producing different values in separate Python processes or subsequent runs.
2. `list(self._servers)` depending on dictionary insertion order.

This PR replaces `hash()` with `zlib.crc32()` over `sorted(self._servers.keys())`, ensuring platform- and process-independent deterministic routing (consistent with the determinism strategy in `verl/experimental/reward_loop/router/naive_router.py`).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+router+determinism
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

- Added `TestFullDeterminismRouting` in `tests/workers/rollout/test_router_on_cpu.py`:
  - `test_full_determinism_cross_process_reproducibility`: Validates that separate Python subprocesses initialized with distinct `PYTHONHASHSEED` values (`0`, `42`, `12345`, `random`) yield identical request-to-server assignments.
  - `test_full_determinism_insertion_order_invariant`: Validates that varying dictionary insertion orders produce identical routing.
  - `test_full_determinism_sticky_session_and_clear`: Validates sticky session retention and cache clearing.
- Ran all 25 unit tests in `tests/workers/rollout/test_router_on_cpu.py` (25 passed).
- Ran ruff lint and format checks (`ruff check`, `ruff format --check`).

### API and Usage Example

No external API changes. Users configuring `actor_rollout_ref.rollout.full_determinism=true` will now obtain identical request-to-replica assignments across distributed worker processes and training runs.

### Design & Code Changes

- In `verl/workers/rollout/router.py`:
  - `acquire_server`: Compute server index using `zlib.crc32(request_id.encode("utf-8")) % len(sorted_servers)` over `sorted(self._servers.keys())`.
  - Updated docstring to document the cross-process determinism guarantee.
- In `tests/workers/rollout/test_router_on_cpu.py`:
  - Added `TestFullDeterminismRouting` suite.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.