### PR TITLE
[misc] fix: register custom modules during execution

### DIFF
--- a/tests/utils/test_import_utils_on_cpu.py
+++ b/tests/utils/test_import_utils_on_cpu.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import os
+import sys
 
 import pytest
 
-from verl.utils.import_utils import load_extern_object
+from verl.utils.import_utils import load_extern_object, load_module
 
 # Path to the test module
 TEST_MODULE_PATH = os.path.join(os.path.dirname(__file__), "_test_module.py")
@@ -95,3 +96,62 @@ def test_load_extern_object_invalid_module():
         # Clean up the temporary file
         if os.path.exists(temp_path):
             os.remove(temp_path)
+
+
+def test_load_extern_object_supports_dataclass_with_postponed_annotations(tmp_path):
+    module_path = tmp_path / "dataclass_plugin.py"
+    module_path.write_text(
+        "from __future__ import annotations\n"
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class Plugin:\n"
+        "    value: int = 1\n"
+    )
+
+    plugin_class = load_extern_object(str(module_path), "Plugin")
+
+    assert plugin_class().value == 1
+    assert plugin_class.__module__ not in sys.modules
+
+
+def test_load_module_registers_explicit_name_before_execution(tmp_path):
+    module_path = tmp_path / "self_checking_plugin.py"
+    module_path.write_text("import sys\nregistered_module = sys.modules[__name__]\n")
+    module_name = "verl_test_self_checking_plugin"
+
+    try:
+        module = load_module(str(module_path), module_name=module_name)
+
+        assert module.registered_module is module
+        assert sys.modules[module_name] is module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_load_module_rejects_name_collision_before_execution(tmp_path):
+    marker_path = tmp_path / "executed"
+    module_path = tmp_path / "plugin.py"
+    module_path.write_text(f"from pathlib import Path\nPath({str(marker_path)!r}).touch()\n")
+    module_name = "verl_test_existing_module"
+    existing_module = sys
+    sys.modules[module_name] = existing_module
+
+    try:
+        with pytest.raises(RuntimeError, match="already exists"):
+            load_module(str(module_path), module_name=module_name)
+
+        assert sys.modules[module_name] is existing_module
+        assert not marker_path.exists()
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_load_module_removes_partial_module_after_failure(tmp_path):
+    module_path = tmp_path / "broken_plugin.py"
+    module_path.write_text("raise ValueError('broken')\n")
+    module_name = "verl_test_broken_plugin"
+
+    with pytest.raises(RuntimeError, match="Error loading module"):
+        load_module(str(module_path), module_name=module_name)
+
+    assert module_name not in sys.modules

--- a/verl/utils/import_utils.py
+++ b/verl/utils/import_utils.py
@@ -19,6 +19,7 @@ We assume package availability won't change during runtime.
 import importlib
 import importlib.util
 import os
+import sys
 import warnings
 from functools import cache, wraps
 from typing import Optional
@@ -161,8 +162,8 @@ def load_module(module_path: str, module_name: Optional[str] = None) -> object:
                     - "file://verl/utils/dataset/rl_dataset.py"
                     - "/path/to/verl/utils/dataset/rl_dataset.py"
         module_name (str, optional):
