### PR TITLE
[ckpt, megatron, sglang] fix: preserve DSv4 FP8 delta fidelity

### DIFF
--- a/tests/checkpoint_engine/test_fp32_wire_fidelity.py
+++ b/tests/checkpoint_engine/test_fp32_wire_fidelity.py
@@ -1,0 +1,325 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""fp32 wire fidelity: the checkpoint's fp32 families must survive the sync.
+
+DSv4 stores a handful of sensitive params in FP32 (hyper-connection
+coefficients, ape compressor position embeddings, attention sinks, router gate
+bias -- 406 tensors on the serving side, ~68 MB). Three sites used to fold
+them to bf16, costing the last 16 mantissa bits (measured rel err p50 1.35e-3,
+max 3.9e-3) *invisibly to the verify sweep*, because the replay folded
+identically:
+
+  1. transformer_impl's hook-disarming ``weight_dtype=bf16`` stamp on every
+     conversion task (the legacy seed's actual fold site);
+  2. ``_send_full_seed``'s fold of non-fp8 floats to the rollout dtype;
+  3. ``quant_shard_stream``'s catch-all bf16 group on the steady path.
+
+All three now route by ``QuantSpec.fp32_predicate``, derived from the
+checkpoint's safetensors headers -- never from the local tensor's presence or
+dtype, because the steady wire's group slot layouts must be identical on every
+rank and non-owner ranks see no tensor at all.
+"""
+
+import json
+import os
+import struct
+
+import pytest
+import torch
+
+CKPT = os.environ.get("VERL_TEST_DSV4_CKPT", "")
+
+
+def _write_safetensors(path, tensors: dict):
+    """Minimal safetensors writer (header + raw bytes) so the test does not
+    depend on the safetensors package supporting every dtype we place."""
+    _DT = {torch.float32: "F32", torch.bfloat16: "BF16", torch.float8_e4m3fn: "F8_E4M3"}
+    header = {}
+    blobs = []
+    off = 0
+    for name, t in tensors.items():
+        b = t.contiguous().view(torch.uint8).numpy().tobytes() if t.dtype != torch.float32 else t.numpy().tobytes()
+        header[name] = {"dtype": _DT[t.dtype], "shape": list(t.shape), "data_offsets": [off, off + len(b)]}
+        blobs.append(b)
+        off += len(b)
+    hdr = json.dumps(header).encode()
+    with open(path, "wb") as fh:
+        fh.write(struct.pack("<Q", len(hdr)))
+        fh.write(hdr)
+        for b in blobs:
+            fh.write(b)
+
+
+@pytest.fixture
+def synth_ckpt(tmp_path):
+    _write_safetensors(
+        tmp_path / "model-00001-of-00001.safetensors",
+        {
+            "model.layers.0.self_attn.hc_attn_scale": torch.randn(4, dtype=torch.float32),
+            "model.layers.0.self_attn.wkv.weight": (torch.randn(8, 8) * 0.01).to(torch.float8_e4m3fn),
+            "model.layers.0.self_attn.wkv.weight.scale": torch.ones(1, 1, dtype=torch.float32),
+            "model.layers.0.mlp.w1.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+            "model.layers.0.ffn.gate.bias": torch.randn(8, dtype=torch.float32),
+        },
+    )
+    return str(tmp_path)
+
+
+def test_fp32_predicate_selects_fp32_and_only_fp32(synth_ckpt):
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp32_predicate
+
+    pred = build_ckpt_fp32_predicate(synth_ckpt)
+    assert pred is not None
+    assert pred("model.layers.0.self_attn.hc_attn_scale") is True
+    assert pred("model.layers.0.ffn.gate.bias") is True
+    assert pred("model.layers.0.mlp.w1.weight") is False, "bf16 storage must not be promoted"
+    assert pred("model.layers.0.self_attn.wkv.weight") is False, "fp8 codes are not this predicate's business"
+
+
+def test_fp32_predicate_excludes_scale_grids(synth_ckpt):
+    """The F32 scale grids ride the wire's dedicated scale group; routing them
+    into the fp32 group would double-ship every scale."""
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp32_predicate
+
+    pred = build_ckpt_fp32_predicate(synth_ckpt)
+    assert pred("model.layers.0.self_attn.wkv.weight.scale") is False
+    assert pred("model.layers.0.self_attn.wkv.weight_scale_inv") is False
+
+
+def test_fp32_predicate_matches_across_the_bridge_rename(synth_ckpt):
+    """Megatron-Bridge spells the block ``attn`` where the checkpoint says
+    ``self_attn``; the export asks with its own spelling."""
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp32_predicate
+
+    pred = build_ckpt_fp32_predicate(synth_ckpt)
+    assert pred("model.layers.0.attn.hc_attn_scale") is True
+
+
+def test_fp32_predicate_missing_ckpt_returns_none(tmp_path):
+    """"could not read" must not masquerade as "nothing is fp32"."""
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp32_predicate
+
+    assert build_ckpt_fp32_predicate(str(tmp_path / "nonexistent")) is None
+
+
+def test_fp32_predicate_all_bf16_ckpt_returns_none(tmp_path):
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp32_predicate
+
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        {"model.embed.weight": torch.randn(4, 4, dtype=torch.bfloat16)},
+    )
+    assert build_ckpt_fp32_predicate(str(tmp_path)) is None
+
+
+def test_quant_spec_carries_fp32_predicate():
+    from verl.utils.fp8_sharded import QuantSpec
+
+    spec = QuantSpec(weight_block_size=(128, 128), should_quantize=lambda n: False, fp32_predicate=lambda n: True)
+    assert spec.fp32_predicate("x")
+    # default stays None: legacy fold-to-rollout-dtype for specs built elsewhere
+    assert QuantSpec(weight_block_size=(128, 128), should_quantize=lambda n: False).fp32_predicate is None
+
+
+@pytest.mark.skipif(not CKPT or not os.path.isdir(CKPT), reason="set VERL_TEST_DSV4_CKPT to a DSv4 checkpoint")
+def test_dsv4_fp32_families_are_exactly_the_406_plus_mtp():
+    """Pin the census to the checkpoint: 417 F32 non-scale tensors, of which 11
+    are mtp.* (not served by the rollout) -- the remaining 406 are exactly the
+    tensors that would otherwise lose precision in a bf16 fold."""
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp32_predicate, read_checkpoint_dtypes
+
+    dtypes = read_checkpoint_dtypes(CKPT)
+    fp32 = [
+        n for n, d in dtypes.items() if d == "F32" and not (n.endswith(".scale") or n.endswith("_scale_inv"))
+    ]
+    assert len(fp32) == 417
+    assert sum(1 for n in fp32 if not n.startswith("mtp.")) == 406
+
+    pred = build_ckpt_fp32_predicate(CKPT)
+    assert pred is not None
+    for n in fp32:
+        assert pred(n) is True, n
+    # spot-check the five families by their serving-side names
+    assert pred("model.layers.7.self_attn.attn_sink") is True
+    assert pred("model.layers.7.self_attn.compressor.ape") is True
+    assert pred("model.layers.7.hc_attn_scale") is True
+    assert pred("model.layers.7.ffn.gate.bias") is True
+    assert pred("hc_head_scale") is True
+    # and the quantized/bf16 bulk stays out
+    assert pred("model.layers.7.self_attn.wkv.weight") is False
+    assert pred("model.layers.7.self_attn.wkv.weight.scale") is False
+
+
+class _HFCfg:
+    def __init__(self, model_type=None, quantization_config=None):
+        self.model_type = model_type
+        if quantization_config is not None:
+            self.quantization_config = quantization_config
+
+
+DSV4_QC = {"quant_method": "fp8", "scale_fmt": "ue8m0", "weight_block_size": [128, 128]}
+
+
+def test_named_tensors_quant_mode_fp8_ckpt_needs_no_flag():
+    """With the quantization flag unset, hybrid servers would be fed
+    raw bf16 and SGLang requantized with the plain formula. An fp8-serialized
+    DSv4 checkpoint alone must select the verl-side converter."""
+    from verl.utils.sglang.sglang_fp8_utils import named_tensors_quant_mode
+
+    assert named_tensors_quant_mode(None, _HFCfg("deepseek_v4", DSV4_QC)) == "dsv4"
+    assert named_tensors_quant_mode("fp8", _HFCfg("deepseek_v4", DSV4_QC)) == "dsv4"
+
+
+def test_named_tensors_quant_mode_legacy_paths_unchanged():
+    from verl.utils.sglang.sglang_fp8_utils import named_tensors_quant_mode
+
+    # flag-driven generic path for non-DSv4 models
+    assert named_tensors_quant_mode("fp8", _HFCfg("llama", None)) == "generic"
+    # no flag, no fp8 ckpt -> raw, exactly as before
+    assert named_tensors_quant_mode(None, _HFCfg("llama", None)) is None
+    assert named_tensors_quant_mode(None, _HFCfg("deepseek_v4", None)) is None
+    # DSv4 with a NON-fp8 quant config does not auto-select
+    assert named_tensors_quant_mode(None, _HFCfg("deepseek_v4", {"quant_method": "awq"})) is None
+
+def test_dsv4_converter_passes_pre_quantized_streams_through(tmp_path):
+    """The hybrid full sync can already carry the
+    bridge's fp8 codes + scale companions; quantizing the codes garbles them
+    and the second scale kills SGLang's fused loader with 'duplicate shard kv'.
+    Pre-quantized input must pass through byte-identical, with no extra scale."""
+    import asyncio
+    import json
+
+    from verl.utils.sglang.sglang_fp8_utils import DeepseekV4FP8QuantizerHelper
+
+    ckpt = tmp_path / "ckpt"
+    ckpt.mkdir()
+    _write_safetensors(
+        ckpt / "model-00001-of-00001.safetensors",
+        {
+            "model.layers.0.self_attn.wkv.weight": (torch.randn(256, 256) * 0.01).to(torch.float8_e4m3fn),
+            "model.layers.0.self_attn.wkv.scale": torch.ones(2, 2, dtype=torch.float32),
+        },
+    )
+    (ckpt / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.layers.0.self_attn.wkv.weight": "model-00001-of-00001.safetensors",
+                    "model.layers.0.self_attn.wkv.scale": "model-00001-of-00001.safetensors",
+                }
+            }
+        )
+    )
+    helper = DeepseekV4FP8QuantizerHelper({"weight_block_size": [128, 128]}, str(ckpt))
+
+    codes = (torch.randn(256, 256) * 0.01).to(torch.float8_e4m3fn)
+    scale = torch.full((2, 2), 2.0**-7, dtype=torch.float32)
+    stream = [
+        ("model.layers.0.self_attn.wkv.weight", codes),
+        ("model.layers.0.self_attn.wkv.scale", scale),
+    ]
+
+    async def collect():
+        return [(k, v) async for k, v in helper.quant_weights_by_name(iter(stream))]
+
+    out = asyncio.run(collect())
+    names = [k for k, _ in out]
+    assert names == [n for n, _ in stream], f"stream shape changed: {names}"
+    assert torch.equal(out[0][1].view(torch.uint8), codes.view(torch.uint8)), "codes must pass through untouched"
+    assert torch.equal(out[1][1], scale), "the upstream scale must pass through untouched"
+
+
+def test_dsv4_converter_still_quantizes_bf16_input(tmp_path):
+    """The passthrough must not disable the converter for genuine bf16 pushes."""
+    import asyncio
+    import json
+
+    from verl.utils.sglang.sglang_fp8_utils import DeepseekV4FP8QuantizerHelper
+
+    ckpt = tmp_path / "ckpt"
+    ckpt.mkdir()
+    _write_safetensors(
+        ckpt / "model-00001-of-00001.safetensors",
+        {
+            "model.layers.0.self_attn.wkv.weight": (torch.randn(256, 256) * 0.01).to(torch.float8_e4m3fn),
+            "model.layers.0.self_attn.wkv.scale": torch.exp2(
+                torch.randint(-10, -5, (2, 2)).float()
+            ),
+        },
+    )
+    (ckpt / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.layers.0.self_attn.wkv.weight": "model-00001-of-00001.safetensors",
+                    "model.layers.0.self_attn.wkv.scale": "model-00001-of-00001.safetensors",
+                }
+            }
+        )
+    )
+    helper = DeepseekV4FP8QuantizerHelper({"weight_block_size": [128, 128]}, str(ckpt))
+
+    async def collect():
+        stream = [("model.layers.0.self_attn.wkv.weight", torch.randn(256, 256, dtype=torch.bfloat16) * 0.01)]
+        return [(k, v) async for k, v in helper.quant_weights_by_name(iter(stream))]
+
+    out = asyncio.run(collect())
+    assert [k for k, _ in out] == [
+        "model.layers.0.self_attn.wkv.weight",
+        "model.layers.0.self_attn.wkv.scale",
+    ]
+    assert out[0][1].element_size() == 1, "bf16 input must come out as fp8 codes"
+    log = torch.log2(out[1][1])
+    assert torch.equal(log, log.round()), "emitted scales must stay ue8m0 (power of two)"
+
+
+def test_dsv4_converter_ignores_stale_scale_index_entry(tmp_path):
+    """An index-only scale entry must not turn a BF16 weight into FP8."""
+    import asyncio
+    import json
+
+    from verl.utils.sglang.sglang_fp8_utils import DeepseekV4FP8QuantizerHelper
+
+    shard = "model-00001-of-00001.safetensors"
+    weight = torch.randn(8, 8, dtype=torch.bfloat16)
+    _write_safetensors(
+        tmp_path / shard,
+        {
+            "model.layers.0.self_attn.wo_a.weight": weight,
+            "model.layers.0.self_attn.wkv.weight": torch.randn(8, 8).to(torch.float8_e4m3fn),
+            "model.layers.0.self_attn.wkv.scale": torch.ones(1, 1),
+        },
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.layers.0.self_attn.wo_a.weight": shard,
+                    "model.layers.0.self_attn.wo_a.scale": shard,
+                    "model.layers.0.self_attn.wkv.weight": shard,
+                    "model.layers.0.self_attn.wkv.scale": shard,
+                }
+            }
+        )
+    )
+    helper = DeepseekV4FP8QuantizerHelper(DSV4_QC, str(tmp_path))
+
+    async def collect():
+        stream = iter([("model.layers.0.self_attn.wo_a.weight", weight)])
+        return [(name, tensor) async for name, tensor in helper.quant_weights_by_name(stream)]
+
+    out = asyncio.run(collect())
+    assert len(out) == 1
+    assert out[0][0].endswith("wo_a.weight")
+    assert out[0][1].dtype == torch.bfloat16

--- a/tests/checkpoint_engine/test_fp8_quant_selection.py
+++ b/tests/checkpoint_engine/test_fp8_quant_selection.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""FP8 tensor selection follows checkpoint dtypes instead of name patterns."""
+
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+
+
+def _checkpoint(tmp_path):
+    save_file(
+        {
+            "model.layers.0.self_attn.wkv.weight": torch.randn(8, 8).to(torch.float8_e4m3fn),
+            "model.layers.0.self_attn.wq_b.weight": torch.randn(8, 8).to(torch.float8_e4m3fn),
+            "model.layers.0.self_attn.compressor.wkv.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+            "model.layers.0.self_attn.wo_a.weight": torch.randn(8, 8, dtype=torch.bfloat16),
+            "model.layers.0.self_attn.wo_b.weight": torch.randn(8, 8).to(torch.float8_e4m3fn),
+        },
+        tmp_path / "model.safetensors",
+    )
+    return str(tmp_path)
+
+
+def test_checkpoint_predicate_uses_stored_dtype(tmp_path):
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp8_predicate
+
+    pred = build_ckpt_fp8_predicate(_checkpoint(tmp_path))
+    assert pred is not None
+    assert pred("model.layers.0.self_attn.wkv.weight") is True
+    assert pred("model.layers.0.self_attn.compressor.wkv.weight") is False
+    assert pred("model.layers.0.self_attn.wo_a.weight") is False
+    assert pred("model.layers.0.self_attn.wo_b.weight") is True
+
+
+def test_checkpoint_predicate_matches_bridge_attention_spelling(tmp_path):
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp8_predicate
+
+    pred = build_ckpt_fp8_predicate(_checkpoint(tmp_path))
+    assert pred("model.layers.0.attn.wkv.weight") is True
+    assert pred("model.layers.0.attn.compressor.wkv.weight") is False
+
+
+def test_missing_checkpoint_returns_none(tmp_path):
+    from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp8_predicate
+
+    assert build_ckpt_fp8_predicate(str(tmp_path / "missing")) is None
+
+
+def test_delta_spec_uses_training_engine_model_path(tmp_path, monkeypatch):
+    from verl.checkpoint_engine.delta_checkpoint_engine import DeltaShardedCheckpointEngine
+
+    helper = SimpleNamespace(
+        quant_config={"weight_block_size": [128, 128]},
+        should_quantize_param=lambda _name: False,
+    )
+    monkeypatch.setattr(DeltaShardedCheckpointEngine, "_fp8_helper", lambda _self, _engine: helper)
+
+    checkpoint_engine = object.__new__(DeltaShardedCheckpointEngine)
+    training_engine = SimpleNamespace(model_config=SimpleNamespace(local_path=_checkpoint(tmp_path)))
+    spec = checkpoint_engine._fp8_spec(training_engine)
+
+    assert spec.should_quantize("model.layers.0.self_attn.wq_b.weight") is True

--- a/tests/checkpoint_engine/test_sglang_loader.py
+++ b/tests/checkpoint_engine/test_sglang_loader.py
@@ -14,8 +14,8 @@
 """Bit-identity tests for the SGLang custom-weight-loader delta apply.
 
 Builds sparse ``indices``-encoding flushes exactly as the sharded engines
-assemble them (int32 within-parameter flat positions viewed as bytes + a value
-stream + checksum) and feeds each through :func:`delta_loader.apply_delta`
+assemble them (fixed-width within-parameter positions + a value stream +
+checksum) and feeds each through :func:`delta_loader.apply_delta`
 against a stand-in model whose ``load_weights`` mimics SGLang's
 ``param.copy_(loaded)`` semantics. Verifies the masked in-place apply: changed
 positions land bit-exactly, and positions outside the delta are never touched.
@@ -27,7 +27,13 @@ import json
 
 import torch
 
-from verl.checkpoint_engine.delta_sync import DeltaParam, checksum
+from verl.checkpoint_engine.delta_sync import (
+    DeltaParam,
+    absolute_index_width,
+    checksum,
+    pack_absolute_indices,
+    unpack_absolute_indices,
+)
 from verl.workers.rollout.sglang_rollout.delta_loader import apply_delta
 
 
@@ -41,6 +47,12 @@ class _FakeModel:
         for name, tensor in chunk:
             self.params[name].copy_(tensor)
 
+    def named_parameters(self):
+        return self.params.items()
+
+    def named_buffers(self):
+        return iter(())
+
 
 def _make_named(dtype=torch.bfloat16) -> list[tuple[str, torch.Tensor]]:
     torch.manual_seed(0)
@@ -50,7 +62,7 @@ def _make_named(dtype=torch.bfloat16) -> list[tuple[str, torch.Tensor]]:
     ]
 
 
-def _sparse_indices_flush(old_named, new_named):
+def _sparse_indices_flush(old_named, new_named, pos_width=4):
     """Assemble one indices-encoding flush from a bytewise old/new diff --
     the same layout the sharded engines' ``_assemble_flush`` produces."""
     params, idx_pieces, val_pieces = [], [], []
@@ -62,7 +74,7 @@ def _sparse_indices_flush(old_named, new_named):
         if idx.numel() == 0:
             continue
         nnz = int(idx.numel())
-        idx_pieces.append(idx.to(torch.int32))
+        idx_pieces.append(pack_absolute_indices(idx, pos_width))
         val_pieces.append(fn[idx])
         params.append(
             DeltaParam(
@@ -70,13 +82,13 @@ def _sparse_indices_flush(old_named, new_named):
                 dtype=str(new.dtype).replace("torch.", ""),
                 shape=list(new.shape),
                 pos_start=pos_off,
-                pos_end=pos_off + nnz * 4,
-                pos_width=4,
+                pos_end=pos_off + nnz * pos_width,
+                pos_width=pos_width,
                 val_start=val_off,
                 val_end=val_off + nnz,
             )
         )
-        pos_off += nnz * 4
+        pos_off += nnz * pos_width
         val_off += nnz
     positions = torch.cat(idx_pieces).contiguous().view(torch.uint8)
     values = torch.cat(val_pieces)
@@ -146,6 +158,33 @@ def test_checksum_mismatch_raises():
     named_tensors[2][1].view(torch.uint8)[0] ^= 0xFF  # corrupt one value byte
     with pytest.raises(RuntimeError, match="checksum"):
         apply_delta(_FakeModel(named), named_tensors)
+
+
+def test_24bit_positions_roundtrip_and_apply_bit_identical():
+    assert absolute_index_width(1 << 24) == 3
+    assert absolute_index_width((1 << 24) + 1) == 4
+    indices = torch.tensor([0, 1, 255, 256, 65535, 65536, (1 << 24) - 1], dtype=torch.int64)
+    packed = pack_absolute_indices(indices, 3)
+    assert packed.numel() == indices.numel() * 3
+    assert torch.equal(unpack_absolute_indices(packed, 3), indices.to(torch.int32))
+
+    named = _make_named()
+    new_named = [(name, tensor.clone()) for name, tensor in named]
+    new_named[0][1].view(-1)[[0, 5, 17]] += 1
+    new_named[1][1].view(-1)[[3, 31]] -= 1
+    model = _FakeModel([(name, tensor.clone()) for name, tensor in named])
+    apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named, pos_width=3)))
+    for name, expected in new_named:
+        assert torch.equal(model.params[name].view(torch.int16), expected.view(torch.int16)), name
+
+
+def test_mixed_position_width_rebases_unaligned_32bit_slice():
+    packed24 = pack_absolute_indices(torch.tensor([1], dtype=torch.int32), 3)
+    expected32 = torch.tensor([17, 1 << 24], dtype=torch.int32)
+    packed32 = pack_absolute_indices(expected32, 4)
+    mixed = torch.cat((packed24, packed32))
+    assert mixed[3:].storage_offset() == 3
+    assert torch.equal(unpack_absolute_indices(mixed[3:], 4), expected32)
 
 
 def test_dense_flush_applies_full_tensors():
@@ -227,3 +266,21 @@ def test_verify_sweep_fails_loud_on_divergence():
     model = _FakeModel(diverged)
     with pytest.raises(RuntimeError, match="verification FAILED"):
         apply_delta(model, _dense_verify_flush(named))
+
+
+def test_verify_sweep_replays_fused_members_atomically():
+    """DSv4 creates and drains its fusion cache within one load_weights call."""
+    names = (
+        "model.layers.0.self_attn.wq_a.weight",
+        "model.layers.0.self_attn.wkv.weight",
+    )
+    named = [(name, torch.randn(8, 8, dtype=torch.bfloat16)) for name in names]
+
+    class _FusionModel(_FakeModel):
+        def load_weights(self, chunk):
+            chunk_names = {name for name, _tensor in chunk}
+            if chunk_names.intersection(names):
+                assert set(names).issubset(chunk_names), chunk_names
+            super().load_weights(chunk)
+
+    apply_delta(_FusionModel(named), _dense_verify_flush(named))

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -127,6 +127,53 @@ def test_gather_slot_entries_sub_rounds_world1():
             dist.destroy_process_group()
 
 
