### PR TITLE
[megatron] feat: project LM head only for response tokens

### DIFF
--- a/tests/models/mcore/test_response_only_lm_head_on_cpu.py
+++ b/tests/models/mcore/test_response_only_lm_head_on_cpu.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from verl.models.mcore import model_forward_fused as mff
+from verl.models.mcore.model_forward import _build_full_loss_mask_nested
+from verl.models.mcore.response_only_lm_head import (
+    response_only_output_projection,
+    restore_response_only_outputs,
+    select_response_only_inputs,
+)
+from verl.models.mcore.util import preprocess_thd_engine
+
+
+class _OutputLayer(torch.nn.Module):
+    def __init__(self, hidden_size=None, vocab_size=None, *, sequence_parallel=False):
+        super().__init__()
+        self.sequence_parallel = sequence_parallel
+        self.disable_grad_reduce = False
+        self.tp_group = object()
+        self.weight = torch.nn.Parameter(torch.randn(vocab_size, hidden_size)) if hidden_size is not None else None
+
+    def forward(self, input_):
+        output = input_ if self.weight is None else torch.nn.functional.linear(input_, self.weight)
+        return output, None
+
+
+class _Model(torch.nn.Module):
+    def __init__(self, output_layer):
+        super().__init__()
+        self.output_layer = output_layer
+
+    def forward(self, hidden_states):
+        logits, _ = self.output_layer(hidden_states)
+        return logits.transpose(0, 1).contiguous()
+
+
+def test_response_mask_is_next_token_aligned():
+    response_mask = torch.nested.as_nested_tensor(
+        [torch.tensor([1, 1, 0, 1, 0]), torch.tensor([1, 0, 1, 1])], layout=torch.jagged
+    )
+    full_mask = _build_full_loss_mask_nested(response_mask, [8, 8], None)
+
+    with (
+        patch("verl.models.mcore.util.mpu.get_context_parallel_world_size", return_value=1),
+        patch("verl.models.mcore.util.mpu.get_context_parallel_rank", return_value=0),
+        patch("verl.models.mcore.util.mpu.get_tensor_model_parallel_world_size", return_value=1),
+    ):
+        projection_mask = preprocess_thd_engine(full_mask, need_roll=True)[0]
+
+    expected = torch.tensor([[0, 0, 1, 1, 0, 1, 0, 0], [0, 0, 0, 1, 0, 1, 1, 0]], dtype=torch.bool).reshape(1, -1)
+    torch.testing.assert_close(projection_mask, expected)
+
+
+@pytest.mark.parametrize("empty", [False, True])
+def test_unfused_projection_preserves_values_and_gradients(empty):
+    torch.manual_seed(7)
+    mask = torch.tensor([[False, True, True, False], [True, False, True, False]])
+    if empty:
+        mask.zero_()
+
+    dense_layer = _OutputLayer(3, 5)
+    sparse_layer = _OutputLayer(3, 5)
+    sparse_layer.load_state_dict(dense_layer.state_dict())
+    dense_model, sparse_model = _Model(dense_layer), _Model(sparse_layer)
+    dense_hidden = torch.randn(4, 2, 3, requires_grad=True)
+    sparse_hidden = dense_hidden.detach().clone().requires_grad_()
+
+    dense_logits = dense_model(dense_hidden)
+    dense_logits[mask].square().sum().backward()
+
+    with response_only_output_projection(sparse_model, mask):
+        sparse_logits = sparse_model(sparse_hidden)
+    labels = torch.arange(mask.numel()).reshape_as(mask)
+    sparse_labels, _, num_selected = select_response_only_inputs(labels, torch.ones_like(labels), mask)
+    restored = restore_response_only_outputs({"values": sparse_logits.square().sum(-1)}, mask, num_selected)["values"]
+    restored.sum().backward()
+
+    assert num_selected == int(mask.sum())
+    if num_selected:
+        torch.testing.assert_close(sparse_logits[0], dense_logits[mask])
+        torch.testing.assert_close(sparse_labels[0], labels[mask])
+    torch.testing.assert_close(sparse_hidden.grad, dense_hidden.grad)
+    torch.testing.assert_close(sparse_layer.weight.grad, dense_layer.weight.grad)
+
+
+def test_unfused_sequence_parallel_gathers_before_selection():
+    output_layer = _OutputLayer(sequence_parallel=True)
+    model = _Model(output_layer)
+    hidden = torch.arange(4, dtype=torch.float32).reshape(2, 1, 2)
+    gathered = torch.cat((hidden, hidden + 10))
+    mask = torch.tensor([[False, True, True, False]])
+
+    with (
+        patch(
+            "megatron.core.tensor_parallel.gather_from_sequence_parallel_region",
+            return_value=gathered,
+        ) as gather,
+        response_only_output_projection(model, mask),
+    ):
+        selected, _ = output_layer(hidden)
+        assert not output_layer.sequence_parallel
+        assert output_layer.disable_grad_reduce
+
+    gather.assert_called_once_with(hidden, tensor_parallel_output_grad=True, group=output_layer.tp_group)
+    torch.testing.assert_close(selected[:, 0], gathered[[1, 2], 0])
+    assert output_layer.sequence_parallel
+    assert not output_layer.disable_grad_reduce
+
+
+@pytest.mark.parametrize("sequence_parallel", [False, True])
+def test_fused_projection_matches_dense_values_and_gradients(sequence_parallel):
+    torch.manual_seed(42)
+    mask = torch.tensor([[False, True, False, True, True, False]])
+    labels = torch.tensor([[0, 1, 2, 3, 4, 0]])
+    initial_hidden = torch.randn(6, 1, 3)
+    initial_weight = torch.randn(5, 3)
+    coefficients = torch.randn(1, 6) * mask
+
+    def run(projection_mask):
+        hidden = initial_hidden.clone().requires_grad_()
+        weight = initial_weight.clone().requires_grad_()
+        projected_rows = []
+
+        def kernel(h, w, y, temperature, reduction, group):
+            projected_rows.append(h.shape[0])
+            log_probs = (h.reshape(-1, 3) @ w.T / temperature).log_softmax(-1)
+            return log_probs.gather(-1, y.reshape(-1, 1)).squeeze(-1), -(log_probs.exp() * log_probs).sum(-1)
+
+        with (
+            patch.object(mff, "linear_cross_entropy", side_effect=kernel),
+            patch.object(mff.parallel_state, "get_tensor_model_parallel_group", return_value=object()),
+            patch.object(mff, "gather_from_sequence_parallel_region", side_effect=lambda value: value) as gather,
+            patch.object(mff, "copy_to_tensor_model_parallel_region", side_effect=lambda value, group: value) as copy,
+        ):
+            log_probs, entropy = mff._compute_fused_lm_head(
+                hidden, weight, labels, 0.7, sequence_parallel, projection_mask
+            )
+
+        assert gather.called == sequence_parallel
+        assert copy.called != sequence_parallel
+        log_probs, entropy = log_probs.reshape_as(mask), entropy.reshape_as(mask)
+        ((log_probs + 0.1 * entropy) * coefficients).sum().backward()
+        return log_probs, entropy, hidden.grad, weight.grad, projected_rows
+
+    sparse = run(mask)
+    dense = run(None)
+    torch.testing.assert_close(sparse[0][mask], dense[0][mask])
+    torch.testing.assert_close(sparse[1][mask], dense[1][mask])
+    torch.testing.assert_close(sparse[2], dense[2])
+    torch.testing.assert_close(sparse[3], dense[3])
+    assert sparse[4] == [int(mask.sum())]
+    assert dense[4] == [mask.numel()]
+    assert torch.count_nonzero(sparse[0][~mask]) == 0
+    assert torch.count_nonzero(sparse[1][~mask]) == 0

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from contextlib import nullcontext
 
 import torch
 from torch.nested._internal.nested_tensor import NestedTensor
