### PR TITLE
[rollout, vllm] fix: skip detokenize in vLLM rollout SamplingParams

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -629,6 +629,15 @@ class vLLMHttpServer:
             extra_args["kv_transfer_params"] = kv_transfer_params
             sampling_params["extra_args"] = extra_args
 
+        # verl rollout is token-in-token-out: the output path below only reads token_ids
+        # and numeric logprobs (never .text), so detokenizing every generated token into a
+        # string is pure overhead. Skip it. Guard: string-based `stop` / `bad_words` need
+        # detokenized text to match, so only skip when neither is used (`stop_token_ids`
+        # is unaffected). Teacher requests already set detokenize=False upstream, so this
+        # setdefault leaves them untouched.
+        if not sampling_params.get("stop") and not sampling_params.get("bad_words"):
+            sampling_params.setdefault("detokenize", False)
+
         sampling_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
         prompt_ids = qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
         multi_modal_data = {}


### PR DESCRIPTION
## Summary

  verl's vLLM rollout is token-in-token-out: `vLLMHttpServer.generate` only consumes `outputs[0].token_ids`, `logprobs`, `finish_reason`, and `num_preempted`. It never reads `.text`. Yet vLLM's default `SamplingParams.detokenize=True` still runs
  the tokenizer decode step for every generated token on the rollout hot path — pure overhead.

  This PR sets `detokenize=False` on the rollout `SamplingParams` when it's safe to do so, mirroring the same fix that already landed in the teacher path (#7648).

  ## Change

  One block in `verl/workers/rollout/vllm_rollout/vllm_async_server.py::vLLMHttpServer.generate`, right before `SamplingParams(...)` is built:

  ```python
  if not sampling_params.get("stop") and not sampling_params.get("bad_words"):
      sampling_params.setdefault("detokenize", False)
```

  - setdefault (not =) preserves any caller-supplied value.
  - Guard skips the optimization when string-based stop / bad_words are used, since those matchers need detokenized text. stop_token_ids is unaffected.
  - Teacher requests already set detokenize=False upstream (#7648), so this is a no-op for them.