### PR TITLE
[doc] fix: update rollout backends list in install.rst

### DIFF
--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -10,7 +10,7 @@ Requirements
 verl supports various backends. Currently, the following configurations are available:
 
 - **FSDP** and **Megatron-LM** (optional) for training.
-- **SGLang**, **vLLM** and **TGI** for rollout generation.
+- **vLLM**, **SGLang**, **TensorRT-LLM** and **HF** for rollout generation.
 
 Choices of Backend Engines
 ----------------------------
@@ -26,7 +26,7 @@ For inference, vllm 0.18.0 and later versions are supported; older releases are 
 
 For SGLang, refer to the :doc:`SGLang Backend<../workers/sglang_worker>` for detailed installation and usage instructions. SGLang rollout is under extensive development and offers many advanced features and optimizations. We encourage users to report any issues or provide feedback via the `SGLang Issue Tracker <https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/issues/106>`_.
 
-For huggingface TGI integration, it is usually used for debugging and single GPU exploration.
+For HuggingFace (``hf``) rollout, it is usually used for debugging and single GPU exploration.
 
 Install with uv
 ---------------------------------------------------------


### PR DESCRIPTION
## Summary

`docs/start/install.rst` still says rollout generation uses **SGLang, vLLM and TGI**, and describes huggingface TGI as the debug/single-GPU option. That is stale relative to the current config:

- `verl/trainer/config/rollout/rollout.yaml` documents `actor_rollout_ref.rollout.name: hf/vllm/sglang/trtllm`
- TGI is no longer a rollout name; HF is the debug/single-GPU backend

This PR updates the backends list to **vLLM, SGLang, TensorRT-LLM and HF**, and replaces the TGI sentence with HuggingFace (`hf`) rollout.

## Repro

On `5b79827b04cee6e4b7b5ff737e047f1d72d50433`:

```bash
# Stale doc lines
sed -n '13,29p' docs/start/install.rst

# Current enum in config
rg -n 'hf/vllm/sglang/trtllm' verl/trainer/config/rollout/rollout.yaml
```

## Test plan

- [x] Diff limited to `docs/start/install.rst`
- [x] Confirmed wording matches `rollout.yaml` name enum (`hf` / `vllm` / `sglang` / `trtllm`)
- [x] No remaining TGI mentions in this file
- [ ] Docs render check (optional)