### PR TITLE
[doc] fix: update rollout backends list in perf_tuning.rst

### DIFF
--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -28,7 +28,7 @@ In this section, we will discuss how to tune the performance of all the stages i
 Rollout Generation Tuning
 --------------------------
 
-verl currently supports two rollout backends: vLLM and TGI (with SGLang support coming soon). 
+verl currently supports four rollout backends: vLLM, SGLang, TensorRT-LLM, and HF (``actor_rollout_ref.rollout.name``: ``vllm`` / ``sglang`` / ``trtllm`` / ``hf``). 
 
 Below are key factors for tuning vLLM-based rollout. Before tuning, we recommend setting ``actor_rollout_ref.rollout.disable_log_stats=False`` so that rollout statistics are logged.
 


### PR DESCRIPTION
## Summary

`docs/perf/perf_tuning.rst` still says verl supports **two** rollout backends: **vLLM and TGI (with SGLang support coming soon)**. That is stale relative to the current config and docs:

- `verl/trainer/config/rollout/rollout.yaml` documents `actor_rollout_ref.rollout.name: hf/vllm/sglang/trtllm`
- README already lists **vLLM**, **SGLang**, and **HF Transformers** for rollout generation, and SGLang is fully supported (not "coming soon")
- TGI is no longer the documented rollout name

This PR updates that one sentence to list **vLLM, SGLang, TensorRT-LLM, and HF**, and drops TGI / "coming soon". The nearby `gpu_memory_utilization` notes for vLLM vs SGLang are left as-is so they stay coherent with multi-backend rollout.

## Repro

On `5b79827b04cee6e4b7b5ff737e047f1d72d50433`:

```bash
# Stale doc line
sed -n '31p' docs/perf/perf_tuning.rst
# -> verl currently supports two rollout backends: vLLM and TGI (with SGLang support coming soon).

# Current enum in config
rg -n 'hf/vllm/sglang/trtllm' verl/trainer/config/rollout/rollout.yaml
# -> # actor_rollout_ref.rollout.name: hf/vllm/sglang/trtllm. ...

# README already treats SGLang as supported for rollout
rg -n 'vLLM.*SGLang.*HF Transformers for rollout' README.md
```

## Test plan

- [x] Diff limited to `docs/perf/perf_tuning.rst`
- [x] Confirmed wording matches `rollout.yaml` name enum (`hf` / `vllm` / `sglang` / `trtllm`)
- [x] Left SGLang `gpu_memory_utilization` subsection unchanged
- [ ] Docs render check (optional)