### PR TITLE
[megatron] feat: deduplicate host parameter-offload replicas

### DIFF
--- a/tests/utils/megatron/test_param_offload_deduplication.py
+++ b/tests/utils/megatron/test_param_offload_deduplication.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import create_autospec
+
+import pytest
+import torch
+
+from verl.utils import megatron_utils
+
+
+def _non_owner_group():
+    return megatron_utils.MegatronParamOffloadGroup(process_group=object(), source_rank=0, is_owner=False)
+
+
+def _owner_group():
+    return megatron_utils.MegatronParamOffloadGroup(process_group=object(), source_rank=0, is_owner=True)
+
+
+def test_param_offload_group_builder_uses_dense_and_expert_replica_groups(monkeypatch):
+    dense_process_group = object()
+    expert_process_group = object()
+    get_dense_group = create_autospec(
+        lambda with_context_parallel, with_gtp_remat=True: None, return_value=dense_process_group
+    )
+    get_expert_group = create_autospec(lambda with_gtp_remat=True: None, return_value=expert_process_group)
+    monkeypatch.setattr(megatron_utils.mpu, "get_data_parallel_group", get_dense_group)
+    monkeypatch.setattr(megatron_utils.mpu, "get_expert_data_parallel_group", get_expert_group)
+    monkeypatch.setattr(megatron_utils, "_make_param_offload_group", lambda process_group: process_group)
+
+    groups = megatron_utils.build_megatron_param_offload_groups(enabled=True)
+
+    assert groups.dense is dense_process_group
+    assert groups.expert is expert_process_group
+    get_dense_group.assert_called_once_with(with_context_parallel=True, with_gtp_remat=False)
+    get_expert_group.assert_called_once_with(with_gtp_remat=False)
+
+
+def test_param_offload_group_builder_supports_mcore_without_gtp_remat(monkeypatch):
+    dense_process_group = object()
+    expert_process_group = object()
+    get_dense_group = create_autospec(lambda with_context_parallel: None, return_value=dense_process_group)
+    get_expert_group = create_autospec(lambda: None, return_value=expert_process_group)
+    monkeypatch.setattr(megatron_utils.mpu, "get_data_parallel_group", get_dense_group)
+    monkeypatch.setattr(megatron_utils.mpu, "get_expert_data_parallel_group", get_expert_group)
+    monkeypatch.setattr(megatron_utils, "_make_param_offload_group", lambda process_group: process_group)
+
+    groups = megatron_utils.build_megatron_param_offload_groups(enabled=True)
+
+    assert groups.dense is dense_process_group
+    assert groups.expert is expert_process_group
+    get_dense_group.assert_called_once_with(with_context_parallel=True)
+    get_expert_group.assert_called_once_with()
+
+
+def test_param_offload_group_builder_returns_none_without_replicas(monkeypatch):
+    monkeypatch.setattr(megatron_utils, "_get_megatron_param_replica_process_groups", lambda: (object(), object()))
+    monkeypatch.setattr(megatron_utils, "_make_param_offload_group", lambda process_group: None)
+
+    assert megatron_utils.build_megatron_param_offload_groups(enabled=True) is None
+
+
+def test_non_owner_ddp_buffer_keeps_no_cpu_copy_and_restores_from_broadcast(monkeypatch):
+    expected = torch.arange(12, dtype=torch.float32)
+    buffer = SimpleNamespace(param_data=expected.clone())
+    group = _non_owner_group()
+
+    megatron_utils._offload_ddp_param_buffer(buffer, group)
+
+    assert buffer.param_data.storage().size() == 0
+    assert buffer.param_data.cpu_data is None
+    monkeypatch.setattr(
+        megatron_utils,
+        "_broadcast_offloaded_parameter",
+        lambda tensor, unused_group: tensor.copy_(expected),
+    )
+    megatron_utils._load_ddp_param_buffer(buffer, group)
+    torch.testing.assert_close(buffer.param_data, expected)
+
+
+@pytest.mark.parametrize("group", [None, _owner_group()], ids=["default", "owner"])
+def test_ddp_owner_reuses_cpu_copy_across_round_trip(monkeypatch, group):
+    torch_empty = torch.empty
+
+    def empty_without_pin_memory(*args, **kwargs):
+        kwargs.pop("pin_memory", None)
+        return torch_empty(*args, **kwargs)
+
+    monkeypatch.setattr(megatron_utils.torch, "empty", empty_without_pin_memory)
+    monkeypatch.setattr(megatron_utils, "_broadcast_offloaded_parameter", lambda tensor, unused_group: None)
+    buffer = SimpleNamespace(param_data=torch.arange(12, dtype=torch.float32))
+
+    megatron_utils._offload_ddp_param_buffer(buffer, group)
+    cpu_data = buffer.param_data.cpu_data
+    megatron_utils._load_ddp_param_buffer(buffer, group)
+    buffer.param_data.add_(1)
+    expected = buffer.param_data.clone()
+    megatron_utils._offload_ddp_param_buffer(buffer, group)
+
+    assert buffer.param_data.cpu_data is cpu_data
+    torch.testing.assert_close(cpu_data, expected)
+
+
+def test_deduplicated_buffer_requires_its_group_on_reload():
+    buffer = SimpleNamespace(param_data=torch.ones(4))
+    megatron_utils._offload_ddp_param_buffer(buffer, _non_owner_group())
+
+    with pytest.raises(RuntimeError, match="missing parameter offload group"):
+        megatron_utils._load_ddp_param_buffer(buffer, None)
+
+    assert buffer.param_data.storage().size() == 0
+
+
+def test_repeated_default_offload_validates_cpu_backing_size():
+    param_data = torch.ones(4)
+    param_data.cpu_data = torch.ones(3)
+    buffer = SimpleNamespace(param_data=param_data, param_data_size=4)
+    param_data.storage().resize_(0)
+
+    with pytest.raises(AssertionError):
+        megatron_utils._offload_ddp_param_buffer(buffer, None)
+
+
+def test_expert_parameter_uses_expert_replica_group():
+    dense_group = _non_owner_group()
+    expert_group = _non_owner_group()
+    groups = megatron_utils.MegatronParamOffloadGroups(dense=dense_group, expert=expert_group)
+    dense = torch.nn.Parameter(torch.ones(1))
+    expert = torch.nn.Parameter(torch.ones(1))
+    expert.allreduce = False
+
+    assert megatron_utils._parameter_offload_group(dense, groups) is dense_group
+    assert megatron_utils._parameter_offload_group(expert, groups) is expert_group
+    assert megatron_utils._parameter_offload_group(dense, None) is None
+
+
+def test_snapshot_skips_non_owner_buffer_without_cpu_copy(monkeypatch):
+    expected = torch.arange(12, dtype=torch.float32)
+    buffer = SimpleNamespace(param_data=expected.clone())
+    model = SimpleNamespace(buffers=[buffer], expert_parallel_buffers=[])
+    monkeypatch.setattr(megatron_utils, "DDP", SimpleNamespace)
+    group = _non_owner_group()
+    groups = megatron_utils.MegatronParamOffloadGroups(dense=group, expert=None)
+
+    megatron_utils._offload_ddp_param_buffer(buffer, group)
+    state = megatron_utils.copy_megatron_model_to_cpu([model], param_offload_groups=groups)
+
+    assert state["model_chunk_0"]["buffer_states"][0][0]["param_data"] is None
+    with pytest.raises(ValueError, match="must match the saved Megatron CPU state"):
+        megatron_utils.restore_megatron_model_from_cpu([model], state)
+    monkeypatch.setattr(
+        megatron_utils,
+        "_broadcast_offloaded_parameter",
+        lambda tensor, unused_group: tensor.copy_(expected),
+    )
+    megatron_utils._load_ddp_param_buffer(buffer, group)
+    buffer.param_data.zero_()
+    megatron_utils.restore_megatron_model_from_cpu([model], state, param_offload_groups=groups)
+    torch.testing.assert_close(buffer.param_data, expected)
+
+
+def test_default_snapshot_omits_deduplication_marker():
+    state = megatron_utils.copy_megatron_model_to_cpu([torch.nn.Module()])
+
+    assert "deduplicated" not in state
+
+
+def test_non_ddp_snapshot_restores_loaded_non_owner_from_owner(monkeypatch):
+    expected = torch.arange(6, dtype=torch.float32)
+    model = torch.nn.Module()
+    model.register_parameter("weight", torch.nn.Parameter(expected.clone()))
+    group = _non_owner_group()
+    groups = megatron_utils.MegatronParamOffloadGroups(dense=group, expert=None)
+
+    megatron_utils._offload_replicated_parameter(model.weight, group)
+    state = megatron_utils.copy_megatron_model_to_cpu([model], param_offload_groups=groups)
+    assert state["model_chunk_0"]["model_state"]["weight"]["data"] is None
+
+    monkeypatch.setattr(
+        megatron_utils,
+        "_broadcast_offloaded_parameter",
+        lambda tensor, unused_group: tensor.copy_(expected),
+    )
+    megatron_utils._load_replicated_parameter(model.weight, group, "cpu")
+    model.weight.zero_()
+    megatron_utils.restore_megatron_model_from_cpu([model], state, param_offload_groups=groups)
+    torch.testing.assert_close(model.weight, expected)