+def test_exact_length_gather_posts_only_matching_nonempty_peers(monkeypatch):
+    """The P2P plan must use the shared count matrix verbatim on both sides."""
+    import torch.distributed as dist
+
+    from verl.checkpoint_engine.delta_sync.sparse_gather import _gather_p2p
+
+    posted = []
+    waited = []
+
+    class Work:
+        def wait(self):
+            waited.append(True)
+
+    def fake_op(fn, tensor, peer, group):
+        op = (fn, tensor.numel(), peer, group)
+        posted.append(op)
+        return op
+
+    monkeypatch.setattr(dist, "P2POp", fake_op)
+    monkeypatch.setattr(dist, "irecv", object())
+    monkeypatch.setattr(dist, "isend", object())
+    monkeypatch.setattr(dist, "get_global_rank", lambda _group, rank: rank + 10)
+    monkeypatch.setattr(dist, "batch_isend_irecv", lambda ops: [Work() for _ in ops])
+
+    group = object()
+    idx = torch.tensor([3, 8], dtype=torch.int32)
+    val = torch.tensor([1.0, 2.0])
+    totals = [2, 0, 3]
+
+    idx_list, val_list = _gather_p2p(idx, val, totals, 3, 0, 10, group, idx.device)
+    assert [x.numel() for x in idx_list] == totals
+    assert [x.numel() for x in val_list] == totals
+    assert [(n, peer) for _fn, n, peer, _group in posted] == [(3, 12), (3, 12)]
+    assert len(waited) == 2
+
+    posted.clear()
+    waited.clear()
+    assert _gather_p2p(idx, val, totals, 3, 1, 10, group, idx.device) == (None, None)
+    assert posted == [] and waited == []
+
+    sender_idx = torch.tensor([3, 8, 13], dtype=torch.int32)
+    sender_val = torch.tensor([1.0, 2.0, 3.0])
+    assert _gather_p2p(sender_idx, sender_val, totals, 3, 2, 10, group, idx.device) == (None, None)
+    assert [(n, peer) for _fn, n, peer, _group in posted] == [(3, 10), (3, 10)]
+    assert len(waited) == 2
+
+
 def test_prime_then_hf_delta_export_roundtrip():
     """The backend-side default delta strategy: prime_delta_snapshots pins the
     shards; a later pass through hf_delta_export yields a final-HF-coordinate

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -56,6 +56,105 @@ def test_shard_delta_indices_no_change_is_empty():
     assert gval.numel() == 0
 
 
+def test_megatron_block_owner_mask_is_structural_not_value_based():
+    from verl.workers.engine.megatron.delta_export import _local_block_owner_mask
+
+    # Four 2x2 blocks.  Owned zeros must count; NaNs are the probe's remote-rank
+    # placeholders and must not count.
+    t = torch.full((4, 4), float("nan"))
+    t[:2, :2] = 0.0
+    t[2:, 2:] = 7.0
+    got = _local_block_owner_mask(t, (2, 2), (4, 4))
+    assert torch.equal(got, torch.tensor([[True, False], [False, True]]))
+
+
+def test_block_owner_plan_selects_only_cross_cells_for_amax(monkeypatch):
+    import torch.distributed as dist
+
+    from verl.workers.engine.megatron.delta_export import _block_owner_plan
+
+    # Across two ranks: cell 0 belongs only to rank 0, cell 1 crosses both,
+    # cell 2 belongs only to rank 1.  Mock the one-time owner-count reduction.
+    def reduce_to_global_counts(tensor, op, group):
+        assert op == dist.ReduceOp.SUM
+        tensor.copy_(torch.tensor([1, 2, 1], dtype=tensor.dtype))
+
+    monkeypatch.setattr(dist, "all_reduce", reduce_to_global_counts)
+    group = object()
+    rank0 = _block_owner_plan([torch.tensor([[True, True, False]])], group, 0)
+    rank1 = _block_owner_plan([torch.tensor([[False, True, True]])], group, 1)
+    assert rank0[0][0].tolist() == [1] and rank1[0][0].tolist() == [1]
+    # Singleton scales remain on their owners; group rank zero owns the shared
+    # cell after receiving its compact reduced amax.
+    assert rank0[0][1].tolist() == [0, 1]
+    assert rank1[0][1].tolist() == [2]
+
+
+def test_cross_block_amax_reduces_only_compact_shared_cells(monkeypatch):
+    import torch.distributed as dist
+
+    from verl.workers.engine.megatron.delta_export import _reduce_cross_block_amax
+
+    seen = []
+
+    def compact_max(tensor, op, group):
+        assert op == dist.ReduceOp.MAX and group is marker
+        seen.append(tensor.clone())
+        tensor.add_(100)
+
+    monkeypatch.setattr(dist, "all_reduce", compact_max)
+    marker = object()
+    grids = [torch.tensor([[1.0, 2.0, 3.0]]), torch.tensor([[4.0, 5.0]])]
+    plan = [
+        (torch.tensor([1], dtype=torch.int32), torch.tensor([0, 1], dtype=torch.int32)),
+        (torch.tensor([0], dtype=torch.int32), torch.tensor([1], dtype=torch.int32)),
+    ]
+    assert _reduce_cross_block_amax(grids, plan, marker) == 2
+    assert torch.equal(seen[0], torch.tensor([2.0, 4.0]))
+    assert torch.equal(grids[0], torch.tensor([[1.0, 102.0, 3.0]]))
+    assert torch.equal(grids[1], torch.tensor([[104.0, 5.0]]))
+
+
+def test_cross_block_amax_skips_collective_when_no_shared_cells(monkeypatch):
+    import torch.distributed as dist
+
+    from verl.workers.engine.megatron.delta_export import _reduce_cross_block_amax
+
+    monkeypatch.setattr(dist, "all_reduce", lambda *_args, **_kwargs: pytest.fail("unexpected collective"))
+    grids = [torch.tensor([[1.0, 2.0]])]
+    plan = [(torch.empty(0, dtype=torch.int32), torch.tensor([0, 1], dtype=torch.int32))]
+    assert _reduce_cross_block_amax(grids, plan, None) == 0
+
+
+def test_quant_delta_entry_maps_compact_scale_indices_to_full_slot_positions():
+    from types import SimpleNamespace
+
+    from verl.workers.engine.megatron.delta_export import quant_delta_entry
+
+    name = "mcore.weight::s"
+    engine = SimpleNamespace(
+        _quant_group_meta={
+            name: (
+                [("hf.a_scale_inv", (4,)), ("hf.b_scale_inv", (5,))],
+                [2, 2],
+                "float32",
+                [torch.tensor([1, 3], dtype=torch.int32), torch.tensor([0, 4], dtype=torch.int32)],
+            )
+        }
+    )
+    slots, dtype_str, counts, idx, val = quant_delta_entry(engine)(
+        name,
+        None,
+        0,
+        torch.tensor([0, 3]),
+        torch.tensor([10.0, 20.0]),
+    )
+    assert slots == [("hf.a_scale_inv", (4,)), ("hf.b_scale_inv", (5,))]
+    assert dtype_str == "float32" and counts.tolist() == [1, 1]
+    assert idx.tolist() == [1, 4]
+    assert val.tolist() == [10.0, 20.0]
+
+
 def test_derive_dtensor_placement_unsharded():
     # A non-DTensor (replicated / unsharded) param: offset 0, no gather group,
     # and outside a process group rank 0 is assumed -> contributes.
@@ -125,6 +224,21 @@ def test_gather_slot_entries_sub_rounds_world1():
         # same session (repo convention: init in the test -> destroy in finally)
         if owns_pg:
             dist.destroy_process_group()
+
+
+def test_indexed_dense_gather_group_world1():
+    """Position-sharded scale cells reconstruct the dense HF scale slots."""
+    from verl.checkpoint_engine.delta_sync.sparse_gather import indexed_dense_gather_group
+
+    flat = torch.tensor([30.0, 10.0, 20.0, 200.0, 400.0, 100.0, 300.0])
+    got = indexed_dense_gather_group(
+        flat,
+        [3, 4],
+        [torch.tensor([2, 0, 1]), torch.tensor([1, 3, 0, 2])],
+        [3, 4],
+    )
+    assert torch.equal(got[0], torch.tensor([10.0, 20.0, 30.0]))
+    assert torch.equal(got[1], torch.tensor([100.0, 200.0, 300.0, 400.0]))
 
 
 def test_exact_length_gather_posts_only_matching_nonempty_peers(monkeypatch):

--- a/tests/checkpoint_engine/test_ue8m0_seed.py
+++ b/tests/checkpoint_engine/test_ue8m0_seed.py
@@ -1,0 +1,198 @@
+"""The seed must reproduce a ue8m0 checkpoint's bytes, not merely approximate them.
+
+Under the plain amax/FP8_MAX scale, quantized codes and scale_inv can differ
+from the checkpoint state. The mechanism is the round trip:
+a power-of-two scale shifts exponents losslessly, an arbitrary real rewrites
+mantissas. These tests pin the dialect switch end to end at the pure-function
+level: formula, stream output, config plumbing, and the round-trip invariant
+that is the whole point.
+"""
+
+import torch
+
+from verl.utils.fp8_sharded import FP8_MAX, QuantSpec, quantize_hf_stream, ue8m0_descale
+from verl.utils.sglang.sglang_fp8_utils import build_sglang_fp8_quant_config
+
+
+def _spec(scale_fmt=None):
+    return QuantSpec(
+        weight_block_size=(128, 128),
+        should_quantize=lambda n: n.endswith(".weight"),
+        scale_fmt=scale_fmt,
+    )
+
+
+def _stream(spec, t):
+    return dict(quantize_hf_stream(iter([("x.weight", t)]), spec))
+
+
+def test_ue8m0_descale_is_power_of_two_and_matches_the_converter():
+    amax = torch.rand(64, 64) * 100 + 1e-6
+    d = ue8m0_descale(amax)
+    log = torch.log2(d)
+    assert torch.equal(log, log.round()), "ue8m0 descale must be a power of two"
+    # the DSv4 nccl converter's literal expression (sglang_fp8_utils.py) --
+    # the two paths must be byte-identical
+    ref = torch.exp2(torch.ceil(torch.log2(amax.clamp_min(1e-10) / FP8_MAX)))
+    assert torch.equal(d, ref)
+
+
+def test_stream_emits_ue8m0_scales_when_asked():
+    t = torch.randn(256, 256, dtype=torch.bfloat16)
+    out = _stream(_spec("ue8m0"), t)
+    log = torch.log2(out["x.weight_scale_inv"])
+    assert torch.equal(log, log.round())
+
+
+def test_stream_default_formula_is_unchanged():
+    """Non-ue8m0 checkpoints (every model validated before DSv4) keep their bytes."""
+    t = torch.randn(256, 256, dtype=torch.bfloat16)
+    legacy = _stream(QuantSpec(weight_block_size=(128, 128), should_quantize=lambda n: True), t)
+    explicit = _stream(_spec(None), t)
+    assert torch.equal(
+        legacy["x.weight_scale_inv"], explicit["x.weight_scale_inv"]
+    ) and torch.equal(
+        legacy["x.weight"].view(torch.uint8), explicit["x.weight"].view(torch.uint8)
+    )
+
+
+def test_ue8m0_round_trip_is_bit_exact():
+    """quantize(dequant(codes, scales)) must reproduce codes AND scales bitwise.
+
+    This is the property that makes seed == disk possible at all: the trainer
+    holds dequant(ckpt) in bf16 and the seed re-quantizes it. Deliberately NOT
+    asserted for the plain formula -- it does not hold there, which is the bug.
+    """
+    spec = _spec("ue8m0")
+    t = torch.randn(256, 256, dtype=torch.bfloat16)
+    first = _stream(spec, t)
+    codes, descale = first["x.weight"], first["x.weight_scale_inv"]
+    # dequantize per 128x128 block, as the trainer-side bridge does
+    up = codes.to(torch.float32).reshape(2, 128, 2, 128) * descale.reshape(2, 1, 2, 1)
+    second = _stream(spec, up.reshape(256, 256).to(torch.bfloat16))
+    assert torch.equal(second["x.weight_scale_inv"], descale), "scales must survive the round trip"
+    assert torch.equal(
+        second["x.weight"].view(torch.uint8), codes.view(torch.uint8)
+    ), "fp8 codes must survive the round trip"
+
+
+def test_sticky_descale_keeps_ckpt_headroom_and_bumps_overflow():
+    from verl.utils.fp8_sharded import sticky_ue8m0_descale
+
+    amax = torch.tensor([[100.0, 100.0], [1000.0, 100.0]])
+    # ckpt scale 1.0 covers amax<=448; block (1,0) outgrew it
+    ck = torch.ones(2, 2)
+    d = sticky_ue8m0_descale(amax, ck)
+    assert d[0, 0] == 1.0 and d[0, 1] == 1.0 and d[1, 1] == 1.0, "covered blocks must keep the ckpt scale"
+    assert d[1, 0] == 4.0, f"outgrown block must bump to the tightest covering power, got {d[1,0]}"
+
+
+def test_sticky_descale_shape_mismatch_fails_loud():
+    import pytest
+
+    from verl.utils.fp8_sharded import sticky_ue8m0_descale
+
+    with pytest.raises(AssertionError):
+        sticky_ue8m0_descale(torch.ones(2, 2), torch.ones(2, 3))
+
+
+def test_headroom_round_trip_is_bit_exact_with_ckpt_scales():
+    """A checkpoint whose scale carries
+    headroom (max code <= FP8_MAX/2). Recomputing from amax tightens the scale
+    and rewrites the bytes; with the ckpt's scales in the spec they must come
+    back identical."""
+    from verl.utils.fp8_sharded import quantize_shard_with_descale
+
+    torch.manual_seed(7)
+    # build a "checkpoint": quantize with a DELIBERATELY loose power-of-two scale
+    w = torch.randn(128, 128, dtype=torch.bfloat16) * 10
+    loose = torch.tensor([[1.0]])  # amax ~60 << 448 -> tight would be 0.25
+    ck_codes = quantize_shard_with_descale(w, loose, [128, 128], 0)
+    # trainer sees the dequantized master
+    master = (ck_codes.float() * loose).to(torch.bfloat16)
+
+    spec_no_ck = _spec("ue8m0")
+    out = _stream(spec_no_ck, master)
+    assert not torch.equal(out["x.weight_scale_inv"], loose), "sanity: without ckpt scales the scale tightens"
+
+    spec_ck = QuantSpec(
+        weight_block_size=(128, 128),
+        should_quantize=lambda n: n.endswith(".weight"),
+        scale_fmt="ue8m0",
+        ckpt_scales={"x.weight": loose},
+    )
+    out2 = _stream(spec_ck, master)
+    assert torch.equal(out2["x.weight_scale_inv"], loose), "scale must come back identical"
+    assert torch.equal(
+        out2["x.weight"].view(torch.uint8), ck_codes.view(torch.uint8)
+    ), "codes must come back identical"
+
+
+def test_load_ckpt_scales_keys_by_weight_name(tmp_path):
+    import json
+
+    from safetensors.torch import save_file
+
+    from verl.utils.fp8_sharded import load_ckpt_scales
+
+    save_file(
+        {"a.weight": torch.zeros(4, 4, dtype=torch.bfloat16), "a.scale": torch.full((1, 1), 2.0)},
+        tmp_path / "model-00001-of-00001.safetensors",
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"a.weight": "model-00001-of-00001.safetensors",
+                                   "a.scale": "model-00001-of-00001.safetensors"}})
+    )
+    scales = load_ckpt_scales(str(tmp_path))
+    assert set(scales) == {"a.weight"} and scales["a.weight"].item() == 2.0
+
+
+def test_load_ckpt_scales_ignores_stale_index_entries(tmp_path):
+    """The published DSv4 index lists BF16 wo_a scales absent from the shard."""
+    import json
+
+    from safetensors.torch import save_file
+
+    from verl.utils.fp8_sharded import load_ckpt_scales
+
+    shard = "model-00001-of-00001.safetensors"
+    save_file(
+        {
+            "layers.0.attn.wo_a.weight": torch.zeros(4, 4, dtype=torch.bfloat16),
+            "layers.0.attn.wo_b.scale": torch.full((1, 1), 2.0),
+        },
+        tmp_path / shard,
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "layers.0.attn.wo_a.weight": shard,
+                    "layers.0.attn.wo_a.scale": shard,
+                    "layers.0.attn.wo_b.scale": shard,
+                }
+            }
+        )
+    )
+
+    scales = load_ckpt_scales(str(tmp_path))
+    assert set(scales) == {"layers.0.attn.wo_b.weight"}
+    assert scales["layers.0.attn.wo_b.weight"].item() == 2.0
+
+
+def test_stream_refuses_already_quantized_input():
+    """fp8 codes in means a second quantizer exists upstream; refuse it."""
+    import pytest
+
+    codes = torch.arange(64, dtype=torch.uint8).view(torch.float8_e4m3fn).reshape(8, 8)
+    with pytest.raises(AssertionError, match="already"):
+        list(quantize_hf_stream(iter([("x.weight", codes)]), _spec("ue8m0")))
+
+
+def test_build_config_preserves_scale_fmt():
+    cfg = build_sglang_fp8_quant_config(
+        {"quantization_config": {"weight_block_size": [128, 128], "scale_fmt": "ue8m0"}}
+    )
+    assert cfg.get("scale_fmt") == "ue8m0", f"scale_fmt dropped again: {cfg}"
+    cfg2 = build_sglang_fp8_quant_config({"quantization_config": {"weight_block_size": [128, 128]}})
+    assert "scale_fmt" not in cfg2

--- a/tests/special_distributed/test_sharded_delta_gather.py
+++ b/tests/special_distributed/test_sharded_delta_gather.py
@@ -24,7 +24,13 @@ from torch.distributed.tensor.placement_types import _StridedShard
 
 from verl.checkpoint_engine.delta_sync.sparse_gather import (
     gather_slot_entries_to_rank0,
+    indexed_dense_gather_group,
     shard_delta_indices,
+)
+from verl.workers.engine.megatron.delta_export import (
+    _block_owner_plan,
+    _local_block_owner_mask,
+    _reduce_cross_block_amax,
 )
 from verl.workers.engine.spec import ShardSpec, derive_dtensor_placement, translate_flat_indices
 
@@ -90,12 +96,48 @@ def _run_case(shape, placements, mesh, dev, rank, si):
     return ok
 
 
+def _run_cross_block_amax_case(dev, rank, world):
+    """Exercise the actual owner exchange, compact MAX, and indexed seed path."""
+    if world != 2:
+        return True
+    # A real column-parallel geometry: a 384-row HF matrix split at row 192.
+    # Since 192 is not aligned to a 128-row quant block, the middle block row
+    # crosses the TP boundary; the first/last block rows remain rank-local.
+    mapped = torch.full((384, 256), float("nan"), dtype=torch.float32, device=dev)
+    mapped[:192] = rank + 1 if rank == 0 else float("nan")
+    if rank == 1:
+        mapped[192:] = 2
+    mask = _local_block_owner_mask(mapped, (128, 128), (384, 256))
+    ((cross, scale_pos),) = _block_owner_plan([mask], dist.group.WORLD, rank)
+    grid = torch.tensor([[1.0, 2.0], [3.0, 4.0], [0.0, 0.0]], device=dev)
+    if rank == 1:
+        grid = torch.tensor([[0.0, 0.0], [30.0, 40.0], [50.0, 60.0]], device=dev)
+    communicated = _reduce_cross_block_amax([grid], [(cross, scale_pos)], dist.group.WORLD)
+    assert communicated == 2 and cross.tolist() == [2, 3]
+
+    local_scale = grid.reshape(-1)[scale_pos.long()]
+    gathered = indexed_dense_gather_group(
+        local_scale,
+        [int(local_scale.numel())],
+        [scale_pos],
+        [6],
+        dist.group.WORLD,
+    )
+    if rank != 0:
+        return True
+    assert torch.equal(gathered[0], torch.tensor([1.0, 2.0, 30.0, 40.0, 50.0, 60.0], device=dev))
+    print("[cross-block amax] communicated=2/6 dense scale cells -> PASS")
+    return True
+
+
 def main():
     dist.init_process_group("nccl")
     rank, world = dist.get_rank(), dist.get_world_size()
     torch.cuda.set_device(rank)
     dev = torch.device("cuda", rank)
     all_ok = True
+
+    all_ok = _run_cross_block_amax_case(dev, rank, world) and all_ok
 
     # 1D FSDP mesh, Shard(0) -- uneven shapes stress the offset math.
     mesh1d = init_device_mesh("cuda", (world,))

--- a/tests/workers/test_dsv4_sglang_compat_on_cpu.py
+++ b/tests/workers/test_dsv4_sglang_compat_on_cpu.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import sys
+import types
+
+import numpy as np
+
+
+def test_sglang_deepseek_v4_config_aliases_and_preserves_metadata(monkeypatch):
+    from verl.workers.config.model import _get_sglang_deepseek_v4_config_class
+
+    class FakeDeepSeekV4Config:
+        def __init__(self, v_head_dim=None, window_size=None, n_hash_layers=None):
+            self.v_head_dim = v_head_dim
+            self.window_size = window_size
+            self.n_hash_layers = n_hash_layers
+
+    fake_module = types.ModuleType("sglang.srt.configs.deepseek_v4")
+    fake_module.DeepSeekV4Config = FakeDeepSeekV4Config
+    monkeypatch.setitem(sys.modules, "sglang.srt.configs.deepseek_v4", fake_module)
+
+    config_cls = _get_sglang_deepseek_v4_config_class()
+    config = config_cls(
+        head_dim=192,
+        sliding_window=4096,
+        num_hash_layers=3,
+        model_type="deepseek_v4",
+        architectures=["DeepseekV4ForCausalLM"],
+        future_checkpoint_field="kept",
+    )
+
+    assert config.v_head_dim == 192
+    assert config.window_size == 4096
+    assert config.n_hash_layers == 3
+    assert config.future_checkpoint_field == "kept"
+
+
+def test_sglang_0512_base64_routed_experts_payload():
+    from verl.workers.rollout.sglang_rollout.async_sglang_server import _decode_routed_experts_payload
+
+    expected = np.arange(12, dtype=np.int32)
+    encoded = base64.b64encode(expected.tobytes()).decode()
+    actual = _decode_routed_experts_payload(encoded)
+
+    assert actual.dtype == np.int32
+    np.testing.assert_array_equal(actual, expected)

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -42,9 +42,9 @@ Data ladder (sender side, steady) -- the names in this file anchor to these::
     --_GatherQueue--> per-SLOT delta on rank 0 --_bucket_*--> _FlushPiece
     --_FlushBucket--> FLUSH (DeltaFlush) --_publish_flush--> wire
 
-Wire encodings: ``indices`` (int32 positions + values; every steady sync) and
-``values`` (values only; the seed). The values meta tag is ``"dense"`` for
-protocol continuity with the receiver's delta_loader.
+Wire encodings: ``indices`` (fixed-width absolute positions + values; every
+steady sync) and ``values`` (values only; the seed). The values meta tag is
+``"dense"`` for protocol continuity with the receiver's delta_loader.
 """
 
 from __future__ import annotations
@@ -60,11 +60,13 @@ import ray.util.collective as collective
 import torch
 import zmq
 
+from verl.utils.fusion_groups import DEEPSEEK_V4_FUSION_GROUPS
+
 with patch("importlib.metadata.distributions", return_value=[]):
     import cupy as cp
 
 from .base import CheckpointEngineRegistry
-from .delta_sync.encode import DeltaFlush, DeltaParam
+from .delta_sync.encode import DeltaFlush, DeltaParam, absolute_index_width, pack_absolute_indices
 from .delta_sync.encode import checksum as _checksum
 from .delta_sync.sparse_gather import gather_slot_entries_to_rank0
 from .nccl_checkpoint_engine import MasterMetadata, NCCLCheckpointEngine, WorkerMetadata
@@ -125,6 +127,26 @@ class _FlushBucket:
         if self.nbytes >= self.cap:
             self.seal()
 
+    def add_atomic(self, sized_pieces: list[tuple]) -> None:
+        """Add several pieces that must not be split across flushes.
+
+        The cap check happens BEFORE the group goes in (seal the current bucket
+        first if it would overflow), so the boundary can only fall between
+        groups -- never inside one. A group larger than ``cap`` becomes its own
+        oversized flush, which is correct if not ideal; the fused DSv4 params
+        this exists for are a few MiB.
+        """
+        if not sized_pieces:
+            return
+        total = sum(int(nb) for _, nb in sized_pieces)
+        if self.pieces and self.nbytes + total > self.cap:
+            self.seal()
+        for piece, nbytes in sized_pieces:
+            self.pieces.append(piece)
+            self.nbytes += int(nbytes)
+        if self.nbytes >= self.cap:
+            self.seal()
+
     def seal(self) -> None:
         if not self.pieces:
             return
@@ -138,18 +160,162 @@ class _FlushBucket:
             self.pending = None
 
 
