### PR TITLE
[rollout, vllm] feat: pluggable router with FQN/YAML plugins

### DIFF
--- a/docs/advance/determinism.md
+++ b/docs/advance/determinism.md
@@ -96,7 +96,7 @@ If the policy or RM model is not covered by vLLM batch invariance, add `actor_ro
 
 ### Deterministic routing
 
-- **Actor rollout**: `SingleTurnAgentLoop` uses `request_id=f"det-{priority}"` (priority from `non_tensor_batch["priority"]`), and `GlobalRequestLoadBalancer` (with `full_determinism=True`) routes with `hash(request_id) % len(servers)` — the same request always routes to the same vLLM server across runs. (`priority` is vLLM-only; `LLMServerClient.generate()` filters it for non-vLLM backends.) When `full_determinism=True`, `LLMServerClient._vllm_request_id()` forwards this stable `request_id` to vLLM itself.
+- **Actor rollout**: `SingleTurnAgentLoop` uses `request_id=f"det-{priority}"` (priority from `non_tensor_batch["priority"]`), and `GlobalRequestLoadBalancer` (in `verl/workers/rollout/router.py`, with `full_determinism=True`) routes with `hash(request_id) % len(servers)` — the same request always routes to the same vLLM server across runs. (`priority` is vLLM-only; `LLMServerClient.generate()` filters it for non-vLLM backends.) When `full_determinism=True`, `LLMServerClient._vllm_request_id()` forwards this stable `request_id` to vLLM itself.
 - **Reward**: `NaiveRouter` routes with `binascii.crc32(request body) % len(candidates)` among equally-loaded RM replicas, so the same reward request always routes to the same replica. This neutralizes replica-level floating-point differences that seed alone cannot equalize.
 
 ### Trainer backend (V0 required)

--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -752,7 +752,8 @@ The returned scalar loss is what `engine.train_batch` backpropagates.
 - `verl/workers/engine/{fsdp,megatron}/transformer_impl.py` — training-engine forward steps; invoke `distillation_ppo_loss` first as a logits processor (top-$k$ modes) and again as the final loss
 - `verl/trainer/main_ppo.py` — `is_distillation_enabled` gate; allocates the dedicated `teacher_pool` resource pool
 - `verl/trainer/ppo/ray_trainer.py` — constructs `MultiTeacherModelManager` and hands its `get_client()` dict to `AgentLoopWorker(... teacher_client=...)`
-- `verl/workers/rollout/llm_server.py` — `LLMServerClient` and `GlobalRequestLoadBalancer` used for both student rollout and teacher logprob computation
+- `verl/workers/rollout/llm_server.py` — `LLMServerClient` used for both student rollout and teacher logprob computation
+- `verl/workers/rollout/router.py` — pluggable router (`GlobalRequestLoadBalancer`, `get_router_handle`) selecting the backing server
 
 ### **Configuration Files**
 

--- a/tests/experimental/agent_loop/test_basic_agent_loop.py
+++ b/tests/experimental/agent_loop/test_basic_agent_loop.py
@@ -27,7 +27,7 @@ from verl.protocol import DataProto
 from verl.tools.base_tool import BaseTool, OpenAIFunctionToolSchema
 from verl.tools.schemas import ToolResponse
 from verl.utils import hf_tokenizer
-from verl.workers.rollout.llm_server import GlobalRequestLoadBalancer
+from verl.workers.rollout.router import GlobalRequestLoadBalancer
 
 
 @pytest.fixture

--- a/tests/workers/rollout/test_router_on_cpu.py
+++ b/tests/workers/rollout/test_router_on_cpu.py
@@ -1,0 +1,421 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for verl.workers.rollout.router"""
+
+import logging
+from typing import Any
+
+import pytest
+import ray
+import yaml
+
+from verl.workers.rollout.router import GlobalRequestLoadBalancer, get_router_handle
+
+
+@ray.remote
+class _MockPluginLoadBalancer:
+    """Ray actor implementing RequestLoadBalancer Protocol.
+
+    Used as the ``router_class`` for plugin tests via ``importlib`` dynamic
+    loading, and directly for Protocol structural checks."""
+
+    def __init__(self, servers: dict[str, Any], router_kwargs: dict):
+        self._servers = dict(servers)
+        self._inflight: dict[str, int] = {sid: 0 for sid in self._servers}
+        self._router_kwargs = dict(router_kwargs)
+        self.releases: list[tuple] = []
+        self.acquire_calls: list[tuple] = []
+
+    def get_router_kwargs(self) -> dict:
+        """Return the kwargs dict passed to the constructor."""
+        return dict(self._router_kwargs)
+
+    def get_releases(self) -> list[tuple]:
+        """Return recorded release_server calls (server_id, request_id)."""
+        return list(self.releases)
+
+    def get_acquire_calls(self) -> list[tuple]:
+        """Return recorded acquire_server calls as (request_id, prompt_ids)."""
+        return list(self.acquire_calls)
+
+    def require_acquire_fields(self) -> list[str]:
+        """Protocol: this content-aware mock routes on prompt token ids."""
+        return ["prompt_ids"]
+
+    def require_release_fields(self) -> list[str]:
+        """Protocol: attribute releases by request_id."""
+        return ["request_id"]
+
+    def acquire_server(self, request_id: str, prompt_ids: list[int] | None = None) -> tuple[str, Any]:
+        self.acquire_calls.append((request_id, prompt_ids))
+        if not prompt_ids:
+            raise RuntimeError("No available prompt_ids")
+        if not self._inflight:
+            raise RuntimeError("No available servers")
+
+        sid = min(self._inflight, key=self._inflight.get)
+        self._inflight[sid] += 1
+        return sid, self._servers[sid]
+
+    def release_server(self, server_id: str, request_id: str | None = None) -> None:
+        self.releases.append((server_id, request_id))
+        if server_id in self._inflight and self._inflight[server_id] > 0:
+            self._inflight[server_id] -= 1
+
+    def add_servers(self, servers: dict[str, Any]) -> None:
+        for sid, handle in servers.items():
+            self._servers[sid] = handle
+            self._inflight[sid] = 0
+
+    def remove_servers(self, server_ids: list[str]) -> None:
+        for sid in server_ids:
+            self._inflight.pop(sid, None)
+            self._servers.pop(sid, None)
+
+    def get_all_servers(self) -> list[str]:
+        return list(self._inflight.keys())
+
+    def get_status(self) -> dict:
+        return {
+            "servers": dict(self._inflight),
+            "total_inflight": sum(self._inflight.values()),
+            "active_servers": len(self._inflight),
+        }
+
+    def clear_sticky_cache(self) -> dict:
+        """Protocol: clear sticky state (mock has none) and report loads."""
+        return {"cleared_entries": 0, "server_loads": dict(self._inflight)}
+
+    def get_total_inflight(self) -> int:
+        """Protocol: total in-flight across servers."""
+        return sum(self._inflight.values())
+
+
+class TestRequireFields:
+    """Balancers declare which generate() kwargs they consume at acquire time.
+    LLMServerClient._acquire_server packs all keyword args locally (free,
+    same-process) and only serializes the declared fields into the RPC."""
+
+    def test_default_balancer_needs_nothing(self):
+        """The default strategy routes on request_id only — no extra payload."""
+        lb = GlobalRequestLoadBalancer(servers={"s0": None})
+        assert lb.require_acquire_fields() == []
+        assert lb.require_release_fields() == []
+
+    def test_plugin_declares_prompt_ids(self, ray_session, tmp_path):
+        yaml_path = TestGetRouterHandlePluginExtensionYaml._write_router_yaml(
+            tmp_path, __name__ + "._MockPluginLoadBalancer"
+        )
+        lb = get_router_handle(servers={"s0": None}, router_config_path=yaml_path)
+        assert ray.get(lb.require_acquire_fields.remote()) == ["prompt_ids"]
+        assert ray.get(lb.require_release_fields.remote()) == ["request_id"]
+
+    def test_client_acquire_serializes_only_declared_fields(self, ray_session, tmp_path):
+        """_acquire_server lazily queries both field declarations (two light
+        RPCs issued concurrently, then cached) and filters the packed
+        generate() kwargs by the acquire declaration; sampling_params and
+        friends never cross the wire."""
+        import asyncio
+
+        from omegaconf import OmegaConf
+
+        from verl.workers.rollout.llm_server import LLMServerClient
+
+        yaml_path = TestGetRouterHandlePluginExtensionYaml._write_router_yaml(
+            tmp_path, __name__ + "._MockPluginLoadBalancer"
+        )
+        lb = get_router_handle(servers={"s0": None}, router_config_path=yaml_path)
+        client = LLMServerClient(config=OmegaConf.create({}), load_balancer_handle=lb)
+        assert client._lb_require_acquire_fields is None  # not queried yet
+        sid, _ = asyncio.run(
+            client._acquire_server(
+                "req-1",
+                prompt_ids=[1, 2, 3],
+                sampling_params={"temperature": 1.0},
+                image_data=["img-bytes"],
+            )
+        )
+        # Both declarations queried and cached on first acquire, so the
+        # release path never has to block the event loop on a lookup.
+        assert client._lb_require_acquire_fields == ["prompt_ids"]
+        assert client._lb_require_release_fields == ["request_id"]
+        # The mock received only (request_id, prompt_ids) — sampling_params /
+        # image_data stayed in-process.
+        calls = ray.get(lb.get_acquire_calls.remote())
+        assert calls == [("req-1", [1, 2, 3])]
+
+    def test_client_acquire_with_empty_declaration_sends_request_id_only(self, ray_session):
+        """The default balancer declares [] — the acquire RPC carries
+        request_id only and matches the single-arg acquire signature."""
+        import asyncio
+
+        from omegaconf import OmegaConf
+
+        from verl.workers.rollout.llm_server import LLMServerClient
+
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
+        client = LLMServerClient(config=OmegaConf.create({}), load_balancer_handle=lb)
+        sid, _ = asyncio.run(
+            client._acquire_server(
+                "req-2",
+                prompt_ids=[1, 2, 3],  # packed but never serialized: [] declaration
+                sampling_params={"temperature": 1.0},
+            )
+        )
+        assert client._lb_require_acquire_fields == []
+        assert client._lb_require_release_fields == []
+        # Routed fine on request_id alone (sticky/least-inflight).
+        assert ray.get(lb.get_status.remote())["total_inflight"] == 1
+
+    def test_legacy_signatures_survive_client_path(self, ray_session):
+        """A subclass overriding acquire/release with main's pre-plugin
+        signatures keeps working through the client: the default ([], [])
+        declaration sends request_id/server_id only."""
+        import asyncio
+        import time
+
+        from omegaconf import OmegaConf
+
+        from verl.workers.rollout.llm_server import LLMServerClient
+
+        @ray.remote
+        class _LegacyBalancer(GlobalRequestLoadBalancer):
+            def acquire_server(self, request_id):  # main's single-arg signature
+                return super().acquire_server(request_id)
+
+            def release_server(self, server_id):  # main's single-arg signature
+                return super().release_server(server_id)
+
+        lb = _LegacyBalancer.remote(servers={"s0": None, "s1": None})
+        client = LLMServerClient(config=OmegaConf.create({}), load_balancer_handle=lb)
+        sid, _ = asyncio.run(
+            client._acquire_server(
+                "req-1",
+                prompt_ids=[1, 2, 3],  # packed but never serialized: ([], [])
+                sampling_params={"temperature": 1.0},
+            )
+        )
+        client._release_server(sid, request_id="req-1")  # fire-and-forget
+        time.sleep(1)  # let the actor process the release
+        # Both legacy overrides executed (no swallowed TypeError): the counter
+        # went up on acquire and back down on release.
+        assert ray.get(lb.get_status.remote())["total_inflight"] == 0
+
+
+@pytest.fixture(scope="module")
+def ray_session():
+    ray.init(ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+class TestGetRouterHandleDefault:
+    def test_none_config_defaults_to_sticky_inflight(self, ray_session):
+        lb = get_router_handle(servers={"s0": None, "s1": None}, router_config_path=None)
+        status = ray.get(lb.get_status.remote())
+        assert status["active_servers"] == 2
+        assert status["total_inflight"] == 0
+
+    def test_empty_router_config_defaults_to_sticky_inflight(self, ray_session):
+        lb = get_router_handle(servers={"a": None, "b": None}, router_config_path="")
+        status = ray.get(lb.get_status.remote())
+        assert status["active_servers"] == 2
+
+
+class TestGetRouterHandlePluginExtensionYaml:
+    """Plugin router via external YAML (router_config_path), with Hydra
+    ``defaults`` composition and pkg:// package-relative resolution."""
+
+    @staticmethod
+    def _write_router_yaml(tmp_path, router_class, **kwargs):
+        """Write a temporary router YAML and return its path."""
+        content = {"router_class": router_class, **kwargs}
+        yaml_path = tmp_path / "router.yaml"
+        yaml_path.write_text(yaml.dump(content))
+        return str(yaml_path)
+
+    def test_missing_yaml_file_raises(self, ray_session):
+        config = "/nonexistent/path/router.yaml"
+        with pytest.raises(FileNotFoundError, match="Router config file not found"):
+            get_router_handle(servers={"s0": None}, router_config_path=config)
+
+    def test_yaml_missing_router_class_raises(self, ray_session, tmp_path):
+        yaml_path = tmp_path / "no_class.yaml"
+        yaml_path.write_text(yaml.dump({"some_key": "value"}))
+        config = str(yaml_path)
+        with pytest.raises(ValueError, match="must contain 'router_class'"):
+            get_router_handle(servers={"s0": None}, router_config_path=config)
+
+    def test_acquire_least_loaded(self, ray_session, tmp_path):
+        yaml_path = self._write_router_yaml(tmp_path, __name__ + "._MockPluginLoadBalancer")
+        config = yaml_path
+        lb = get_router_handle(servers={"s0": None, "s1": None, "s2": None}, router_config_path=config)
+        s_a, _ = ray.get(lb.acquire_server.remote("a", prompt_ids=[1]))
+        s_b, _ = ray.get(lb.acquire_server.remote("b", prompt_ids=[1]))
+        s_c, _ = ray.get(lb.acquire_server.remote("c", prompt_ids=[1]))
+        assert len({s_a, s_b, s_c}) == 3
+
+    def test_add_remove_get_all_servers(self, ray_session, tmp_path):
+        yaml_path = self._write_router_yaml(tmp_path, __name__ + "._MockPluginLoadBalancer")
+        config = yaml_path
+        lb = get_router_handle(servers={"s0": None}, router_config_path=config)
+        ray.get(lb.add_servers.remote({"s1": None, "s2": None}))
+        assert sorted(ray.get(lb.get_all_servers.remote())) == ["s0", "s1", "s2"]
+        ray.get(lb.remove_servers.remote(["s0"]))
+        assert ray.get(lb.get_all_servers.remote()) == ["s1", "s2"]
+
+    def test_release_and_get_status(self, ray_session, tmp_path):
+        yaml_path = self._write_router_yaml(tmp_path, __name__ + "._MockPluginLoadBalancer")
+        config = yaml_path
+        lb = get_router_handle(servers={"s0": None, "s1": None}, router_config_path=config)
+        ray.get(lb.acquire_server.remote("a", prompt_ids=[1]))  # s0: 1
+        ray.get(lb.acquire_server.remote("a", prompt_ids=[1]))  # s0: 2
+        ray.get(lb.acquire_server.remote("b", prompt_ids=[1]))  # s1: 1
+        assert ray.get(lb.get_status.remote())["total_inflight"] == 3
+        ray.get(lb.release_server.remote("s0"))
+        assert ray.get(lb.get_status.remote())["total_inflight"] == 2
+
+    def test_empty_pool_raises(self, ray_session, tmp_path):
+        yaml_path = self._write_router_yaml(tmp_path, __name__ + "._MockPluginLoadBalancer")
+        config = yaml_path
+        lb = get_router_handle(servers={"s0": None}, router_config_path=config)
+        ray.get(lb.remove_servers.remote(["s0"]))
+        with pytest.raises(ray.exceptions.RayTaskError, match="No available servers"):
+            ray.get(lb.acquire_server.remote("req", prompt_ids=[1]))
+
+    def test_yaml_forwards_composed_dict_to_constructor(self, ray_session, tmp_path):
+        """The whole composed YAML dict (router_class included) is passed as kwargs."""
+        yaml_path = self._write_router_yaml(tmp_path, __name__ + "._MockPluginLoadBalancer", extra_param="hello")
+        config = yaml_path
+        lb = get_router_handle(servers={"s0": None}, router_config_path=config)
+        kwargs = ray.get(lb.get_router_kwargs.remote())
+        assert kwargs.get("extra_param") == "hello"
+        assert kwargs.get("router_class") == __name__ + "._MockPluginLoadBalancer"
+
+    def test_yaml_defaults_block_rejected(self, ray_session, tmp_path):
+        """A Hydra 'defaults' block is not composed — reject it with guidance
+        instead of silently passing it through as a plain field."""
+        main = tmp_path / "composed.yaml"
+        main.write_text(
+            yaml.dump({"defaults": [{"strategy": "kvc"}], "router_class": __name__ + "._MockPluginLoadBalancer"})
+        )
+        with pytest.raises(ValueError, match="defaults.*not.*supported|not supported"):
+            get_router_handle(servers={"s0": None}, router_config_path=str(main))
+
+
+class TestResolveConfigPath:
+    """Path resolution via the shared verl.utils.import_utils.resolve_config_path:
+    absolute → CWD → verl project root → verl package dir."""
+
+    def test_absolute_path_passthrough(self):
+        from verl.utils.import_utils import resolve_config_path
+
+        assert resolve_config_path("/abs/path/router.yaml") == "/abs/path/router.yaml"
+
+    def test_relative_path_found_in_cwd(self, tmp_path, monkeypatch):
+        import os
+
+        from verl.utils.import_utils import resolve_config_path
+
+        (tmp_path / "router.yaml").write_text("router_class: x.Y")
+        monkeypatch.chdir(tmp_path)
+        assert resolve_config_path("router.yaml") == os.path.join(tmp_path, "router.yaml")
+
+    def test_relative_path_not_found_raises(self, tmp_path, monkeypatch):
+        from verl.utils.import_utils import resolve_config_path
+
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError, match="configuration file not found"):
+            resolve_config_path("no_such_router.yaml")
+
+
+class TestReleaseServerSignature:
+    """release_server carries only request_id; content-aware balancers look up the
+    prompt length from their own acquire-time bookkeeping instead of re-receiving
+    the full token list over RPC."""
+
+    def test_release_accepts_request_id_only(self, ray_session, tmp_path):
+        """release_server takes (server_id, request_id) — no prompt_ids."""
+        yaml_path = TestGetRouterHandlePluginExtensionYaml._write_router_yaml(
+            tmp_path, __name__ + "._MockPluginLoadBalancer"
+        )
+        config = yaml_path
+        lb = get_router_handle(servers={"s0": None, "s1": None}, router_config_path=config)
+        sid, _ = ray.get(lb.acquire_server.remote("req-1", prompt_ids=[1, 2, 3]))
+        ray.get(lb.release_server.remote(sid, request_id="req-1"))
+        recs = ray.get(lb.get_releases.remote())
+        assert recs == [(sid, "req-1")]
+        # In-flight decremented alongside the recording
+        assert ray.get(lb.get_status.remote())["total_inflight"] == 0
+
+    def test_default_balancer_release_ignores_request_id(self, ray_session):
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
+        sid, _ = ray.get(lb.acquire_server.remote("req-1"))
+        ray.get(lb.release_server.remote(sid, request_id="req-1"))
+        assert ray.get(lb.get_status.remote())["total_inflight"] == 0
+
+
+def _write_plugin_yaml(tmp_path, router_class):
+    """Write a plugin router YAML and return its path."""
+    path = tmp_path / "router.yaml"
+    path.write_text(yaml.dump({"router_class": router_class}))
+    return str(path)
+
+
+class TestGetRouterHandlePrecedence:
+    """``load_balancer_cls`` overrides ``router_config_path``; the YAML path is
+    ignored with a warning. Downstream config schemas (e.g. verl-omni's
+    DiffusionRolloutConfig) may omit ``router_config_path`` entirely — it must
+    be read defensively."""
+
+    def test_both_set_warns_and_uses_subclass(self, ray_session, tmp_path, caplog):
+        """load_balancer_cls takes precedence over router_config_path; the
+        YAML is ignored and a warning is logged."""
+        # A YAML that would, if loaded, point at a *different* class.
+        bogus_yaml = _write_plugin_yaml(tmp_path, "nonexistent.BogusRouter")
+        caplog.set_level(logging.WARNING, logger="verl.workers.rollout.router")
+
+        lb = get_router_handle(
+            servers={"s0": None, "s1": None},
+            router_config_path=bogus_yaml,
+            load_balancer_cls=GlobalRequestLoadBalancer,
+        )
+        # Subclass (not the YAML's BogusRouter) was instantiated.
+        status = ray.get(lb.get_status.remote())
+        assert status["active_servers"] == 2
+        # The bogus YAML was never loaded (no BogusRouter import error), and a
+        # precedence warning fired.
+        assert any("load_balancer_cls" in r.message and "ignored" in r.message for r in caplog.records), (
+            f"expected precedence warning; got {[r.message for r in caplog.records]}"
+        )
+
+    def test_router_config_path_missing_from_struct_config_does_not_raise(self, ray_session):
+        """A struct/DictConfig rollout config without ``router_config_path``
+        (e.g. verl-omni's DiffusionRolloutConfig) must not raise when the
+        manager reads it via getattr-default."""
+        from omegaconf import OmegaConf
+
+        # Simulate a downstream rollout config that predates this field.
+        rollout_config = OmegaConf.create({"full_determinism": False})  # no router_config_path key
+
+        # This is the exact access pattern in LLMServerManager._init_global_load_balancer.
+        path = getattr(rollout_config, "router_config_path", None)
+        assert path is None
+
+        lb = get_router_handle(
+            servers={"s0": None, "s1": None},
+            router_config_path=path,
+            full_determinism=getattr(rollout_config, "full_determinism", False),
+        )
+        assert ray.get(lb.get_status.remote())["active_servers"] == 2

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -45,12 +45,12 @@ from pydantic import BaseModel, ConfigDict
 from tensordict import TensorDict
 from transformers import AutoProcessor, AutoTokenizer
 
-from verl.experimental.agent_loop.utils import resolve_config_path
 from verl.protocol import DataProto
 from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
+from verl.utils.import_utils import resolve_config_path
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.profiler import simple_timer
 from verl.utils.ray_utils import auto_await, get_event_loop

--- a/verl/experimental/agent_loop/utils.py
+++ b/verl/experimental/agent_loop/utils.py
@@ -12,64 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from typing import Any
 
-
-def resolve_config_path(config_path: str) -> str:
-    """Resolve agent loop configuration file path.
-
-    In multi-node Ray training, relative paths may not resolve correctly
-    because the working directory on remote nodes can differ from the driver node.
-    This function resolves relative paths by checking multiple locations in order:
-    1. If already absolute, return as-is
-    2. Try current working directory
-    3. Try relative to verl package installation (project root)
-
-    Args:
-        config_path: Configuration file path (relative or absolute)
-
-    Returns:
-        Absolute path to the configuration file
-
-    Raises:
-        FileNotFoundError: If the configuration file cannot be found
-    """
-    # Return absolute paths unchanged
-    if os.path.isabs(config_path):
-        return config_path
-
-    # Try current working directory first
-    cwd = os.path.abspath(os.getcwd())
-    cwd_path = os.path.abspath(os.path.join(cwd, config_path))
-    if (cwd_path == cwd or cwd_path.startswith(cwd + os.sep)) and os.path.exists(cwd_path):
-        return cwd_path
-
-    # Try relative to verl project root (where verl package is installed)
-    try:
-        import verl
-
-        verl_package_dir = os.path.abspath(os.path.dirname(verl.__file__))
-
-        # Strategy 1: For development/editable installs.
-        project_root = os.path.dirname(verl_package_dir)
-        dev_path = os.path.abspath(os.path.join(project_root, config_path))
-        if (dev_path == project_root or dev_path.startswith(project_root + os.sep)) and os.path.exists(dev_path):
-            return dev_path
-
-        # Strategy 2: For standard package installations.
-        install_path = os.path.abspath(os.path.join(verl_package_dir, config_path))
-        if (install_path == verl_package_dir or install_path.startswith(verl_package_dir + os.sep)) and os.path.exists(
-            install_path
-        ):
-            return install_path
-    except (ImportError, AttributeError):
-        pass  # verl not installed or __file__ not available
-
-    # File not found - raise clear error
-    raise FileNotFoundError(
-        f"Agent loop configuration file not found: {config_path}. Tried current directory and verl project root."
-    )
+# Moved to verl.utils.import_utils; re-exported for compat.
+from verl.utils.import_utils import resolve_config_path  # noqa: F401
 
 
 # tokenizer.apply_chat_template is not working properly for gpt-oss model.

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -153,12 +153,11 @@ class TeacherModelManager:
                 )
 
     def _initialize_load_balancer_handle(self):
-        import ray
+        from verl.workers.rollout.router import get_router_handle
 
-        from verl.workers.rollout.llm_server import GlobalRequestLoadBalancer
-
-        self.load_balancer_handle = ray.remote(GlobalRequestLoadBalancer).remote(
-            servers=dict(zip(self.server_addresses, self.server_handles, strict=True))
+        self.load_balancer_handle = get_router_handle(
+            servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
+            router_config_path=self.teacher_model_config.inference.router_config_path,
         )
 
 

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -357,6 +357,7 @@ actor_rollout_ref:
       temperature: 0
       'n': 1
       do_sample: false
+    router_config_path: null
     multi_turn:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -299,6 +299,7 @@ actor_rollout_ref:
       temperature: 0
       'n': 1
       do_sample: false
+    router_config_path: null
     multi_turn:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -310,6 +310,7 @@ actor_rollout_ref:
       temperature: 0
       'n': 1
       do_sample: false
+    router_config_path: null
     multi_turn:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -315,6 +315,7 @@ actor_rollout_ref:
       temperature: 0
       'n': 1
       do_sample: false
+    router_config_path: null
     multi_turn:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -169,6 +169,10 @@ val_kwargs:
   # Whether to sample during training rollout. False uses greedy sampling.
   do_sample: False
 
+# Null uses the built-in router; set a plugin YAML path to use an external router.
+# Relative paths resolve against the working directory, then the verl package root.
+router_config_path: null
+
 # Multi-turn tool config.
 multi_turn:
 

--- a/verl/utils/import_utils.py
+++ b/verl/utils/import_utils.py
@@ -88,6 +88,62 @@ def import_external_libs(external_libs=None):
         importlib.import_module(external_lib)
 
 
+def resolve_config_path(config_path: str) -> str:
+    """Resolve agent loop configuration file path.
+
+    In multi-node Ray training, relative paths may not resolve correctly
+    because the working directory on remote nodes can differ from the driver node.
+    This function resolves relative paths by checking multiple locations in order:
+    1. If already absolute, return as-is
+    2. Try current working directory
+    3. Try relative to verl package installation (project root)
+
+    Args:
+        config_path: Configuration file path (relative or absolute)
+
+    Returns:
+        Absolute path to the configuration file
+
+    Raises:
+        FileNotFoundError: If the configuration file cannot be found
+    """
+    # Return absolute paths unchanged
+    if os.path.isabs(config_path):
+        return config_path
+
+    # Try current working directory first
+    cwd = os.path.abspath(os.getcwd())
+    cwd_path = os.path.abspath(os.path.join(cwd, config_path))
+    if (cwd_path == cwd or cwd_path.startswith(cwd + os.sep)) and os.path.exists(cwd_path):
+        return cwd_path
+
+    # Try relative to verl project root (where verl package is installed)
+    try:
+        import verl
+
+        verl_package_dir = os.path.abspath(os.path.dirname(verl.__file__))
+
+        # Strategy 1: For development/editable installs.
+        project_root = os.path.dirname(verl_package_dir)
+        dev_path = os.path.abspath(os.path.join(project_root, config_path))
+        if (dev_path == project_root or dev_path.startswith(project_root + os.sep)) and os.path.exists(dev_path):
+            return dev_path
+
+        # Strategy 2: For standard package installations.
+        install_path = os.path.abspath(os.path.join(verl_package_dir, config_path))
+        if (install_path == verl_package_dir or install_path.startswith(verl_package_dir + os.sep)) and os.path.exists(
+            install_path
+        ):
+            return install_path
+    except (ImportError, AttributeError):
+        pass  # verl not installed or __file__ not available
+
+    # File not found - raise clear error
+    raise FileNotFoundError(
+        f"Agent loop configuration file not found: {config_path}. Tried current directory and verl project root."
+    )
+
+
 PKG_PATH_PREFIX = "pkg://"
 FILE_PATH_PREFIX = "file://"
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -273,6 +273,8 @@ class RolloutConfig(BaseConfig):
 
     disaggregation: DisaggregationConfig = field(default_factory=DisaggregationConfig)
 
+    router_config_path: Optional[str] = None
+
     def __post_init__(self):
         """Validate the rollout config"""
         # Deprecation warning for mode field - only async mode is supported

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -15,7 +15,6 @@
 Utility classes for manage and request LLM servers:
 - LLMServerManager: manage life-cycle of LLM servers, including launch, tear-down replicas.
 - LLMServerClient: proxy client to request LLM servers, used by AgentLoopWorker.
-- GlobalRequestLoadBalancer: global load balancer for LLMServerClient.
 """
 
 import asyncio
@@ -26,7 +25,6 @@ from uuid import uuid4
 
 import numpy as np
 import ray
-from cachetools import LRUCache
 from omegaconf import DictConfig
 
 from verl.single_controller.ray.base import RayResourcePool, RayWorkerGroup
@@ -35,163 +33,11 @@ from verl.utils.ray_utils import auto_await
 from verl.utils.rollout_trace import rollout_trace_op
 from verl.utils.tracking import RLInsightLogger
 from verl.workers.rollout.replica import RolloutReplica, TokenOutput, get_rollout_replica_class
+from verl.workers.rollout.router import GlobalRequestLoadBalancer  # noqa: F401
 from verl.workers.rollout.utils import update_prometheus_config
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
-
-DEFAULT_ROUTING_CACHE_SIZE = 10000
-
-
-class GlobalRequestLoadBalancer:
-    """Global sticky-session + in-flight load balancer shared by all AgentLoopWorkers.
-
-    When a sticky session points to a removed server, the cache entry is
-    automatically invalidated and a new server is selected.
-
-    This is a plain Python class (not a Ray actor). It is wrapped with
-    ``ray.remote(...)`` at instantiation time so callers can subclass it and
-    override :meth:`acquire_server` before registering the subclass as an actor.
-
-    Key features:
-    - **Atomic acquire**: ``acquire_server()`` returns ``(server_id, handle)``
-    - **Sticky Session**: Uses LRUCache to map request_id → server_id, ensuring
-      multi-turn conversations route to the same server.
-    - **Least-loaded Selection**: When no sticky session exists, selects the
-      server with the fewest in-flight requests.
-    - **Deterministic Routing**: When ``full_determinism=True``, routes every
-      request by ``hash(request_id) % len(servers)`` over the full pool so the
-      same request always routes to the same replica across runs.
-    - **Dynamic Server Management**: Supports add/remove servers at runtime
-      for hybrid scaling.
-    """
-
-    def __init__(
-        self,
-        servers: dict[str, ray.actor.ActorHandle],
-        max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE,
-        full_determinism: bool = False,
-    ):
-        # Allow empty initial servers: in dynamic-resource-scheduling mode all
-        # replicas are hybrid and will be registered later via add_servers().
-
-        self._servers: dict[str, ray.actor.ActorHandle] = dict(servers)
-        self._inflight_requests: dict[str, int] = {sid: 0 for sid in servers}
-        self._request_id_to_server: LRUCache = LRUCache(maxsize=max_cache_size)
-        self._full_determinism = full_determinism
-
-    def acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
-        """Acquire a server for the given request (sticky + least-loaded).
-
-        Returns:
-            A tuple of ``(server_id, actor_handle)`` in a single atomic call.
-        """
-        # Try sticky session first
-        if request_id in self._request_id_to_server:
-            server_id = self._request_id_to_server[request_id]
-            # Check if server is still in the active pool
-            if server_id in self._inflight_requests:
-                self._inflight_requests[server_id] += 1
-                return server_id, self._servers[server_id]
-            # Server was removed, clear stale cache entry and re-select
-            del self._request_id_to_server[request_id]
-
-        # Select new server (least-loaded among available)
-        if not self._inflight_requests:
-            raise RuntimeError("No available servers in load balancer")
-
-        if self._full_determinism:
-            # Full-hash routing: same request_id always lands on the same replica
-            # across runs. Least-loaded selection depends on async arrival timing,
-            # which varies run-to-run, so it is bypassed entirely here.
-            server_id = list(self._servers)[hash(request_id) % len(self._servers)]
-        else:
-            min_count = min(self._inflight_requests.values())
-            candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]
-            server_id = candidates[0]
-        self._request_id_to_server[request_id] = server_id
-        self._inflight_requests[server_id] += 1
-        return server_id, self._servers[server_id]
-
-    def release_server(self, server_id: str) -> None:
-        """Release a server after a request completes."""
-        if server_id not in self._inflight_requests:
-            return
-        if self._inflight_requests[server_id] > 0:
-            self._inflight_requests[server_id] -= 1
-
-    def add_servers(self, servers: dict[str, ray.actor.ActorHandle]) -> None:
-        """Atomically add multiple servers to the load balancer pool.
-
-        This is more efficient than calling :meth:`add_server` in a loop
-        because it performs a single bulk update on the internal state.
-
-        Args:
-            servers: Dict mapping server_id → actor_handle for all servers
-                to register.
-        """
-        for sid, handle in servers.items():
-            self._inflight_requests[sid] = 0
-            self._servers[sid] = handle
-        logger.info(f"[GlobalLoadBalancer] added {len(servers)} servers")
-
-    def remove_servers(self, server_ids: list[str]) -> None:
-        """Atomically remove multiple servers from the load balancer pool.
-
-        More efficient than calling :meth:`remove_server` in a loop.
-
-        Args:
-            server_ids: List of server identifiers to remove.
-        """
-        for sid in server_ids:
-            self._inflight_requests.pop(sid, None)
-            self._servers.pop(sid, None)
-        logger.info(f"[GlobalLoadBalancer] removed {len(server_ids)} servers")
-
-    def get_inflight_count(self, server_id: str) -> int:
-        """Get number of in-flight requests for a server."""
-        return self._inflight_requests.get(server_id, 0)
-
-    def get_all_servers(self) -> list[str]:
-        """Get list of all active server IDs."""
-        return list(self._inflight_requests.keys())
-
-    def clear_sticky_cache(self) -> dict:
-        """Clear the sticky-session cache to force request redistribution.
-
-        After clearing, all subsequent ``acquire_server()`` calls will select
-        the least-loaded server (based on ``_inflight_requests``), which
-        naturally balances load across all active replicas — including newly
-        added ones with zero in-flight requests.
-
-        Returns:
-            A dict with ``cleared_entries`` (number of cache entries dropped)
-            and ``server_loads`` (current per-server inflight counts for
-            diagnostics).
-        """
-        cleared = len(self._request_id_to_server)
-        self._request_id_to_server.clear()
-        logger.info(
-            f"[GlobalLoadBalancer] Sticky cache cleared: {cleared} entries dropped. "
-            f"Server loads: {dict(self._inflight_requests)}"
-        )
-        return {
-            "cleared_entries": cleared,
-            "server_loads": dict(self._inflight_requests),
-        }
-
-    def get_status(self) -> dict:
-        """Return current load balancer state for debugging."""
-        return {
-            "servers": dict(self._inflight_requests),
-            "total_inflight": sum(self._inflight_requests.values()),
-            "active_servers": len(self._inflight_requests),
-            "registered_handles": list(self._servers.keys()),
-        }
-
-    def get_total_inflight(self) -> int:
-        """Return the sum of in-flight requests across all currently registered servers."""
-        return sum(self._inflight_requests.values())
 
 
 class LLMServerClient:
@@ -217,16 +63,29 @@ class LLMServerClient:
         """
         self.config = config
         self._load_balancer = load_balancer_handle
+        # Balancer field declarations, queried lazily once.
+        self._lb_require_acquire_fields: list[str] | None = None
+        self._lb_require_release_fields: list[str] | None = None
 
-    async def _acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
+    async def _acquire_server(self, request_id: str, **extra) -> tuple[str, ray.actor.ActorHandle]:
         # Atomic acquire: returns (server_id, handle) in one Ray RPC.
-        server_id, handle = await self._load_balancer.acquire_server.remote(request_id=request_id)
-        return server_id, handle
+        # Only the declared fields are serialized.
+        if self._lb_require_acquire_fields is None:
+            acquire_fields, release_fields = await asyncio.gather(
+                self._load_balancer.require_acquire_fields.remote(),
+                self._load_balancer.require_release_fields.remote(),
+            )
+            self._lb_require_acquire_fields = list(acquire_fields)
+            self._lb_require_release_fields = list(release_fields)
+        fields = {name: extra[name] for name in self._lb_require_acquire_fields if name in extra}
+        return await self._load_balancer.acquire_server.remote(request_id=request_id, **fields)
 
-    def _release_server(self, server_id: str) -> None:
+    def _release_server(self, server_id: str, request_id: str | None = None) -> None:
         # Fire-and-forget: release is just a counter decrement, no need to await.
         # Awaiting here risks blocking the finally clause if the LB actor is unresponsive.
-        self._load_balancer.release_server.remote(server_id=server_id)
+        pool = {"request_id": request_id}
+        fields = {name: pool[name] for name in self._lb_require_release_fields if name in pool}
+        self._load_balancer.release_server.remote(server_id=server_id, **fields)
 
     def _vllm_request_id(self, request_id: str) -> str:
         # request_id passed to vLLM. Default: a fresh uuid per turn so each turn
@@ -259,7 +118,16 @@ class LLMServerClient:
         Returns:
             TokenOutput | DiffusionOutput: token or diffusion output
         """
-        server_id, server = await self._acquire_server(request_id)
+        server_id, server = await self._acquire_server(
+            request_id,
+            prompt_ids=prompt_ids,
+            sampling_params=sampling_params,
+            image_data=image_data,
+            video_data=video_data,
+            audio_data=audio_data,
+            mm_processor_kwargs=mm_processor_kwargs,
+            **kwargs,
+        )
         try:
             multimodal_kwargs = {}
             if audio_data is not None:
@@ -286,7 +154,10 @@ class LLMServerClient:
             output.extra_fields.setdefault("max_global_steps", global_steps)
             return output
         finally:
-            self._release_server(server_id)
+            self._release_server(
+                server_id,
+                request_id=request_id,
+            )
 
 
 class FullyAsyncLLMServerClient(LLMServerClient):
@@ -315,7 +186,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
         super().__init__(config=config, load_balancer_handle=load_balancer_handle, **kwargs)
         self._only_hybrid = only_hybrid
 
-    async def _acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
+    async def _acquire_server(self, request_id: str, **extra) -> tuple[str, ray.actor.ActorHandle]:
         # Atomic acquire: returns (server_id, handle) in one Ray RPC.
         # When only_hybrid is True, hybrid replicas are the sole rollout resource and
         # the LB may be temporarily empty during weight sync / scaling transitions.
@@ -323,7 +194,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
         # Otherwise raise immediately so callers see the error right away.
         while True:
             try:
-                return await super()._acquire_server(request_id)
+                return await super()._acquire_server(request_id, **extra)
             except RuntimeError as e:
                 if "No available servers in load balancer" in str(e) and self._only_hybrid:
                     await asyncio.sleep(1)
@@ -473,12 +344,11 @@ class LLMServerManager:
             else init standalone server with a new resource pool.
         rollout_resource_pool (RayResourcePool): Resource pool for the server replicas, only needed for TensorRT-LLM.
         start_rank (int): First ``replica_rank`` to assign.  Defaults to 0.
-        load_balancer_cls: Optional subclass of
-            :class:`GlobalRequestLoadBalancer` to use as the routing actor
-            (wrapped with ``ray.remote`` at instantiation). Defaults to
-            :class:`GlobalRequestLoadBalancer`, whose routing honors the
-            ``full_determinism`` flag. Pass a subclass that overrides
-            :meth:`acquire_server` to take full control of routing.
+        load_balancer_cls: Optional subclass of the default router strategy's
+            load balancer to use as the routing actor (wrapped with
+            ``ray.remote`` at instantiation). When given, it takes precedence
+            over ``rollout.router_config_path``. Pass a subclass that
+            overrides :meth:`acquire_server` to take full control of routing.
     """
 
     def __init__(
@@ -495,7 +365,7 @@ class LLMServerManager:
         self.worker_group = worker_group
         self.rollout_resource_pool = rollout_resource_pool
         self.start_rank = start_rank
-        self._load_balancer_cls = load_balancer_cls or GlobalRequestLoadBalancer
+        self._load_balancer_cls = load_balancer_cls
 
         assert worker_group is not None or self.rollout_config.nnodes > 0, "nnodes must be > 0 in standalone mode"
 
@@ -598,17 +468,14 @@ class LLMServerManager:
                 )
 
     async def _init_global_load_balancer(self) -> None:
-        load_balancer_cls = self._load_balancer_cls
-        kwargs = dict(
+        from verl.workers.rollout.router import get_router_handle
+
+        self.global_load_balancer = get_router_handle(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
-            max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
+            router_config_path=getattr(self.rollout_config, "router_config_path", None),
+            full_determinism=getattr(self.rollout_config, "full_determinism", False),
+            load_balancer_cls=self._load_balancer_cls,
         )
-        # The default GlobalRequestLoadBalancer honors the full_determinism flag
-        # in acquire_server. A custom subclass overrides acquire_server and takes
-        # full control of routing, so the flag is not forwarded to it.
-        if load_balancer_cls is GlobalRequestLoadBalancer:
-            kwargs["full_determinism"] = getattr(self.rollout_config, "full_determinism", False)
-        self.global_load_balancer = ray.remote(load_balancer_cls).remote(**kwargs)
 
     def get_client(self, client_cls: type[LLMServerClient] | None = None, **kwargs) -> LLMServerClient:
         """Get the LLMServerClient to request LLM server replicas.

--- a/verl/workers/rollout/router.py
+++ b/verl/workers/rollout/router.py
@@ -1,0 +1,432 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from typing import Any, Protocol
+
+import ray
+from cachetools import LRUCache
+from omegaconf import OmegaConf
+
+from verl.utils.import_utils import load_class_from_fqn, resolve_config_path
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+DEFAULT_ROUTING_CACHE_SIZE = 10000
+
+
+class RequestLoadBalancer(Protocol):
+    """Protocol for rollout inference load balancers.
+
+    All strategies must satisfy this interface via structural subtyping.
+    """
+
+    def acquire_server(self, request_id: str, **extra) -> tuple[str, Any]:
+        """Acquire a server for the given request.
+
+        Args:
+            request_id: Request identifier for sticky session routing.
+            **extra: Keyword fields declared via :meth:`require_acquire_fields`
+                (e.g. ``prompt_ids`` for content-aware routing). Only the
+                declared fields are serialized into this RPC.
+
+        Returns:
+            A ``(server_id, actor_handle)`` tuple.
+
+        Raises:
+            RuntimeError: If no servers are available in the pool.
+        """
+        ...
+
+    def require_acquire_fields(self) -> list[str]:
+        """``generate()`` kwargs this router consumes at acquire time; only
+        these are serialized into the ``acquire_server`` RPC (e.g.
+        ``["prompt_ids"]``; ``[]`` if routing on ``request_id`` alone)."""
+        ...
+
+    def require_release_fields(self) -> list[str]:
+        """Identity fields this router consumes at release time (currently
+        only ``"request_id"``); ``[]`` if counting by ``server_id`` alone."""
+        ...
+
+    def release_server(self, server_id: str, request_id: str | None = None) -> None:
+        """Release a server after a request completes.
+
+        Args:
+            server_id: Identifier of the server to release.
+            request_id: Request identifier. Content-aware balancers that need
+                the prompt length at release time look it up by this id from
+                their own acquire-time bookkeeping, so the full token list is
+                not re-serialized over RPC.
+        """
+        ...
+
+    def add_servers(self, servers: dict[str, Any]) -> None:
+        """Bulk-add servers to the load balancer pool.
+
+        Args:
+            servers: Mapping from ``server_id`` to ``actor_handle``.
+        """
+        ...
+
+    def remove_servers(self, server_ids: list[str]) -> None:
+        """Bulk-remove servers from the load balancer pool.
+
+        Args:
+            server_ids: List of server identifiers to remove.
+        """
+        ...
+
+    def get_all_servers(self) -> list[str]:
+        """List all active server IDs.
+
+        Returns:
+            List of server identifier strings.
+        """
+        ...
+
+    def get_status(self) -> dict:
+        """Return current load balancer state for debugging.
+
+        Returns:
+            A dictionary with ``servers``, ``total_inflight``,
+            and ``active_servers`` keys.
+        """
+        ...
+
+    def clear_sticky_cache(self) -> dict:
+        """Clear sticky-session state to force request redistribution.
+
+        Called by trainers on training/rollout phase switches and by
+        fully-async rebalancing, so all strategies (plugins included)
+        must implement it.
+
+        Returns:
+            A diagnostics dict, conventionally with ``cleared_entries``
+            and ``server_loads`` keys.
+        """
+        ...
+
+    def get_total_inflight(self) -> int:
+        """Return the total in-flight requests across registered servers.
+
+        Polled by fully-async drain/rebalance loops to wait for the
+        pool to quiesce.
+        """
+        ...
+
+
+class GlobalRequestLoadBalancer:
+    """Global sticky-session + in-flight load balancer shared by all AgentLoopWorkers.
+
+    When a sticky session points to a removed server, the cache entry is
+    automatically invalidated and a new server is selected.
+
+    This is a plain Python class (not a Ray actor). It is wrapped with
+    ``ray.remote(...)`` at instantiation time so callers can subclass it and
+    override :meth:`acquire_server` before registering the subclass as an actor.
+
+    Key features:
+    - **Atomic acquire**: ``acquire_server()`` returns ``(server_id, handle)``
+    - **Sticky Session**: Uses LRUCache to map request_id → server_id, ensuring
+      multi-turn conversations route to the same server.
+    - **Least-loaded Selection**: When no sticky session exists, selects the
+      server with the fewest in-flight requests.
+    - **Deterministic Routing**: When ``full_determinism=True``, routes every
+      request by ``hash(request_id) % len(servers)`` over the full pool so the
+      same request always routes to the same replica across runs.
+    - **Dynamic Server Management**: Supports add/remove servers at runtime
+      for hybrid scaling.
+    """
+
+    def __init__(
+        self,
+        servers: dict[str, ray.actor.ActorHandle],
+        max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE,
+        full_determinism: bool = False,
+    ):
+        # Allow empty initial servers: in dynamic-resource-scheduling mode all
+        # replicas are hybrid and will be registered later via add_servers().
+
+        self._servers: dict[str, ray.actor.ActorHandle] = dict(servers)
+        self._inflight_requests: dict[str, int] = {sid: 0 for sid in servers}
+        self._request_id_to_server: LRUCache = LRUCache(maxsize=max_cache_size)
+        self._full_determinism = full_determinism
+
+    def acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
+        """Acquire a server for the given request (sticky + least-loaded).
+
+        Args:
+            request_id: Request identifier for sticky session routing.
+
+        Returns:
+            A tuple of ``(server_id, actor_handle)`` in a single atomic call.
+        """
+        # Try sticky session first
+        if request_id in self._request_id_to_server:
+            server_id = self._request_id_to_server[request_id]
+            # Check if server is still in the active pool
+            if server_id in self._inflight_requests:
+                self._inflight_requests[server_id] += 1
+                return server_id, self._servers[server_id]
+            # Server was removed, clear stale cache entry and re-select
+            del self._request_id_to_server[request_id]
+
+        # Select new server (least-loaded among available)
+        if not self._inflight_requests:
+            raise RuntimeError("No available servers in load balancer")
+
+        if self._full_determinism:
+            # Full-hash routing: same request_id always lands on the same replica
+            # across runs. Least-loaded selection depends on async arrival timing,
+            # which varies run-to-run, so it is bypassed entirely here.
+            server_id = list(self._servers)[hash(request_id) % len(self._servers)]
+        else:
+            min_count = min(self._inflight_requests.values())
+            candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]
+            server_id = candidates[0]
+        self._request_id_to_server[request_id] = server_id
+        self._inflight_requests[server_id] += 1
+        return server_id, self._servers[server_id]
+
+    def release_server(self, server_id: str, request_id: str | None = None) -> None:
+        """Release a server after a request completes.
+
+        ``request_id`` is accepted for signature parity with content-aware
+        balancers (which look up the prompt length from their own
+        acquire-time bookkeeping); this balancer tracks request counts only
+        and ignores it.
+        """
+        if server_id not in self._inflight_requests:
+            return
+        if self._inflight_requests[server_id] > 0:
+            self._inflight_requests[server_id] -= 1
+
+    def require_acquire_fields(self) -> list[str]:
+        """Sticky + least-inflight routing keys on ``request_id`` alone."""
+        return []
+
+    def require_release_fields(self) -> list[str]:
+        """Counts by ``server_id``; no identity needed at release."""
+        return []
+
+    def add_servers(self, servers: dict[str, ray.actor.ActorHandle]) -> None:
+        """Atomically add multiple servers to the load balancer pool.
+
+        This is more efficient than calling :meth:`add_server` in a loop
+        because it performs a single bulk update on the internal state.
+
+        Args:
+            servers: Dict mapping server_id → actor_handle for all servers
+                to register.
+        """
+        for sid, handle in servers.items():
+            self._inflight_requests[sid] = 0
+            self._servers[sid] = handle
+        logger.info(f"[GlobalLoadBalancer] added {len(servers)} servers")
+
+    def remove_servers(self, server_ids: list[str]) -> None:
+        """Atomically remove multiple servers from the load balancer pool.
+
+        More efficient than calling :meth:`remove_server` in a loop.
+
+        Args:
+            server_ids: List of server identifiers to remove.
+        """
+        for sid in server_ids:
+            self._inflight_requests.pop(sid, None)
+            self._servers.pop(sid, None)
+        logger.info(f"[GlobalLoadBalancer] removed {len(server_ids)} servers")
+
+    def get_inflight_count(self, server_id: str) -> int:
+        """Get number of in-flight requests for a server."""
+        return self._inflight_requests.get(server_id, 0)
+
+    def get_all_servers(self) -> list[str]:
+        """Get list of all active server IDs."""
+        return list(self._inflight_requests.keys())
+
+    def clear_sticky_cache(self) -> dict:
+        """Clear the sticky-session cache to force request redistribution.
+
+        After clearing, all subsequent ``acquire_server()`` calls will select
+        the least-loaded server (based on ``_inflight_requests``), which
+        naturally balances load across all active replicas — including newly
+        added ones with zero in-flight requests.
+
+        Returns:
+            A dict with ``cleared_entries`` (number of cache entries dropped)
+            and ``server_loads`` (current per-server inflight counts for
+            diagnostics).
+        """
+        cleared = len(self._request_id_to_server)
+        self._request_id_to_server.clear()
+        logger.info(
+            f"[GlobalLoadBalancer] Sticky cache cleared: {cleared} entries dropped. "
+            f"Server loads: {dict(self._inflight_requests)}"
+        )
+        return {
+            "cleared_entries": cleared,
+            "server_loads": dict(self._inflight_requests),
+        }
+
+    def get_status(self) -> dict:
+        """Return current load balancer state for debugging."""
+        return {
+            "servers": dict(self._inflight_requests),
+            "total_inflight": sum(self._inflight_requests.values()),
+            "active_servers": len(self._inflight_requests),
+            "registered_handles": list(self._servers.keys()),
+        }
+
+    def get_total_inflight(self) -> int:
+        """Return the sum of in-flight requests across all currently registered servers."""
+        return sum(self._inflight_requests.values())
+
+
+def _create_global_sticky_inflight(
+    servers: dict[str, Any],
+    full_determinism: bool = False,
+    load_balancer_cls: type | None = None,
+):
+    """Factory for the default sticky-session + least-inflight strategy.
+
+    Args:
+        servers: ``{server_address: actor_handle}`` mapping.
+        full_determinism: Rollout-level ``rollout.full_determinism`` flag;
+            enables full-hash deterministic routing.
+        load_balancer_cls: Class to use as the routing actor. A subclass overrides
+            :meth:`acquire_server` and takes full control of routing, so
+            ``full_determinism`` is not forwarded to it.
+    """
+    kwargs = dict(servers=servers, max_cache_size=DEFAULT_ROUTING_CACHE_SIZE)
+    # The default GlobalRequestLoadBalancer honors the full_determinism flag
+    # in acquire_server. A custom subclass overrides acquire_server and takes
+    # full control of routing, so the flag is not forwarded to it.
+    if load_balancer_cls is GlobalRequestLoadBalancer:
+        kwargs["full_determinism"] = full_determinism
+    return ray.remote(load_balancer_cls).remote(**kwargs)
+
+
+def _load_router_yaml(router_config_path: str) -> dict:
+    """Load a router YAML config into a plain dict.
+
+    Hydra ``defaults`` blocks are rejected: inline the referenced configs or
+    compose them inside the router plugin's constructor.
+    """
+    full_path = resolve_config_path(router_config_path)
+    if not os.path.isfile(full_path):
+        raise FileNotFoundError(f"Router config file not found: {full_path}")
+
+    cfg = OmegaConf.load(full_path)
+    if "defaults" in cfg:
+        raise ValueError(
+            f"Router config {full_path} uses a Hydra 'defaults' block, which is not "
+            "supported. Inline the referenced configs or compose them inside the "
+            "router plugin's constructor."
+        )
+    return OmegaConf.to_container(cfg, resolve=True)
+
+
+def _resolve_router_class(router_class: str) -> type:
+    """Validate and import a load-balancer class from an FQN string.
+
+    Raises:
+        TypeError: If the resolved object is not callable.
+    """
+    cls = load_class_from_fqn(router_class, "load balancer class")
+    if not callable(cls):
+        raise TypeError(
+            f"'{router_class}' is not callable (type: {type(cls).__name__}). "
+            f"Expected a class with a .remote() constructor."
+        )
+    return cls
+
+
+def _create_plugin_extension(
+    servers: dict[str, Any],
+    router_config_path: str,
+):
+    """Factory for a user-defined load balancer loaded from an external YAML.
+
+    The file must contain ``router_class`` (FQN); the whole loaded dict is
+    passed to the constructor.
+
+    Args:
+        servers: ``{server_address: actor_handle}`` mapping.
+        router_config_path: Path to the external YAML file.
+
+    Raises:
+        ValueError: If ``router_config_path`` is missing or the YAML lacks
+            ``router_class``.
+        ImportError: If a module or package cannot be imported.
+        AttributeError: If the class does not exist in the module.
+    """
+    yaml_config = _load_router_yaml(router_config_path)
+    router_class = yaml_config.get("router_class", None)
+    if not router_class:
+        raise ValueError(
+            "External router YAML must contain 'router_class'. "
+            "Example: router_class: uni_agent.llm_router.KvcAwareRouter"
+        )
+    cls = _resolve_router_class(router_class)
+    logger.info(
+        "Creating plugin load balancer from YAML: class=%s, servers=%d, config=%s",
+        router_class,
+        len(servers),
+        yaml_config,
+    )
+    ray_cls = cls if isinstance(cls, ray.actor.ActorClass) else ray.remote(cls)
+    return ray_cls.remote(servers, yaml_config)
+
+
+def get_router_handle(
+    servers: dict[str, Any],
+    router_config_path: str | None = None,
+    full_determinism: bool = False,
+    load_balancer_cls: type | None = None,
+) -> Any:
+    """Create a load balancer instance from router configuration.
+
+    Args:
+        servers: ``{server_address: actor_handle}`` mapping.
+        router_config_path: Optional external router YAML path. When set, a
+            user-defined plugin is loaded; otherwise the default sticky-session
+            + least-inflight strategy is used.
+        full_determinism: Rollout-level ``rollout.full_determinism`` flag,
+            forwarded to strategies that support deterministic routing.
+        load_balancer_cls: Optional subclass of the default strategy's load
+            balancer. Takes precedence over the config-selected strategy; not
+            applicable to the YAML plugin.
+    """
+    if router_config_path and load_balancer_cls is None:
+        return _create_plugin_extension(servers=servers, router_config_path=router_config_path)
+
+    # Programmatic injection (e.g. verl-omni's Deterministic* subclasses)
+    # overrides the config-selected strategy. If both are set, the YAML is
+    # ignored — warn so the mismatch doesn't fail silently.
+    if router_config_path and load_balancer_cls is not None:
+        logger.warning(
+            "Both router_config_path=%r and load_balancer_cls=%s are set; "
+            "the YAML plugin is ignored in favor of the injected subclass.",
+            router_config_path,
+            getattr(load_balancer_cls, "__name__", load_balancer_cls),
+        )
+    return _create_global_sticky_inflight(
+        servers=servers,
+        full_determinism=full_determinism,
+        load_balancer_cls=load_balancer_cls or GlobalRequestLoadBalancer,
+    )

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -203,6 +203,15 @@ class vLLMHttpServer:
         assert self._server_port is not None, "http server is not launched, port is None"
         return self._server_address, self._server_port
 
+    def get_rollout_config(self):
+        """Get the RolloutConfig (e.g. max_num_seqs, max_model_len).
+
+        Lets external routers fetch server-side config (vLLM doesn't expose
+        these on /metrics) via the same handler-getter pattern as
+        ``get_server_address``.
+        """
+        return self.config
+
     @property
     def lora_as_adapter(self) -> bool:
         return (


### PR DESCRIPTION
  ### What does this PR do?

  Refs: #6383

  Make verl's rollout request routing **pluggable** and give external routers what they need to drive multi-replica vLLM servers:

  **Pluggable router strategy with FQN/YAML plugins** — the load balancer is extracted out of `llm_server.py` into a standalone
  `verl/workers/rollout/router.py` module exposing a `RequestLoadBalancer` Protocol and a single `get_router_handle()` factory. With no config, the factory
  builds the existing sticky-session + least-inflight `GlobalRequestLoadBalancer` (behavior unchanged). With a `router_config_path`, it loads an
  **external router plugin** from a YAML file: the `router_class` FQN is imported (e.g. `uni_agent.llm_router.KvcAwareRouter`) and the whole YAML dict is
  passed to the plugin constructor as its `router_kwargs` argument. Paths are resolved by the shared `resolve_config_path` (absolute → working directory → verl project root
  → verl package dir), so configs resolve identically from driver and Ray worker processes. The config is flattened to `rollout.router_config_path:
  Optional[str] = None` on `RolloutConfig`.

  **Declaration-driven RPC payload** — routers declare which `generate()` kwargs they consume via `require_acquire_fields()` /
  `require_release_fields()`. The client packs all kwargs locally (same-process, free) and serializes only the declared fields into the
  acquire/release RPCs, so content-aware routers (e.g. prompt-length-aware KV-cache routing) get `prompt_ids` at acquire time while the default
  balancer declares `[]` and keeps its `request_id`-only wire format. `release_server` carries only `request_id`; balancers that need the prompt length
  at release look it up from their own acquire-time bookkeeping.

  Fully **opt-in and backward compatible**: with `router_config_path: null` (the default), the built-in balancer path is untouched, and subclasses
  overriding `acquire_server`/`release_server` with the pre-PR signatures keep working (the default declarations send `request_id`/`server_id` only).

  ### Checklist Before Starting

  - [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+router — searched; no conflicting open PR.
  - [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
    - Suggested title: `[rollout, vllm] feat: pluggable router with FQN/YAML plugins`

  ### Test

  New/updated suites:

  - `pytest tests/workers/rollout/test_router_on_cpu.py` — 22 tests: YAML loading (missing file / missing `router_class` / Hydra `defaults` rejected),
    default-vs-plugin selection, `load_balancer_cls` precedence warning, declaration-driven acquire/release filtering, legacy-signature compat
    through the client path, `resolve_config_path` fallbacks. **22 passed**.
  - `pytest tests/experimental/agent_loop/test_basic_agent_loop.py -k LoadBalancer` — the 15 pre-existing routing/sticky/hybrid tests against the
    moved class. **15 passed**.
  - `pre-commit run --all-files` — all hooks passed.

  ### API and Usage Example

  **Config (flattened, backward compatible):** `null` (default) → built-in `GlobalRequestLoadBalancer`; a path → external plugin.

  ```yaml
  actor_rollout_ref:
    rollout:
      name: vllm
      # null -> built-in sticky + least-inflight balancer (unchanged).
      # A path -> external router plugin YAML (plain path; resolved against
      # the working directory, then the verl project/package root).
      router_config_path: /path/to/kvc_aware_router.yaml
  ```

  **External plugin YAML** — must contain `router_class`; the whole dict is passed to the constructor as `router_kwargs`. Hydra `defaults` blocks are
  rejected with guidance (inline the referenced configs or compose them inside the plugin constructor):

  ```yaml
  router_class: xxx.CustomRouter                 # FQN, imported via load_class_from_fqn
  any_extra_param: hello                              # lands verbatim inside router_kwargs
  ```

  **Plugin contract** (structural, no inheritance required; see `RequestLoadBalancer` in `router.py`):

  ```python
  class CustomRouter:
      def require_acquire_fields(self) -> list[str]:
          return ["prompt_ids"]      # only these kwargs are serialized into acquire_server
      def require_release_fields(self) -> list[str]:
          return ["request_id"]      # identity needed at release ([] = server_id only)
      def acquire_server(self, request_id, prompt_ids=None): ...   # -> (server_id, handle)
      def release_server(self, server_id, request_id=None): ...
      def add_servers(self, servers): ...
      def remove_servers(self, server_ids): ...
      def get_all_servers(self): ...
      def get_status(self): ...
      def clear_sticky_cache(self): ...
      def get_total_inflight(self): ...
  ```

  ### Design & Code Changes

  - **New `verl/workers/rollout/router.py`** (moved out of `llm_server.py`):
    - `RequestLoadBalancer` Protocol — the 10-method structural interface all strategies satisfy, including the `require_acquire_fields` /
      `require_release_fields` declarations, `clear_sticky_cache` and `get_total_inflight` (polled by fully-async drain/rebalance loops).
    - `GlobalRequestLoadBalancer` — sticky-session + least-inflight balancer, moved with behavior unchanged; declares `[]` / `[]`.
    - Plugin loading chain: `resolve_config_path` (shared util, see below) → `_load_router_yaml` (`OmegaConf.load`; Hydra `defaults` blocks rejected) →
      `_resolve_router_class` (FQN via `load_class_from_fqn`) → `_create_plugin_extension` (whole YAML dict → the constructor's `router_kwargs`).
    - `get_router_handle()` — plugin when `router_config_path` is set, else `_create_global_sticky_inflight`; programmatic `load_balancer_cls`
      injection (e.g. verl-omni subclasses) still takes precedence and warns when both are set.
  - **`llm_server.py`**: inline `GlobalRequestLoadBalancer` removed (re-exported for compat); the client packs all `generate()` kwargs locally and
    serializes only the balancer-declared fields into the acquire/release RPCs (declarations queried once, then cached);
    `_release_server(server_id, request_id=None)`; `_init_global_load_balancer()` delegates to `get_router_handle()` and reads
    `router_config_path` defensively so downstream rollout configs without the field keep working.
  - **`teacher_model.py`**: `_initialize_load_balancer_handle()` uses `get_router_handle()` with `inference.router_config_path`.
  - **`vllm_async_server.py`**: new `get_rollout_config()` handler getter (same pattern as `get_server_address`) so external routers can fetch
    server-side config such as `max_num_seqs` / `max_model_len` that vLLM does not expose on `/metrics`.
  - **`verl/utils/import_utils.py`**: `resolve_config_path` moved verbatim from `agent_loop/utils.py` (absolute → CWD → verl project root → verl
    package dir) and shared by both agent-loop and router config loading; `agent_loop/utils.py` re-exports it for compat.
  - **Config**: `router_config_path: Optional[str] = None` on `RolloutConfig`, `rollout.yaml` and the generated trainer yamls.
  - **Docs**: pointer updates in `docs/advance/determinism.md` (balancer location) and `docs/algo/opd.md` (router.py entry).
  - **Tests**: `tests/workers/rollout/test_router_on_cpu.py` (new); `tests/experimental/agent_loop/test_basic_agent_loop.py` import repointed to
    `router.py`.

  ### Checklist Before Submitting

  > [!IMPORTANT]
  > Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

  - [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
  - [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs) — pointer updates in `determinism.md` / `opd.md`; the router YAML schema is documented in `rollout.yaml` next to the field.
  - [x] Add unit or end-to-end test(s) to the CI workflow to cover all the code. If not feasible, explain why: covered by `tests/workers/rollout/test_router_on_cpu.py` (collected by `cpu_unit_tests.yml` via the `*_on_cpu.py` convention).
  - [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
  - [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