-            The name of the module to added to ``sys.modules``. If not provided, the module will not be added,
-                thus will not be cached and directly ``import``able.
+            The name under which to cache the module in ``sys.modules``. If not provided, the module is registered
+            only while it executes and is not cached or directly importable afterward.
     """
     if not module_path:
         return None
@@ -184,21 +185,36 @@ def load_module(module_path: str, module_name: Optional[str] = None) -> object:
         if spec is None or spec.loader is None:
             raise ImportError(f"Could not load module from {module_path=}")
 
+        # Match Python's import semantics by making the module visible while its
+        # code executes. Some decorators (notably dataclasses with postponed
+        # annotations) look up the module namespace through sys.modules.
+        missing = object()
+        previous_module = sys.modules.get(spec_name, missing)
+        if module_name is not None and previous_module is not missing:
+            raise RuntimeError(f"Module name '{module_name}' already exists in `sys.modules`.")
+
         module = importlib.util.module_from_spec(spec)
+        sys.modules[spec_name] = module
+        execution_succeeded = False
         try:
             spec.loader.exec_module(module)
+            execution_succeeded = True
         except Exception as e:
             raise RuntimeError(f"Error loading module from {module_path=}") from e
+        finally:
+            if module_name is None:
+                if previous_module is missing:
+                    sys.modules.pop(spec_name, None)
+                else:
+                    sys.modules[spec_name] = previous_module
+            elif not execution_succeeded:
+                # Match importlib by removing partially initialized modules.
+                sys.modules.pop(spec_name, None)
 
         if module_name is not None:
-            import sys
-
-            # Avoid overwriting an existing module with a different object.
-            if module_name in sys.modules and sys.modules[module_name] is not module:
-                raise RuntimeError(
-                    f"Module name '{module_name}' already in `sys.modules` and points to a different module."
-                )
-            sys.modules[module_name] = module
+            # Keep the returned module and the importable module in sync even if
+            # module initialization replaced its own sys.modules entry.
+            sys.modules[spec_name] = module
 
     return module
 


### PR DESCRIPTION
### What does this PR do?

`load_module()` previously executed file-based modules before registering them in `sys.modules`. That differs from normal Python import semantics and breaks valid custom dataset/reward plugins whose initialization needs to resolve their own module. One concrete case is a `@dataclass` declared with postponed annotations, which failed with:

```text
AttributeError: 'NoneType' object has no attribute '__dict__'
```

This PR:

- registers file-based modules in `sys.modules` before executing their code;
- preserves anonymous loading's documented non-caching behavior by restoring/removing the temporary entry afterward;
- rejects explicit module-name collisions before plugin code can produce side effects;
- removes partially initialized named modules if execution fails;
- adds focused regression coverage for these behaviors.

No user-facing API signature or configuration changes are introduced.

### Checklist Before Starting

- [x] Searched for similar open PRs: [`load_module` search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+load_module)
  - No open PR directly addresses registration in `sys.modules` during file-module execution or the dataclass failure.
  - #1040 also touches `import_utils.py`, but adds dotted-module support to `load_extern_type`; it does not address execution-time registration, collision side effects, or failed-import cleanup.
- [x] PR title follows the required `[{modules}] {type}: {description}` format.

### Test

- `.venv/bin/python -m pytest -q tests/utils/test_import_utils_on_cpu.py` — **11 passed**
- `.venv/bin/python -m ruff format --check verl/utils/import_utils.py tests/utils/test_import_utils_on_cpu.py` — passed
- `.venv/bin/python -m ruff check verl/utils/import_utils.py tests/utils/test_import_utils_on_cpu.py` — passed
- `git diff --check` — passed
- Targeted pre-commit run on both changed files — Ruff, formatting, mypy, generated-config verification, docs metadata, docstring coverage, license, device API, DataProto, test structure, example naming, uv-branch, and compile hooks passed. The repository-wide naming hook was checked separately on the changed files because its recursive scan includes the ignored local `.venv` and reports third-party Ray package names.

The full GPU/Ray distributed training suites were not run. This change is limited to pure-Python import behavior and does not depend on GPU or Ray.

### API and Usage Example

No API changes. Existing file-based plugins using standard Python constructs such as postponed dataclass annotations now load correctly:

```python
from __future__ import annotations
from dataclasses import dataclass

@dataclass
class Plugin:
    value: int = 1
```

### Design & Code Changes

The implementation follows the import protocol used by Python:

1. Create the module object.
2. Register it in `sys.modules` before `exec_module()`.
3. Execute the module.
4. For anonymous loads, restore the previous entry or remove the temporary registration.
5. For named loads, retain the successfully initialized module and remove partial registrations on failure.

Regression tests cover postponed dataclass annotations, initialization-time self-lookup, pre-execution collision rejection, and cleanup after failure.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied pre-commit checks to the changed files; environment-specific naming-hook handling is documented in **Test** above.
- [x] Documentation impact reviewed; no update is needed because this fixes existing behavior without changing the public API.
- [x] Added tests to the existing `test_import_utils_on_cpu.py` suite, which is already collected by `cpu_unit_tests.yml`.
- [ ] Request project CI in Slack/Feishu after the PR is opened.
- [x] Recipe submodule update is not applicable.

### AI assistance disclosure

OpenAI Codex assisted with bug reproduction, implementation, test execution, and drafting this PR. The human submitter reviewed every changed line and confirmed the change before submission.