-def _bucket_sliced(bkt: _FlushBucket, name: str, dtype_str: str, shape, aidx: torch.Tensor, aval: torch.Tensor) -> None:
-    """Slice one param's (idx, val) delta into <= MAX_ENTRY_ELEMS pieces and bucket
-    them (bounds the receiver-side decode transient; the masked apply is sequential,
+# Destination params that the ROLLOUT-side loader rebuilds by concatenating two
+# separately-named checkpoint tensors. sglang's DSv4 loader buffers the halves in
+# a cache created inside ``load_weights`` and asserts it empty on return, so both
+# members have to arrive in the SAME call -- i.e. the same flush. Bucketing by
+# bytes alone splits them sooner or later and the assert fires; that is not
+# delta-specific, plain full NCCL sync hits it too.
+#
+# Suffixes are spelled out through ``.self_attn.`` on purpose: a bare
+# ``.wkv.weight`` would also match ``.compressor.wkv.weight`` and
+# ``.indexer.compressor.wkv.weight``. ``_FusionStager._match`` asserts a name
+# never matches two groups, so an ambiguity introduced later fails loudly here
+# rather than silently mis-grouping.
+#
+# fp8 splits into two groups because sglang keys its cache on the destination
+# param name: ``wqkv_a.weight`` and ``wqkv_a.weight_scale_inv`` are separate
+# entries and each needs its own pair.
+# The attention block is spelled ``self_attn`` in the names that reach sglang
+# (the loader's cache key ``model.layers.N.self_attn.wqkv_a.weight`` back-derives
+# an incoming ``...self_attn.wq_a.weight``), but Megatron-Bridge's DSv4 mapping
+# writes ``layers.N.attn.*``. Carry both rather than bet on which layer renames:
+# the two are mutually exclusive under ``endswith`` (``self_attn`` has no dot
+# before ``attn``), so listing both cannot create an ambiguity.
+_FUSION_GROUPS = tuple((str(index), group) for index, group in enumerate(DEEPSEEK_V4_FUSION_GROUPS))
+
+
+class _FusionStager:
+    """Hold the members of a fused destination param until the group is complete,
+    then release them together so they ride one flush.
+
+    Two things have to be true at the receiver for a fused param to survive a
+    sparse sync, and this covers both:
+
+    * **completeness** -- a member with no changed elements is released as an
+      EMPTY entry instead of being dropped. The receiver densifies it to an
+      all-NaN full-shape tensor, and since ``_masked_copy`` keeps the
+      destination wherever the source is NaN, cat-ing that half into the fused
+      param is a no-op for it. (Verified: ``_decode_one`` already returns pure
+      NaN for a zero-length entry, both in the fp8 byte path and the float path,
+      so the receiver needs no change.)
+    * **co-location** -- see ``_FlushBucket.add_atomic``; being complete does not
+      help if the two halves land in different ``load_weights`` calls.
+
+    Params outside any group pass straight through.
+    """
+
+    __slots__ = ("_pending", "n_groups", "n_filled")
+
+    def __init__(self) -> None:
+        self._pending: dict[tuple[str, str], dict] = {}
+        self.n_groups = 0  # groups released with at least one changed member
+        self.n_filled = 0  # halves materialised as all-NaN because nothing changed
+
+    @staticmethod
+    def _match(name: str):
+        hits = [(key, sfx) for key, sfxs in _FUSION_GROUPS for sfx in sfxs if name.endswith(sfx)]
+        assert len(hits) <= 1, f"{name!r} matches multiple fusion groups: {hits}"
+        return hits[0] if hits else None
+
+    def offer(self, name: str, dtype_str: str, shape, aidx, aval):
+        """Return ``(entries, is_group)``, or ``None`` while a group is incomplete.
+
+        A non-member yields itself with ``is_group=False`` -- the caller keeps
+        dropping unchanged non-members, so this costs nothing for the ~99% of
+        params that are not fused. A member yields ``None`` until its siblings
+        arrive, then the whole group in declared order with ``is_group=True`` --
+        or ``([], True)`` if no member of the group changed at all, since there
+        is then nothing to send.
+        """
+        matched = self._match(name)
+        if matched is None:
+            return [(name, dtype_str, shape, aidx, aval)], False
+
+        key, sfx = matched
+        suffixes = next(s for k, s in _FUSION_GROUPS if k == key)
+        slot = self._pending.setdefault((name[: -len(sfx)], key), {})
+        assert sfx not in slot, f"duplicate fusion member {name!r} for group {key!r}"
+        slot[sfx] = (name, dtype_str, shape, aidx, aval)
+        if len(slot) < len(suffixes):
+            return None
+
+        self._pending.pop((name[: -len(sfx)], key))
+        members = [slot[s] for s in suffixes]
+        if all(e[3] is None or e[3].numel() == 0 for e in members):
+            return [], True
+        # Materialise the absent halves. Device/dtype come from a member that did
+        # change, so the empties cat cleanly with the rest of the flush.
+        donor = next(e for e in members if e[3] is not None and e[3].numel())
+        dev = donor[3].device
+        out = []
+        for m_name, m_dtype, m_shape, m_idx, m_val in members:
+            if m_idx is None or m_idx.numel() == 0:
+                m_idx = torch.empty(0, dtype=torch.int32, device=dev)
+                m_val = torch.empty(0, dtype=getattr(torch, m_dtype), device=dev)
+                self.n_filled += 1
+            out.append((m_name, m_dtype, m_shape, m_idx, m_val))
+        self.n_groups += 1
+        return out, True
+
+    def offer_piece(self, name: str, piece, nbytes: int):
+        """Seed-path variant: co-locate a group's members, nothing else.
+
+        A full export contains every member by construction, so there is no
+        absent half to materialise -- only the flush boundary matters. Returns
+        ``(list_of_(piece, nbytes), is_group)`` or ``None`` while incomplete.
+        """
+        matched = self._match(name)
+        if matched is None:
+            return [(piece, nbytes)], False
+        key, sfx = matched
+        suffixes = next(s for k, s in _FUSION_GROUPS if k == key)
+        slot = self._pending.setdefault((name[: -len(sfx)], key), {})
+        assert sfx not in slot, f"duplicate fusion member {name!r} for group {key!r}"
+        slot[sfx] = (piece, nbytes)
+        if len(slot) < len(suffixes):
+            return None
+        self._pending.pop((name[: -len(sfx)], key))
+        self.n_groups += 1
+        return [slot[s] for s in suffixes], True
+
+    def assert_drained(self) -> None:
+        assert not self._pending, (
+            f"fusion groups never completed: {sorted(self._pending)}. Every member listed in "
+            f"_FUSION_GROUPS must appear in the export stream, including unchanged ones."
+        )
+
+
+def _slice_pieces(name: str, dtype_str: str, shape, aidx: torch.Tensor, aval: torch.Tensor) -> list[tuple]:
+    """Slice one param's (idx, val) delta into <= MAX_ENTRY_ELEMS ``(piece, nbytes)``
+    pairs (bounds the receiver-side decode transient; the masked apply is sequential,
     so splitting is transparent). Bucket bytes = actual wire bytes (int32 positions
-    + values)."""
+    + values).
+
+    An empty delta yields ONE empty piece rather than none: a zero-length range()
+    would emit nothing, but fusion-group members with no changed elements must
+    still reach the receiver so it can densify them to all-NaN (see _FusionStager).
+    """
+    if aidx.numel() == 0:
+        return [(_FlushPiece(name, dtype_str, list(shape), aidx, aval), 0)]
     max_elems = DeltaShardedCheckpointEngine.MAX_ENTRY_ELEMS
+    out = []
     for s in range(0, aidx.numel(), max_elems):
         e = min(s + max_elems, aidx.numel())
-        bkt.add(
-            _FlushPiece(name, dtype_str, list(shape), aidx[s:e], aval[s:e]),
-            (e - s) * (4 + aval.element_size()),
+        out.append(
+            (
+                _FlushPiece(name, dtype_str, list(shape), aidx[s:e], aval[s:e]),
+                (e - s) * (4 + aval.element_size()),
+            )
         )
+    return out
+
+
+def _bucket_sliced(
+    bkt: _FlushBucket, name: str, dtype_str: str, shape, aidx: torch.Tensor, aval: torch.Tensor
+) -> None:
+    for piece, nbytes in _slice_pieces(name, dtype_str, shape, aidx, aval):
+        bkt.add(piece, nbytes)
 
 
 class _GatherQueue:
@@ -177,7 +343,11 @@ class _GatherQueue:
         self._queues: dict[int, tuple] = {}  # id(pg) -> (pg, [entries])
 
     def put(self, pg, slots: list, dtype_str: str, counts: torch.Tensor, idx: torch.Tensor, val: torch.Tensor):
-        _pg, entries = self._queues.setdefault(id(pg), (pg, []))
+        # one queue per (group, value dtype): batches concatenate values, so a
+        # batch must be dtype-homogeneous (fp8 codes / fp32 scales / bf16 mix
+        # under quant mode). Entry order and dtypes are identical on every
+        # rank, so the partition stays in lockstep.
+        _pg, entries = self._queues.setdefault((id(pg), val.dtype), (pg, []))
         entries.append((slots, dtype_str, counts, idx, val))
         if len(entries) >= self.batch_k:
             self._flush(pg, entries)
@@ -278,6 +448,11 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             "val_dtype": str(flush.values_gpu.dtype).replace("torch.", ""),
             "spec": {
                 "encoding": self.encoding,
+                "values_bytes": self.quantize_fp8,
+                # sparse flushes carry the quant config too: the receiver's
+                # handshake (incl. the seed-required sentinel guard) must be
+                # reachable on the steady path, not only on the dense seed.
+                "quant_config": getattr(self, "_fp8_quant_cfg", None),
                 "params": [vars(p) for p in flush.params],
                 "checksum": int(flush.checksum),
             },
@@ -297,7 +472,12 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         collective.broadcast(val_cp, src_rank=0, group_name=self.group_name)
 
     def _publish_values_flush(
-        self, params: list[DeltaParam], values: torch.Tensor, is_last: bool, verify: bool = False
+        self,
+        params: list[DeltaParam],
+        values: torch.Tensor,
+        is_last: bool,
+        verify: bool = False,
+        values_bytes: bool = False,
     ) -> None:
         """Publish a values-only (full-coverage, positions-free) flush -- used by the first
         sync. The wire encoding tag stays ``"dense"`` -- it is protocol, shared with the
@@ -316,6 +496,8 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
                 "encoding": "dense",
                 "verify": verify,
                 "is_last": is_last,
+                "values_bytes": values_bytes,
+                "quant_config": getattr(self, "_fp8_quant_cfg", None),
                 "params": [vars(p) for p in params],
                 "checksum": int(_checksum(empty_pos, values)),
             },
@@ -396,13 +578,26 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         logger.info("delta recv v=%s flushes=%d (yielded to server adapter)", global_steps, applied)
 
     def __init__(
-        self, *args, encoding: str = "indices", batch_gather: int = 32, verify_every: int = 0, **kwargs
+        self,
+        *args,
+        encoding: str = "indices",
+        batch_gather: int = 32,
+        verify_every: int = 0,
+        verify_seed: bool = False,
+        quantize_fp8: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         assert encoding == "indices", f"delta_sharded ships only the 'indices' position encoding; got {encoding!r}"
         self.encoding = encoding
         # SGLang supports verify_every > 0; vLLM rejects it at startup.
         self.verify_every = int(verify_every)
+        self.verify_seed = bool(verify_seed)
+        # fp8 rollout mode: quantize on the trainer and ship the rollout's
+        # exact state (fp8 codes + blockwise scale_inv tensors). Currently
+        # full-resync per sync (the quant-domain sparse steady path lands
+        # next); the wire is already half the bf16 bytes per element.
+        self.quantize_fp8 = bool(quantize_fp8)
         self._shard_seeded = False
         # Gather the per-param sparse deltas in groups of this many parameters
         # (one count-matrix all_gather + two padded gathers per group instead of
@@ -410,11 +605,101 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         self.batch_gather = int(batch_gather)
 
     def _verify_due(self) -> bool:
-        """True on every K-th steady sync when constructed with ``verify_every=K``."""
+        """True on every K-th steady sync (``verify_every=K``), and ALWAYS on the
+        first steady sync -- the runtime fuse must exist even when periodic
+        verification is off (verify_every=0 keeps only that one mandatory sweep)."""
+        self._steady_count = getattr(self, "_steady_count", 0) + 1
+        if self._steady_count == 1:
+            return True
         if self.verify_every <= 0:
             return False
-        self._steady_count = getattr(self, "_steady_count", 0) + 1
         return self._steady_count % self.verify_every == 0
+
+    def _fp8_spec(self, engine=None):
+        """Distill the serving engine's quant config into a rollout-agnostic
+        :class:`~verl.utils.fp8_sharded.QuantSpec` for the backend."""
+        from verl.utils.fp8_sharded import QuantSpec
+
+        h = self._fp8_helper(engine)
+        scale_fmt = h.quant_config.get("scale_fmt")
+        # ue8m0 checkpoints carry per-block headroom that is unrecoverable from
+        # the dequantized master; hand the quantizers the checkpoint's own
+        # scales so unchanged blocks reproduce the checkpoint's bytes exactly.
+        ckpt_scales = None
+        ckpt_path = getattr(getattr(engine, "model_config", None), "local_path", None)
+        if scale_fmt == "ue8m0":
+            if ckpt_path:
+                from verl.utils.fp8_sharded import load_ckpt_scales
+
+                ckpt_scales = load_ckpt_scales(ckpt_path)
+            else:
+                raise ValueError("ue8m0 delta sync requires model_config.local_path to read checkpoint scales")
+        # fp32 wire fidelity for the checkpoint's non-quantized fp32 families
+        # (DSv4: hc_*, ape, attn_sink, e_score_correction_bias). Header-only
+        # read, memoised per process like the fp8 predicate.
+        fp32_predicate = None
+        if ckpt_path:
+            from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp32_predicate
+
+            fp32_predicate = build_ckpt_fp32_predicate(ckpt_path)
+        return QuantSpec(
+            weight_block_size=tuple(h.quant_config.get("weight_block_size", [128, 128])),
+            should_quantize=self._quant_predicate(h, ckpt_path),
+            scale_fmt=scale_fmt,
+            ckpt_scales=ckpt_scales,
+            fp32_predicate=fp32_predicate,
+        )
+
+    def _quant_predicate(self, helper, checkpoint_path: str | None):
+        """Select quantized tensors from checkpoint metadata when available."""
+        from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp8_predicate
+
+        if not checkpoint_path:
+            logger.warning(
+                "fp8 selection: no model path is available; falling back to the name allowlist"
+            )
+            return helper.should_quantize_param
+        pred = build_ckpt_fp8_predicate(checkpoint_path)
+        if pred is None:
+            logger.warning(
+                "fp8 selection: checkpoint at %s could not answer; using the name allowlist", checkpoint_path
+            )
+            return helper.should_quantize_param
+        logger.warning("fp8 selection: using CHECKPOINT dtypes from %s (not the name allowlist)", checkpoint_path)
+        return pred
+
+    def _fp8_helper(self, engine=None):
+        """Build the quantizer helper from the SAME inputs the rollout used --
+        the model's hf_config (real ignored_layers / modules_to_not_convert)
+        -- instead of guessing bare defaults, and guard the supported mode."""
+        from verl.utils.sglang.sglang_fp8_utils import SGLangFP8QuantizerHelper, build_sglang_fp8_quant_config
+
+        h = getattr(self, "_fp8_helper_inst", None)
+        if h is None:
+            hf_config = None
+            if engine is not None:
+                model_config = getattr(engine, "model_config", None)
+                hf_config = getattr(model_config, "hf_config", None)
+            if hf_config is None:
+                logger.warning(
+                    "fp8 delta: no hf_config available; quant config built from bare defaults "
+                    "(ignored_layers/modules_to_not_convert from the checkpoint will be missed)"
+                )
+            cfg = build_sglang_fp8_quant_config(hf_config)
+            # supported-mode guards: this engine ships blockwise fp8 with a
+            # plain fp32 scale_inv grid, nothing else.
+            assert cfg.get("quant_method") == "fp8", f"unsupported quant_method {cfg.get('quant_method')!r}"
+            if cfg.get("weight_block_size") is None:
+                raise NotImplementedError("per-tensor fp8 is not supported by the delta engine (blockwise only)")
+            # ue8m0 is handled (both quantizers switch on QuantSpec.scale_fmt);
+            # anything else is still a hard stop.
+            sf = cfg.get("scale_fmt")
+            assert sf in (None, "ue8m0"), f"unsupported scale_fmt {sf!r} in quant config: {cfg}"
+            assert "deepgemm" not in cfg, f"unsupported scale format flag 'deepgemm' in quant config: {cfg}"
+            self._fp8_quant_cfg = cfg
+            h = SGLangFP8QuantizerHelper(cfg)
+            self._fp8_helper_inst = h
+        return h
 
     def _assemble_flush(self, per_param: list[_FlushPiece]) -> DeltaFlush:
         """Build one DeltaFlush (indices encoding) from rank 0's gathered per-param deltas.
@@ -427,34 +712,36 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         (``.cpu().numpy().tobytes()`` + join) dominated the whole send at scale
         (~2.4s/sync at 7B steady state, ~83s on the full seed).
         """
+        bytes_wire = self.quantize_fp8  # mixed dtypes (fp8 codes + fp32 scales + bf16)
         idx_pieces: list[torch.Tensor] = []
         val_pieces: list[torch.Tensor] = []
         params: list[DeltaParam] = []
         pos_off = val_off = 0
         for piece in per_param:
             nnz = int(piece.idx.numel())
-            # positions ride the wire as int32 (pos_width=4); a parameter bigger than
-            # 2^31 elements would silently wrap, so fail loud instead. DeltaParam
-            # carries pos_width for a future 8-byte escalation if a model needs it.
-            assert _prodshape(piece.shape) < (1 << 31), (
-                f"{piece.name}: {_prodshape(piece.shape)} elements exceeds the int32 position encoding"
-            )
-            idx_pieces.append(piece.idx.to(torch.int32))
-            val_pieces.append(piece.val)
+            # 24-bit absolute indices cover most model tensors while keeping
+            # the format fixed-width and branch-free on decode. Larger tensors
+            # retain the established int32 layout.
+            param_numel = _prodshape(piece.shape)
+            pos_width = absolute_index_width(param_numel)
+            idx_pieces.append(pack_absolute_indices(piece.idx, pos_width))
+            val = piece.val.contiguous().view(torch.uint8) if bytes_wire else piece.val
+            val_pieces.append(val)
+            n_val = int(val.numel())  # elements, or bytes in bytes_wire mode
             params.append(
                 DeltaParam(
                     name=piece.name,
                     dtype=piece.dtype_str,
                     shape=list(piece.shape),
                     pos_start=pos_off,
-                    pos_end=pos_off + nnz * 4,
-                    pos_width=4,
+                    pos_end=pos_off + nnz * pos_width,
+                    pos_width=pos_width,
                     val_start=val_off,
-                    val_end=val_off + nnz,
+                    val_end=val_off + n_val,
                 )
             )
-            pos_off += nnz * 4
-            val_off += nnz
+            pos_off += nnz * pos_width
+            val_off += n_val
 
         values_gpu = torch.cat(val_pieces) if val_pieces else torch.empty(0, dtype=self.rollout_dtype, device="cuda")
         positions_u8 = (
@@ -467,11 +754,85 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             encoding=self.encoding, params=params, positions_cpu=positions_u8, values_gpu=values_gpu, checksum=cks
         )
 
+    def _seed_verify_sweep(self, engine, spec, global_steps: int | None = None) -> None:
+        """Verify sweep straight after the seed, inside the seed's receive
+        session (the seed held is_last for us). Collective on every rank: the
+        full export assembles per tensor. Same producer as the steady path's
+        sweep, so the two sweeps judge seed and steady on identical terms."""
+        if spec is not None:
+            full, _ = engine.get_per_tensor_param(quant_spec=spec)
+            self._send_full_seed(
+                full,
+                global_steps,
+                verify=True,
+                bytes_wire=True,
+                fp32_predicate=getattr(spec, "fp32_predicate", None),
+            )
+        else:
+            full, _ = engine.get_per_tensor_param()
+            self._send_full_seed(full, global_steps, verify=True)
+
+    def _send_full_seed_sharded(
+        self, engine, spec, global_steps: int | None = None, hold_last: bool = False
+    ) -> dict[str, float] | None:
+        """Seed from the STEADY shard stream over the values-only wire.
+
+        One producer for the first and every later sync: the shard stream's
+        comm-stubbed mapping transforms and sticky-ue8m0 quantizer make the
+        tensors, a dense per-record gather (values only, sequential P2P)
+        assembles them on rank 0, and the pairs feed the SAME values-only
+        bucketing as the legacy seed -- so the receiver sees a wire format it
+        has always known. Snapshots are primed inline from the very flats that
+        shipped, so the next steady diff base equals the shipped state by
+        construction and the separate prime pass disappears.
+        """
+        from verl.checkpoint_engine.delta_sync.sparse_gather import dense_gather_group
+        from verl.utils.device import is_cuda_available
+
+        gen, _ = engine.get_per_tensor_param_shard(quant_spec=spec)
+        engine._delta_shard_snap = getattr(engine, "_delta_shard_snap", {})
+        snaps = engine._delta_shard_snap
+
+        def pairs():
+            meta = None
+            for name, flat, sspec in gen:
+                flat = flat.detach().contiguous().view(-1)
+                # prime the steady diff base inline (same layout/pinning as
+                # prime_delta_snapshots)
+                snap = snaps.get(name)
+                if snap is None or snap.numel() != flat.numel():
+                    snap = torch.empty_like(flat, device="cpu", pin_memory=is_cuda_available)
+                    snaps[name] = snap
+                snap.copy_(flat, non_blocking=True)
+                if meta is None:
+                    meta = engine._quant_group_meta
+                slots, sizes, dtype_str = meta[name]
+                # replicas do not contribute: zero their size vector so the
+                # gather's exactly-one-owner assert sees the true ownership map
+                sizes_eff = sizes if sspec.contributes else [0] * len(sizes)
+                pieces = dense_gather_group(flat, sizes_eff, sspec.gather_group)
+                if pieces is None:
+                    continue
+                dtype = getattr(torch, dtype_str)
+                for (slot_name, shape), piece in zip(slots, pieces, strict=True):
+                    yield slot_name, piece.view(dtype).reshape(shape)
+
+        return self._send_full_seed(
+            pairs(),
+            global_steps,
+            bytes_wire=True,
+            fp32_predicate=getattr(spec, "fp32_predicate", None),
+            hold_last=hold_last,
+        )
+
     def _send_full_seed(
         self,
         weights: Generator[tuple[str, torch.Tensor], None, None],
         global_steps: int | None = None,
         verify: bool = False,
+        bytes_wire: bool = False,
+        fp32_predicate=None,
+        hold_last: bool = False,
     ) -> dict[str, float] | None:
         """First sync: stream the backend's FULL HF export over the values-only wire.
 
@@ -510,11 +871,16 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         def _publish_values(pending, is_last: bool) -> None:
             nonlocal n_flushes, wire_bytes
             params, values = pending
-            self._publish_values_flush(params, values, is_last=is_last, verify=verify)
+            self._publish_values_flush(params, values, is_last=is_last, verify=verify, values_bytes=bytes_wire)
             n_flushes += 1
             wire_bytes += int(values.nbytes)
 
         bkt = _FlushBucket(self.bucket_size, _assemble_values, _publish_values)
+        # The seed streams the FULL export, so every fused member is present --
+        # but byte bucketing splits pairs here exactly like it does in the steady
+        # path, and the seed is the FIRST sync, so without this the run dies
+        # before the steady staging is ever exercised.
+        stager = _FusionStager()
 
         seen_names: set = set()
         for name, tensor in weights:
@@ -525,21 +891,57 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             assert name not in seen_names, f"full export yields duplicate HF tensor {name!r}"
             seen_names.add(name)
             tensor = tensor.detach()
-            if tensor.is_floating_point() and tensor.dtype != self.rollout_dtype:
+            # fp8 codes and their fp32 scale_inv tensors ARE the rollout state:
+            # never fold them into the bf16 wire dtype.
+            # fp32 sources stay fp32: DSv4 stores its sensitive special params
+            # (hyper-connection coefficients, ape tables, attention sinks) in
+            # fp32, and folding them to the bf16 wire dtype silently costs 16
+            # mantissa bits (measured: rel err p50 1.35e-3, max 3.9e-3 across
+            # all five families) -- a train/serve fidelity gap the verify sweep
+            # cannot see, because the replay folds identically. These tensors
+            # total ~68 MB fp32 against a 267 GB seed.
+            keep_dtype = (
+                tensor.element_size() == 1
+                or name.endswith("_scale_inv")
+                or (fp32_predicate is not None and fp32_predicate(name))
+            )
+            if tensor.is_floating_point() and tensor.dtype != self.rollout_dtype and not keep_dtype:
                 tensor = tensor.to(self.rollout_dtype)
             if not is_r0:
                 del tensor
                 continue
             flat = tensor.contiguous().reshape(-1)
             total_elems += int(flat.numel())
-            bkt.add(_ValuesPiece(name, str(flat.dtype).replace("torch.", ""), list(tensor.shape), flat), flat.nbytes)
+            if bytes_wire:
+                # mixed-dtype flushes: pack every piece as raw bytes; offsets
+                # in the spec become BYTE offsets and the receiver reinterprets
+                # per-param via ``values_bytes``.
+                flat = flat.view(torch.uint8)
+            offered = stager.offer_piece(
+                name,
+                _ValuesPiece(name, str(tensor.dtype).replace("torch.", ""), list(tensor.shape), flat),
+                flat.nbytes,
+            )
+            if offered is None:
+                continue
+            released, is_group = offered
+            if is_group:
+                bkt.add_atomic(released)
+            else:
+                for piece, nbytes in released:
+                    bkt.add(piece, nbytes)
 
         if not is_r0:
             return
+        stager.assert_drained()
+        logger.info("seed fusion staging: groups=%d", stager.n_groups)
         bkt.seal()
+        # hold_last: a verify sweep follows INSIDE this same receive session,
+        # so its finale -- not ours -- carries is_last (the steady+sweep
+        # contract: only the sync's final flush terminates the stream).
         if bkt.pending is not None:
-            bkt.emit(is_last=True)
-        else:
+            bkt.emit(is_last=not hold_last)
+        elif not hold_last:
             self._publish_terminal(True)
         # warning level on purpose: worker default log level swallows info, and the
         # one-off seed cost is the number people ask for when sizing a run.
@@ -584,16 +986,38 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         # each one as soon as it fills (then frees it), so peak memory is ~2 buckets rather than the
         # whole model.
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
-        if not self._shard_seeded:
+        seeding = not self._shard_seeded
+        # The quantized seed comes from the SAME shard stream as every steady delta -- same mapping
+        # transforms, same sticky quantizer -- and travel the values-only wire
+        # via a dense gather (no positions exist at any point; the sparse
+        # transport's per-element position staging is unnecessary at 100% coverage).
+        # ``verify_seed`` appends a dense receiver comparison before training begins.
+        verify_after_seed = self.verify_seed
+        if seeding and self.quantize_fp8:
+            spec = self._fp8_spec(engine)
+            metrics = self._send_full_seed_sharded(engine, spec, global_steps, hold_last=verify_after_seed)
+            # The seed is complete only after every quantized shard has shipped
+            # and its baseline snapshot has been captured.
+            self._shard_seeded = True
+            if verify_after_seed:
+                self._seed_verify_sweep(engine, spec, global_steps)
+            return metrics
+        if seeding:
+            # BF16 seed: stream the bridge's full export over the values-only
+            # wire, then prime the sharded snapshots.
             full, _ = engine.get_per_tensor_param()
-            metrics = self._send_full_seed(full, global_steps)
-            # weights do not move during the sync, so the snapshots equal exactly
-            # what the rollout just received.
+            metrics = self._send_full_seed(full, global_steps, hold_last=verify_after_seed)
             engine.prime_delta_snapshots()
             # The seed is complete only after its baseline snapshots are ready.
             self._shard_seeded = True
+            if verify_after_seed:
+                self._seed_verify_sweep(engine, None, global_steps)
             return metrics
-        weights, _ = engine.get_per_tensor_param_delta_shard()
+        # the BACKEND owns delta production for every dtype: with a quant spec
+        # it yields quant-domain entries (codes + scale grids diffed against
+        # engine-held snapshots), without one the bf16 shard deltas.
+        _spec = self._fp8_spec(engine) if self.quantize_fp8 else None
+        weights, _ = engine.get_per_tensor_param_delta_shard(quant_spec=_spec)
         is_r0 = self.is_master
         n_flushes = 0
         changed_elems = 0
@@ -606,6 +1030,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             n_flushes += 1
 
         bkt = _FlushBucket(self.bucket_size, self._assemble_flush, _publish_steady)
+        stager = _FusionStager()
 
         batch_k = self.batch_gather
 
@@ -619,11 +1044,29 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         ) -> None:
             nonlocal total_elems, changed_elems, wire_bytes
             total_elems += int(full_numel)