--- a/tests/workers/config/test_engine_config_on_cpu.py
+++ b/tests/workers/config/test_engine_config_on_cpu.py
@@ -44,6 +44,17 @@ class TestMcoreEngineConfig:
         config = McoreEngineConfig(**{offload_field: True})
         assert getattr(config, offload_field) is True
 
+    def test_deduplicate_param_offload_requires_param_offload(self):
+        with pytest.raises(ValueError, match="requires param_offload"):
+            McoreEngineConfig(deduplicate_param_offload=True)
+
+        config = McoreEngineConfig(param_offload=True, deduplicate_param_offload=True)
+        assert config.deduplicate_param_offload is True
+
+    def test_deduplicate_param_offload_rejects_megatron_fsdp(self):
+        with pytest.raises(ValueError, match="not supported with use_megatron_fsdp"):
+            McoreEngineConfig(param_offload=True, deduplicate_param_offload=True, use_megatron_fsdp=True)
+
 
 class TestFSDPEngineConfigCPU:
     def test_default_values(self):

--- a/verl/experimental/separation/engine_workers.py
+++ b/verl/experimental/separation/engine_workers.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+from functools import partial
 from typing import Callable, Optional
 
 from omegaconf import DictConfig
@@ -103,7 +104,11 @@ class DetachActorWorker(ActorRolloutRefWorker):
                 restore_megatron_model_from_cpu,
             )
 
-            self._strategy_handlers = (copy_megatron_model_to_cpu, restore_megatron_model_from_cpu)
+            param_offload_groups = self.actor.engine._param_offload_groups
+            self._strategy_handlers = (
+                partial(copy_megatron_model_to_cpu, param_offload_groups=param_offload_groups),
+                partial(restore_megatron_model_from_cpu, param_offload_groups=param_offload_groups),
+            )
         else:
             raise NotImplementedError(f"Unsupported strategy: {strategy}")
 

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -45,6 +45,7 @@ actor_rollout_ref:
     megatron:
       _target_: verl.workers.config.McoreEngineConfig
       param_offload: false
+      deduplicate_param_offload: false
       optimizer_offload: false
       tensor_model_parallel_size: 1
       expert_model_parallel_size: 1
@@ -254,6 +255,7 @@ actor_rollout_ref:
     megatron:
       _target_: verl.workers.config.McoreEngineConfig
       param_offload: ${oc.select:actor_rollout_ref.actor.megatron.param_offload,False}
+      deduplicate_param_offload: ${oc.select:actor_rollout_ref.actor.megatron.deduplicate_param_offload,False}
       optimizer_offload: false
       tensor_model_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.tensor_model_parallel_size,1}
       expert_model_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.expert_model_parallel_size,1}
@@ -587,6 +589,7 @@ critic:
   megatron:
     _target_: verl.workers.config.McoreEngineConfig
     param_offload: false
+    deduplicate_param_offload: false
     optimizer_offload: false
     tensor_model_parallel_size: 1
     expert_model_parallel_size: 1

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -4,6 +4,9 @@ _target_: verl.workers.config.McoreEngineConfig
 # Whether to offload model parameters to CPU and release gradient buffers while inactive
 param_offload: False
 
