### PR TITLE
[doc] fix: point TRT-LLM fully-async example at existing 8_8 script

### DIFF
--- a/docs/workers/trtllm_worker.rst
+++ b/docs/workers/trtllm_worker.rst
@@ -71,4 +71,4 @@ Using TensorRT-LLM rollout in fully async with GRPO
 .. code-block:: bash
 
     # Fully async policy with Megatron-Core training engine
-    bash verl/experimental/fully_async_policy/shell/grpo_30b_a3b_base_math_megatron_4_4_mis_trtllm.sh
+    bash verl/experimental/fully_async_policy/shell/grpo_30b_a3b_base_math_megatron_8_8_mis_trtllm.sh


### PR DESCRIPTION
## Summary
- `docs/workers/trtllm_worker.rst` referenced `grpo_30b_a3b_base_math_megatron_4_4_mis_trtllm.sh`, which does not exist on `main`.
- Update the fully-async GRPO + TensorRT-LLM example to `grpo_30b_a3b_base_math_megatron_8_8_mis_trtllm.sh` (present under `verl/experimental/fully_async_policy/shell/`).

## Test plan
- [x] Confirmed `..._4_4_mis_trtllm.sh` is 404 on `main`
- [x] Confirmed `..._8_8_mis_trtllm.sh` exists on `main`
- [x] Docs-only one-line path fix