### PR TITLE
[doc] chore: add launchable AMD Developer Cloud Fully Async DAPO notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ verl is fast with:
   - [Ray API design tutorial](https://verl.readthedocs.io/en/latest/advance/placement.html)
 
 **Blogs from the community**
-
+- [Hands-on: Launch verl Fully Async DAPO Training on 4 AMD Instinct GPUs with AMD Developer Cloud](https://cloud.oneclickamd.ai/templates/1925/preview)
 - [When Reasoning Models Break Tokenization: The Hidden Complexity of Multiturn Training](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/rlhf/verl/multi-turn/fast_tokenization/multiturn_tokenization_and_masking.md)
 - [verl deployment on AWS SageMaker](https://medium.com/@kaige.yang0110/run-verl-on-sagemaker-using-4x8-l40s-gpus-8e6d5c3c61d3)
 - [verl x SGLang Multi-turn Code Walkthrough](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/rlhf/verl/multi-turn/code-walk-through/readme_EN.md)


### PR DESCRIPTION
### What does this PR do?

Hi maintainers,

Since the last AMD Developer Day in Shanghai, where we demonstrated single-GPU LoRA training with verl on AMD Instinct GPUs, several developers have asked whether we could provide a multi-GPU DAPO hands-on tutorial.

We now have a ready-to-launch notebook tutorial on AMD Developer Cloud that allows developers to directly experiment with verl Fully Async DAPO training on 4 AMD Instinct GPUs. After signing in, developers can use the free GPU credits provided by AMD Developer Cloud to launch the environment and complete the hands-on tutorial.

This PR adds a link to that hands-on environment in the README so that community developers can easily discover and launch the tutorial.

P.S. We plan to keep this tutorial aligned with future verl-on-AMD Docker image updates, including migration to the latest `verl` `trainer.v1`.

Thanks!

### Design & Code Changes

Add a direct link in the README to the AMD Developer Cloud hands-on notebook.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