+# Keep one host copy per dense/expert replica group and restore replicas via broadcast. Requires param_offload=True.
+deduplicate_param_offload: False
+
 # Whether to offload optimizer state to CPU
 optimizer_offload: False
 

--- a/verl/trainer/config/ref/megatron_ref.yaml
+++ b/verl/trainer/config/ref/megatron_ref.yaml
@@ -37,4 +37,5 @@ megatron:
   expert_model_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.expert_model_parallel_size,1}
   expert_tensor_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.expert_tensor_parallel_size,null}
   param_offload: ${oc.select:actor_rollout_ref.actor.megatron.param_offload,False}
+  deduplicate_param_offload: ${oc.select:actor_rollout_ref.actor.megatron.deduplicate_param_offload,False}
   forward_only: True

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -49,6 +49,166 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+@dataclass(frozen=True)
+class MegatronParamOffloadGroup:
+    """Ranks that hold identical parameter shards and share one CPU copy."""
+
+    process_group: Any
+    source_rank: int
+    is_owner: bool
+
+
+@dataclass(frozen=True)
+class MegatronParamOffloadGroups:
+    """Replica groups used by dense and expert parameter buffers."""
+
+    dense: MegatronParamOffloadGroup | None
+    expert: MegatronParamOffloadGroup | None
+
+
+def _make_param_offload_group(process_group) -> MegatronParamOffloadGroup | None:
+    if process_group is None or torch.distributed.get_world_size(process_group) <= 1:
+        return None
+    source_rank = torch.distributed.get_global_rank(process_group, 0)
+    return MegatronParamOffloadGroup(
+        process_group=process_group,
+        source_rank=source_rank,
+        is_owner=torch.distributed.get_rank(process_group) == 0,
+    )
+
+
+def _get_megatron_param_replica_process_groups():
+    """Return dense and expert groups whose ranks hold identical parameters."""
+    dense_kwargs = {"with_context_parallel": True}
+    if "with_gtp_remat" in inspect.signature(mpu.get_data_parallel_group).parameters:
+        dense_kwargs["with_gtp_remat"] = False
+
+    expert_kwargs = {}
+    if "with_gtp_remat" in inspect.signature(mpu.get_expert_data_parallel_group).parameters:
+        expert_kwargs["with_gtp_remat"] = False
+
+    return (
+        mpu.get_data_parallel_group(**dense_kwargs),
+        mpu.get_expert_data_parallel_group(**expert_kwargs),
+    )
+
+
+def build_megatron_param_offload_groups(enabled: bool) -> MegatronParamOffloadGroups | None:
+    """Build groups of ranks that own identical dense or expert shards."""
+    if not enabled:
+        return None
+    dense_process_group, expert_process_group = _get_megatron_param_replica_process_groups()
+    groups = MegatronParamOffloadGroups(
+        dense=_make_param_offload_group(dense_process_group),
+        expert=_make_param_offload_group(expert_process_group),
+    )
+    return groups if groups.dense is not None or groups.expert is not None else None
+
+
+def _parameter_offload_group(
+    param: torch.nn.Parameter,
+    groups: MegatronParamOffloadGroups | None,
+) -> MegatronParamOffloadGroup | None:
+    if groups is None:
+        return None
+    return groups.dense if getattr(param, "allreduce", True) else groups.expert
+
+
+def _ddp_param_buffer_groups(model_chunk, groups: MegatronParamOffloadGroups | None):
+    return (
+        (model_chunk.buffers, groups.dense if groups else None),
+        (model_chunk.expert_parallel_buffers, groups.expert if groups else None),
+    )
+
+
+def _broadcast_offloaded_parameter(tensor: torch.Tensor, group: MegatronParamOffloadGroup) -> None:
+    torch.distributed.broadcast(tensor, src=group.source_rank, group=group.process_group)
+
+
+def _offload_ddp_param_buffer(buffer, group: MegatronParamOffloadGroup | None) -> None:
+    param_data = buffer.param_data
+    if param_data.storage().size() == 0:
+        if group is None or group.is_owner:
+            assert buffer.param_data_size == param_data.cpu_data.storage().size()
+        return
+    if group is None or group.is_owner:
+        # Reuse the pinned host buffer to avoid a transient 2x host-memory peak.
+        existing = getattr(param_data, "cpu_data", None)
+        if existing is None:
+            param_data.cpu_data = torch.empty(param_data.size(), dtype=param_data.dtype, device="cpu", pin_memory=True)
+            buffer.param_data_size = param_data.storage().size()
+        else:
+            assert existing.shape == param_data.shape, (
+                f"cpu_data shape {tuple(existing.shape)} != param_data shape {tuple(param_data.shape)}; "
+                "reallocating would reintroduce the 2x peak."
+            )
+            assert existing.dtype == param_data.dtype, (
+                f"cpu_data dtype {existing.dtype} != param_data dtype {param_data.dtype}; "
+                "reallocating would reintroduce the 2x peak."
+            )
+        # Complete the blocking D2H copy before releasing device storage.
+        param_data.cpu_data.copy_(param_data, non_blocking=False)
+        assert buffer.param_data_size == param_data.cpu_data.storage().size()
+    else:
+        buffer.param_data_size = param_data.storage().size()
+        param_data.cpu_data = None
+    param_data.storage().resize_(0)
+
+
+def _load_ddp_param_buffer(buffer, group: MegatronParamOffloadGroup | None) -> None:
+    param_data = buffer.param_data
+    if param_data.storage().size() != 0:
+        return
+    if group is None and getattr(param_data, "cpu_data", None) is None:
+        raise RuntimeError("missing parameter offload group for a deduplicated buffer")
+    param_data.storage().resize_(buffer.param_data_size)
+    if group is None or group.is_owner:
+        param_data.copy_(param_data.cpu_data, non_blocking=True)
+    if group is not None:
+        _broadcast_offloaded_parameter(param_data, group)
+
+
+def _offload_replicated_parameter(param: torch.nn.Parameter, group: MegatronParamOffloadGroup) -> None:
+    if getattr(param, "_verl_param_offloaded", False):
+        return
+    param._verl_offload_shape = tuple(param.shape)
+    param._verl_offload_stride = tuple(param.stride())
+    param._verl_param_offloaded = True
+    old_data = param.data
+    if group.is_owner:
+        if old_data.device.type != "cpu":
+            param.data = old_data.to("cpu")
+            if _can_safely_resize_storage(old_data):
+                old_data.storage().resize_(0)
+    else:
+        param.data = torch.empty(0, dtype=param.dtype, device="cpu")
+        if _can_safely_resize_storage(old_data):
+            old_data.storage().resize_(0)
+    if param.grad is not None and param.grad.device.type != "cpu":
+        old_grad = param.grad
+        param.grad = old_grad.to("cpu")
+        if _can_safely_resize_storage(old_grad):
+            old_grad.storage().resize_(0)
+
+
+def _load_replicated_parameter(param: torch.nn.Parameter, group: MegatronParamOffloadGroup, device) -> None:
+    if not getattr(param, "_verl_param_offloaded", False):
+        return
+    if group.is_owner:
+        param.data = param.data.to(device, non_blocking=True)
+    else:
+        param.data = torch.empty_strided(
+            param._verl_offload_shape,
+            param._verl_offload_stride,
+            dtype=param.dtype,
+            device=device,
+        )
+    _broadcast_offloaded_parameter(param.data, group)
+    if param.grad is not None:
+        param.grad = param.grad.to(device, non_blocking=True)
+    param._verl_param_offloaded = False
+
+
 def get_model_config(model):
     return get_attr_wrapped_model(model, "config", allow_none=False)
 