@@ -21,6 +21,7 @@ from torch.nested._internal.nested_tensor import NestedTensor
 from verl.utils.megatron_utils import unwrap_model
 from verl.workers.config import MtpConfig
 
+from .response_only_lm_head import response_only_output_projection
 from .util import (
     build_vlm_attn_mask_bshd,
     build_vlm_attn_mask_thd,
@@ -210,8 +211,8 @@ def _convert_to_nested_tensor(v, input_ids_lengths):
     return v
 
 
-def _build_mtp_loss_mask_nested(response_mask, input_ids_lengths, response_attention_mask):
-    """Build a nested loss_mask aligned to ``input_ids = [prompt; response]`` for MTP.
+def _build_full_loss_mask_nested(response_mask, input_ids_lengths, response_attention_mask):
+    """Build a nested loss_mask aligned to ``input_ids = [prompt; response]``.
 
     ``response_mask`` is response-only data. This expands it to full packed
     input length as prompt zeros followed by valid response positions.
@@ -222,7 +223,7 @@ def _build_mtp_loss_mask_nested(response_mask, input_ids_lengths, response_atten
         batch_size = len(response_lengths)
         response_values = response_mask.values()
     else:
-        assert response_attention_mask is not None, "response_attention_mask is required to align padded MTP loss_mask"
+        assert response_attention_mask is not None, "response_attention_mask is required to align a padded loss_mask"
         assert not isinstance(response_attention_mask, NestedTensor), (
             "response_attention_mask must be a padded (bs, max_response_len) tensor, got NestedTensor"
         )
@@ -272,9 +273,10 @@ def gptmodel_forward_model_engine(
     pad_token_id=None,
     data_format: str = "thd",
     mtp_enable_train: bool = False,
-    local_cp_size: Optional[int] = None,
-    forced_max_seqlen: Optional[int] = None,
-    pad_to_length_bucket: Optional[int] = None,
+    response_only_lm_head: bool = False,
+    local_cp_size: int | None = None,
+    forced_max_seqlen: int | None = None,
+    pad_to_length_bucket: int | None = None,
     cp_layout: str = "zigzag",
     router_padding_mask: torch.Tensor | None = None,
     mtp_loss_normalization_factor: float | None = None,
@@ -284,7 +286,6 @@ def gptmodel_forward_model_engine(
     assert data_format in ["thd", "bshd"], "data_format must be 'thd' or 'bshd'"
     pre_process = unwrap_model(model).pre_process
     post_process = unwrap_model(model).post_process
-
     fp8 = unwrap_model(model).config.fp8
     use_fp8_padding = fp8 in ["e4m3", "hybrid"]
 
@@ -312,6 +313,24 @@ def gptmodel_forward_model_engine(
             packed_seq_params._verl_mtp_loss_normalization_factor = mtp_loss_normalization_factor
         input_ids_rmpad = input_ids_rmpad.contiguous()
 
+        projection_mask = None
+        if response_only_lm_head and post_process and logits_processor is not None:
+            input_ids_lengths = input_ids.offsets().diff().tolist()
+            full_loss_mask = _build_full_loss_mask_nested(
+                logits_processor_args["loss_mask"],
+                input_ids_lengths,
+                logits_processor_args.get("response_attention_mask"),
+            )
+            projection_mask = preprocess_thd_engine(
+                full_loss_mask,
+                pre_process=True,
+                need_roll=True,
+                use_fp8_padding=use_fp8_padding,
+                local_cp_size=local_cp_size,
+                pad_to_length_bucket=pad_to_length_bucket,
+                cp_layout=cp_layout,
+            )[0].to(torch.bool)
+
         args = {}
         if mtp_enable_train and post_process:
             # Use input_ids sequence length to ensure label and loss_mask alignment
@@ -322,7 +341,7 @@ def gptmodel_forward_model_engine(
             for k in ["label", "loss_mask"]:
                 v = logits_processor_args[k]
                 if k == "loss_mask":
-                    v = _build_mtp_loss_mask_nested(v, input_ids_lengths, response_attention_mask)
+                    v = _build_full_loss_mask_nested(v, input_ids_lengths, response_attention_mask)
                 else:
                     v = _convert_to_nested_tensor(v, input_ids_lengths)
                 logits_processor_args[k] = v
@@ -352,13 +371,17 @@ def gptmodel_forward_model_engine(
         if router_padding_mask is not None:
             model_kwargs["padding_mask"] = router_padding_mask
 
-        output_orig = model(
-            input_ids=input_ids_rmpad,
-            attention_mask=attention_mask,
-            position_ids=position_ids_rmpad if mtp_enable_train else None,  # position_ids is only needed for MTP
-            packed_seq_params=packed_seq_params,
-            **model_kwargs,
+        projection_context = (
+            response_only_output_projection(model, projection_mask) if projection_mask is not None else nullcontext()
         )
+        with projection_context:
+            output_orig = model(
+                input_ids=input_ids_rmpad,
+                attention_mask=attention_mask,
+                position_ids=position_ids_rmpad if mtp_enable_train else None,  # position_ids is only needed for MTP
+                packed_seq_params=packed_seq_params,
+                **model_kwargs,
+            )
 
         if post_process and logits_processor is not None:
             args = {
@@ -373,6 +396,8 @@ def gptmodel_forward_model_engine(
                 )[0]
                 for k, v in logits_processor_args.items()
             }
+            if projection_mask is not None:
+                args["projection_mask"] = projection_mask
             output_dict = logits_processor(output_orig, **args)
             output = {
                 k: postprocess_thd_engine(
@@ -413,6 +438,22 @@ def gptmodel_forward_model_engine(
             forced_max_seqlen=forced_max_seqlen,
         )
 
+        projection_mask = None
+        if response_only_lm_head and post_process and logits_processor is not None:
+            input_ids_lengths = input_ids.offsets().diff().tolist()
+            full_loss_mask = _build_full_loss_mask_nested(
+                logits_processor_args["loss_mask"],
+                input_ids_lengths,
+                logits_processor_args.get("response_attention_mask"),
+            )
+            projection_mask = preprocess_bshd_engine(
+                full_loss_mask,
+                pre_process=True,
+                need_roll=True,
+                use_fp8_padding=use_fp8_padding,
+                forced_max_seqlen=forced_max_seqlen,
+            )[0].to(torch.bool)
+
         if mtp_enable_train and post_process:
             args = {}
             # Use input_ids sequence length to ensure label and loss_mask alignment
@@ -423,7 +464,7 @@ def gptmodel_forward_model_engine(
             for k in ["label", "loss_mask"]:
                 v = logits_processor_args[k]
                 if k == "loss_mask":
-                    v = _build_mtp_loss_mask_nested(v, input_ids_lengths, response_attention_mask)
+                    v = _build_full_loss_mask_nested(v, input_ids_lengths, response_attention_mask)
                 else:
                     v = _convert_to_nested_tensor(v, input_ids_lengths)
                 logits_processor_args[k] = v
@@ -450,12 +491,16 @@ def gptmodel_forward_model_engine(
         else:
             attention_mask = attention_mask_bshd
 
-        output_orig = model(
-            input_ids=input_ids_bshd,
-            attention_mask=attention_mask,
-            position_ids=None if vision_model else position_ids_bshd,
-            **model_kwargs,
+        projection_context = (
+            response_only_output_projection(model, projection_mask) if projection_mask is not None else nullcontext()
         )
+        with projection_context:
+            output_orig = model(
+                input_ids=input_ids_bshd,
+                attention_mask=attention_mask,
+                position_ids=None if vision_model else position_ids_bshd,
+                **model_kwargs,
+            )
         if post_process and logits_processor is not None:
             args = {
                 k: preprocess_bshd_engine(
@@ -467,6 +512,8 @@ def gptmodel_forward_model_engine(
                 )[0]
                 for k, v in logits_processor_args.items()
             }
+            if projection_mask is not None:
+                args["projection_mask"] = projection_mask
             output_dict = logits_processor(output_orig, **args)
             output = {
                 k: postprocess_bshd_engine(v, attention_mask_bshd, post_process=post_process)

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -17,7 +17,6 @@
 import inspect
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Optional
 
 import megatron.core as mcore
 import torch
@@ -26,7 +25,10 @@ from megatron.core.config_logger import has_config_logger_enabled, log_config_to
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
+from megatron.core.tensor_parallel.mappings import (
+    copy_to_tensor_model_parallel_region,
+    gather_from_sequence_parallel_region,
+)
 from megatron.core.utils import deprecate_inference_params
 from packaging import version
 from torch import Tensor
@@ -36,6 +38,8 @@ from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 from verl.utils.megatron_utils import unwrap_model
 from verl.utils.model import CausalLMOutputForPPO
 
+from .model_forward import _build_full_loss_mask_nested
+from .response_only_lm_head import restore_response_only_outputs, select_response_only_hidden_states
 from .util import postprocess_packed_seqs_for_dict_output, postprocess_thd_engine
 
 _FUSED_FORWARD_MODE_ATTR = "_verl_fused_forward_mode"
@@ -78,6 +82,35 @@ class FusedOutputProcessorContext:
     """Context passed through Megatron's native output-processor hook."""
 
     temperature: float
+    projection_mask: Tensor | None = None
+
+
+def _compute_fused_lm_head(hidden_states, weight, labels, temperature, sequence_parallel, projection_mask=None):
+    """Run the fused head on all rows or only the loss-bearing predictor rows."""
+    tp_group = parallel_state.get_tensor_model_parallel_group()
+    if sequence_parallel:
+        hidden_states = gather_from_sequence_parallel_region(hidden_states)
+    elif tp_group is not None:
+        # The fused kernel returns a vocabulary-local input gradient. Without
+        # SP's backward reduce-scatter, sum that gradient over TP explicitly.
+        hidden_states = copy_to_tensor_model_parallel_region(hidden_states, group=tp_group)
+
+    if projection_mask is not None:
+        hidden_states = select_response_only_hidden_states(hidden_states, projection_mask)
+        labels = labels[projection_mask]
+        num_selected = labels.numel()
+        if not num_selected:
+            labels = labels.new_zeros(1)
+
+    log_probs, entropy = linear_cross_entropy(hidden_states, weight, labels, temperature, "none", tp_group)
+    if projection_mask is not None:
+        outputs = restore_response_only_outputs(
+            {"log_probs": log_probs.reshape(1, -1), "entropy": entropy.reshape(1, -1)},
+            projection_mask,
+            num_selected,
+        )
+        log_probs, entropy = outputs["log_probs"], outputs["entropy"]
+    return log_probs, entropy
 
 
 def fused_output_processor(
@@ -99,21 +132,18 @@ def fused_output_processor(
         attentions=None,
     )
 
-    if config.sequence_parallel:
-        hidden_states = gather_from_sequence_parallel_region(hidden_states)
-
     # Megatron passes the shared embedding as output_weight for tied models. For
     # untied models the weight lives on output_layer.
     weight = output_weight if output_weight is not None else output_layer.weight
 
     temperature = context.temperature
-    logprobs, entropy = linear_cross_entropy(
+    logprobs, entropy = _compute_fused_lm_head(
         hidden_states,
         weight,
         labels,
         temperature,
-        "none",
-        parallel_state.get_tensor_model_parallel_group(),
+        config.sequence_parallel,
+        context.projection_mask,
     )
 
     if has_config_logger_enabled(config):
@@ -269,6 +299,8 @@ def fused_forward_model_engine(vision_model: bool = False):
         local_cp_size: int | None = None,
         router_padding_mask: Tensor | None = None,
         pad_to_length_bucket: int | None = None,
+        loss_mask: Tensor | None = None,
+        response_attention_mask: Tensor | None = None,
     ):
         pre_process = unwrap_model(model).pre_process
         post_process = unwrap_model(model).post_process
@@ -323,6 +355,21 @@ def fused_forward_model_engine(vision_model: bool = False):
             local_cp_size=local_cp_size,
         )
         labels_rmpad = labels_rmpad.contiguous()
+        projection_mask = None
+        if loss_mask is not None and post_process:
+            full_loss_mask = _build_full_loss_mask_nested(
+                loss_mask, input_ids.offsets().diff().tolist(), response_attention_mask
+            )
+            projection_mask = preprocess_thd_engine(
+                full_loss_mask,
+                pre_process=True,
+                need_roll=True,
+                use_fp8_padding=use_fp8_padding,
+                min_local_rows=min_local_rows,
+                pad_to_length_bucket=pad_to_length_bucket,
+                cp_layout=cp_layout,
+                local_cp_size=local_cp_size,
+            )[0].to(torch.bool)
         forward_kwargs = dict(
             input_ids=input_ids_rmpad,
             attention_mask=attention_mask,
@@ -335,10 +382,12 @@ def fused_forward_model_engine(vision_model: bool = False):
             output_orig: CausalLMOutputForPPO = model(
                 **forward_kwargs,
                 output_processor=fused_output_processor,
-                output_processor_context=FusedOutputProcessorContext(temperature=temperature),
+                output_processor_context=FusedOutputProcessorContext(temperature, projection_mask),
             )
         else:
-            output_orig: CausalLMOutputForPPO = model(temperature=temperature, **forward_kwargs)
+            output_orig: CausalLMOutputForPPO = model(
+                temperature=temperature, projection_mask=projection_mask, **forward_kwargs
+            )
 
         if not post_process:
             return output_orig
@@ -388,12 +437,13 @@ def _fused_GPTModel_forward(
     inference_context: BaseInferenceContext = None,
     packed_seq_params: PackedSeqParams = None,
     extra_block_kwargs: dict = None,
-    runtime_gather_output: Optional[bool] = None,
+    runtime_gather_output: bool | None = None,
     *,
-    inference_params: Optional[BaseInferenceContext] = None,
-    loss_mask: Optional[Tensor] = None,
+    inference_params: BaseInferenceContext | None = None,
+    loss_mask: Tensor | None = None,
     temperature: float = 1.0,
     padding_mask: Tensor | None = None,
+    projection_mask: Tensor | None = None,
     **kwargs,
 ) -> CausalLMOutputForPPO:
     """
@@ -455,9 +505,6 @@ def _fused_GPTModel_forward(
         attentions=None,
     )
 
-    if model.config.sequence_parallel:
-        hidden_states = gather_from_sequence_parallel_region(hidden_states)
-
     # Get the output weight - use embedding weight if output_layer is None or weight is shared
     if hasattr(model, "output_layer") and model.output_layer is not None and model.output_layer.weight is not None:
         output_weight = model.output_layer.weight
@@ -465,13 +512,13 @@ def _fused_GPTModel_forward(
         # When embeddings are tied, use the embedding weight
         output_weight = model.embedding.word_embeddings.weight
 
-    logprobs, entropy = linear_cross_entropy(
+    logprobs, entropy = _compute_fused_lm_head(
         hidden_states,
         output_weight,
         labels,
         temperature,
-        "none",
-        parallel_state.get_tensor_model_parallel_group(),
+        model.config.sequence_parallel,
+        projection_mask,
     )
 
     if has_config_logger_enabled(model.config):

--- a/verl/models/mcore/response_only_lm_head.py
+++ b/verl/models/mcore/response_only_lm_head.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import torch
+
+
+def select_response_only_hidden_states(hidden_states: torch.Tensor, projection_mask: torch.Tensor) -> torch.Tensor:
+    """Select batch-major active rows from gathered [sequence, batch, hidden] states."""
+    expected = (projection_mask.shape[1], projection_mask.shape[0])
+    if hidden_states.shape[:2] != expected:
+        raise RuntimeError(
+            "LM-head hidden states and response projection mask are misaligned: "
+            f"hidden={tuple(hidden_states.shape)}, mask={tuple(projection_mask.shape)}"
+        )
+    selected = hidden_states.transpose(0, 1)[projection_mask]
+    if selected.numel() == 0:
+        # Keep empty CP ranks in the distributed backward graph. Restoration
+        # connects this dummy row to the loss with zero gradient.
+        selected = hidden_states[:1, :1, :].reshape(1, hidden_states.shape[-1])
+    return selected.reshape(-1, 1, hidden_states.shape[-1]).contiguous()
+
+
+def _get_output_layer(model):
+    from verl.utils.megatron_utils import unwrap_model
+
+    unwrapped = unwrap_model(model)
+    language_model = getattr(unwrapped, "language_model", None)
+    if language_model is None:
+        language_model = unwrapped
+    output_layer = getattr(language_model, "output_layer", None)
+    if output_layer is None:
+        raise RuntimeError("response_only_lm_head requires a Megatron language model with an output_layer")
+    return output_layer
+
+
+@contextmanager
+def response_only_output_projection(model, projection_mask: torch.Tensor) -> Iterator[None]:
+    """Project only hidden states whose next token contributes to the policy loss.
+
+    ``projection_mask`` is already CP-local and next-token aligned. Megatron's
+    sequence-parallel output layer normally gathers hidden states over TP before
+    projecting them. Gather explicitly, select active rows, and disable the
+    layer's second gather for this invocation.
+    """
+    if projection_mask.ndim != 2:
+        raise ValueError(f"projection_mask must have shape [batch, sequence], got {projection_mask.shape}")
+    if projection_mask.dtype != torch.bool:
+        projection_mask = projection_mask.to(torch.bool)
+
+    output_layer = _get_output_layer(model)
+    sequence_parallel = bool(getattr(output_layer, "sequence_parallel", False))
+    if sequence_parallel and not hasattr(output_layer, "disable_grad_reduce"):
+        raise RuntimeError(
+            "response_only_lm_head requires an output layer that supports disable_grad_reduce "
+            "when sequence parallelism is enabled"
+        )
+    disable_grad_reduce = getattr(output_layer, "disable_grad_reduce", None)
+
+    def select_hidden_states(_module, args, kwargs):
+        if args:
+            hidden_states = args[0]
+        else:
+            hidden_states = kwargs.get("input_")
+            if hidden_states is None:
+                raise RuntimeError("Could not find the LM-head hidden-state input")
+
+        if sequence_parallel:
+            from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
+
+            hidden_states = gather_from_sequence_parallel_region(
+                hidden_states,
+                tensor_parallel_output_grad=True,
+                group=getattr(output_layer, "tp_group", None),
+            )
+
+        selected = select_response_only_hidden_states(hidden_states, projection_mask)
+
+        if args:
+            return (selected, *args[1:]), kwargs
+        kwargs["input_"] = selected
+        return args, kwargs
+
+    handle = output_layer.register_forward_pre_hook(select_hidden_states, with_kwargs=True)
+    if sequence_parallel:
+        output_layer.sequence_parallel = False
+        # The explicit gather above owns the reduce-scatter in backward. Avoid
+        # ColumnParallelLinear's non-SP input-gradient all-reduce as well.
+        output_layer.disable_grad_reduce = True
+    try:
+        yield
+    finally:
+        handle.remove()
+        if sequence_parallel:
+            output_layer.sequence_parallel = True
+            output_layer.disable_grad_reduce = disable_grad_reduce
+
+
+def select_response_only_inputs(
+    label: torch.Tensor,
+    temperature: torch.Tensor,
+    projection_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Select labels and temperatures aligned with sparse LM-head logits."""
+    if projection_mask.dtype != torch.bool:
+        projection_mask = projection_mask.to(torch.bool)
+    if label.shape != projection_mask.shape or temperature.shape != projection_mask.shape:
+        raise ValueError(
+            "label, temperature, and projection_mask must have identical shapes; "
+            f"got label={label.shape}, temperature={temperature.shape}, mask={projection_mask.shape}"
+        )
+
+    sparse_label = label[projection_mask]
+    sparse_temperature = temperature[projection_mask]
+    num_selected = sparse_label.numel()
+    if num_selected == 0:
+        sparse_label = label.new_zeros(1)
+        sparse_temperature = temperature.new_ones(1)
+    return sparse_label.unsqueeze(0), sparse_temperature.unsqueeze(0), num_selected
+
+
+def restore_response_only_outputs(
+    outputs: dict[str, torch.Tensor], projection_mask: torch.Tensor, num_selected: int
+) -> dict[str, torch.Tensor]:
+    """Scatter sparse per-token outputs back to their CP-local dense layout."""
+    projected_tokens = max(num_selected, 1)
+    restored = {}
+    for name, value in outputs.items():
+        if value.shape[:2] != (1, projected_tokens):
+            raise ValueError(
+                f"Sparse output {name!r} has shape {tuple(value.shape)}; expected prefix (1, {projected_tokens})"
+            )
+        dense = value.new_zeros((*projection_mask.shape, *value.shape[2:]))
+        if num_selected:
+            dense[projection_mask] = value[0]
+        else:
+            # Preserve a zero-gradient path through the LM head on empty CP ranks.
+            dense = dense + value.reshape(-1)[:0].sum()
+        restored[name] = dense
+    return restored

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -57,6 +57,7 @@ actor_rollout_ref:
       use_dist_checkpointing: false
       dist_checkpointing_path: null
       dynamic_context_parallel: false
+      response_only_lm_head: false
       max_seqlen_per_dp_cp_rank: null
       dist_checkpointing_prefix: ''
       dist_ckpt_optim_fully_reshardable: false
@@ -266,6 +267,7 @@ actor_rollout_ref:
       use_dist_checkpointing: false
       dist_checkpointing_path: null
       dynamic_context_parallel: ${oc.select:actor_rollout_ref.actor.megatron.dynamic_context_parallel,False}
+      response_only_lm_head: false
       max_seqlen_per_dp_cp_rank: ${oc.select:actor_rollout_ref.actor.megatron.max_seqlen_per_dp_cp_rank,null}
       dist_checkpointing_prefix: ''
       dist_ckpt_optim_fully_reshardable: false
@@ -599,6 +601,7 @@ critic:
     use_dist_checkpointing: false
     dist_checkpointing_path: null
     dynamic_context_parallel: false
+    response_only_lm_head: false
     max_seqlen_per_dp_cp_rank: null
     dist_checkpointing_prefix: ''
     dist_ckpt_optim_fully_reshardable: false

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -40,6 +40,10 @@ dist_checkpointing_path: null
 # Whether to use dynamic context parallel scheduling
 dynamic_context_parallel: False
 
+# Project the LM head only for next-token-aligned positions selected by loss_mask.
+# Scalar log-probability and entropy outputs retain the regular sequence layout.
+response_only_lm_head: False
+
 # Maximum packed sequence length per DPxCP rank. A positive integer is required
 # when dynamic_context_parallel=True.
 max_seqlen_per_dp_cp_rank: null

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -161,6 +161,8 @@ class McoreEngineConfig(EngineConfig):
             for interleaved scheduling.
         context_parallel_size (int): Context parallel size for long sequences.
         dynamic_context_parallel (bool): Whether to enable dynamic context parallel scheduling.
+        response_only_lm_head (bool): Project LM-head logits only for response tokens selected by
+            the policy loss mask, then restore the original scalar-output layout.
         max_seqlen_per_dp_cp_rank (Optional[int]): Maximum sequence length per DPxCP rank.
         sequence_parallel (bool): Whether to enable sequence parallelism.
         use_distributed_optimizer (bool): Whether to use distributed optimizer.
@@ -189,6 +191,7 @@ class McoreEngineConfig(EngineConfig):
     virtual_pipeline_model_parallel_size: Optional[int] = None
     context_parallel_size: int = 1
     dynamic_context_parallel: bool = False
+    response_only_lm_head: bool = False
     entropy_from_logits_with_chunking: bool = False
     entropy_from_logits_chunk_size: int = 2048
     max_seqlen_per_dp_cp_rank: Optional[int] = None

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -28,6 +28,10 @@ from tensordict import TensorDict
 
 import verl.utils.torch_functional as verl_F
 from verl.models.mcore import get_mcore_weight_converter
+from verl.models.mcore.response_only_lm_head import (
+    restore_response_only_outputs,
+    select_response_only_inputs,
+)
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.megatron_checkpoint_manager import MegatronCheckpointManager
@@ -1192,8 +1196,13 @@ class MegatronEngineWithLMHead(MegatronEngine):
         logits_processor_func: Callable,
         batch: TensorDict,
         data_format: str,
+        projection_mask: torch.Tensor | None = None,
     ):
-        assert logits.shape[:2] == label.shape[:2]
+        num_selected = None
+        if projection_mask is not None:
+            label, temperature, num_selected = select_response_only_inputs(label, temperature, projection_mask)
+        if logits.ndim != 3 or logits.shape[:2] != label.shape:
+            raise ValueError(f"logits and labels are misaligned: logits={logits.shape}, label={label.shape}")
         # avoid non-positive temperature such as padding
         temperature[temperature <= 0] = 1e-8
         assert torch.all(temperature > 0).item(), f"temperature tensor must be positive. Got {temperature}"
@@ -1229,6 +1238,8 @@ class MegatronEngineWithLMHead(MegatronEngine):
         if not distillation_only:
             ret["log_probs"] = vocab_parallel_log_probs_from_logits(logits_bak, label)
 
+        if projection_mask is not None:
+            ret = restore_response_only_outputs(ret, projection_mask, num_selected)
         return ret
 
     def forward_step(
@@ -1249,6 +1260,15 @@ class MegatronEngineWithLMHead(MegatronEngine):
         calculate_sum_pi_squared = tu.get_non_tensor_data(batch, key="calculate_sum_pi_squared", default=False)
         distillation_use_topk = tu.get_non_tensor_data(batch, key="distillation_use_topk", default=False)
         distillation_only = tu.get_non_tensor_data(batch, key="distillation_only", default=False)
+
+        if self.engine_config.response_only_lm_head and distillation_use_topk:
+            raise NotImplementedError("response_only_lm_head does not support top-k distillation")
+        if (
+            self.engine_config.response_only_lm_head
+            and self.model_config.mtp.enable
+            and self.model_config.mtp.enable_train
+        ):
+            raise NotImplementedError("response_only_lm_head does not support MTP training")
         pad_to_length_bucket = (
             self.engine_config.pad_to_length_bucket
             if self.engine_config.pad_to_length and self.engine_config.use_remove_padding
@@ -1322,6 +1342,9 @@ class MegatronEngineWithLMHead(MegatronEngine):
         if use_fused_kernels:
             from verl.models.mcore import get_mcore_forward_fused_model_engine_fn
 
+            response_attention_mask = None
+            if self.engine_config.response_only_lm_head and attention_mask is not None and not loss_mask.is_nested:
+                response_attention_mask = attention_mask[:, -loss_mask.shape[-1] :]
             fused_forward_fn = get_mcore_forward_fused_model_engine_fn(self.model_config.hf_config)
             output = fused_forward_fn(
                 model=model,
@@ -1335,6 +1358,8 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 local_cp_size=local_cp_size,
                 router_padding_mask=router_padding_mask,
                 pad_to_length_bucket=pad_to_length_bucket,
+                loss_mask=loss_mask if self.engine_config.response_only_lm_head else None,
+                response_attention_mask=response_attention_mask,
             )
         else:
             if not isinstance(temperature, torch.Tensor):
@@ -1390,6 +1415,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 pad_token_id=self.model_config.tokenizer.pad_token_id,
                 data_format=data_format,
                 mtp_enable_train=self.model_config.mtp.enable and self.model_config.mtp.enable_train,
+                response_only_lm_head=self.engine_config.response_only_lm_head,
                 local_cp_size=local_cp_size,
                 router_padding_mask=router_padding_mask,
                 mtp_loss_normalization_factor=mtp_loss_normalization_factor,


### PR DESCRIPTION
<!-- Suggested title: [megatron] feat: project LM head only for response tokens -->

### What does this PR do?

Megatron currently applies the vocabulary projection to every token row in a packed or padded micro-batch, even though PPO losses often select only assistant tokens through `loss_mask`. Long agent trajectories may contain prompts, tool outputs, environment observations, and padding that do not contribute to the policy loss but still materialize vocabulary-sized logits.

This change adds an opt-in `response_only_lm_head` setting for the unfused Megatron language-model path. It applies the same causal shift, padding, and context-parallel layout used for labels to the loss mask; selects active hidden rows immediately before the output projection; computes log-probability, entropy, and sum-of-squared-probability values only for those rows; and scatters the scalar outputs back to the existing token layout. Unselected positions are zero-filled and remain excluded by the existing loss mask.

The option defaults to `false`. Transformer, attention, and required sequence-parallel hidden-state communication are unchanged.

#### Why this is needed

For a processed token count `T`, padded vocabulary size `V`, tensor-parallel size `TP`, context-parallel size `CP`, and logits element size `b`, one dense vocabulary tensor occupies approximately:

```text
T * V * b / (TP * CP) bytes per final-pipeline-stage rank
```

If the active-row ratio is `r`, response-only projection reduces LM-head GEMM rows and vocabulary tensor elements to approximately `r` of the dense path. The corresponding logits saving is approximately `1 - r`. Entropy computation currently clones logits, so the transient LM-head saving can be larger than one logits tensor.

Example BF16 estimates for one logits tensor per rank:

| Processed shape | Dense logits | Saved at 10% active | Saved at 25% active | Saved at 50% active |
| --- | ---: | ---: | ---: | ---: |
| 32K tokens, V=152064, TP=4, CP=1 | 2.320 GiB | 2.088 GiB | 1.740 GiB | 1.160 GiB |
| 128K tokens, V=248320, TP=2, CP=8 | 3.789 GiB | 3.410 GiB | 2.842 GiB | 1.895 GiB |

These estimates cover vocabulary logits only, not whole-process peak memory.

### Checklist Before Starting

- [x] Searched open PRs for `response only LM head`, `active rows LM head`, `loss mask vocabulary projection`, and related Megatron/fused-kernel terms.
- [x] This does not duplicate [#7370](https://github.com/verl-project/verl/pull/7370), which implements the same row-selection principle only for the FSDP/FSDP2 Torch fused LM head and explicitly leaves other paths for follow-up work.
- [x] This does not duplicate [#5130](https://github.com/verl-project/verl/pull/5130), which integrates a Blackwell-specific fused linear cross-entropy path for Megatron.
- [x] This PR targets the unfused Megatron path and preserves TP/SP/CP/PP behavior, so its implementation and compatibility surface are different.

### Design and correctness

#### Causal alignment

`loss_mask` is response-only data. The implementation first builds a full `[prompt zeros; response mask]` sequence and then applies the same next-token roll as labels. A loss-bearing target token at position `t` therefore selects the predictor hidden state at `t - 1`. Internal zero spans, such as tool output, are preserved rather than treated as the end of the response.

The mask is passed through the same THD/BSHD preprocessing, FP8 padding, length-bucket padding, dynamic/static CP size, and zigzag/contiguous CP layout as the model inputs and labels.

#### Tensor and sequence parallelism

With sequence parallelism, Megatron's output layer normally gathers hidden states over TP before vocabulary projection. The implementation performs that gather explicitly, selects active rows, and disables the output layer's second gather for that invocation. The explicit gather owns backward reduce-scatter; the output layer's non-SP input-gradient all-reduce is disabled to avoid double reduction. Without sequence parallelism, the regular ColumnParallelLinear gradient reduction remains unchanged.

Each CP rank may have a different active-row count. A rank with no active rows projects one dummy row and restores a zero-gradient scalar path so all ranks retain the LM head in the distributed backward graph.

#### Output compatibility

Sparse labels and temperatures are selected in the same order as hidden rows. After log-probability, entropy, and sum-pi-squared computation, token-level scalars are scattered back to the original CP-local dense layout. Existing CP postprocessing and downstream PPO loss code remain unchanged.

### Compatibility and limitations

- Supported data formats: THD and BSHD.
- Supported parallel dimensions: TP, SP, static/dynamic CP, and PP.
- The option uses the unfused Megatron forward path. If fused kernels were requested, they are disabled before the model forward patch is selected.
- MTP training is not supported.
- Top-k distillation is not supported.
- The optimization does not reduce transformer/attention work or the required SP hidden-state gather.
- Benefits become small when most token rows are active; a 100% active control should show approximately zero improvement.

### Test

#### A100 controlled A/B

The verl v0.9.0 adaptation was exercised on one node with 8 NVIDIA A100 GPUs using Qwen3-8B BF16, THD/remove-padding, TP=2, PP=2, CP=2, sequence parallelism enabled, and rollout TP=4. Actor/ref parameter offload was enabled. Each workload used one prompt with two rollouts per step and ran for four steps. A cache-fill run generated the trajectories; both measured arms injected the same two cached trajectories at every step.

Step 1 was treated as warmup. Mean results for steps 2-4 were:

| Workload | Actual prompt | Response | Baseline step | Optimized step | Step reduction | Throughput gain |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| balanced | 8046-8052 | 8192 | 47.815 s | 47.249 s | 1.18% | 1.20% |
| prompt-heavy | 16230-16232 | 4096 | 54.398 s | 50.663 s | **6.86%** | **7.37%** |

The three prompt-heavy steady-step reductions were 7.03%, 6.88%, and 6.68%. The measured stage means were:

| Workload | Stage | Baseline | Optimized | Reduction |
| --- | --- | ---: | ---: | ---: |
| balanced | actor old-log-prob | 7.201 s | 6.546 s | 9.09% |
| balanced | ref log-prob | 7.777 s | 7.578 s | 2.56% |
| balanced | actor update | 19.267 s | 18.815 s | 2.34% |
| prompt-heavy | actor old-log-prob | 8.605 s | 7.253 s | **15.71%** |
| prompt-heavy | ref log-prob | 9.008 s | 8.421 s | **6.52%** |
| prompt-heavy | actor update | 22.918 s | 21.501 s | **6.18%** |

`actor old-log-prob` requests entropy in the v1 trainer. The measured actor update did not request entropy because both `actor.calculate_entropy` and `actor.entropy_coeff` were zero. Actor-update stage time also includes backward and optimizer-facing work.

#### Correctness evidence and limitation

Baseline and optimized runs injected identical cached trajectories. Prompt and response lengths, actor entropy, rollout-correlation metrics, rewards, and loss metrics matched step by step. The runs provide real TP=2, SP=true, CP=2, PP=2 coverage, including CP-local empty masks and NCCL forward/backward collective liveness.

The synthetic NIAH reward saturated: all two-rollout groups received reward 1, so GRPO advantages, actor loss, and gradient norm were zero. These runs therefore validate selected-token forward outputs and distributed liveness, but do not establish non-zero-gradient multi-GPU backward parity. That remains a submission gate and should be covered with a non-saturated reward workload or a non-zero entropy coefficient using the same cached-token A/B procedure.

#### CPU tests

The tests were run with:

```bash
python -m pytest -q \
  tests/models/mcore/test_response_only_lm_head_on_cpu.py \
  tests/workers/test_megatron_distillation_only_on_cpu.py \
  tests/workers/config/test_engine_config_on_cpu.py
```

Result: `24 passed`.

Coverage includes:

- causal next-token mask alignment for nested THD and padded BSHD inputs with internal tool-output spans;
- sparse/dense active-logits and hidden/LM-head gradient parity;
- SP gather invocation and output-layer state restoration;
- empty local mask through the real projection hook, including zero hidden and LM-head weight gradients;
- sparse input selection and output-layout restoration, including non-empty backward scatter;
- fused-forward initialization behavior;
- configuration defaults.

### API and usage

```yaml
actor_rollout_ref:
  actor:
    megatron:
      response_only_lm_head: true
  ref:
    megatron:
      response_only_lm_head: true
```

Actor and reference settings are independent. Enable only the roles whose log-probability or training passes should use sparse vocabulary projection.

### Code changes

- add the output-layer hidden-row selection and sparse-output restoration helpers;
- construct next-token-aligned CP-local masks for THD and BSHD;
- integrate sparse labels, temperatures, log-probability, entropy, and sum-pi-squared processing;
- add opt-in engine/Hydra configuration and generated config;
- add correctness, gradient, compatibility, and configuration tests;
- document usage and limitations.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md) and repository `AGENTS.md`.
- [ ] Run `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Add/update configuration documentation and usage examples.
- [x] Add focused tests. Run real A100 TP=2/SP/CP=2/PP=2 A/B.
- [ ] Request CI through the verl `ci-request` channel when ready.
- [x] Recipe-submodule update is not applicable.

Codex assisted with this PR.