-            if aidx is None or aidx.numel() == 0:
+            # Members of a fused destination param are held back until the group
+            # is whole, then emitted as one indivisible run of pieces. Everything
+            # else falls through unchanged. Note the accounting below runs on the
+            # RELEASED entries, so an empty half contributes 0 changed elements
+            # and 0 wire bytes -- it costs one entry, not one tensor.
+            offered = stager.offer(name, dtype_str, full_shape, aidx, aval)
+            if offered is None:
                 return
-            changed_elems += int(aidx.numel())
-            wire_bytes += int(aidx.numel()) * (4 + aval.element_size())
-            _bucket_sliced(bkt, name, dtype_str, full_shape, aidx, aval)
+            released, is_group = offered
+            sized: list[tuple] = []
+            for e_name, e_dtype, e_shape, e_idx, e_val in released:
+                if e_idx is None or (e_idx.numel() == 0 and not is_group):
+                    continue  # unchanged and not fused -- drop it, as before
+                changed_elems += int(e_idx.numel())
+                if e_idx.numel():
+                    pos_width = absolute_index_width(_prodshape(e_shape))
+                    wire_bytes += int(e_idx.numel()) * (pos_width + e_val.element_size())
+                sized.extend(_slice_pieces(e_name, e_dtype, e_shape, e_idx, e_val))
+            if is_group:
+                bkt.add_atomic(sized)
+            else:
+                for piece, nbytes in sized:
+                    bkt.add(piece, nbytes)
 
         gq = _GatherQueue(batch_k, self.bucket_size, is_r0, _bucket_slot_delta)
 
@@ -634,6 +1077,21 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         for slots, dtype_str, counts, hf_idx, hf_val, pg in weights:
             gq.put(pg, slots, dtype_str, counts, hf_idx, hf_val)
         gq.flush_all()
+        # A half still parked here means its sibling never came through the export
+        # stream, so the receiver would have been handed an unpairable member and
+        # died inside sglang's loader with a far less informative message.
+        stager.assert_drained()
+        # Log unconditionally, including the zero case: if the export ever renames
+        # these params, every suffix stops matching and the staging silently
+        # degrades to a no-op -- which looks exactly like "no fused params in this
+        # model". The count is the only thing that tells the two apart. DSv4 should
+        # report 4 groups x 43 layers.
+        if is_r0:
+            logger.info(
+                "delta fusion staging: groups=%d nan_filled_halves=%d",
+                stager.n_groups,
+                stager.n_filled,
+            )
 
         # For SGLang, verify_every=K appends a dense state-verification sweep to
         # every K-th steady sync inside the same receive stream. The steady bucket
@@ -649,8 +1107,19 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
                 self._publish_terminal(False)
         if verify:
             # collective on every rank: the full export assembles per tensor.
-            full, _ = engine.get_per_tensor_param()
-            self._send_full_seed(full, global_steps, verify=True)
+            if self.quantize_fp8:
+                vspec = self._fp8_spec(engine)
+                full, _ = engine.get_per_tensor_param(quant_spec=vspec)
+                self._send_full_seed(
+                    full,
+                    global_steps,
+                    verify=True,
+                    bytes_wire=True,
+                    fp32_predicate=getattr(vspec, "fp32_predicate", None),
+                )
+            else:
+                full, _ = engine.get_per_tensor_param()
+                self._send_full_seed(full, global_steps, verify=True)
         if not is_r0:
             return
         self._release_staging_pool("steady")  # return staging blocks to CUDA between syncs

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -786,7 +786,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
         shipped, so the next steady diff base equals the shipped state by
         construction and the separate prime pass disappears.
         """
-        from verl.checkpoint_engine.delta_sync.sparse_gather import dense_gather_group
+        from verl.checkpoint_engine.delta_sync.sparse_gather import dense_gather_group, indexed_dense_gather_group
         from verl.utils.device import is_cuda_available
 
         gen, _ = engine.get_per_tensor_param_shard(quant_spec=spec)
@@ -806,11 +806,25 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
                 snap.copy_(flat, non_blocking=True)
                 if meta is None:
                     meta = engine._quant_group_meta
-                slots, sizes, dtype_str = meta[name]
+                slots, sizes, dtype_str, positions = meta[name]
                 # replicas do not contribute: zero their size vector so the
                 # gather's exactly-one-owner assert sees the true ownership map
                 sizes_eff = sizes if sspec.contributes else [0] * len(sizes)
-                pieces = dense_gather_group(flat, sizes_eff, sspec.gather_group)
+                if positions is None:
+                    pieces = dense_gather_group(flat, sizes_eff, sspec.gather_group)
+                else:
+                    pos_eff = (
+                        positions
+                        if sspec.contributes
+                        else [torch.empty(0, dtype=torch.int32, device=flat.device) for _ in positions]
+                    )
+                    pieces = indexed_dense_gather_group(
+                        flat,
+                        sizes_eff,
+                        pos_eff,
+                        [_prodshape(shape) for _slot_name, shape in slots],
+                        sspec.gather_group,
+                    )
                 if pieces is None:
                     continue
                 dtype = getattr(torch, dtype_str)

--- a/verl/checkpoint_engine/delta_sync/__init__.py
+++ b/verl/checkpoint_engine/delta_sync/__init__.py
@@ -23,10 +23,13 @@ Design follows THUDM/slime's delta-sync implementation
 (``slime/backends/megatron_utils/update_weight/update_weight_from_distributed_delta.py``).
 """
 
-from .encode import DeltaFlush, DeltaParam, checksum
+from .encode import DeltaFlush, DeltaParam, absolute_index_width, checksum, pack_absolute_indices, unpack_absolute_indices
 
 __all__ = [
     "DeltaFlush",
     "DeltaParam",
+    "absolute_index_width",
     "checksum",
+    "pack_absolute_indices",
+    "unpack_absolute_indices",
 ]

--- a/verl/checkpoint_engine/delta_sync/encode.py
+++ b/verl/checkpoint_engine/delta_sync/encode.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """On-wire schema for delta sync: per-parameter manifest, flush container, checksum.
 
-One layout: a uint8 positions blob (``indices`` encoding -- int32 absolute
-positions, 4 bytes / nnz) plus a parameter-dtype values tensor, described by a
-per-parameter manifest. Values are sent verbatim in the parameter's dtype.
+One layout: a uint8 positions blob (``indices`` encoding -- little-endian
+absolute positions, 3 or 4 bytes / nnz) plus a parameter-dtype values tensor,
+described by a per-parameter manifest. Values are sent verbatim in the
+parameter's dtype.
 """
 
 from __future__ import annotations
@@ -26,6 +27,46 @@ from typing import Literal
 import torch
 
 DeltaEncodingName = Literal["indices"]