@@ -660,84 +820,52 @@ def _clear_te_fp8_weight_workspaces(model_chunk):
 
 
 @torch.no_grad()
-def offload_megatron_model_to_cpu(models):
+def offload_megatron_model_to_cpu(models, param_offload_groups: MegatronParamOffloadGroups | None = None):
     """
     In megatron, the model and optimizer storage are:
     - bf16 parameter data chunked in model parallel group
     - fp32 grad chunked in model parallel group
     - fp32 main_parameter chunked in model and dp group
     - fp32 optimizer state chunked in model and dp group
+
+    ``param_offload_groups`` enables one host parameter copy per replica group.
     """
+    if param_offload_groups is not None:
+        get_torch_device().synchronize()
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
-            for buffers in model_chunk_all_buffers:
+            for buffers, offload_group in _ddp_param_buffer_groups(model_chunk, param_offload_groups):
                 for buffer in buffers:
-                    # offload parameters
-                    if buffer.param_data.storage().size() > 0:
-                        # Reuse a single pinned cpu_data buffer per DDP buffer.
-                        # The previous implementation reallocated cpu_data via
-                        # `.cpu().pin_memory()` on every offload. Python evaluates
-                        # the RHS before the assignment, so the new pinned block is
-                        # allocated while the old cpu_data is still referenced --
-                        # peak host memory at the moment of allocation is 2x
-                        # param_data size. On large Megatron models this transient
-                        # peak exceeds the cgroup limit and OOMKills the pod even
-                        # though steady-state usage would be 1x. Reallocating here
-                        # would re-trigger the same 2x peak, so we allocate at most
-                        # once per buffer and assert shape/dtype invariance on
-                        # subsequent calls -- a mismatch means a caller rebuilt
-                        # param_data under us, which is a bug we want surfaced
-                        # rather than silently worked around.
-                        existing = getattr(buffer.param_data, "cpu_data", None)
-                        if existing is None:
-                            buffer.param_data.cpu_data = torch.empty(
-                                buffer.param_data.size(),
-                                dtype=buffer.param_data.dtype,
-                                device="cpu",
-                                pin_memory=True,
-                            )
-                            buffer.param_data_size = buffer.param_data.storage().size()
-                        else:
-                            assert existing.shape == buffer.param_data.shape, (
-                                f"cpu_data shape {tuple(existing.shape)} != "
-                                f"param_data shape {tuple(buffer.param_data.shape)}; "
-                                "reallocating would reintroduce the 2x peak."
-                            )
-                            assert existing.dtype == buffer.param_data.dtype, (
-                                f"cpu_data dtype {existing.dtype} != "
-                                f"param_data dtype {buffer.param_data.dtype}; "
-                                "reallocating would reintroduce the 2x peak."
-                            )
-                        # Synchronous D2H copy into the preexisting pinned
-                        # buffer; must complete before resize_(0) frees the
-                        # GPU storage.
-                        buffer.param_data.cpu_data.copy_(buffer.param_data.data, non_blocking=False)
-                        buffer.param_data.storage().resize_(0)
-
-                    assert buffer.param_data_size == buffer.param_data.cpu_data.storage().size()
+                    _offload_ddp_param_buffer(buffer, offload_group)
 
                     if buffer.grad_data.storage().size() > 0:
                         # if the grad_data size is already zero, we assume that it is already offloaded
                         buffer.grad_data_size = buffer.grad_data.storage().size()
                         buffer.grad_data.storage().resize_(0)
-            # Offload frozen parameters not in DDP buffers (e.g. base model in LoRA/PEFT)
-            # DDP buffers only contain requires_grad=True params, so frozen params must be offloaded separately.
+            # Offload frozen parameters excluded from DDP buffers, such as a LoRA/PEFT base model.
             for param in model_chunk.module.parameters():
-                if not param.requires_grad and param.device.type != "cpu":
-                    param.data = param.data.to("cpu", non_blocking=True)
+                if not param.requires_grad:
+                    offload_group = _parameter_offload_group(param, param_offload_groups)
+                    if offload_group is not None:
+                        _offload_replicated_parameter(param, offload_group)
+                    elif param.device.type != "cpu":
+                        param.data = param.data.to("cpu", non_blocking=True)
         else:
             # we need this for ref module
             for _, param in model_chunk.named_parameters():
