### PR TITLE
[doc] fix: replace missing requirements_sglang.txt with sglang extra

### DIFF
--- a/docs/sglang_multiturn/search_tool_example.rst
+++ b/docs/sglang_multiturn/search_tool_example.rst
@@ -70,9 +70,8 @@ Install verl Upstream
    git clone https://github.com/verl-project/verl.git
    cd verl
 
-   # Install verl
-   python3 -m uv pip install .
-   python3 -m uv pip install -r ./requirements_sglang.txt
+   # Install verl with the sglang extra (pyproject.toml; requirements_sglang.txt removed)
+   python3 -m uv pip install ".[sglang]"
 
    # Manually install flash-attn
    python3 -m uv pip install wheel


### PR DESCRIPTION
## Summary
`docs/sglang_multiturn/search_tool_example.rst` still installs via `./requirements_sglang.txt`, which does not exist on main (404). Only `requirements.txt` / `requirements-npu.txt` / `requirements-test.txt` remain. Use the `sglang` optional extra from `pyproject.toml` (same approach as `docs/workers/sglang_worker.rst` / uv extras).

## Repro
```bash
curl -sI https://raw.githubusercontent.com/verl-project/verl/main/requirements_sglang.txt | head -1
# HTTP/2 404

# on a main checkout:
ls requirements*.txt
# requirements.txt  requirements-npu.txt  requirements-test.txt

rg -n 'requirements_sglang' docs/sglang_multiturn/search_tool_example.rst
# L75: python3 -m uv pip install -r ./requirements_sglang.txt

rg -n 'sglang =' -A2 pyproject.toml
# [project.optional-dependencies] sglang = [...]

rg -n 'pip install.*sglang' docs/workers/sglang_worker.rst
# pip install -e ".[sglang]"
```

## Fix
Replace:
```bash
python3 -m uv pip install .
python3 -m uv pip install -r ./requirements_sglang.txt
```
with:
```bash
python3 -m uv pip install ".[sglang]"
```

## Test plan
- [ ] Confirm `requirements_sglang.txt` remains absent on main
- [ ] Confirm `pyproject.toml` defines optional extra `sglang`
- [ ] Doc install line uses `.[sglang]`
