### PR TITLE
[doc] fix: mark SGLang as supported on AMD ROCm in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Furthermore, FSDP2 cpu offloading is compatible with gradient accumulation. You 
 
 ## AMD Support (ROCm Kernel)
 
-verl runs on AMD ROCm GPUs (MI300X / MI325X / MI355X) with FSDP, FSDP2, and Megatron trainer backends, and vLLM as the validated inference engine (SGLang support is in progress). See the [AMD ROCm quick-start guide](https://github.com/verl-project/verl/blob/main/docs/amd_tutorial/amd_quick_start.rst) for container bring-up, environment verification, and training examples.
+verl runs on AMD ROCm GPUs (MI300X / MI325X / MI355X) with FSDP, FSDP2, and Megatron trainer backends, and vLLM and SGLang as validated inference engines. See the [AMD ROCm quick-start guide](https://github.com/verl-project/verl/blob/main/docs/amd_tutorial/amd_quick_start.rst) for container bring-up, environment verification, and training examples.
 
 ## Citation and acknowledgement
 


### PR DESCRIPTION
### What does this PR do?

Update the README AMD Support blurb so it matches `docs/amd_tutorial/amd_quick_start.rst`, which already documents full **vLLM** and **SGLang** support on ROCm. The previous "(SGLang support is in progress)" wording was stale.

### Test

N/A — documentation-only one-liner. Verified against `docs/amd_tutorial/amd_quick_start.rst` ("Inference engine: fully supports **vLLM** and **SGLang**").

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Documentation-only change.
- [x] No functional code modifications.