-                old_data = param.data
-                param.data = param.data.to("cpu")
-                if _can_safely_resize_storage(old_data):
-                    old_data.storage().resize_(0)
-                if param.grad is not None:
-                    old_grad = param.grad
-                    param.grad = param.grad.to("cpu")
-                    if _can_safely_resize_storage(old_grad):
-                        old_grad.storage().resize_(0)
+                offload_group = _parameter_offload_group(param, param_offload_groups)
+                if offload_group is None:
+                    old_data = param.data
+                    param.data = param.data.to("cpu")
+                    if _can_safely_resize_storage(old_data):
+                        old_data.storage().resize_(0)
+                    if param.grad is not None:
+                        old_grad = param.grad
+                        param.grad = old_grad.to("cpu")
+                        if _can_safely_resize_storage(old_grad):
+                            old_grad.storage().resize_(0)
+                else:
+                    _offload_replicated_parameter(param, offload_group)
 
         # Drop Transformer-Engine FP8 weight-workspace caches, which hold quantized
         # copies of the weights on GPU and are not covered by the parameter offload above.
@@ -750,18 +878,23 @@ def offload_megatron_model_to_cpu(models):
 
 
 @torch.no_grad()
-def load_megatron_model_to_gpu(models, load_grad=True, load_frozen_params=True):
+def load_megatron_model_to_gpu(
+    models,
+    load_grad=True,
+    load_frozen_params=True,
+    param_offload_groups: MegatronParamOffloadGroups | None = None,
+):
     """
     Load megatron model to GPU.
     Args:
         models: The model to load.
         load_grad: Whether to load gradients.
         load_frozen_params: Whether to load frozen parameters.
+        param_offload_groups: Optional replica groups used to rebuild deduplicated parameters.
     """
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
-            for buffers in model_chunk_all_buffers:
+            for buffers, offload_group in _ddp_param_buffer_groups(model_chunk, param_offload_groups):
                 for buffer in buffers:
                     # sometimes, we don't want to load grad for pure inference
                     if load_grad and hasattr(buffer, "grad_data_size"):
@@ -775,24 +908,33 @@ def load_megatron_model_to_gpu(models, load_grad=True, load_frozen_params=True):
                             # zero in-place with current storage.
                             buffer.grad_data.zero_()
 
-                    if buffer.param_data.storage().size() == 0:
-                        buffer.param_data.storage().resize_(buffer.param_data_size)
-                        # copy data from cpu to cuda
-                        buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
+                    _load_ddp_param_buffer(buffer, offload_group)
 
             # Load frozen parameters that were offloaded (e.g. base model in LoRA/PEFT)
             if load_frozen_params:
                 device_id = get_device_id()
                 for param in model_chunk.module.parameters():
-                    if not param.requires_grad and param.device.type == "cpu":
-                        param.data = param.data.to(device_id, non_blocking=True)
+                    if not param.requires_grad:
+                        offload_group = _parameter_offload_group(param, param_offload_groups)
+                        if offload_group is not None:
+                            _load_replicated_parameter(param, offload_group, device_id)
+                        elif getattr(param, "_verl_param_offloaded", False):
+                            raise RuntimeError("missing parameter offload group for a deduplicated parameter")
+                        elif param.device.type == "cpu":
+                            param.data = param.data.to(device_id, non_blocking=True)
         else:
             # we need this for ref module
             device_id = get_device_id()
             for _, param in model_chunk.named_parameters():
-                param.data = param.data.to(device_id, non_blocking=True)
-                if param.grad is not None:
-                    param.grad = param.grad.to(device_id, non_blocking=True)
+                offload_group = _parameter_offload_group(param, param_offload_groups)
+                if offload_group is None:
+                    if getattr(param, "_verl_param_offloaded", False):
+                        raise RuntimeError("missing parameter offload group for a deduplicated parameter")
+                    param.data = param.data.to(device_id, non_blocking=True)
+                    if param.grad is not None:
+                        param.grad = param.grad.to(device_id, non_blocking=True)
+                else:
+                    _load_replicated_parameter(param, offload_group, device_id)
     gc.collect()
     get_torch_device().empty_cache()
 
@@ -1861,7 +2003,7 @@ def patch_engine_mtp(module, model_config):
 
 
 @torch.no_grad()
-def copy_megatron_model_to_cpu(models):
+def copy_megatron_model_to_cpu(models, param_offload_groups: MegatronParamOffloadGroups | None = None):
     """
     Copy Megatron model parameters to CPU memory (non-destructive copy).
     Unlike offload_megatron_model_to_cpu which moves data, this function creates
@@ -1869,30 +2011,33 @@ def copy_megatron_model_to_cpu(models):
 
     Args:
         models: List of model chunks (DDP-wrapped or unwrapped)
+        param_offload_groups: Optional replica groups used to deduplicate the snapshot.
 
     Returns:
         dict: CPU state containing copied parameters and buffers
     """
     cpu_state = {}
+    if param_offload_groups is not None:
+        cpu_state["deduplicated"] = True
 
     for model_idx, model_chunk in enumerate(models):
         if isinstance(model_chunk, DDP):
             # Handle DDP-wrapped models
-            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             buffer_states = []
 
-            for buffers in model_chunk_all_buffers:
+            for buffers, offload_group in _ddp_param_buffer_groups(model_chunk, param_offload_groups):
                 buffer_list = []
                 for buffer in buffers:
-                    buffer_state = {}
-
+                    owns_cpu_copy = offload_group is None or offload_group.is_owner
                     # Copy parameter data to CPU
                     if buffer.param_data.storage().size() > 0:
-                        buffer_state["param_data"] = buffer.param_data.data.cpu().clone().pin_memory()
+                        saved_param_data = buffer.param_data.data.cpu().clone().pin_memory() if owns_cpu_copy else None
+                    elif owns_cpu_copy:
+                        saved_param_data = buffer.param_data.cpu_data.clone().pin_memory()
                     else:
-                        buffer_state["param_data"] = buffer.param_data.cpu_data.clone().pin_memory()
+                        saved_param_data = None
 
-                    buffer_list.append(buffer_state)
+                    buffer_list.append({"param_data": saved_param_data})
                 buffer_states.append(buffer_list)
 
             cpu_state[f"model_chunk_{model_idx}"] = {"buffer_states": buffer_states, "is_ddp": True}
@@ -1900,8 +2045,10 @@ def copy_megatron_model_to_cpu(models):
             # Handle non-DDP models (ref module)
             model_state = {}
             for name, param in model_chunk.named_parameters():