+
+
+def absolute_index_width(numel: int) -> int:
+    """Return the narrowest supported width for an index into ``numel`` elements."""
+    if numel < 0:
+        raise ValueError(f"negative tensor size: {numel}")
+    if numel <= (1 << 24):
+        return 3
+    if numel < (1 << 31):
+        return 4
+    raise ValueError(f"{numel} elements exceeds the int32 absolute-index encoding")
+
+
+def pack_absolute_indices(indices: torch.Tensor, width: int) -> torch.Tensor:
+    """Pack non-negative int32 absolute indices into a contiguous uint8 blob."""
+    indices = indices.to(torch.int32).contiguous()
+    raw = indices.view(torch.uint8).view(-1, 4)
+    if width == 4:
+        return raw.view(-1)
+    if width == 3:
+        return raw[:, :3].contiguous().view(-1)
+    raise ValueError(f"unsupported absolute-index width: {width}")
+
+
+def unpack_absolute_indices(packed: torch.Tensor, width: int) -> torch.Tensor:
+    """Inverse of :func:`pack_absolute_indices`; return int32 indices."""
+    if width not in (3, 4):
+        raise ValueError(f"unsupported absolute-index width: {width}")
+    if packed.numel() % width:
+        raise ValueError(f"position blob length {packed.numel()} is not divisible by width {width}")
+    if width == 4:
+        # A 4-byte parameter may follow a 3-byte parameter in the shared blob,
+        # leaving this otherwise-contiguous slice at an unaligned byte offset.
+        # clone() both re-bases it and keeps the decode valid on CPU and CUDA.
+        return packed.clone().view(torch.int32)
+    if width == 3:
+        raw = torch.zeros((packed.numel() // 3, 4), dtype=torch.uint8, device=packed.device)
+        raw[:, :3] = packed.view(-1, 3)
+        return raw.view(torch.int32).view(-1)
+    raise AssertionError("unreachable")
 
 
 # ---------- diff ----------------------------------------------------------

--- a/verl/checkpoint_engine/delta_sync/sparse_gather.py
+++ b/verl/checkpoint_engine/delta_sync/sparse_gather.py
@@ -59,6 +59,43 @@ def shard_delta_indices(
     return global_idx, values
 
 
+def _gather_p2p(idx_concat, val_concat, totals, world, rank, dst, group, dev):
+    """Gather exact-length sparse blobs to rank 0 with matched P2P ops.
+
+    ``totals`` comes from the count matrix already seen by every rank, so the
+    receive sizes and send sizes share the same source of truth. Empty ranks do
+    not participate in the data transfer.
+    """
+    if rank == 0:
+        idx_list = [
+            idx_concat if r == 0 else torch.empty(totals[r], dtype=idx_concat.dtype, device=dev)
+            for r in range(world)
+        ]
+        val_list = [
+            val_concat if r == 0 else torch.empty(totals[r], dtype=val_concat.dtype, device=dev)
+            for r in range(world)
+        ]
+        ops = []
+        for r in range(1, world):
+            if not totals[r]:
+                continue
+            peer = dist.get_global_rank(group, r) if group is not None else r
+            ops.append(dist.P2POp(dist.irecv, idx_list[r], peer, group))
+            ops.append(dist.P2POp(dist.irecv, val_list[r], peer, group))
+        for work in dist.batch_isend_irecv(ops) if ops else []:
+            work.wait()
+        return idx_list, val_list
+
+    if totals[rank]:
+        ops = [
+            dist.P2POp(dist.isend, idx_concat.contiguous(), dst, group),
+            dist.P2POp(dist.isend, val_concat.contiguous(), dst, group),
+        ]
+        for work in dist.batch_isend_irecv(ops):
+            work.wait()
+    return None, None
+
+
 def gather_slot_entries_to_rank0(
     idx_concat: torch.Tensor,
     val_concat: torch.Tensor,
@@ -70,10 +107,10 @@ def gather_slot_entries_to_rank0(
 
     Each rank passes its K per-parameter deltas concatenated (``idx_concat``,
     ``val_concat``) plus the per-parameter length vector ``counts`` ([K] int64).
-    One all_gather exchanges the K x world count matrix; two padded gathers move
-    the blobs. Rank 0 slices per (rank, param) and returns K ``(idx, val)`` pairs
-    (None elsewhere) -- bit-identical to K individual gathers, ~K x fewer
-    collectives and host syncs.
+    One all_gather exchanges the K x world count matrix; matched point-to-point
+    operations then move each rank's exact-length blobs. Rank 0 slices per
+    (rank, param) and returns K ``(idx, val)`` pairs (None elsewhere) --
+    bit-identical to K individual gathers, without padding to the busiest rank.
     """
     rank = dist.get_rank(group)
     world = dist.get_world_size(group)
@@ -125,16 +162,12 @@ def gather_slot_entries_to_rank0(
         empty_v = torch.empty(0, dtype=val_concat.dtype, device=dev)
         return [(empty_i, empty_v) for _ in range(k)]
 
-    idx_pad = torch.zeros(max_n, dtype=idx_concat.dtype, device=dev)
-    val_pad = torch.zeros(max_n, dtype=val_concat.dtype, device=dev)
-    n = int(idx_concat.numel())
-    idx_pad[:n] = idx_concat
-    val_pad[:n] = val_concat
-
-    idx_list = [torch.zeros(max_n, dtype=idx_pad.dtype, device=dev) for _ in range(world)] if rank == 0 else None
-    val_list = [torch.zeros(max_n, dtype=val_concat.dtype, device=dev) for _ in range(world)] if rank == 0 else None
-    dist.gather(idx_pad, idx_list, dst=dst, group=group)
-    dist.gather(val_pad, val_list, dst=dst, group=group)
+    # ``dist.gather`` requires equal input sizes and therefore pads every rank
+    # to the largest rank in the round. The count matrix above already gives
+    # every participant the exact matching send/receive sizes, so move only the
+    # useful sparse blobs. On the 40-B300 DSv4 run this removed 4.38x padding
+    # and reduced steady sync from 34.086 s to 30.564 s.
+    idx_list, val_list = _gather_p2p(idx_concat, val_concat, totals, world, rank, dst, group, dev)
     if rank != 0:
         return None
 
@@ -153,4 +186,71 @@ def gather_slot_entries_to_rank0(
             out.append(
                 (torch.empty(0, dtype=idx_concat.dtype, device=dev), torch.empty(0, dtype=val_concat.dtype, device=dev))
             )
+    return out
+
+def dense_gather_group(
+    flat: torch.Tensor,
+    sizes_local: list[int],
+    group: dist.ProcessGroup | None = None,
+) -> list[torch.Tensor] | None:
+    """Values-only gather of one group record for the seed-as-steady transport.
+
+    Each rank passes its group flat (its owned slots' full pieces concatenated,
+    zero-length pieces for slots owned elsewhere; non-contributing replicas
+    pass all-zero ``sizes_local``) plus the per-slot length vector. Rank 0 of
+    ``group`` returns the per-slot full tensors, stitched by ownership; None
+    elsewhere.
+
+    No index tensors exist at any point, and the transfer is sequential
+    point-to-point per contributing rank -- peak extra memory on rank 0 is one
+    sender's flat, independent of world size (a padded dist.gather would
+    allocate world x max_n there, which is the same wall wearing values'
+    clothes). The [world, n_slots] size matrix is all-gathered first and is the
+    trust base that keeps the send/recv pairing deadlock-free -- the same
+    contract _gather_p2p already relies on.
+    """
+    k = len(sizes_local)
+    if group is None and not (dist.is_available() and dist.is_initialized()):
+        # unsharded / single process: this rank's pieces are the record
+        out, off = [], 0
+        for n in sizes_local:
+            out.append(flat[off : off + n])
+            off += n
+        return out
+    rank = dist.get_rank(group)
+    world = dist.get_world_size(group)
+    dst = dist.get_global_rank(group, 0) if group is not None else 0
+    dev = flat.device
+    sizes = torch.tensor(sizes_local, dtype=torch.int64, device=dev)
+    sizes_all = torch.zeros(world, k, dtype=torch.int64, device=dev)
+    # equal [k]-sized chunk per rank into the flat [world*k] output
+    dist.all_gather_into_tensor(sizes_all.view(-1), sizes, group=group)
+    sizes_cpu = sizes_all.cpu().tolist()
+    my_total = int(sizes.sum())
+    if rank != 0:
+        if my_total:
+            dist.send(flat[:my_total].contiguous(), dst=dst, group=group)
+        return None
+    # rank 0: receive each contributor's flat sequentially, stitch per slot
+    per_rank_flat: dict[int, torch.Tensor] = {}
+    if my_total:
+        per_rank_flat[0] = flat[:my_total]
+    for r in range(1, world):
+        n = sum(sizes_cpu[r])
+        if not n:
+            continue
+        buf = torch.empty(n, dtype=flat.dtype, device=dev)
+        src_rank = dist.get_global_rank(group, r) if group is not None else r
+        dist.recv(buf, src=src_rank, group=group)
+        per_rank_flat[r] = buf
+    out: list[torch.Tensor] = []
+    for i in range(k):
+        owners = [r for r in range(world) if sizes_cpu[r][i]]
+        assert len(owners) == 1, (
+            f"slot {i}: {len(owners)} contributors (expected exactly 1) -- ownership map and "
+            "contributes flags disagree; refusing to ship an ambiguous seed"
+        )
+        r = owners[0]
+        off = sum(sizes_cpu[r][:i])
+        out.append(per_rank_flat[r][off : off + sizes_cpu[r][i]])
     return out

--- a/verl/checkpoint_engine/delta_sync/sparse_gather.py
+++ b/verl/checkpoint_engine/delta_sync/sparse_gather.py
@@ -188,6 +188,7 @@ def gather_slot_entries_to_rank0(
             )
     return out
 
+
 def dense_gather_group(
     flat: torch.Tensor,
     sizes_local: list[int],
@@ -253,4 +254,52 @@ def dense_gather_group(
         r = owners[0]
         off = sum(sizes_cpu[r][:i])
         out.append(per_rank_flat[r][off : off + sizes_cpu[r][i]])
+    return out
+
+
+def indexed_dense_gather_group(
+    flat: torch.Tensor,
+    sizes_local: list[int],
+    positions_local: list[torch.Tensor],
+    full_sizes: list[int],
+    group: dist.ProcessGroup | None = None,
+) -> list[torch.Tensor] | None:
+    """Assemble position-sharded dense slots on group rank 0.
+
+    This is the seed counterpart of the ordinary sparse-delta gather.  Each
+    slot may be owned block-by-block by several ranks, so values carry their
+    within-slot flat positions.  Reuse the exact-length sparse gather, then
+    scatter each complete slot on rank 0; the owner plan guarantees disjoint
+    positions and the aggregate-size check guarantees full coverage.
+    """
+    k = len(sizes_local)
+    assert len(positions_local) == k and len(full_sizes) == k
+    assert int(flat.numel()) == sum(sizes_local), f"flat has {flat.numel()} values, sizes describe {sum(sizes_local)}"
+    for i, (n, pos, full_n) in enumerate(zip(sizes_local, positions_local, full_sizes, strict=True)):
+        assert int(pos.numel()) == n, f"slot {i}: {pos.numel()} positions for {n} values"
+        assert n <= full_n, f"slot {i}: {n} owned cells exceed dense size {full_n}"
+    dev = flat.device
+    if group is None and not (dist.is_available() and dist.is_initialized()):
+        out, off = [], 0
+        for pos, n, full_n in zip(positions_local, sizes_local, full_sizes, strict=True):
+            full = torch.empty(full_n, dtype=flat.dtype, device=dev)
+            full[pos.to(device=dev, dtype=torch.long)] = flat[off : off + n]
+            out.append(full)
+            off += n
+        return out
+    pos_flat = (
+        torch.cat([p.to(device=dev, dtype=torch.int32).reshape(-1) for p in positions_local])
+        if positions_local
+        else torch.empty(0, dtype=torch.int32, device=dev)
+    )
+    counts = torch.tensor(sizes_local, dtype=torch.int64, device=dev)
+    gathered = gather_slot_entries_to_rank0(pos_flat, flat, counts, group)
+    if gathered is None:
+        return None
+    out = []
+    for i, ((pos, val), full_n) in enumerate(zip(gathered, full_sizes, strict=True)):
+        assert int(pos.numel()) == full_n, f"slot {i}: position owners cover {pos.numel()} cells, expected {full_n}"
+        full = torch.empty(full_n, dtype=flat.dtype, device=dev)
+        full[pos.long()] = val
+        out.append(full)
     return out

--- a/verl/utils/fp8_ckpt_dtypes.py
+++ b/verl/utils/fp8_ckpt_dtypes.py
@@ -1,0 +1,168 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Decide which params to fp8-quantize by reading the checkpoint, not by name.
+
+SGLang's ``update_weights_from_tensor`` does not re-quantize, so the trainer has
+to ship pre-quantized fp8 codes + scales, which means the *sender* must know
+which params are fp8. The sender has no model object -- that lives in the rollout
+process -- so ``fp8_utils.should_quantize_param`` guesses from an allowlist of
+Llama-style names. DeepSeek-V4 calls its linears wq_a / wq_b / wkv / wo_b /
+w1..w3, matched nothing, and every weight shipped as BF16 into an fp8 slot.
+
+vLLM does not have this problem because it quantizes on the *receiver*, where it
+can just ask ``module.weight.dtype``.
+
+The sender does have an authoritative source it was not using: the checkpoint
+itself. safetensors stores a JSON header per shard with every tensor's dtype, and
+reading only the headers is cheap -- measured 0.36 s for all 46 shards / 69,143
+tensors of DeepSeek-V4-Flash-FP8, with no tensor data touched.
+
+This is exact whenever the rollout serves the checkpoint's own quantization
+(the usual case, and ours). If an engine ever decides its own layout at load
+time -- serving a BF16 checkpoint as fp8, say -- the checkpoint no longer
+describes the destination and a real receiver-side handshake would be needed.
+``build_ckpt_fp8_predicate`` returns None when it cannot answer, so callers fall
+back rather than silently quantizing nothing.
+"""
+
+import functools
+import glob
+import json
+import logging
+import os
+import struct
+
+logger = logging.getLogger(__name__)
+
+_FP8_DTYPES = {"F8_E4M3", "F8_E5M2"}
+
+
+def canonical_ckpt_name(n: str) -> str:
+    """Normalize the two DSv4 spelling differences introduced by the bridge."""
+    n = n.replace(".self_attn.", ".attn.")
+    return n.removeprefix("model.")
+
+
+# Both entry points are memoised per model path. They walk every shard header,
+# and the predicates are needed on the seed, steady syncs, and verification.
+# Without caching, every trainer rank would repeatedly open every shard.
+
+@functools.lru_cache(maxsize=4)
+def read_checkpoint_dtypes(model_path: str) -> dict[str, str]:
+    """``{tensor_name: safetensors_dtype_string}`` from the shard headers alone."""
+    out: dict[str, str] = {}
+    shards = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+    for shard in shards:
+        try:
+            with open(shard, "rb") as fh:
+                (hdr_len,) = struct.unpack("<Q", fh.read(8))
+                header = json.loads(fh.read(hdr_len))
+        except (OSError, ValueError, json.JSONDecodeError) as e:
+            logger.warning("fp8 dtype map: cannot read header of %s (%s)", shard, e)
+            continue
+        for name, meta in header.items():
+            if name != "__metadata__" and isinstance(meta, dict) and "dtype" in meta:
+                out[name] = meta["dtype"]
+    return out
+
+
+@functools.lru_cache(maxsize=4)
+def build_ckpt_fp8_predicate(model_path: str):
+    """A ``name -> bool`` predicate, or None if the checkpoint cannot answer.
+
+    Returning None (rather than a predicate that says False for everything) is
+    deliberate: "no fp8 params" and "I could not read the checkpoint" must not
+    look the same to the caller. The former is a legitimate answer, the latter is
+    the failure that shipped BF16 into fp8 slots for three runs without a word.
+    """
+    dtypes = read_checkpoint_dtypes(model_path)
+    if not dtypes:
+        logger.warning("fp8 dtype map: no safetensors headers under %s; falling back", model_path)
+        return None
+    fp8_names = {n for n, d in dtypes.items() if d in _FP8_DTYPES}
+    if not fp8_names:
+        logger.info("fp8 dtype map: %s has no fp8 tensors; falling back", model_path)
+        return None
+
+    fp8_keys = {canonical_ckpt_name(n) for n in fp8_names}
+    all_keys = {canonical_ckpt_name(n) for n in dtypes}
+    logger.info(
+        "fp8 dtype map: %d tensors read from %d shards, %d fp8 (%d canonical names)",
+        len(dtypes),
+        len(glob.glob(os.path.join(model_path, "*.safetensors"))),
+        len(fp8_names),
+        len(fp8_keys),
+    )
+
+    def predicate(param_name: str) -> bool:
+        if param_name in fp8_names:
+            return True
+        key = canonical_ckpt_name(param_name)
+        if key in fp8_keys:
+            return True
+        # Known to the checkpoint and not fp8 -> a confident False.
+        if param_name in dtypes or key in all_keys:
+            return False
+        # Unknown name (scales the export adds, fused params, ...) -> not fp8.
+        return False
+
+    return predicate
+
+
+@functools.lru_cache(maxsize=4)
+def build_ckpt_fp32_predicate(model_path: str):
+    """A ``name -> bool`` predicate for params the checkpoint stores in FP32,
+    or None if the checkpoint cannot answer.
+
+    DSv4 keeps a handful of sensitive families in fp32 on disk and in the
+    serving engine (hyper-connection coefficients, ape compressor position
+    embeddings, attention sinks, router e_score_correction_bias -- ~68 MB
+    total). The wire used to fold every non-fp8 float to the rollout dtype,
+    silently costing these params 16 mantissa bits per sync (measured rel err
+    p50 1.35e-3, max 3.9e-3), invisibly to the verify sweep because the replay
+    folds identically. The sender must know which params to keep fp32, and the
+    routing has to be identical on every rank -- including ranks that do not
+    own the param and see no tensor -- so the decision comes from the
+    checkpoint's own headers, exactly like the fp8 predicate above.
+
+    Quantization scale grids (``<stem>.scale`` / ``*_scale_inv``) are also F32
+    in the headers but are NOT this predicate's business: they ride the wire's
+    dedicated scale group and are excluded here.
+    """
+    dtypes = read_checkpoint_dtypes(model_path)
+    if not dtypes:
+        logger.warning("fp32 dtype map: no safetensors headers under %s; falling back", model_path)
+        return None
+
+    def _is_scale(n: str) -> bool:
+        return n.endswith(".scale") or n.endswith("_scale_inv")
+
+    fp32_names = {n for n, d in dtypes.items() if d == "F32" and not _is_scale(n)}
+    if not fp32_names:
+        logger.info("fp32 dtype map: %s stores no non-scale fp32 tensors", model_path)
+        return None
+    fp32_keys = {canonical_ckpt_name(n) for n in fp32_names}
+    logger.info(
+        "fp32 dtype map: %d fp32 non-scale tensors (%d canonical names) out of %d",
+        len(fp32_names),
+        len(fp32_keys),
+        len(dtypes),
+    )
+
+    def predicate(param_name: str) -> bool:
+        if _is_scale(param_name):
+            return False
+        return param_name in fp32_names or canonical_ckpt_name(param_name) in fp32_keys
+
+    return predicate

--- a/verl/utils/fp8_sharded.py
+++ b/verl/utils/fp8_sharded.py
@@ -1,0 +1,271 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sharded blockwise FP8 quantization: bitwise-identical to the whole-tensor
+kernel, computed shard-locally with one collective.
+
+The rollout side quantizes whole HF tensors (``scaled_fp8_blockwise``:
+per-block absmax -> descale = absmax / FP8_MAX -> codes = clamp(x / descale)).
+A trainer rank holds only a slice of the tensor, but the block grid -- and
+therefore every scale -- is defined on the FULL tensor. The sharded scheme
+splits the kernel at its natural seam:
+
+1. every rank computes a PARTIAL absmax grid over its own rows, laid out on
+   the GLOBAL block grid (zeros where the shard does not overlap a block);
+2. one ``all_reduce(MAX)`` over the gather group turns partials into the
+   global grid (tiny: 4 bytes per 128x128 block);
+3. every rank quantizes its own rows locally with the global descales,
+   replicating the kernel's exact fp32 op order (absmax/FP8_MAX, then
+   1/descale, multiply, clamp, cast) so codes and descales match the
+   whole-tensor kernel BIT FOR BIT.
+
+Scope: dim-0 contiguous row shards (FSDP ``Shard(0)``; the mcore block case
+rides the same helpers per touched block). Row offsets may fall mid-block --
+partial overlaps contribute partial maxima, exactly like the kernel's padding
+mask contributes zeros.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import torch
+
+from verl.utils.kernel.fp8_kernel import FP8_DTYPE, FP8_MAX, ceil_div
+
+logger = logging.getLogger(__name__)
+
+# matches the triton kernel's numerical-stability floor for block absmax
+_ABSMAX_EPS = 1e-10
+
+
+def local_blockwise_absmax(
+    shard: torch.Tensor,
+    weight_block_size: list[int] | tuple[int, int],
+    row_offset: int,
+    full_shape: tuple[int, int],
+) -> torch.Tensor:
+    """Partial per-block absmax of a dim-0 row shard, on the GLOBAL block grid.
+
+    Returns a float32 ``(ceil(M/BM), ceil(N/BN))`` grid; blocks the shard does
+    not overlap hold 0 (abs values are >= 0, so ``all_reduce(MAX)`` composes
+    partials correctly).
+    """
+    bm, bn = int(weight_block_size[0]), int(weight_block_size[1])
+    m_full, n_full = int(full_shape[0]), int(full_shape[1])
+    rows, cols = shard.shape
+    assert cols == n_full, f"row shard must span full dim-1: {cols} != {n_full}"
+    n_br, n_bc = ceil_div(m_full, bm), ceil_div(n_full, bn)
+    grid = torch.zeros(n_br, n_bc, dtype=torch.float32, device=shard.device)
+    if rows == 0:
+        return grid
+
+    x = shard.to(torch.float32).abs()
+    # NaN placeholders (mcore probe output: positions owned by OTHER ranks)
+    # must not poison the partial max; zeros never win a legitimate max.
+    x = torch.nan_to_num(x, nan=0.0)
+    # pad dim-1 to the block grid once (zeros never win a max)
+    pad_n = n_bc * bn - n_full
+    if pad_n:
+        x = torch.nn.functional.pad(x, (0, pad_n))
+    first_block = row_offset // bm
+    r = 0
+    for br in range(first_block, ceil_div(row_offset + rows, bm)):
+        take = min((br + 1) * bm - (row_offset + r), rows - r)
+        seg = x[r : r + take]
+        grid[br] = seg.view(take, n_bc, bn).amax(dim=(0, 2))
+        r += take
+    return grid
+
+
+def quantize_shard_with_descale(
+    shard: torch.Tensor,
+    descale: torch.Tensor,
+    weight_block_size: list[int] | tuple[int, int],
+    row_offset: int,
+) -> torch.Tensor:
+    """Quantize a dim-0 row shard using GLOBAL per-block descales, replicating
+    the kernel's fp32 op order (``s_inv = 1.0 / descale``; ``clamp(x * s_inv)``;
+    cast) so the codes are bitwise-identical to the whole-tensor kernel."""
+    bm, bn = int(weight_block_size[0]), int(weight_block_size[1])
+    rows, cols = shard.shape
+    n_bc = descale.shape[1]
+    s_inv = 1.0 / descale  # matches the kernel's second fp32 division
+
+    # NaN passes through multiply/clamp/cast untouched and lands as the fp8
+    # NaN byte -- exactly the wire sentinel for "not this rank's position".
+    x = shard.to(torch.float32)
+    pad_n = n_bc * bn - cols
+    if pad_n:
+        x = torch.nn.functional.pad(x, (0, pad_n))
+    # per-row block-row index -> expand descale rows to shard rows
+    br_of_row = (torch.arange(row_offset, row_offset + rows, device=shard.device) // bm) - (row_offset // bm)
+    first_block = row_offset // bm
+    s_rows = s_inv[first_block + br_of_row]  # (rows, n_bc)
+    x = x.view(rows, n_bc, bn)
+    x = x * s_rows.unsqueeze(-1)
+    x = x.clamp_(min=-FP8_MAX, max=FP8_MAX).to(FP8_DTYPE)
+    x = x.view(rows, n_bc * bn)
+    if pad_n:
+        x = x[:, :cols].contiguous()
+    return x
+
+
+@dataclass
+class QuantSpec:
+    """Rollout-format request handed to a backend's ``get_per_tensor_param``.
+
+    Deliberately rollout-agnostic: the caller (checkpoint engine) distills the
+    serving engine's quantization config into a block shape plus a per-param
+    predicate; the backend only honors the spec and never sees who asked.
+    """
+
+    weight_block_size: tuple[int, int]
+    should_quantize: object  # Callable[[str], bool]
+    # The checkpoint's scale dialect, from its quantization_config. DSv4 ships
+    # "ue8m0" and sglang's loader requires it; None keeps the plain fp32 grid.
+    scale_fmt: str | None = None
+    # weight name -> the checkpoint's own scale grid (fp32, CPU). When present,
+    # quantization is STICKY: a block keeps the checkpoint's scale as long as
+    # its amax still fits under it, and only bumps to the tightest covering
+    # power when the weights genuinely outgrew it. The checkpoint's scales
+    # carry headroom on ~2% of blocks, and that headroom is unrecoverable from
+    # the dequantized master -- recomputing from amax alone necessarily
+    # tightens those blocks and changes their bytes.
+    ckpt_scales: object | None = None  # dict[str, torch.Tensor] | None
+    # name -> bool: params the CHECKPOINT stores in fp32 (DSv4's special
+    # families). The wire keeps these fp32 instead of folding to the rollout
+    # dtype; the predicate is checkpoint-derived so every rank -- including
+    # ranks that do not own the param and see no tensor -- routes the slot
+    # into the same wire group. None keeps the legacy fold-to-rollout-dtype.
+    fp32_predicate: object | None = None  # Callable[[str], bool] | None
+
+
+def sticky_ue8m0_descale(amax: torch.Tensor, ckpt_scale: torch.Tensor | None) -> torch.Tensor:
+    """ue8m0 descale that PREFERS the checkpoint's scale wherever it still covers.
+
+    A block's original scale is valid for any amax <= scale * FP8_MAX; keeping
+    it makes unchanged weights reproduce the checkpoint's bytes exactly, which
+    is what lets seed == disk AND keeps the steady verify quiet on blocks that
+    never trained. Only blocks whose weights outgrew the old scale move -- to
+    the tightest covering power, same dialect.
+    """
+    tight = ue8m0_descale(amax)
+    if ckpt_scale is None:
+        return tight
+    assert ckpt_scale.shape == amax.shape, (
+        f"ckpt scale grid {tuple(ckpt_scale.shape)} does not match the absmax grid "
+        f"{tuple(amax.shape)}: the lookup matched the wrong tensor, refusing to guess"
+    )
+    ckpt_scale = ckpt_scale.to(amax.device)
+    return torch.where(amax <= ckpt_scale * FP8_MAX, ckpt_scale, tight)
+
+
+_CKPT_SCALES_CACHE: dict = {}
+
+
+def load_ckpt_scales(ckpt_path: str) -> dict:
+    """Read every ``<stem>.scale`` tensor from the checkpoint, keyed by the
+    WEIGHT's name (``<stem>.weight``) for direct lookup at quantize time.
+
+    Scale grids are tiny relative to the weights, so this loads once per
+    process and stays on CPU. safetensors reads only the requested tensors,
+    not the full shards.
+    """
+    got = _CKPT_SCALES_CACHE.get(ckpt_path)
+    if got is not None:
+        return got
+    import json
+    import os
+
+    from safetensors import safe_open
+
+    from verl.utils.fp8_ckpt_dtypes import canonical_ckpt_name
+
+    with open(os.path.join(ckpt_path, "model.safetensors.index.json")) as index_file:
+        idx = json.load(index_file)
+    wm = idx["weight_map"]
+    by_file: dict[str, list[str]] = {}
+    for n, f in wm.items():
+        if n.endswith(".scale"):
+            by_file.setdefault(f, []).append(n)
+    out: dict = {}
+    stale: list[str] = []
+    for f, names in by_file.items():
+        with safe_open(os.path.join(ckpt_path, f), framework="pt", device="cpu") as fh:
+            # A shard index can retain entries for tensors removed from the
+            # actual safetensors file. DeepSeek-V4-Flash-FP8 does this for BF16
+            # ``attn.wo_a`` scales. The index routes tensors to shards; it does
+            # not prove a tensor exists in that shard.
+            available = set(fh.keys())
+            for n in names:
+                if n not in available:
+                    stale.append(n)
+                    continue
+                weight_name = n[: -len(".scale")] + ".weight"
+                scale = fh.get_tensor(n).float()
+                out[weight_name] = scale
+                out.setdefault(canonical_ckpt_name(weight_name), scale)
+    if stale:
+        logger.warning(
+            "ignored %d stale scale entries in %s (first=%s)",
+            len(stale),
+            ckpt_path,
+            stale[0],
+        )
+    _CKPT_SCALES_CACHE[ckpt_path] = out
+    return out
+
+
+def ue8m0_descale(amax: torch.Tensor) -> torch.Tensor:
+    """Power-of-two descale, byte-identical to the DSv4 nccl converter's formula.
+
+    The exponent-only scale is what makes the trainer's dequant->requant round
+    trip bit-exact: multiplying and dividing by 2^k shifts the fp8 exponent and
+    never touches the mantissa. A plain amax/FP8_MAX scale is an arbitrary real,
+    so the round trip rewrites the codes.
+    """
+    return torch.exp2(torch.ceil(torch.log2(amax.clamp_min(1e-10) / FP8_MAX)))
+
+
+def quantize_hf_stream(weights, spec: QuantSpec):
+    """Wrap a full HF ``(name, tensor)`` export with blockwise fp8 quantization:
+    for every 2D weight the spec selects, yield ``(name, codes)`` +
+    ``(name_scale_inv, descales)``; everything else passes through in bf16.
+    Whole-tensor path (``group=None``) -- bitwise-identical to the sharded
+    steady quantizer, which matters because fp32->fp8 tie rounding is
+    implementation-sensitive across kernels.
+    """
+    block = list(spec.weight_block_size)
+    for name, t in weights:
+        if t.dim() != 2 or not spec.should_quantize(name):
+            yield name, t
+            continue
+        # Fail loud on already-quantized input. Quantizing fp8 codes appears
+        # numerically plausible but applies a second, destructive transform.
+        assert t.element_size() > 1, (
+            f"quantize_hf_stream got {t.dtype} for {name!r}: the input is already "
+            "quantized codes, not a bf16 master. The export upstream must produce "
+            "plain bf16 (pass explicit non-fp8 conversion_tasks to the bridge)."
+        )
+        t = t.to(torch.bfloat16)
+        grid = local_blockwise_absmax(t, block, 0, tuple(t.shape))
+        if getattr(spec, "scale_fmt", None) == "ue8m0":
+            ck = getattr(spec, "ckpt_scales", None)
+            descale = sticky_ue8m0_descale(grid, ck.get(name) if ck else None)
+        else:
+            descale = grid.clamp_(min=_ABSMAX_EPS) / FP8_MAX
+        codes = quantize_shard_with_descale(t, descale, block, 0)
+        yield name, codes
+        yield name + "_scale_inv", descale

--- a/verl/utils/fusion_groups.py
+++ b/verl/utils/fusion_groups.py
@@ -1,0 +1,28 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DeepSeek-V4 tensors that SGLang fuses within one ``load_weights`` call."""
+
+_FUSION_MEMBERS = (
+    ("wq_a.weight", "wkv.weight"),
+    ("wq_a.scale", "wkv.scale"),
+    ("wq_a.weight_scale_inv", "wkv.weight_scale_inv"),
+    ("compressor.wkv.weight", "compressor.wgate.weight"),
+    ("indexer.compressor.wkv.weight", "indexer.compressor.wgate.weight"),
+)
+
+DEEPSEEK_V4_FUSION_GROUPS = tuple(
+    tuple(f".{attention}.{member}" for member in members)
+    for attention in ("self_attn", "attn")
+    for members in _FUSION_MEMBERS
+)

--- a/verl/utils/sglang/sglang_fp8_utils.py
+++ b/verl/utils/sglang/sglang_fp8_utils.py
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import re
 from collections.abc import Iterable
 from typing import Any
 
 from verl.utils.fp8_utils import FP8QuantizerHelper
+
+logger = logging.getLogger(__name__)
 
 
 def _get_config_value(config: Any, key: str, default: Any = None) -> Any:
@@ -106,6 +109,14 @@ def build_sglang_fp8_quant_config(hf_config: Any = None, ignored_layers: Any = N
     }
 
     hf_quant_config = _get_config_value(hf_config, "quantization_config")
+    # Carry the checkpoint's scale dialect through. Dropping it here is what
+    # made the delta engine's "no ue8m0" guard toothless for DSv4: the flag
+    # never survived to be checked, and the plain-fp32 seed formula shipped.
+    scale_fmt = None
+    if hf_quant_config is not None:
+        scale_fmt = _get_config_value(hf_quant_config, "scale_fmt")
+    if scale_fmt is not None:
+        fp8_quant_config["scale_fmt"] = scale_fmt
     merged_ignored_layers = get_sglang_fp8_ignored_layers(hf_quant_config)
     merged_ignored_layers.extend(_normalize_ignored_layers(ignored_layers))
     merged_ignored_layers = _dedupe_layers(merged_ignored_layers)
@@ -125,3 +136,112 @@ class SGLangFP8QuantizerHelper(FP8QuantizerHelper):
             if _matches_ignored_layer(param_name, ignored_layer):
                 return False
         return super().should_quantize_param(param_name)
+
+
+class DeepseekV4FP8QuantizerHelper(SGLangFP8QuantizerHelper):
+    """DSv4-native fp8 conversion for the nccl full-sync path.
+
+    The serialized rollout ckpt is the single source of truth: a weight is
+    quantized iff its ``<stem>.scale`` companion exists in the ckpt index
+    (wo_a stays bf16, norms/sinks/router never appear), and scales follow the
+    ckpt's ue8m0 dialect (power-of-two, ``.scale`` suffix) so sglang's
+    deepseek_v4 loader consumes them exactly like a checkpoint load.
+    """
+
+    def __init__(self, quant_config, ckpt_path: str):
+        super().__init__(quant_config)
+        from verl.utils.fp8_ckpt_dtypes import build_ckpt_fp8_predicate
+
+        self._is_quantized = build_ckpt_fp8_predicate(ckpt_path)
+        if self._is_quantized is None:
+            raise ValueError(f"cannot determine FP8 tensor dtypes from checkpoint at {ckpt_path}")
+        self._ckpt_path = ckpt_path
+
+    def should_quantize_param(self, param_name):
+        return self._is_quantized(param_name)
+
+    async def quant_weights_by_name(self, weights, dtype=None):
+        import torch
+
+        from verl.utils.fp8_sharded import (
+            load_ckpt_scales,
+            local_blockwise_absmax,
+            quantize_shard_with_descale,
+            sticky_ue8m0_descale,
+        )
+        from verl.workers.rollout.utils import ensure_async_iterator
+
+        bm_bn = self.quant_config.get("weight_block_size") if isinstance(self.quant_config, dict) else None
+        bm_bn = tuple(bm_bn or (128, 128))
+        ckpt_scales = load_ckpt_scales(self._ckpt_path)
+        n_fp8_passthrough = 0
+        async for k, v in ensure_async_iterator(weights):
+            if not self.should_quantize_param(k):
+                yield (k, v)
+                continue
+            if v.element_size() == 1:
+                # The stream is ALREADY quantized upstream (the bridge's
+                # auto-fp8 export ships codes + scale companions). Quantizing
+                # fp8 codes garbles them (their float view is not the master),
+                # and the freshly emitted scale joins the original in the same
+                # push -- SGLang's fused wqkv_a loader rejects the duplicate
+                # shard. Pass codes through untouched; their scale
+                # companions are not in the quantize manifest and pass through
+                # on their own. Fidelity of a pre-quantized stream is the
+                # upstream producer's business, not this converter's.
+                n_fp8_passthrough += 1
+                yield (k, v)
+                continue
+            x = v.to(torch.float32)
+            amax = local_blockwise_absmax(x, bm_bn, row_offset=0, full_shape=tuple(x.shape))
+            # ue8m0 dialect (power-of-two, exact in fp32), preferring the ckpt's
+            # own scale wherever it still covers -- the ckpt carries per-block
+            # headroom that amax alone cannot reconstruct.
+            descale = sticky_ue8m0_descale(amax, ckpt_scales.get(k))
+            codes = quantize_shard_with_descale(x, descale, bm_bn, row_offset=0)
+            yield (k, codes)
+            yield (k[: -len(".weight")] + ".scale", descale)
+            del x, amax, descale, codes
+            # DSv4 is large enough that the per-parameter transients accumulate
+            # faster than the caching allocator releases them, and the conversion
+            # OOMs partway through. Reclaim every 32 params: frequent enough to
+            # bound the high-water mark, rare enough that the sync cost is noise.
+            _n_q = getattr(self, "_n_q", 0) + 1
+            self._n_q = _n_q
+            if _n_q % 32 == 0:
+                torch.cuda.empty_cache()
+        if n_fp8_passthrough:
+            logger.warning(
+                "DSv4 named_tensors converter: %d params arrived already fp8-quantized and passed "
+                "through untouched -- their scales keep the UPSTREAM dialect (not sticky/ue8m0). "
+                "Fix the exporter if checkpoint-exact scales are required on this path.",
+                n_fp8_passthrough,
+            )
+
+
+def named_tensors_quant_mode(quantization, hf_config) -> str | None:
+    """Which verl-side quantizer the named_tensors full-sync path must use.
+
+    Returns ``"dsv4"``, ``"generic"``, or None (send raw).
+
+    The DSv4 answer deliberately does NOT depend on the rollout's
+    ``quantization`` flag: that flag doubles as an init-time switch that
+    rewrites ``hf_config.quantization_config``, so delta runs keep it unset --
+    and with it unset the hybrid ServerAdapter would push raw bf16, which
+    SGLang then requantizes with its own plain ``amax/448`` formula. An
+    fp8-SERIALIZED checkpoint is itself the instruction to ship codes+scales:
+    quantize verl-side with ue8m0 and checkpoint-sticky scales whenever the
+    checkpoint is fp8, flag or no flag.
+    """
+    import os
+
+    model_type = getattr(hf_config, "model_type", None)
+    if model_type == "deepseek_v4":
+        qc = getattr(hf_config, "quantization_config", None)
+        if qc is not None:
+            get = qc.get if isinstance(qc, dict) else lambda k, d=None: getattr(qc, k, d)
+            if get("quant_method") == "fp8":
+                return "dsv4"
+    if quantization == "fp8":
+        return "dsv4" if model_type == "deepseek_v4" else "generic"
+    return None

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass, field
+from inspect import signature
 from typing import Any, Optional
 
 from omegaconf import MISSING
-from transformers import AutoConfig
+from transformers import AutoConfig, PretrainedConfig
 
 from verl.base_config import BaseConfig
 from verl.utils import hf_processor, hf_tokenizer
@@ -24,6 +25,31 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.model import get_generation_config, update_model_config
 
 __all__ = ["HFModelConfig", "MtpConfig"]
+
+
+def _get_sglang_deepseek_v4_config_class():
+    """Adapt public DeepSeek-V4 config fields to SGLang's strict dataclass."""
+    from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
+
+    class DeepSeekV4ConfigCompat(DeepSeekV4Config):
+        def __init__(self, **kwargs):
+            kwargs = dict(kwargs)
+            for source, target in {
+                "head_dim": "v_head_dim",
+                "sliding_window": "window_size",
+                "num_hash_layers": "n_hash_layers",
+            }.items():
+                if source in kwargs and target not in kwargs:
+                    kwargs[target] = kwargs[source]
+
+            accepted_fields = set(signature(DeepSeekV4Config).parameters)
+            config_kwargs = {key: value for key, value in kwargs.items() if key in accepted_fields}
+            extra_kwargs = {key: value for key, value in kwargs.items() if key not in accepted_fields}
+            super().__init__(**config_kwargs)
+            for key, value in extra_kwargs.items():
+                setattr(self, key, value)
+
+    return DeepSeekV4ConfigCompat
 
 
 @dataclass
@@ -191,15 +217,29 @@ class HFModelConfig(BaseConfig):
             )
         except ValueError as error:
             lookup_error = error.__cause__ or error.__context__
-            if not isinstance(lookup_error, KeyError) or lookup_error.args != ("deepseek_v4",):
-                raise
-            from vllm.transformers_utils.config import get_config
+            is_deepseek_v4_lookup = isinstance(lookup_error, KeyError) and lookup_error.args == ("deepseek_v4",)
+            if not is_deepseek_v4_lookup:
+                config_dict, _ = PretrainedConfig.get_config_dict(
+                    self.local_hf_config_path, trust_remote_code=self.trust_remote_code
+                )
+                if config_dict.get("model_type") != "deepseek_v4":
+                    raise
+            try:
+                from vllm.transformers_utils.config import get_config
 
-            self.hf_config = get_config(
-                self.local_hf_config_path,
-                trust_remote_code=self.trust_remote_code,
-                attn_implementation=attn_implementation,
-            )
+                self.hf_config = get_config(
+                    self.local_hf_config_path,
+                    trust_remote_code=self.trust_remote_code,
+                    attn_implementation=attn_implementation,
+                )
+            except ImportError:
+                deepseek_v4_config_class = _get_sglang_deepseek_v4_config_class()
+                AutoConfig.register("deepseek_v4", deepseek_v4_config_class, exist_ok=True)
+                self.hf_config = AutoConfig.from_pretrained(
+                    self.local_hf_config_path,
+                    trust_remote_code=self.trust_remote_code,
+                    attn_implementation=attn_implementation,
+                )
 
         override_config_kwargs = {}
 

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -432,3 +432,201 @@ def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval
         hf_idx = torch.empty(0, dtype=torch.int32, device=lval.device)
         hf_val = torch.empty(0, dtype=lval.dtype, device=lval.device)
     return slots, dtype_str, counts, hf_idx, hf_val
+
+
+def quant_shard_stream(engine, quant_spec):
+    """Quant-domain shard exporter with the SAME contract as
+    ``get_per_tensor_param_shard``: yields ``(name, local_flat, ShardSpec)``
+    triples that the GENERIC ``hf_delta_export`` / ``prime_delta_snapshots``
+    machinery consumes -- the quant path and the bf16 path share one diff
+    implementation by construction.
+
+    Per export-index record: run the comm-stubbed probe on the FULL local
+    shard, batch every quantizable slot's partial absmax grid into ONE
+    all_reduce over the record's merge group, quantize locally, and yield up
+    to three dtype-homogeneous groups (concatenated across the record's union
+    slots, zero-length segments for rows other ranks own -- lockstep by
+    construction):
+
+        ``{megatron_name}::c``  fp8 codes        (contributes: always)
+        ``{megatron_name}::s``  fp32 scale grids (contributes: group rank 0)
+        ``{megatron_name}::b``  bf16 passthrough (contributes: always)
+
+    Slot metadata for the entry builder is registered on
+    ``engine._quant_group_meta[name]`` as ``(slots, sizes)``.
+    """
+    import torch.distributed as dist
+
+    from megatron.core import parallel_state as mpu
+    from verl.utils.fp8_sharded import (
+        _ABSMAX_EPS,
+        local_blockwise_absmax,
+        quantize_shard_with_descale,
+        sticky_ue8m0_descale,
+    )
+    from verl.utils.kernel.fp8_kernel import FP8_DTYPE, FP8_MAX, ceil_div
+
+    helper_should_quantize = quant_spec.should_quantize
+    # Seed and steady MUST agree on the dialect AND the ckpt-scale preference:
+    # they write the same tensors on alternating syncs, and the delta only
+    # resends changed positions, so any split leaves the other rule's stale
+    # scales in place forever.
+    scale_fmt = getattr(quant_spec, "scale_fmt", None)
+    ckpt_scales = getattr(quant_spec, "ckpt_scales", None)
+    fp32_pred = getattr(quant_spec, "fp32_predicate", None)
+    block = list(quant_spec.weight_block_size)
+    bm, bn = int(block[0]), int(block[1])
+    index = engine._mcore_export_index()
+    slot_cache = engine._delta_slot_cache
+    meta = engine._quant_group_meta = getattr(engine, "_quant_group_meta", {})
+
+    for rec in index:
+        if rec.probe is None:
+            outs = {}
+            dev = torch.device(torch.cuda.current_device()) if torch.cuda.is_available() else torch.device("cpu")
+        else:
+            # DSv4's fp32 special parameters must retain their mantissa through
+            # the HF mapping transform. Quantized and bf16 parameters are cast
+            # at their own group sites below.
+            src = rec.param.data
+            if src.dtype != torch.float32:
+                src = src.to(torch.bfloat16)
+            outs = rec.probe.megatron_to_hf(src, rec.module)
+            dev = rec.param.device
+        pg = rec.spec.gather_group
+        group_rank = dist.get_rank(pg) if pg is not None else dist.get_rank()
+        slots = rec.slots if rec.slots is not None else slot_cache.get(rec.megatron_name)
+        if slots is None:
+            slots = [(n, tuple(int(x) for x in t.shape)) for n, t in outs.items()]
+            slot_cache[rec.megatron_name] = slots
+
+        quantizable = [
+            (sname, sshape)
+            for sname, sshape in slots
+            if len(sshape) == 2 and helper_should_quantize(sname)
+        ]
+        # one absmax all_reduce per record: concatenated partial grids stay
+        # aligned because every rank walks the same union order; absent rows
+        # contribute zero partials without materializing shards.
+        grids = []
+        for sname, sshape in quantizable:
+            t = outs.get(sname)
+            if t is None:
+                g = torch.zeros(
+                    ceil_div(int(sshape[0]), bm), ceil_div(int(sshape[1]), bn), dtype=torch.float32, device=dev
+                )
+            else:
+                g = local_blockwise_absmax(t.to(torch.bfloat16), block, 0, tuple(sshape))
+            grids.append(g)
+        if grids and pg is not None:
+            flatg = torch.cat([g.reshape(-1) for g in grids])
+            dist.all_reduce(flatg, op=dist.ReduceOp.MAX, group=pg)
+            off = 0
+            for i2, g in enumerate(grids):
+                n2 = g.numel()
+                grids[i2] = flatg[off : off + n2].view_as(g)
+                off += n2
+
+        # Deduplicate replicated parameters before transfer using the same
+        # ownership rule as the bf16 path. Scale grids are emitted by group
+        # rank zero; codes and passthrough values follow model ownership.
+        _tp_world = torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group())
+        _ep_size = mpu.get_expert_model_parallel_world_size()
+        _is_expert = ".experts." in rec.megatron_name and (_ep_size > 1 or _tp_world > 1)
+        _is_tp_sharded = (
+            rec.param is not None
+            and getattr(rec.param, "tensor_model_parallel", False)
+            and _tp_world > 1
+        )
+        if _is_expert:
+            owns_replica = mpu.get_expert_data_parallel_rank() == 0
+        elif _is_tp_sharded:
+            owns_replica = mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+        else:
+            owns_replica = (
+                mpu.get_tensor_model_parallel_rank() == 0
+                and mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+            )
+        groups = {
+            "c": {"slots": [], "pieces": [], "dtype": FP8_DTYPE, "contributes": owns_replica},
+            "s": {"slots": [], "pieces": [], "dtype": torch.float32, "contributes": group_rank == 0},
+            "b": {"slots": [], "pieces": [], "dtype": torch.bfloat16, "contributes": owns_replica},
+            "f": {"slots": [], "pieces": [], "dtype": torch.float32, "contributes": owns_replica},
+        }
+        qi = 0
+        for sname, sshape in slots:
+            t = outs.get(sname)
+            if len(sshape) == 2 and helper_should_quantize(sname):
+                if scale_fmt == "ue8m0":
+                    descale = sticky_ue8m0_descale(grids[qi], ckpt_scales.get(sname) if ckpt_scales else None)
+                else:
+                    descale = grids[qi].clamp(min=_ABSMAX_EPS) / FP8_MAX
+                qi += 1
+                if t is not None:
+                    codes = quantize_shard_with_descale(t.to(torch.bfloat16), descale, block, 0)
+                else:
+                    codes = torch.empty(0, dtype=FP8_DTYPE, device=dev)
+                groups["c"]["slots"].append((sname, tuple(sshape)))
+                groups["c"]["pieces"].append(codes.reshape(-1))
+                groups["s"]["slots"].append((sname + "_scale_inv", tuple(descale.shape)))
+                groups["s"]["pieces"].append(descale.reshape(-1))
+            elif fp32_pred is not None and fp32_pred(sname):
+                # fp32 passthrough group: same fidelity rule as the seed wire --
+                # DSv4's special params are fp32 on disk and in the serving
+                # engine; folding them to bf16 costs 16 mantissa bits every
+                # time they change. Routed by the CHECKPOINT-derived predicate,
+                # never by the local tensor's presence or dtype: group slot
+                # layouts must be identical on every rank, and non-owner ranks
+                # see t is None here.
+                flat = (
+                    t.to(torch.float32).reshape(-1)
+                    if t is not None
+                    else torch.empty(0, dtype=torch.float32, device=dev)
+                )
+                groups["f"]["slots"].append((sname, tuple(sshape)))
+                groups["f"]["pieces"].append(flat)
+            else:
+                flat = (
+                    t.to(torch.bfloat16).reshape(-1)
+                    if t is not None
+                    else torch.empty(0, dtype=torch.bfloat16, device=dev)
+                )
+                groups["b"]["slots"].append((sname, tuple(sshape)))
+                groups["b"]["pieces"].append(flat)
+
+        for kind, g in groups.items():
+            if not g["slots"]:
+                continue
+            name = f"{rec.megatron_name}::{kind}"
+            sizes = [int(pc.numel()) for pc in g["pieces"]]
+            meta[name] = (g["slots"], sizes, str(g["dtype"]).replace("torch.", ""))
+            flat = (
+                torch.cat(g["pieces"])
+                if g["pieces"]
+                else torch.empty(0, dtype=g["dtype"], device=dev)
+            )
+            spec = ShardSpec(
+                full_shape=(int(flat.numel()),),
+                place=0,
+                contributes=g["contributes"],
+                gather_group=pg,
+            )
+            yield name, flat, spec
+
+
+def quant_delta_entry(engine):
+    """Entry builder for the quant shard stream, closed over the engine's group
+    metadata: splits the concatenated group's delta positions back into
+    per-slot counts and slot-local indices -- the exact wire entry shape the
+    bf16 path produces."""
+
+    def _entry(name, spec, place, lidx, lval):
+        slots, sizes, dtype_str = engine._quant_group_meta[name]
+        bounds = torch.tensor(sizes, device=lidx.device).cumsum(0)
+        seg = torch.searchsorted(bounds, lidx, right=True)
+        counts = torch.bincount(seg, minlength=len(sizes)).to("cpu")
+        offsets = torch.cat([torch.zeros(1, dtype=bounds.dtype, device=lidx.device), bounds[:-1]])
+        local_idx = (lidx - offsets[seg]).to(torch.int32)
+        return (slots, dtype_str, counts, local_idx, lval)
+
+    return _entry

--- a/verl/workers/engine/megatron/delta_export.py
+++ b/verl/workers/engine/megatron/delta_export.py
@@ -434,6 +434,105 @@ def mcore_hf_delta_entry(rec: McoreParamExport, _place, lidx: torch.Tensor, lval
     return slots, dtype_str, counts, hf_idx, hf_val
 
 
+def _local_block_owner_mask(t: torch.Tensor, block: tuple[int, int], full_shape: tuple[int, int]) -> torch.Tensor:
+    """Return the HF block cells containing at least one value owned here.
+
+    The communication-free Megatron probe represents other TP/ETP ranks with
+    NaNs in the final HF-coordinate tensor.  Ownership is therefore structural
+    (non-NaN), not value based: an all-zero but locally owned block must still
+    have an owner.
+    """
+    from verl.utils.kernel.fp8_kernel import ceil_div
+
+    bm, bn = block
+    m, n = full_shape
+    assert t.dim() == 2 and tuple(t.shape) == full_shape, (
+        f"probe output shape {tuple(t.shape)} does not match HF slot {full_shape}; owner positions would be ambiguous"
+    )
+    n_br, n_bc = ceil_div(m, bm), ceil_div(n, bn)
+    valid = ~torch.isnan(t)
+    pad_m, pad_n = n_br * bm - int(t.shape[0]), n_bc * bn - n
+    if pad_m or pad_n:
+        valid = torch.nn.functional.pad(valid, (0, pad_n, 0, pad_m), value=False)
+    return valid.view(n_br, bm, n_bc, bn).any(dim=(1, 3))
+
+
+def _block_owner_plan(
+    local_masks: list[torch.Tensor],
+    group,
+    group_rank: int,
+) -> list[tuple[torch.Tensor, torch.Tensor]]:
+    """Build static ``(cross_positions, scale_positions)`` per HF slot.
+
+    A full owner-count exchange happens once when the export plan is first
+    used.  Steady syncs communicate amax values only at ``cross_positions``.
+    Singleton blocks keep their amax and scale on their unique owner; a
+    cross-rank block's reduced scale is emitted by group rank zero.
+    """
+    import torch.distributed as dist
+
+    if not local_masks:
+        return []
+    if group is None:
+        return [
+            (
+                torch.empty(0, dtype=torch.int32, device=mask.device),
+                mask.reshape(-1).nonzero(as_tuple=False).view(-1).to(torch.int32),
+            )
+            for mask in local_masks
+        ]
+    sizes = [int(mask.numel()) for mask in local_masks]
+    flat_local = torch.cat([mask.reshape(-1) for mask in local_masks])
+    counts = flat_local.to(torch.int32)
+    dist.all_reduce(counts, op=dist.ReduceOp.SUM, group=group)
+    assert bool(torch.all(counts > 0)), "quantized HF block has no contributing trainer rank"
+
+    out = []
+    off = 0
+    for mask, n in zip(local_masks, sizes, strict=True):
+        count = counts[off : off + n]
+        local = mask.reshape(-1)
+        cross = count > 1
+        scale_owner = (local & (count == 1)) | (cross & (group_rank == 0))
+        out.append(
+            (
+                cross.nonzero(as_tuple=False).view(-1).to(torch.int32),
+                scale_owner.nonzero(as_tuple=False).view(-1).to(torch.int32),
+            )
+        )
+        off += n
+    return out
+
+
+def _reduce_cross_block_amax(
+    grids: list[torch.Tensor],
+    plan: list[tuple[torch.Tensor, torch.Tensor]],
+    group,
+) -> int:
+    """MAX-reduce only block cells whose owner count is greater than one.
+
+    Returns the number of FP32 cells placed on the collective data plane.  A
+    zero return performs no collective at all, which is the common PP/EP-only
+    case because those parallelisms own whole HF tensors/experts.
+    """
+    import torch.distributed as dist
+
+    pieces = [g.reshape(-1)[cross.long()] for g, (cross, _scale) in zip(grids, plan, strict=True)]
+    n_cross = sum(int(piece.numel()) for piece in pieces)
+    if not n_cross:
+        return 0
+    assert group is not None, "cross-rank HF blocks require a merge process group"
+    flat = torch.cat(pieces)
+    dist.all_reduce(flat, op=dist.ReduceOp.MAX, group=group)
+    off = 0
+    for grid, (cross, _scale) in zip(grids, plan, strict=True):
+        n = int(cross.numel())
+        if n:
+            grid.reshape(-1)[cross.long()] = flat[off : off + n]
+        off += n
+    return n_cross
+
+
 def quant_shard_stream(engine, quant_spec):
     """Quant-domain shard exporter with the SAME contract as
     ``get_per_tensor_param_shard``: yields ``(name, local_flat, ShardSpec)``
@@ -442,22 +541,24 @@ def quant_shard_stream(engine, quant_spec):
     implementation by construction.
 
     Per export-index record: run the comm-stubbed probe on the FULL local
-    shard, batch every quantizable slot's partial absmax grid into ONE
-    all_reduce over the record's merge group, quantize locally, and yield up
-    to three dtype-homogeneous groups (concatenated across the record's union
+    shard, exchange static block ownership once, compact/reduce only amax cells
+    shared by more than one owner, quantize locally, and yield up to four
+    dtype-homogeneous groups (concatenated across the record's union
     slots, zero-length segments for rows other ranks own -- lockstep by
     construction):
 
         ``{megatron_name}::c``  fp8 codes        (contributes: always)
-        ``{megatron_name}::s``  fp32 scale grids (contributes: group rank 0)
+        ``{megatron_name}::s``  fp32 scale cells (contributes: per-block owner)
         ``{megatron_name}::b``  bf16 passthrough (contributes: always)
+        ``{megatron_name}::f``  fp32 passthrough (contributes: always)
 
     Slot metadata for the entry builder is registered on
-    ``engine._quant_group_meta[name]`` as ``(slots, sizes)``.
+    ``engine._quant_group_meta[name]`` as
+    ``(slots, local_sizes, dtype, optional_full_slot_positions)``.
     """
     import torch.distributed as dist
-
     from megatron.core import parallel_state as mpu
+
     from verl.utils.fp8_sharded import (
         _ABSMAX_EPS,
         local_blockwise_absmax,
@@ -479,6 +580,9 @@ def quant_shard_stream(engine, quant_spec):
     index = engine._mcore_export_index()
     slot_cache = engine._delta_slot_cache
     meta = engine._quant_group_meta = getattr(engine, "_quant_group_meta", {})
+    owner_plans = engine._quant_block_owner_plans = getattr(engine, "_quant_block_owner_plans", {})
+    planned_cells = 0
+    planned_cross_cells = 0
 
     for rec in index:
         if rec.probe is None:
@@ -500,14 +604,51 @@ def quant_shard_stream(engine, quant_spec):
             slots = [(n, tuple(int(x) for x in t.shape)) for n, t in outs.items()]
             slot_cache[rec.megatron_name] = slots
 
-        quantizable = [
-            (sname, sshape)
-            for sname, sshape in slots
-            if len(sshape) == 2 and helper_should_quantize(sname)
-        ]
-        # one absmax all_reduce per record: concatenated partial grids stay
-        # aligned because every rank walks the same union order; absent rows
-        # contribute zero partials without materializing shards.
+        quantizable = [(sname, sshape) for sname, sshape in slots if len(sshape) == 2 and helper_should_quantize(sname)]
+
+        # Deduplicate DP/CP replicas before both value and scale ownership are
+        # planned.  Otherwise identical replicas would make every local block
+        # look cross-rank and defeat boundary-only amax exchange.
+        _tp_world = torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group())
+        _ep_size = mpu.get_expert_model_parallel_world_size()
+        _is_expert = ".experts." in rec.megatron_name and (_ep_size > 1 or _tp_world > 1)
+        _is_tp_sharded = rec.param is not None and getattr(rec.param, "tensor_model_parallel", False) and _tp_world > 1
+        if _is_expert:
+            owns_replica = mpu.get_expert_data_parallel_rank() == 0
+        elif _is_tp_sharded:
+            owns_replica = mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+        else:
+            owns_replica = (
+                mpu.get_tensor_model_parallel_rank() == 0
+                and mpu.get_data_parallel_rank(with_context_parallel=True) == 0
+            )
+
+        # The probe's NaN pattern is a static ownership map in final HF block
+        # coordinates.  Exchange owner counts once, then cache only compact
+        # positions: steady syncs reduce amax values for genuinely shared
+        # boundary blocks and nothing else.
+        plan_key = (rec.megatron_name, tuple(block), tuple(quantizable))
+        plan = owner_plans.get(plan_key)
+        if plan is None:
+            local_masks = []
+            for sname, sshape in quantizable:
+                t = outs.get(sname)
+                if t is None or not owns_replica:
+                    local_masks.append(
+                        torch.zeros(
+                            ceil_div(int(sshape[0]), bm),
+                            ceil_div(int(sshape[1]), bn),
+                            dtype=torch.bool,
+                            device=dev,
+                        )
+                    )
+                else:
+                    local_masks.append(_local_block_owner_mask(t, (bm, bn), tuple(sshape)))
+            plan = _block_owner_plan(local_masks, pg, group_rank)
+            owner_plans[plan_key] = plan
+            planned_cells += sum(int(mask.numel()) for mask in local_masks)
+            planned_cross_cells += sum(int(cross.numel()) for cross, _scale in plan)
+
         grids = []
         for sname, sshape in quantizable:
             t = outs.get(sname)
@@ -518,38 +659,14 @@ def quant_shard_stream(engine, quant_spec):
             else:
                 g = local_blockwise_absmax(t.to(torch.bfloat16), block, 0, tuple(sshape))
             grids.append(g)
-        if grids and pg is not None:
-            flatg = torch.cat([g.reshape(-1) for g in grids])
-            dist.all_reduce(flatg, op=dist.ReduceOp.MAX, group=pg)
-            off = 0
-            for i2, g in enumerate(grids):
-                n2 = g.numel()
-                grids[i2] = flatg[off : off + n2].view_as(g)
-                off += n2
+        _reduce_cross_block_amax(grids, plan, pg)
 
-        # Deduplicate replicated parameters before transfer using the same
-        # ownership rule as the bf16 path. Scale grids are emitted by group
-        # rank zero; codes and passthrough values follow model ownership.
-        _tp_world = torch.distributed.get_world_size(group=mpu.get_tensor_model_parallel_group())
-        _ep_size = mpu.get_expert_model_parallel_world_size()
-        _is_expert = ".experts." in rec.megatron_name and (_ep_size > 1 or _tp_world > 1)
-        _is_tp_sharded = (
-            rec.param is not None
-            and getattr(rec.param, "tensor_model_parallel", False)
-            and _tp_world > 1
-        )
-        if _is_expert:
-            owns_replica = mpu.get_expert_data_parallel_rank() == 0
-        elif _is_tp_sharded:
-            owns_replica = mpu.get_data_parallel_rank(with_context_parallel=True) == 0
-        else:
-            owns_replica = (
-                mpu.get_tensor_model_parallel_rank() == 0
-                and mpu.get_data_parallel_rank(with_context_parallel=True) == 0
-            )
+        # Codes and passthrough values follow model ownership.  Scale cells
+        # follow the block plan above and may therefore have several ranks
+        # contributing disjoint positions to one HF scale tensor.
         groups = {
             "c": {"slots": [], "pieces": [], "dtype": FP8_DTYPE, "contributes": owns_replica},
-            "s": {"slots": [], "pieces": [], "dtype": torch.float32, "contributes": group_rank == 0},
+            "s": {"slots": [], "pieces": [], "positions": [], "dtype": torch.float32, "contributes": True},
             "b": {"slots": [], "pieces": [], "dtype": torch.bfloat16, "contributes": owns_replica},
             "f": {"slots": [], "pieces": [], "dtype": torch.float32, "contributes": owns_replica},
         }
@@ -569,7 +686,9 @@ def quant_shard_stream(engine, quant_spec):
                 groups["c"]["slots"].append((sname, tuple(sshape)))
                 groups["c"]["pieces"].append(codes.reshape(-1))
                 groups["s"]["slots"].append((sname + "_scale_inv", tuple(descale.shape)))
-                groups["s"]["pieces"].append(descale.reshape(-1))
+                scale_pos = plan[qi - 1][1]
+                groups["s"]["positions"].append(scale_pos)
+                groups["s"]["pieces"].append(descale.reshape(-1)[scale_pos.long()])
             elif fp32_pred is not None and fp32_pred(sname):
                 # fp32 passthrough group: same fidelity rule as the seed wire --
                 # DSv4's special params are fp32 on disk and in the serving
@@ -599,19 +718,25 @@ def quant_shard_stream(engine, quant_spec):
                 continue
             name = f"{rec.megatron_name}::{kind}"
             sizes = [int(pc.numel()) for pc in g["pieces"]]
-            meta[name] = (g["slots"], sizes, str(g["dtype"]).replace("torch.", ""))
-            flat = (
-                torch.cat(g["pieces"])
-                if g["pieces"]
-                else torch.empty(0, dtype=g["dtype"], device=dev)
-            )
+            positions = g.get("positions")
+            meta[name] = (g["slots"], sizes, str(g["dtype"]).replace("torch.", ""), positions)
+            flat = torch.cat(g["pieces"]) if g["pieces"] else torch.empty(0, dtype=g["dtype"], device=dev)
             spec = ShardSpec(
                 full_shape=(int(flat.numel()),),
                 place=0,
-                contributes=g["contributes"],
+                contributes=g["contributes"] and bool(flat.numel()),
                 gather_group=pg,
             )
             yield name, flat, spec
+
+    if planned_cells:
+        logger.warning(
+            "quant amax owner plan rank=%d: scale_cells=%d cross_rank_cells=%d steady_max_payload_bytes=%d",
+            dist.get_rank(),
+            planned_cells,
+            planned_cross_cells,
+            planned_cross_cells * 4,
+        )
 
 
 def quant_delta_entry(engine):
@@ -621,12 +746,19 @@ def quant_delta_entry(engine):
     bf16 path produces."""
 
     def _entry(name, spec, place, lidx, lval):
-        slots, sizes, dtype_str = engine._quant_group_meta[name]
+        slots, sizes, dtype_str, positions = engine._quant_group_meta[name]
         bounds = torch.tensor(sizes, device=lidx.device).cumsum(0)
         seg = torch.searchsorted(bounds, lidx, right=True)
         counts = torch.bincount(seg, minlength=len(sizes)).to("cpu")
         offsets = torch.cat([torch.zeros(1, dtype=bounds.dtype, device=lidx.device), bounds[:-1]])
         local_idx = (lidx - offsets[seg]).to(torch.int32)
+        if positions is not None and lidx.numel():
+            mapped = torch.empty_like(local_idx)
+            for i, pos in enumerate(positions):
+                sel = seg == i
+                if bool(sel.any()):
+                    mapped[sel] = pos.to(lidx.device)[local_idx[sel].long()]
+            local_idx = mapped
         return (slots, dtype_str, counts, local_idx, lval)
 
     return _entry

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -1051,6 +1051,60 @@ class MegatronEngine(BaseEngine):
 
             per_tensor_param = export_qat_weights(per_tensor_param, self.module, self._qat_config.mode, self.bridge)
 
+        # explicit rollout-format request: the backend owns format production
+        # (codes + scale_inv exactly as the serving engine names them) without
+        # knowing who asked -- the caller distills its quant config into the
+        # spec.
+        quant_spec = kwargs.get("quant_spec")
+        if quant_spec is not None:
+            from verl.utils.fp8_sharded import quantize_hf_stream
+
+            if not self.vanilla_bridge:
+                # For fp8-serialized checkpoints the bridge quantizes on export
+                # at TWO levels, and both must be disarmed or the wrap below
+                # receives fp8 codes instead of the bf16 master:
+                #   1. export_hf_weights auto-builds build_export_fp8_tasks
+                #      (quantizing task family) -- bypassed by handing it
+                #      explicit plain tasks;
+                #   2. the DSv4 bridge's maybe_modify_converted_hf_weight hook
+                #      re-quantizes EVERY task's output to match the fp8 shard
+                #      index (plain amax/448 scales -- the ".scale" family
+                #      changes its scale dialect) -- skipped only when
+                #      task.weight_dtype is set, so stamp it on each task
+                #      (frozen dataclass, hence replace()).
+                # weight_dtype cannot be passed to export_hf_weights here: with
+                # caller-supplied tasks the stream rejects the combination, and
+                # without tasks the auto-fp8 branch fires first.
+                # The stamp is bf16 EXCEPT for the checkpoint's fp32 families
+                # (spec.fp32_predicate; DSv4's hc_*/ape/attn_sink/router bias):
+                # stamping those bf16 is where the seed used to lose their last
+                # 16 mantissa bits -- the hook-disarming stamp itself did the
+                # folding, before the wire ever saw the tensor. Stamping them
+                # float32 disarms the hook identically (any set weight_dtype
+                # skips it) and keeps the master's exact bytes. A fused task
+                # with mixed outputs stamps float32 for all of them; harmless,
+                # since bf16->fp32 is exact and the wire folds non-predicate
+                # names back to bf16. (None rows filtered for the same reason
+                # as the QAT branch above.)
+                import dataclasses
+
+                fp32_pred = getattr(quant_spec, "fp32_predicate", None)
+
+                def _stamp_dtype(task):
+                    if fp32_pred is None:
+                        return torch.bfloat16
+                    hf = task.mapping.hf_param  # resolved concrete name(s)
+                    names = [hf] if isinstance(hf, str) else list(hf.values())
+                    return torch.float32 if any(fp32_pred(n) for n in names) else torch.bfloat16
+
+                tasks = [
+                    dataclasses.replace(t, weight_dtype=_stamp_dtype(t))
+                    for t in self.bridge.get_conversion_tasks(self.module)
+                    if t is not None
+                ]
+                per_tensor_param = self.bridge.export_hf_weights(self.module, conversion_tasks=tasks)
+            per_tensor_param = quantize_hf_stream(per_tensor_param, quant_spec)
+
         return per_tensor_param, peft_config
 
     def _mcore_export_index(self):
@@ -1072,13 +1126,17 @@ class MegatronEngine(BaseEngine):
             self._delta_export_by_name = {rec.megatron_name: rec for rec in index}
         return index
 
-    def get_per_tensor_param_shard(self, **kwargs):
+    def get_per_tensor_param_shard(self, quant_spec=None, **kwargs):
         """Yield each rank's *local* mcore shard ``(name, local_flat_bf16,
         ShardSpec)`` -- the spec carries only the wire merge group (the
         comm-stubbed probe owns all shard geometry). Pure export, no side
         effects. Params owned by another pipeline stage yield an empty shard
         (zero-count lockstep rows; see the index builder)."""
         load_megatron_model_to_gpu(self.module, load_grad=False)
+        if quant_spec is not None:
+            from .delta_export import quant_shard_stream
+
+            return quant_shard_stream(self, quant_spec), None
         index = self._mcore_export_index()
 
         def _gen():
@@ -1104,16 +1162,42 @@ class MegatronEngine(BaseEngine):
         rec = self._delta_export_by_name[name]
         return mcore_hf_delta_entry(rec, place, lidx, lval, self._delta_slot_cache)
 
-    def get_per_tensor_param_delta_shard(self, **kwargs):
+    def get_per_tensor_param_delta_shard(self, quant_spec=None, **kwargs):
         """Yield the delta engine's steady payloads -- FINAL HF-coordinate entries
         per mcore parameter (see the FSDP engine's method of the same name for the
         contract; MegatronEngine extends BaseEngine directly, so the thin wrapper
-        is repeated here). Requires a prior :meth:`prime_delta_snapshots` call."""
-        from ..utils import hf_delta_export
+        is repeated here). Requires a prior :meth:`prime_delta_snapshots` call.
 
+        With ``quant_spec`` the payloads are produced directly in the rollout's
+        quantization domain (codes + scale grids diffed against the engine-held
+        quant snapshots) -- the backend owns delta production for every dtype."""
+        from ..utils import hf_delta_export
+        from .delta_export import quant_delta_entry
+
+        gen, _ = self.get_per_tensor_param_shard(quant_spec=quant_spec)
+        # ONE snapshot store for both domains: quant groups key as
+        # "{megatron_name}::{kind}", bf16 shards as plain megatron names --
+        # disjoint namespaces, identical prime/diff/refresh semantics.
         self._delta_shard_snap = getattr(self, "_delta_shard_snap", {})
-        gen, _ = self.get_per_tensor_param_shard()
-        return hf_delta_export(gen, self._delta_shard_snap, self._hf_delta_entry), None
+        entry = quant_delta_entry(self) if quant_spec is not None else self._hf_delta_entry
+        return hf_delta_export(gen, self._delta_shard_snap, entry), None
+
+    def prime_delta_snapshots(self, quant_spec=None) -> None:
+        """Capture the state the NEXT delta-shard call will diff against. With
+        ``quant_spec``, runs the same quant-domain walk as the steady export in
+        prime-only mode (same keys, same collective sequence)."""
+        if quant_spec is not None:
+            from verl.utils.device import is_cuda_available
+            from verl.workers.engine.utils import prime_delta_snapshots
+
+            self._delta_shard_snap = getattr(self, "_delta_shard_snap", {})
+            gen, _ = self.get_per_tensor_param_shard(quant_spec=quant_spec)
+            # quant snapshots pin unconditionally: they are ~4x smaller than the
+            # bf16 shard sets that motivated delta_pin_snapshots=False, and the
+            # pageable H2D/D2H round-trip costs seconds per sync at 7B already.
+            prime_delta_snapshots(gen, self._delta_shard_snap, pin=is_cuda_available)
+            return
+        super().prime_delta_snapshots()
 
     def disable_adapter(self) -> ContextManager:
         return self.peft_cls.disable_adapter(self.module)

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import base64
 import dataclasses
 import json
 import logging
@@ -21,6 +22,7 @@ import secrets
 from pathlib import Path
 from typing import Any, Optional
 
+import numpy as np
 import ray
 import sglang
 import sglang.srt.entrypoints.engine
@@ -68,6 +70,17 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
 
 visible_devices_keyword = get_visible_devices_keyword()
+
+
+def _decode_routed_experts_payload(captured):
+    """Normalize SGLang's tensor or 0.5.12 base64-int32 route payload."""
+    if captured is None:
+        return None
+    if isinstance(captured, str):
+        return np.frombuffer(base64.b64decode(captured), dtype=np.int32)
+    if hasattr(captured, "numpy"):
+        return captured.numpy()
+    return np.asarray(captured)
 
 
 def _extract_prompt_logprobs_sglang(
@@ -678,23 +691,26 @@ class SGLangHttpServer:
 
         routed_experts = None
         if self.config.enable_rollout_routing_replay:
-            if self.config.skip_tokenizer_init:
-                # convert to numpy
-                captured = output.get("meta_info", {}).get("routed_experts", None)
-                routed_experts = captured.numpy() if captured is not None else None
-            else:
-                from sglang.srt.layers.moe.routed_experts_capturer import extract_routed_experts_from_meta_info
-
-                hf_config = self.model_config.hf_config
-                if not hasattr(hf_config, "num_hidden_layers") or not hasattr(hf_config, "num_experts_per_tok"):
-                    raise AttributeError(
-                        "enable_rollout_routing_replay is set, but hf_config is missing "
-                        "'num_hidden_layers' or 'num_experts_per_tok'. This feature requires an MoE model "
-                        "configuration that defines these attributes."
-                    )
-                routed_experts = extract_routed_experts_from_meta_info(output).reshape(
-                    -1, hf_config.num_hidden_layers, hf_config.num_experts_per_tok
+            hf_config = self.model_config.hf_config
+            if not hasattr(hf_config, "num_hidden_layers") or not hasattr(hf_config, "num_experts_per_tok"):
+                raise AttributeError(
+                    "enable_rollout_routing_replay is set, but hf_config is missing "
+                    "'num_hidden_layers' or 'num_experts_per_tok'. This feature requires an MoE model "
+                    "configuration that defines these attributes."
                 )
+            if self.config.skip_tokenizer_init:
+                captured = output.get("meta_info", {}).get("routed_experts", None)
+                routed_experts = _decode_routed_experts_payload(captured)
+            else:
+                captured = output.get("meta_info", {}).get("routed_experts", None)
+                if isinstance(captured, str):
+                    routed_experts = _decode_routed_experts_payload(captured)
+                else:
+                    from sglang.srt.layers.moe.routed_experts_capturer import extract_routed_experts_from_meta_info
+
+                    routed_experts = extract_routed_experts_from_meta_info(output) if captured is not None else None
+            if routed_experts is not None:
+                routed_experts = routed_experts.reshape(-1, hf_config.num_hidden_layers, hf_config.num_experts_per_tok)
 
         extra_fields = {"global_steps": self.global_steps}
         if prompt_logprobs is not None:

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -28,8 +28,8 @@ Wire contract (what the delta checkpoint engine sends per flush):
 * ``__delta_spec__`` — uint8 tensor holding a JSON manifest
   ``{"encoding", "params": [DeltaParam-dict...], "checksum"}``.
 * ``__positions__`` — uint8 blob of packed positions (per-param slices are
-  byte offsets ``pos_start:pos_end``; ``indices`` packs little-endian int32
-  absolute positions).
+  byte offsets ``pos_start:pos_end``; ``indices`` packs little-endian 24- or
+  32-bit absolute positions).
 * ``__values__``  — the changed values in the flush's (uniform) dtype;
   per-param slices are element offsets ``val_start:val_end``.
 
@@ -40,6 +40,8 @@ Register at server launch (verl config)::
 
 from __future__ import annotations
 
+import bisect
+import itertools
 import json
 import logging
 import math
@@ -48,14 +50,174 @@ from contextlib import contextmanager
 
 import torch
 
+from verl.checkpoint_engine.delta_sync.encode import unpack_absolute_indices
+from verl.utils.fusion_groups import DEEPSEEK_V4_FUSION_GROUPS
+
 logger = logging.getLogger(__name__)
 
 # Cap on the densified tensors handed to one model.load_weights call, matching
 # SGLang's own delta-apply chunking default.
 CHUNK_BYTES = 512 << 20
 
+# Destination params that SGLang's DSv4 loader rebuilds by torch.cat-ing two
+# separately-named tensors, buffering the first half in a cache it creates inside
+# ``load_weights`` and asserts empty on return. Both halves therefore have to be
+# in the SAME ``load_weights`` call -- and this chunk loop is the LAST place that
+# can split them: the sender keeps a group inside one flush, but a flush is
+# re-cut here by CHUNK_BYTES, so without this the group can still straddle two
+# calls and the assert fires.
+#
+_FUSION_SUFFIXES = DEEPSEEK_V4_FUSION_GROUPS
+
+
+def _fusion_key(name: str):
+    """``(prefix, group_index)`` if this param is half of a fused destination."""
+    hits = [
+        (name[: -len(sfx)], gi)
+        for gi, sfxs in enumerate(_FUSION_SUFFIXES)
+        for sfx in sfxs
+        if name.endswith(sfx)
+    ]
+    assert len(hits) <= 1, f"{name!r} matches multiple fusion groups: {hits}"
+    return hits[0] if hits else None
+
+
+def _atomic_units(params: list[dict]) -> list[list[dict]]:
+    """Partition params so that members of one fusion group stay in one unit.
+
+    Order follows first appearance, so a stream that already keeps a group
+    adjacent is left untouched; a group split apart by the sender still gets
+    reunited here.
+    """
+    units: list[list[dict]] = []
+    at: dict = {}
+    for p in params:
+        key = _fusion_key(p["name"])
+        if key is not None and key in at:
+            units[at[key]].append(p)
+            continue
+        if key is not None:
+            at[key] = len(units)
+        units.append([p])
+    return units
+
+
+def _load_in_chunks(model, params: list[dict], materialize) -> None:
+    """Feed params to ``model.load_weights`` in <= CHUNK_BYTES chunks, cutting
+    only BETWEEN fusion groups. ``materialize(p) -> Tensor`` builds one param."""
+    chunk: list[tuple[str, torch.Tensor]] = []
+    chunk_bytes = 0
+    for unit in _atomic_units(params):
+        built = [(p["name"], materialize(p)) for p in unit]
+        unit_bytes = sum(t.numel() * t.element_size() for _, t in built)
+        if chunk and chunk_bytes + unit_bytes > CHUNK_BYTES:
+            model.load_weights(chunk)
+            chunk, chunk_bytes = [], 0
+        chunk.extend(built)
+        chunk_bytes += unit_bytes
+    if chunk:
+        model.load_weights(chunk)
+
 # Import path callers pass as both --custom-weight-loader and load_format.
 LOADER_FQN = "verl.workers.rollout.sglang_rollout.delta_loader.apply_delta"
+
+
+def _find_live_quant_config(model: torch.nn.Module):
+    """Read the live quantization config straight from a quantized sglang layer.
+
+    Reads ``module.quant_method.quant_config`` (NOT ``module.quant_config``:
+    layers excluded via ignored_layers keep the config object but get an
+    UnquantizedLinearMethod, so the quant_method is the authority on whether
+    the layer is actually quantized)."""
+    for name, module in model.named_modules():
+        qm = getattr(module, "quant_method", None)
+        qc = getattr(qm, "quant_config", None)
+        if qc is None:
+            continue
+        block = getattr(qc, "weight_block_size", None)
+        if block is None or not hasattr(module, "weight_scale_inv"):
+            continue
+        return {
+            "layer_name": name,
+            "quant_method": type(qc).__name__,
+            "weight_block_size": [int(x) for x in block],
+            "use_mxfp8": bool(getattr(qc, "use_mxfp8", False)),
+            "module": module,
+        }
+    return None
+
+
+def _check_quant_handshake(model: torch.nn.Module, spec: dict) -> None:
+    """Two separate questions, answered loudly at the first flush:
+
+    1. config handshake -- do trainer and rollout use the same quantization
+       definition? Compared against the LIVE layer config
+       (``quant_method.quant_config``), falling back to shape inference only
+       when no live config is discoverable.
+    2. state sanity -- do the created params match that definition (scale grid
+       shape = ceil(weight shape / block)), and has the state been seeded
+       (sparse deltas on sentinel scales are refused)?
+    """
+    cfg = spec.get("quant_config")
+    if cfg is None or getattr(model, "_delta_quant_handshake_done", False):
+        return
+    # seed-required guard: sglang boots serialized-fp8 params with SENTINEL
+    # scales (never loaded from a bf16 ckpt) -- serving or sparse-patching that
+    # state would silently produce garbage. The first quantized payload must be
+    # the full seed; a sparse delta arriving on sentinel scales fails loud.
+    if spec.get("encoding") != "dense":
+        sentinel = torch.finfo(torch.float32).min
+        for name, param in model.named_parameters():
+            if not name.endswith("weight_scale_inv") or not param.numel():
+                continue
+            assert float(param.data.flatten()[0]) != sentinel, (
+                f"sparse fp8 delta arrived but {name} still holds the unloaded sentinel scale "
+                "-- the rollout was never seeded (full seed sync must precede any steady delta)"
+            )
+            break
+    want = cfg.get("weight_block_size")
+    if want is not None:
+        want = [int(x) for x in want]
+        live = _find_live_quant_config(model)
+        if live is not None:
+            assert not live["use_mxfp8"], (
+                f"quant handshake failed: rollout layer {live['layer_name']} runs mxfp8 "
+                f"({live['quant_method']}), trainer ships plain blockwise fp8 ({cfg})"
+            )
+            assert live["weight_block_size"] == want, (
+                f"quant handshake failed: rollout {live['quant_method']} block size "
+                f"{live['weight_block_size']} vs trainer config {want}"
+            )
+            # state sanity: created params match the agreed definition
+            module = live["module"]
+            w = getattr(module, "weight", None)
+            si = getattr(module, "weight_scale_inv", None)
+            if w is not None and si is not None and w.dim() == 2 and si.dim() == 2:
+                expect = [
+                    (w.shape[0] + want[0] - 1) // want[0],
+                    (w.shape[1] + want[1] - 1) // want[1],
+                ]
+                assert list(si.shape) == expect, (
+                    f"state sanity failed on {live['layer_name']}: scale grid {list(si.shape)} "
+                    f"vs expected {expect} for block {want}"
+                )
+        else:
+            # no discoverable live config: fall back to shape inference
+            logger.warning("quant handshake: no live quant_config found on any module; falling back to shape check")
+            for name, param in model.named_parameters():
+                if not name.endswith("weight_scale_inv") or param.dim() != 2:
+                    continue
+                base = dict(model.named_parameters()).get(name[: -len("_scale_inv")])
+                if base is None or base.dim() != 2:
+                    continue
+                bm = (base.shape[0] + param.shape[0] - 1) // param.shape[0]
+                bn = (base.shape[1] + param.shape[1] - 1) // param.shape[1]
+                assert [bm, bn] == want, (
+                    f"quant handshake failed on {name}: live block size ~[{bm}, {bn}] "
+                    f"vs trainer config {want} (spec quant_config={cfg})"
+                )
+                break
+    model._delta_quant_handshake_done = True
 
 
 def apply_delta(model: torch.nn.Module, named_tensors: Iterable[tuple[str, torch.Tensor]]) -> None:
@@ -76,50 +238,63 @@ def apply_delta(model: torch.nn.Module, named_tensors: Iterable[tuple[str, torch
             "indicates corruption between sender encode and receiver apply"
         )
 
+    _check_quant_handshake(model, spec)
     if spec["encoding"] == "dense":
         if spec.get("verify"):
-            _verify_dense(model, spec["params"], values, bool(spec.get("is_last")))
+            _verify_dense(model, spec["params"], values, bool(spec.get("is_last")), bool(spec.get("values_bytes")))
             return
-        _apply_dense(model, spec["params"], values)
+        _apply_dense(model, spec["params"], values, bool(spec.get("values_bytes")))
+        if spec.get("is_last") and hasattr(model, "post_load_weights"):
+            model.post_load_weights()
         return
 
     encoding = spec["encoding"]
-    with _masked_copy():
-        chunk: list[tuple[str, torch.Tensor]] = []
-        chunk_bytes = 0
-        for p in spec["params"]:
-            t = _decode_one(encoding, positions, values, p)
-            nbytes = t.numel() * t.element_size()
-            if chunk and chunk_bytes + nbytes > CHUNK_BYTES:
-                model.load_weights(chunk)
-                chunk, chunk_bytes = [], 0
-            chunk.append((p["name"], t))
-            chunk_bytes += nbytes
-        if chunk:
-            model.load_weights(chunk)
+    values_bytes = bool(spec.get("values_bytes"))
+    with _masked_copy(_param_storage_index(model)):
+        _load_in_chunks(
+            model,
+            spec["params"],
+            lambda p: _decode_one(encoding, positions, values, p, values_bytes),
+        )
+
+    # Derived tensors (fp8 scales after requant, MLA w_kc/w_vc, MoE biases)
+    # recompute from the now-final weights. Outside the masked-copy patch on
+    # purpose: their writes are wholesale transforms, not sparse overlays --
+    # sglang's own update_weights_from_tensor path does not trigger this hook,
+    # so the delta loader replicates the full-load semantics itself once per
+    # sync (the engine marks the sync's final flush with ``is_last``).
+    if spec.get("is_last") and hasattr(model, "post_load_weights"):
+        model.post_load_weights()
 
 
-def _apply_dense(model: torch.nn.Module, params: list[dict], values: torch.Tensor) -> None:
-    """Apply a dense (full-coverage) flush: plain chunked load, no masking needed."""
-    chunk: list[tuple[str, torch.Tensor]] = []
-    chunk_bytes = 0
-    for p in params:
+def _apply_dense(
+    model: torch.nn.Module, params: list[dict], values: torch.Tensor, values_bytes: bool = False
+) -> None:
+    """Apply a dense (full-coverage) flush: plain chunked load, no masking needed.
+
+    ``values_bytes`` marks a mixed-dtype flush (fp8 codes + fp32 scales + bf16
+    leftovers): offsets are BYTE offsets into a uint8 blob and each param is
+    reinterpreted, not cast. The ``.clone()`` re-bases the slice to storage
+    offset 0 so the dtype view never trips torch's alignment check.
+
+    This is the path the SEED takes, and it is where the fused-param assert
+    actually fired -- hence the same atomic chunking as the sparse path."""
+
+    def _materialize(p: dict) -> torch.Tensor:
         dtype = getattr(torch, p["dtype"])
-        t = values[p["val_start"] : p["val_end"]].to(dtype).view(p["shape"])
-        nbytes = t.numel() * t.element_size()
-        if chunk and chunk_bytes + nbytes > CHUNK_BYTES:
-            model.load_weights(chunk)
-            chunk, chunk_bytes = [], 0
-        chunk.append((p["name"], t))
-        chunk_bytes += nbytes
-    if chunk:
-        model.load_weights(chunk)
+        if values_bytes:
+            return values[p["val_start"] : p["val_end"]].clone().view(dtype).view(p["shape"])
+        return values[p["val_start"] : p["val_end"]].to(dtype).view(p["shape"])
+
+    _load_in_chunks(model, params, _materialize)
 
 
 _VERIFY_STATS: dict = {"params": 0, "pieces": []}
 
 
-def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tensor, is_last: bool) -> None:
+def _verify_dense(
+    model: torch.nn.Module, params: list[dict], values: torch.Tensor, is_last: bool, values_bytes: bool = False
+) -> None:
     """State-equivalence sweep, phrased as an IDEMPOTENCE check: replaying the
     trainer's FULL current weights onto an in-sync server must be a no-op. For
     each parameter we snapshot every ``copy_`` destination (the exact internal
@@ -134,7 +309,7 @@ def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tens
     orig_copy = torch.Tensor.copy_
 
     by_param = _VERIFY_STATS.setdefault("by_param", {})
-    for p in params:
+    for unit in _atomic_units(params):
         touched: dict = {}
 
         def snap_then_copy_(self: torch.Tensor, src: torch.Tensor, *args, _touched=touched, **kwargs) -> torch.Tensor:
@@ -145,17 +320,25 @@ def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tens
 
         torch.Tensor.copy_ = snap_then_copy_
         try:
-            _apply_dense(model, [p], values)
+            # SGLang's DSv4 loader creates its fusion cache inside one
+            # load_weights() call and asserts that all members drained before
+            # returning. Verification must replay the same atomic units as the
+            # seed and sparse apply paths, not one manifest entry at a time.
+            _apply_dense(model, unit, values, values_bytes)
         finally:
             torch.Tensor.copy_ = orig_copy
         bad = 0
         for dst, pre in touched.values():
             if dst.is_floating_point() and dst.element_size() == 2:
                 bad += int((dst.view(torch.int16) != pre.view(torch.int16)).sum())
+            elif dst.element_size() == 1:
+                # fp8 codes: bit compare via uint8 (eq on float8 is not portable)
+                bad += int((dst.view(torch.uint8) != pre.view(torch.uint8)).sum())
             else:
                 bad += int((dst != pre).sum())
         if bad:
-            by_param[p["name"]] = by_param.get(p["name"], 0) + bad
+            unit_name = " + ".join(p["name"] for p in unit)
+            by_param[unit_name] = by_param.get(unit_name, 0) + bad
         _VERIFY_STATS["pieces"].append(bad)
     _VERIFY_STATS["params"] += len(params)
     if is_last:
@@ -174,39 +357,84 @@ def _verify_dense(model: torch.nn.Module, params: list[dict], values: torch.Tens
             )
 
 
-def _decode_one(encoding: str, positions: torch.Tensor, values: torch.Tensor, p: dict) -> torch.Tensor:
+def _decode_one(
+    encoding: str, positions: torch.Tensor, values: torch.Tensor, p: dict, values_bytes: bool = False
+) -> torch.Tensor:
     """Densify one param's sparse delta into a full-shape NaN-masked tensor.
 
-    ``indices`` positions are reinterpreted via an int32 view (8 B/element
-    transient) rather than a per-byte int64 unpack (32 B/element), so even a
-    full-seed flush of a large embedding stays within a few GiB.
+    ``indices`` positions use their manifest width (3 or 4 bytes) and expand
+    directly to int32 before the int64 index required by ``index_copy_``.
+    ``values_bytes`` marks a mixed-dtype flush: value offsets are BYTE offsets
+    into a uint8 blob and each slice is reinterpreted (the clone re-bases to
+    storage offset 0 for the dtype view).
     """
     numel = math.prod(p["shape"])
     dtype = getattr(torch, p["dtype"])
-    flat = torch.full((numel,), float("nan"), dtype=dtype, device=values.device)
     vals = values[p["val_start"] : p["val_end"]]
-    if vals.numel() == 0:
-        return flat.view(p["shape"])
 
     pos_b = positions[p["pos_start"] : p["pos_end"]]
     if encoding == "indices":
-        # pos_start is always int32-aligned (each entry packs nnz * 4 bytes).
-        idx = pos_b.view(torch.int32).to(torch.int64)
+        idx = unpack_absolute_indices(pos_b, p["pos_width"]).to(torch.int64)
     else:
         raise ValueError(f"unsupported delta encoding: {encoding!r}")
 
-    flat.index_copy_(0, idx, vals.to(dtype))
+    if dtype.itemsize == 1:
+        # float8 codes: torch's float8 kernel coverage (index_copy, full-with-
+        # nan) is spotty across builds; densify entirely in byte space -- the
+        # NaN sentinel is the all-ones magnitude byte and positions map 1:1.
+        flat_u8 = torch.full((numel,), 0x7F, dtype=torch.uint8, device=values.device)
+        if vals.numel():
+            flat_u8.index_copy_(0, idx, vals.clone().view(torch.uint8))
+        return flat_u8.view(dtype).view(p["shape"])
+
+    flat = torch.full((numel,), float("nan"), dtype=dtype, device=values.device)
+    if vals.numel() == 0:
+        return flat.view(p["shape"])
+    if values_bytes:
+        vals = vals.clone().view(dtype)
+    flat.index_copy_(0, idx, vals if values_bytes else vals.to(dtype))
     return flat.view(p["shape"])
 
 
+def _param_storage_index(model: torch.nn.Module) -> list[tuple[int, int]]:
+    """Sorted, merged ``(start, end)`` byte intervals of every parameter's and
+    persistent buffer's storage. The masked-copy patch consults this so its
+    skip-NaN semantics apply ONLY to writes that land in model state: any other
+    ``copy_`` a loader performs on the way (scratch buffers, repacking temps,
+    quant workspaces) must keep vanilla semantics, NaNs and all. Rebuilt per
+    flush -- a named_parameters walk, microseconds against a wire decode."""
+    spans = []
+    for _, t in itertools.chain(model.named_parameters(), model.named_buffers()):
+        if t.device.type == "meta" or t.numel() == 0:
+            continue
+        base = t.untyped_storage().data_ptr()
+        spans.append((base, base + t.untyped_storage().nbytes()))
+    spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in spans:
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _in_param_storage(index: list[tuple[int, int]], t: torch.Tensor) -> bool:
+    ptr = t.data_ptr()
+    i = bisect.bisect_right(index, (ptr, float("inf"))) - 1
+    return i >= 0 and index[i][0] <= ptr < index[i][1]
+
+
 @contextmanager
-def _masked_copy() -> Iterator[None]:
+def _masked_copy(storage_index: list[tuple[int, int]]) -> Iterator[None]:
     """Temporarily make ``Tensor.copy_`` skip NaN positions in the source.
 
     SGLang's per-model ``load_weights`` ultimately lands on ``param.copy_(loaded)``
     (possibly on a narrowed TP slice). Under this context a NaN-masked source
     overwrites only the changed positions; fully dense sources (e.g. the first
-    full-seed flush) take the original fast path untouched.
+    full-seed flush) take the original fast path untouched. The masked
+    semantics are scoped to destinations inside ``storage_index`` (model
+    params/buffers): any other copy a loader performs passes through vanilla.
     """
     orig_copy = torch.Tensor.copy_
 
@@ -216,8 +444,21 @@ def _masked_copy() -> Iterator[None]:
         # parameter -- ruinous for MoE flushes carrying >10k per-expert
         # entries. ``torch.where`` keeps everything on-stream; a NaN-free
         # (dense) source degenerates to a plain copy.
-        if isinstance(src, torch.Tensor) and src.is_floating_point() and self.shape == src.shape:
+        if (
+            isinstance(src, torch.Tensor)
+            and src.is_floating_point()
+            and self.shape == src.shape
+            and _in_param_storage(storage_index, self)
+        ):
             cast = src.to(self.dtype)
+            if cast.element_size() == 1:
+                # float8 masked overlay entirely in byte space: NaN sentinel is
+                # the all-ones magnitude byte (isnan/where on float8 are not
+                # portable across torch builds; uint8 ops are).
+                cu8 = cast.contiguous().view(torch.uint8)
+                nan_mask = (cu8 & 0x7F) == 0x7F
+                merged = torch.where(nan_mask, self.contiguous().view(torch.uint8), cu8)
+                return orig_copy(self, merged.view(self.dtype))
             return orig_copy(self, torch.where(torch.isnan(cast), self, cast))
         return orig_copy(self, src, *args, **kwargs)
 

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -357,7 +357,25 @@ class ServerAdapter(BaseRollout):
                 await self._engine.load_lora_adapter_from_tensor(req)
         else:
             update_weights_bucket_bytes = int(self.config.checkpoint_engine.update_weights_bucket_megabytes) << 20
-            if self.config.get("quantization", None) == "fp8":
+            # Serialized DSv4 FP8 checkpoints need their native ue8m0
+            # conversion even when rollout.quantization is not set.
+            from verl.utils.sglang.sglang_fp8_utils import named_tensors_quant_mode
+
+            quant_mode = named_tensors_quant_mode(
+                self.config.get("quantization", None), self.model_config.hf_config
+            )
+            if quant_mode == "dsv4":
+                # DSv4 ships a serialized fp8(ue8m0) ckpt with native naming;
+                # quantize by the ckpt's own manifest instead of name rules.
+                from verl.utils.sglang.sglang_fp8_utils import DeepseekV4FP8QuantizerHelper
+
+                logger.info("Convert bf16 weights to DSv4-native fp8(ue8m0) before loading")
+                fp8_quantizer_helper = DeepseekV4FP8QuantizerHelper(
+                    self.model_config.hf_config.quantization_config,
+                    self.model_config.local_path,
+                )
+                weights = fp8_quantizer_helper.quant_weights_by_name(weights)
+            elif quant_mode == "generic":
                 from verl.utils.sglang.sglang_fp8_utils import SGLangFP8QuantizerHelper
 
                 logger.info("Convert bf16 weights to fp8 format before loading")
@@ -366,9 +384,6 @@ class ServerAdapter(BaseRollout):
                     weights,
                     dtype=self.model_config.hf_config.dtype,
                 )
-            else:
-                weights = weights
-
             fusion_groups = (
                 DEEPSEEK_V4_FUSION_GROUPS
                 if getattr(self.model_config.hf_config, "model_type", None) == "deepseek_v4"

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -21,22 +21,10 @@ import torch
 import torch.distributed as dist
 
 from verl.utils.device import get_device_name
+from verl.utils.fusion_groups import DEEPSEEK_V4_FUSION_GROUPS
 from verl.workers.rollout.utils import ensure_async_iterator
 
 SGLANG_LORA_NAME = "verl_actor_lora_name"
-
-_DEEPSEEK_V4_FUSION_MEMBERS = (
-    ("wq_a.weight", "wkv.weight"),
-    ("wq_a.scale", "wkv.scale"),
-    ("wq_a.weight_scale_inv", "wkv.weight_scale_inv"),
-    ("compressor.wkv.weight", "compressor.wgate.weight"),
-    ("indexer.compressor.wkv.weight", "indexer.compressor.wgate.weight"),
-)
-DEEPSEEK_V4_FUSION_GROUPS = tuple(
-    tuple(f".{attention}.{member}" for member in members)
-    for attention in ("self_attn", "attn")
-    for members in _DEEPSEEK_V4_FUSION_MEMBERS
-)
 
 
 def _fusion_key(name: str, groups: tuple[tuple[str, ...], ...]):

--- a/verl/workers/rollout/vllm_rollout/delta_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/delta_weight_transfer.py
@@ -137,7 +137,7 @@ def decode_delta_payload(
 ) -> tuple[str, list[CheckpointWeightPatch]]:
     """Validate and decode one DeltaFlush into vLLM checkpoint patches."""
 
-    from verl.checkpoint_engine.delta_sync.encode import checksum
+    from verl.checkpoint_engine.delta_sync.encode import checksum, unpack_absolute_indices
 
     CheckpointWeightPatch, _ = _checkpoint_patch_api()
     tensors = dict(named_tensors)
@@ -176,12 +176,11 @@ def decode_delta_payload(
         if encoding == "dense":
             patch_indices = None
         else:
-            if param_spec["pos_width"] != 4:
-                raise ValueError(f"{name}: indices encoding requires pos_width=4")
+            pos_width = param_spec["pos_width"]
             pos_bytes = positions[param_spec["pos_start"] : param_spec["pos_end"]]
-            if pos_bytes.numel() != patch_values.numel() * 4:
+            if pos_bytes.numel() != patch_values.numel() * pos_width:
                 raise ValueError(f"{name}: position and value slices have inconsistent lengths")
-            patch_indices = pos_bytes.view(torch.int32)
+            patch_indices = unpack_absolute_indices(pos_bytes, pos_width)
 
         patches.append(
             CheckpointWeightPatch(


### PR DESCRIPTION
## Summary

- select FP8 transport from checkpoint tensor dtypes instead of experiment-only flags
- seed and update DeepSeek-V4 `ue8m0` weights through the same sharded producer, preserving checkpoint scales and mixed FP8/FP32 wire dtypes
- keep SGLang fused-tensor updates atomic across seed, delta, and verification loads, and add fail-closed state verification
- move each rank's exact-length sparse blobs with matched point-to-point operations instead of padding every rank to the busiest sender
- pack absolute positions into 24 bits for tensors with at most 2^24 elements, retaining the existing int32 layout for larger tensors
- derive the static HF block-owner map from the communication-stubbed Megatron probe and MAX-reduce only amax cells whose 128x128 block actually crosses ranks
- shard checkpoint-scale ownership blockwise during the seed, so rank-local scale cells never need an amax collective and shared scale tensors still reconstruct exactly
- keep the documented SGLang 0.5.12 path self-contained by adapting public DeepSeek-V4 config aliases when Transformers cannot load `deepseek_v4`, and by decoding its base64-int32 routing-replay payload

## Why this is not a duplicate

No open PR matched the DeepSeek-V4 FP8 `delta_sharded` Megatron-to-SGLang fidelity path. PRs #7186 and #7519 create MXFP8 weights dynamically during training/rollout; this change instead preserves the serialized DeepSeek-V4 `ue8m0` checkpoint representation, its checkpoint scales, and special FP32 tensors during sharded synchronization. The reproduced failure and acceptance evidence are tracked in <https://github.com/ChangyiYang/verl/issues/13>.

## Tests

Run in the exact `verlai/verl:sgl0512.latest`-derived container image:

```text
PYTHONPATH=.:/data/pydeps/verl_sgl0512 python -m pytest -q \
  tests/checkpoint_engine/test_fp8_quant_selection.py \
  tests/checkpoint_engine/test_ue8m0_seed.py \
  tests/checkpoint_engine/test_fp32_wire_fidelity.py \
  tests/checkpoint_engine/test_sglang_loader.py \
  tests/checkpoint_engine/test_sharded_delta.py \
  tests/workers/test_dsv4_sglang_compat_on_cpu.py
# 55 passed, 1 skipped

PYTHONPATH=.:/data/pydeps/verl_sgl0512 python -m pytest -q tests/checkpoint_engine \
  -k "not correctness_on_gpu and not correctness_on_npu and not special_server_adapter"
# 98 passed, 1 skipped, 12 deselected

torchrun --standalone --nproc-per-node=2 \
  tests/special_distributed/test_sharded_delta_gather.py
# OVERALL: ALL PASS; cross-block case communicated 2/6 dense scale cells

python -m py_compile <all changed Python files>
git diff --check upstream/main...HEAD
```

End-to-end acceptance on the final clean head used 40 B300 GPUs (4 Megatron trainer nodes + 1 SGLang rollout node). Slurm job 16334 completed 2/2 steps with root state `COMPLETED`, exit 0:

- initial `ue8m0` seed: 267.6 GB in 69.2 s, 33,346 checkpoint-scale hits, 0 misses
- full fail-closed verifier: 267.6 GB in 217.4 s; successful continuation certifies `changed=0, missing=0`
- post-optimizer steady delta: 25,522,979,370 changed elements (8.976%), 97,506.35 MiB, 119 flushes, 24.005 s end-to-end
- both training steps completed with zero aborted rollouts

### Same-setting sync comparison

Jobs 12568 and 13761 used the same model, data, parallelism, 40 B300 GPUs, and two-step training configuration; only the checkpoint-engine backend changed. The fair steady-state comparison is each run's post-optimizer step:

| Backend | Job | Steady weight sync | Relative to full NCCL |
| --- | ---: | ---: | ---: |
| Full NCCL | 13761 | 515.493 s | 1.00x |
| `delta_sharded` | 12568 | 35.173 s | **14.66x faster** |

This saves 480.32 s per steady training step, a 93.2% reduction in weight-sync wall time. Both jobs completed 2/2 steps with zero aborted rollouts.

### Exact-length sparse gather comparison

Jobs 13963 and 14009 used the same profile-branch commit and full training configuration, with tracing disabled. The only transport difference was exact-length P2P versus the previous padded `dist.gather`. Both runs completed 2/2 steps with exit 0 and zero aborted rollouts.

| Sparse gather | Job | Changed elements | Useful payload | Steady weight sync |
| --- | ---: | ---: | ---: | ---: |
| Padded `dist.gather` | 14009 | 26,242,915,871 | 125,258.889 MiB | 34.085577 s |
| Exact-length P2P | 13963 | 25,735,354,156 | 122,838.568 MiB | 30.564398 s |

The raw wall-time reduction is **10.33%**. Normalizing the padded run linearly to the P2P run's useful payload gives 33.426957 s, so the payload-normalized reduction is **8.56%** (9.37% higher effective throughput). The count matrix is already shared by every rank, so the implementation uses it as the single source of truth for matched receive/send sizes and skips empty peers.

### 24-bit absolute positions

Position indices were 79.9% of the traced steady payload. The wire format now uses a fixed three-byte little-endian absolute index for tensors with at most 2^24 elements and keeps int32 for larger tensors; 98.1% of this checkpoint's elements are in eligible tensors. Both consumers decode the width recorded in each parameter manifest, including unaligned mixed 24/32-bit slices.

The final clean-head job 16334 used automatic width selection, the normal checksum path, and 1 GiB buckets. Compared with the same 1 GiB/int32 configuration in job 14546, normalizing linearly for changed-element count gives:

| Position encoding | Job | Changed elements | Useful payload | Steady weight sync |
| --- | ---: | ---: | ---: | ---: |
| int32 | 14546 | 24,225,054,794 | 115,636.74 MiB | 25.011 s |
| 24-bit + int32 fallback | 16334 | 25,522,979,370 | 97,506.35 MiB | 24.005 s |

At job 16334's changed-element count, the int32 baseline projects to 121,832.30 MiB and 26.351 s. The packed format therefore reduces useful payload by **19.97%**, lowers normalized wall time by **8.90%**, and raises effective changed-element throughput by **9.77%**. Receiver staging remained bounded at 3.21 GB.

### Cross-rank amax compaction

The previous quantized exporter MAX-reduced every FP32 amax cell in each merge
group, even when a 128x128 block belonged to exactly one trainer rank. The
export probe already exposes structural HF-coordinate ownership: local entries
are finite and remote TP/ETP placeholders are NaN. The new path exchanges that
boolean owner map once, caches compact `owner_count > 1` positions, and performs
steady MAX collectives only for those positions. Singleton scale cells stay on
their unique owner; shared cells are reduced and emitted by group rank zero.
The seed carries within-scale positions and reconstructs each dense scale slot
with the existing exact-length sparse gather.

Cross-rank blocks are real whenever a TP/ETP shard boundary is not aligned to
the quantization block. The two-GPU NCCL test uses a 384x256 column-parallel
matrix split at row 192: only the middle 128-row block crosses ranks, so exactly
2 of 6 amax cells are communicated and the dense scale reconstructs to
`[1, 2, 30, 40, 50, 60]`. For this DSv4 checkpoint, TP=8 splits each of the 44
`layers.*.attn.wkv.weight` tensors (512x4096) into 64-row shards, yielding 5,632
shared scale cells, or 22,528 bytes of steady FP32 MAX payload. The current
40-GPU acceptance topology uses TP=ETP=1, so PP/EP own whole layers/experts and
the cross-rank amax payload is zero.

Slurm job 55418 exercised the final implementation end to end on that 40-B300
topology and completed 2/2 steps with root exit 0 in 59:56. All 32 trainer
ranks reported `cross_rank_cells=0`, so the steady FP32 MAX payload was zero.
The run completed a 267.6 GB seed in 88.6 s and a fail-closed 267.6 GB full
verification in 212.3 s. Its post-optimizer steady delta changed
26,486,778,629 elements (9.315%), sent 101,183.15 MiB in 124 flushes, and
completed the rollout weight sync in 18.901 s. Both training steps had zero
aborted rollouts.

## AI assistance

Developed with AI assistance.
