### PR TITLE
[doc] fix: align multiturn.rst rollout keys with MultiTurnConfig

### DIFF
--- a/docs/sglang_multiturn/multiturn.rst
+++ b/docs/sglang_multiturn/multiturn.rst
@@ -10,12 +10,13 @@ To enable multi-turn rollout, make sure to configure the following fields in you
 
 .. code-block:: yaml
 
-    actor_rollout_ref: 
-        rollout: 
-            multi_turn: True
+    actor_rollout_ref:
+        rollout:
             name: "sglang"
+            multi_turn:
+                enable: True
 
-These configuration activates the sglang engine for multi-turn interaction during rollout.
+This configuration activates the sglang engine for multi-turn interaction during rollout.
 
 Custom Tool Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -32,14 +33,14 @@ For custom environment interaction tools, you can implement your own tools based
 
 For stateless tools that don't need ``BaseTool``'s ``create``/``release`` lifecycle, see the `Function Tool Configuration`_ section below for the simpler ``@function_tool`` API.
 
-Finally, set the ``tools_config_file`` in your rollout config:
+Finally, set the ``tool_config_path`` under ``multi_turn`` in your rollout config:
 
 .. code-block:: yaml
 
     actor_rollout_ref:
         rollout:
-            tool_kwargs:
-                tools_config_file: <path_to_tool_yaml_file>
+            multi_turn:
+                tool_config_path: <path_to_tool_yaml_file>
 
 This allows integration of customized tool behaviors during actor rollout steps.
 


### PR DESCRIPTION
### What
Update the Basic Configuration and Custom Tool Configuration examples in `docs/sglang_multiturn/multiturn.rst` so they match `verl/trainer/config/rollout/rollout.yaml` (`MultiTurnConfig`).

### Drift
- Docs used scalar `multi_turn: True`; config expects `multi_turn.enable`.
- Docs used `rollout.tool_kwargs.tools_config_file`; config expects `multi_turn.tool_config_path`.

### Verify
Cross-checked against `verl/trainer/config/rollout/rollout.yaml` on main. The later Function Tool section in the same file already used the correct nested keys; only the early examples were stale.