-                param_state = {"data": param.data.cpu().clone().pin_memory()}
-                model_state[name] = param_state
+                offload_group = _parameter_offload_group(param, param_offload_groups)
+                owns_cpu_copy = offload_group is None or offload_group.is_owner
+                saved_param_data = param.data.cpu().clone().pin_memory() if owns_cpu_copy else None
+                model_state[name] = {"data": saved_param_data}
 
             cpu_state[f"model_chunk_{model_idx}"] = {"model_state": model_state, "is_ddp": False}
 
@@ -1909,14 +2056,18 @@ def copy_megatron_model_to_cpu(models):
 
 
 @torch.no_grad()
-def restore_megatron_model_from_cpu(models, cpu_state):
+def restore_megatron_model_from_cpu(models, cpu_state, param_offload_groups: MegatronParamOffloadGroups | None = None):
     """
     Restore Megatron model parameters from CPU memory back to GPU.
 
     Args:
         models: List of model chunks to restore to
         cpu_state: CPU state dict returned from copy_megatron_model_to_cpu
+        param_offload_groups: Optional replica groups used to broadcast restored parameters.
     """
+    if cpu_state.get("deduplicated", False) != (param_offload_groups is not None):
+        raise ValueError("param_offload_groups must match the saved Megatron CPU state")
+
     for model_idx, model_chunk in enumerate(models):
         chunk_key = f"model_chunk_{model_idx}"
         if chunk_key not in cpu_state:
@@ -1926,22 +2077,34 @@ def restore_megatron_model_from_cpu(models, cpu_state):
 
         if chunk_state["is_ddp"] and isinstance(model_chunk, DDP):
             # Restore DDP buffers
-            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
             buffer_states = chunk_state["buffer_states"]
 
-            for buffers, buffer_list in zip(model_chunk_all_buffers, buffer_states, strict=False):
+            buffer_groups = _ddp_param_buffer_groups(model_chunk, param_offload_groups)
+            for (buffers, offload_group), buffer_list in zip(buffer_groups, buffer_states, strict=False):
                 for buffer, buffer_state in zip(buffers, buffer_list, strict=False):
-                    # Restore parameter data
-                    if "param_data" in buffer_state:
-                        if buffer.param_data.storage().size() > 0:
-                            buffer.param_data.data.copy_(buffer_state["param_data"].to(buffer.param_data.device))
-                        else:
-                            buffer.param_data.cpu_data.copy_(buffer_state["param_data"])
+                    saved_param_data = buffer_state["param_data"]
+                    owns_cpu_copy = offload_group is None or offload_group.is_owner
+                    if buffer.param_data.storage().size() > 0:
+                        if owns_cpu_copy:
+                            buffer.param_data.data.copy_(saved_param_data.to(buffer.param_data.device))
+                        if offload_group is not None:
+                            _broadcast_offloaded_parameter(buffer.param_data, offload_group)
+                    elif owns_cpu_copy:
+                        buffer.param_data.cpu_data.copy_(saved_param_data)
 
         elif not chunk_state["is_ddp"] and not isinstance(model_chunk, DDP):
             # Restore non-DDP models
             model_state = chunk_state["model_state"]
             for name, param in model_chunk.named_parameters():
                 if name in model_state:
-                    param_state = model_state[name]
-                    param.data.copy_(param_state["data"].to(param.device))
+                    saved_param_data = model_state[name]["data"]
+                    offload_group = _parameter_offload_group(param, param_offload_groups)
+                    owns_cpu_copy = offload_group is None or offload_group.is_owner
+                    if getattr(param, "_verl_param_offloaded", False):
+                        if owns_cpu_copy:
+                            param.data.copy_(saved_param_data)
+                    else:
+                        if owns_cpu_copy:
+                            param.data.copy_(saved_param_data.to(param.device))
+                        if offload_group is not None:
+                            _broadcast_offloaded_parameter(param.data, offload_group)

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -153,6 +153,7 @@ class McoreEngineConfig(EngineConfig):
     Args:
         param_offload (bool): Whether to offload parameters to CPU and release gradient buffers while inactive.
         optimizer_offload (bool): Whether to offload optimizer states to CPU.
+        deduplicate_param_offload (bool): Keep one host copy per dense/expert replica group.
         tensor_model_parallel_size (int): Tensor model parallel size.
         expert_model_parallel_size (int): Expert model parallel size for MoE models.
         expert_tensor_parallel_size (Optional[int]): Expert tensor parallel size for MoE models.
@@ -182,6 +183,7 @@ class McoreEngineConfig(EngineConfig):
     # sequence_parallel is not listed as a frozen field for auto-correction purpose
     _mutable_fields = EngineConfig._mutable_fields | {"sequence_parallel"}
     # mcore parallelism
+    deduplicate_param_offload: bool = False
     tensor_model_parallel_size: int = 1
     expert_model_parallel_size: int = 1
     expert_tensor_parallel_size: Optional[int] = None
@@ -216,6 +218,10 @@ class McoreEngineConfig(EngineConfig):
         """config validation logics go here"""
         assert self.strategy == "megatron"
         assert self.dtype in ["bfloat16", "float16"], f"dtype {self.dtype} not supported"
