### PR TITLE
[doc] fix: correct legacy_model_merger path in checkpoint.rst

### DIFF
--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -290,7 +290,7 @@ Convert FSDP and Megatron Checkpoints to HuggingFace Format Model
 -----------------------------------------------------------------
 
 We provide a tool to convert the FSDP and Megatron checkpoints to HuggingFace format model.
-The tool is located in ``verl/model_merger``. For older versions of verl that don't include fsdp_config.json in checkpoints, you can use the legacy model merger located at ``verl/scripts/legacy_model_merger.py``.
+The tool is located in ``verl/model_merger``. For older versions of verl that don't include fsdp_config.json in checkpoints, you can use the legacy model merger located at ``scripts/legacy_model_merger.py``.
 
 The script supports two main sub-commands: `merge` (to convert and save checkpoints) and `test` (to validate merged checkpoints against a reference model).
 The arguments for the `merge` sub-command are as follows:


### PR DESCRIPTION
## Summary
In `docs/advance/checkpoint.rst`, the legacy model merger path `verl/scripts/legacy_model_merger.py` is wrong on current main. The file lives at `scripts/legacy_model_merger.py` (there is no `verl/scripts/` directory). The modern `verl/model_merger` reference is unchanged.

## Repro
```bash
# missing (docs currently point here)
curl -sI https://raw.githubusercontent.com/verl-project/verl/main/verl/scripts/legacy_model_merger.py | head -1
# HTTP/2 404

# present
curl -sI https://raw.githubusercontent.com/verl-project/verl/main/scripts/legacy_model_merger.py | head -1
# HTTP/2 200
```

## Change
- `docs/advance/checkpoint.rst`: ``verl/scripts/legacy_model_merger.py`` → ``scripts/legacy_model_merger.py``