+        if self.deduplicate_param_offload and not self.param_offload:
+            raise ValueError("deduplicate_param_offload requires param_offload=True")
+        if self.deduplicate_param_offload and self.use_megatron_fsdp:
+            raise ValueError("deduplicate_param_offload is not supported with use_megatron_fsdp=True")
         if self.vanilla_mbridge:
             warnings.warn(
                 "The legacy mbridge backend selected by `vanilla_mbridge=True` is deprecated and will be removed "

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -64,6 +64,7 @@ from verl.utils.megatron.tensor_parallel import (
 )
 from verl.utils.megatron_peft_utils import build_peft_config_for_vllm
 from verl.utils.megatron_utils import (
+    build_megatron_param_offload_groups,
     check_mtp_config,
     get_megatron_module_device,
     get_megatron_mtp_loss,
@@ -196,6 +197,7 @@ class MegatronEngine(BaseEngine):
 
         self._is_offload_param = self.engine_config.param_offload
         self._is_offload_optimizer = self.engine_config.optimizer_offload
+        self._param_offload_groups = build_megatron_param_offload_groups(self.engine_config.deduplicate_param_offload)
 
         self.mode = None
 
@@ -719,6 +721,17 @@ class MegatronEngine(BaseEngine):
         self.lr_scheduler.step(1)
         return get_megatron_last_lr(self.optimizer)
 
+    def _load_model(self, *, load_grad: bool = True, load_frozen_params: bool = True) -> None:
+        load_megatron_model_to_gpu(
+            self.module,
+            load_grad=load_grad,
+            load_frozen_params=load_frozen_params,
+            param_offload_groups=self._param_offload_groups,
+        )
+
+    def _offload_model(self) -> None:
+        offload_megatron_model_to_cpu(self.module, param_offload_groups=self._param_offload_groups)
+
     def to(self, device: str, model: bool = True, optimizer: bool = True, grad: bool = True):
         """
         Move model parameters, optimizer states, or both to the specified device.
@@ -736,12 +749,12 @@ class MegatronEngine(BaseEngine):
         assert device in (device_name, "cpu")
         if device == device_name:
             if model:
-                load_megatron_model_to_gpu(self.module, load_grad=grad)
+                self._load_model(load_grad=grad)
             if optimizer and self.optimizer is not None:
                 load_megatron_optimizer(self.optimizer)
         elif device == "cpu":
             if model:
-                offload_megatron_model_to_cpu(self.module)
+                self._offload_model()
             if optimizer and self.optimizer is not None:
                 offload_megatron_optimizer(self.optimizer)
         else:
@@ -790,13 +803,13 @@ class MegatronEngine(BaseEngine):
         """
         origin_module_device = get_megatron_module_device(self.module)
         if self._is_offload_param or origin_module_device == "cpu":
-            load_megatron_model_to_gpu(self.module, load_grad=True)
+            self._load_model()
         self.checkpoint_mananager.save_checkpoint(
             local_path=local_path, hdfs_path=hdfs_path, global_step=global_step, max_ckpt_to_keep=max_ckpt_to_keep
         )
         torch.distributed.barrier()
         if self._is_offload_param:
-            offload_megatron_model_to_cpu(self.module)
+            self._offload_model()
 
     def load_checkpoint(
         self, local_path: str, hdfs_path: str | None = None, del_local_after_load: bool = True, **kwargs
@@ -810,12 +823,12 @@ class MegatronEngine(BaseEngine):
             del_local_after_load: Whether to delete local copy after loading.
         """
         if self._is_offload_param:
-            load_megatron_model_to_gpu(self.module)
+            self._load_model()
         self.checkpoint_mananager.load_checkpoint(
             local_path=local_path, hdfs_path=hdfs_path, del_local_after_load=del_local_after_load
         )
         if self._is_offload_param:
-            offload_megatron_model_to_cpu(self.module)
+            self._offload_model()
         if self._is_offload_optimizer:
             offload_megatron_optimizer(self.optimizer)
 
@@ -1028,7 +1041,7 @@ class MegatronEngine(BaseEngine):
         if non_merge_lora_sync:
             peft_config = build_peft_config_for_vllm(self.model_config.lora)
         # when lora adapter only, we only load adapter weights when base sync is done, otherwise load all weights
-        load_megatron_model_to_gpu(self.module, load_grad=False, load_frozen_params=not adapter_only)
+        self._load_model(load_grad=False, load_frozen_params=not adapter_only)
         if self.vanilla_bridge:
             per_tensor_param = self.bridge.export_weights(self.module)
         elif adapter_only:
@@ -1078,7 +1091,7 @@ class MegatronEngine(BaseEngine):
         comm-stubbed probe owns all shard geometry). Pure export, no side
         effects. Params owned by another pipeline stage yield an empty shard
         (zero-count lockstep rows; see the index builder)."""
-        load_megatron_model_to_gpu(self.module, load_grad=False)
+        self._load_model(load_grad=False)
         index = self._mcore_export_index()
 
         def _gen():


### PR DESCRIPTION
### What does this PR do?

Megatron parameter offload currently keeps one CPU copy of every parameter shard on every data-parallel (DP) and context-parallel (CP) replica. The parameters are identical within these replica groups, so retaining every host copy is redundant.

This PR adds an opt-in `deduplicate_param_offload` setting. For each replica group, only group rank zero retains the offloaded CPU parameter storage. On reload, that rank copies the shard to its accelerator and broadcasts it to the remaining replicas. Dense parameters use the DP x CP replica group, while expert parameters use the expert-data-parallel group. Gradient and optimizer offload are unchanged.

The option defaults to `false`, requires `param_offload=true`, and is not supported with Megatron FSDP. Existing behavior is unchanged when it is disabled.

#### Why this is needed

Host memory is increasingly a limiting resource for colocated agentic RL:

- Agentic workloads commonly use multi-turn conversations with tool calls, generating long trajectories. Their longer sequences substantially increase activation and rollout KV-cache pressure on the accelerator.
- Colocated sync/async training therefore often needs full parameter, gradient, and optimizer offload so that the rollout engine can reclaim accelerator memory between training phases.
- Long sequences also require larger CP degrees. CP partitions sequence activations, but it does not shard model weights: identical weight shards are replicated across CP ranks. Existing parameter offload moves every replica to host memory, so redundant host weight storage grows linearly with the DP x CP replica-group size.
- Actor and reference models can both be offloaded, doubling this redundant storage. Optimizer/gradient offload, rollout state, and deployments that also offload or swap KV cache compete for the same host-memory budget.

As a result, increasing CP to solve accelerator-memory pressure can move the bottleneck to host memory. This PR removes only the redundant parameter replicas; it does not change optimizer, gradient, or KV-cache storage. For a replica group of size `r`, that group's offloaded parameter storage falls from `r` copies to one, a theoretical reduction of `1 - 1/r`.

### Checklist Before Starting

- [x] Searched open PRs for [`deduplicate_param_offload`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+deduplicate_param_offload), [`context parallel parameter offload`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22context+parallel%22+%22parameter+offload%22), and [`parameter offload`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22parameter+offload%22).
- [x] No open PR found by those searches implements host parameter ownership per DP x CP / expert-DP replica group as of 2026-08-18.
- [x] This does not duplicate [#6193](https://github.com/verl-project/verl/pull/6193), which avoids an allocate-before-free host-memory peak, or [#5651](https://github.com/verl-project/verl/pull/5651), which offloads optimizer FP32 master weights. Neither deduplicates persistent host parameter replicas.

### Test

The accelerator measurements below were collected before rebasing this change from the v0.9.0 release branch to `main`. The rebase did not change the deduplication algorithm or measured configuration; main-branch compatibility is covered by the focused checks below.

#### Four-node controlled A/B

Environment:

- Model: Qwen3.6-35B-A3B, BF16
- Hardware: 4 nodes x 8 Ascend NPUs, 32 GiB device memory per NPU
- Parallelism: TP=2, PP=4, CP=4, EP=4, ETP=1, world size=32
- Offload: actor/ref parameter offload enabled
- Workload: four training steps, 32 prompts x 5 responses per step
- Control: identical pre-generated trajectory cache, checkpoint, seeds, topology, and rank-to-host placement
- All measured runs reported four cache injections, zero cache misses, zero cache writes, and completed 4/4 steps without OOM or fatal errors.

The dense replica group size was 4 and the expert replica group size was 2. Tracked CPU parameter tensor storage was:

| Scope | Baseline host GiB | Dedup host GiB | Saved GiB | Reduction |
| --- | ---: | ---: | ---: | ---: |
| Actor dense parameters | 21.761 | 5.440 | 16.321 | 75.0% |
| Actor expert parameters | 120.000 | 60.000 | 60.000 | 50.0% |
| Actor total | 141.761 | 65.440 | 76.321 | 53.8% |
| Reference total | 141.761 | 65.440 | 76.321 | 53.8% |
| Actor + reference | 283.523 | 130.881 | **152.642** | **53.8%** |

Accelerator peak allocated memory was unchanged at 17.785 GiB, as expected for a host-memory optimization.

End-to-end timing with identical profiling enabled in all measured arms was:

| Run | Mean step time | Difference from first baseline |
| --- | ---: | ---: |
| Baseline | 1232.59 s | - |
| Baseline repeat | 1211.60 s | -1.70% |
| Dedup | 1224.95 s | -0.62% |

Dedup was 1.10% slower than the repeated baseline and 0.62% faster than the first baseline, so its result lies inside the observed 1.70% baseline run-to-run spread. No measurable end-to-end performance regression was observed.

Transition profiling showed the expected trade-off. The ref-model reload median increased from 1.45 s to 1.98 s because reload now includes a broadcast. Parameter offload medians decreased because only owners perform D2H copies: actor offload medians decreased by about 14-16%, and ref offload decreased from 1.56 s to 1.00 s.

Training correctness was evaluated against both the first baseline and an independent baseline repeat. All runs used the same cached tokens. Token counts, policy-gradient loss, rewards, advantages, and prompt/response-length statistics matched. Full determinism was disabled, so the baseline repeat quantifies the NPU/MoE run-to-run variation:

| Metric over four steps | Max baseline vs repeat | Max baseline vs dedup |
| --- | ---: | ---: |
| Policy-gradient loss, absolute | 0 | 0 |
| Actor loss, absolute (relative) | 4.00e-7 (5.12%) | 3.70e-7 (4.74%) |
| KL loss, absolute (relative) | 4.01e-5 (5.14%) | 3.72e-5 (4.76%) |
| Entropy, absolute (relative) | 9.90e-5 (0.055%) | 7.83e-5 (0.043%) |
| Gradient norm, absolute (relative) | 9.21e-2 (47.06%) | 6.11e-2 (36.79%) |

The dedup differences did not exceed the run-to-run variation observed between the two baseline runs. In particular, the largest gradient-norm deviation was larger between the two baselines than between baseline and dedup. No training correctness regression was observed over these four controlled steps.

#### Single-node host-OOM case

A second experiment used Qwen3.6-35B-A3B on one node with 1 TB host memory and 16 x 64 GiB Ascend NPUs, using TP=2, CP=8, EP=8, ETP=1 (world size=16), with actor parameter offload enabled. KL loss was disabled, so this run did not instantiate or offload a reference model. The existing offload path exhausted host memory during the run. With `deduplicate_param_offload=true`, observed host-memory peak stayed around 900 GB and the workload fit.

The four-node profile above measured approximately 5.44 GiB of unique dense BF16 parameters and 60.00 GiB of unique expert BF16 parameters per model role. For the single-node topology, the dense replica group has size 8 and the expert-DP group has size 2. This gives the following parameter-storage estimate:

```text
baseline = 8 * 5.44 + 2 * 60.00 = 163.52 GiB
dedup    =     5.44 +     60.00 =  65.44 GiB

theoretical saving = 163.52 - 65.44 = 98.08 GiB
```

The 98.08 GiB actor-only estimate covers only redundant parameter tensor storage. The reported ~900 GB peak is whole-node memory and also includes optimizer and gradient state, pinned/staging buffers, Ray processes, allocator overhead, and rollout memory. The theoretical reduction is therefore not expected to equal the observed peak difference exactly, but it explains why removing parameter replicas changes this configuration from host OOM to fit.

### API and Usage Example

```yaml
actor_rollout_ref:
  actor:
    megatron:
      param_offload: true
      deduplicate_param_offload: true
```

The reference model inherits the actor setting by default and can be overridden independently:

```yaml
actor_rollout_ref:
  ref:
    megatron:
      param_offload: true
      deduplicate_param_offload: true
```

Enabling deduplication without parameter offload raises a configuration error.

### Design & Code Changes

- Build dense DP x CP and expert-DP replica groups after Megatron parallel-state initialization; exclude GTP/EGTP rematerialization axes when supported.
- Retain pinned DDP CPU parameter buffers only on group rank zero and broadcast flat device buffers on reload.
- Apply the same ownership/broadcast rule to frozen and forward-only non-DDP parameters.
- Preserve replica-group information across checkpoint save/load, weight export, and experimental separation snapshot/restore paths.
- Leave optimizer and gradient offload unchanged. When the feature is disabled, retain the existing offload/load path without additional collectives.
- Add focused configuration and utility tests.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md) and repository `AGENTS.md`.
- [ ] Run `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Add/update configuration documentation and usage examples.
- [x] Add focused tests. Large-scale host-memory validation is hardware-only and is covered by the experiments above rather than CPU CI.
- [ ] Request CI through the verl `ci-request` channel when ready.
- [x] Recipe-submodule update is not applicable.

Codex assisted with this PR.