### PR TITLE
[megatron] fix: resolve Hub ids to a local snapshot before Megatron-Bridge

### DIFF
--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -338,11 +338,21 @@ class MegatronEngine(BaseEngine):
             if self.is_value_model and hasattr(tf_config, "share_embeddings_and_output_weights"):
                 tf_config.share_embeddings_and_output_weights = False
         else:
+            from huggingface_hub import snapshot_download
             from verl.models.mcore.bridge import AutoBridge
 
-            # Use Megatron-Bridge to convert HF config to Megatron config
+            # Megatron-Bridge looks for safetensors on the filesystem. Hub ids are
+            # not directories; pin revision via snapshot_download (HF cache hit).
+            hf_src = self.model_config.local_path
+            rev = getattr(self.model_config, "revision", None)
+            snap_kw = {}
+            if rev and not str(hf_src).startswith("/"):
+                snap_kw["revision"] = rev
+            if not str(hf_src).startswith("/"):
+                hf_src = snapshot_download(hf_src, **snap_kw)
+            self._megatron_hf_src = hf_src
             bridge = AutoBridge.from_hf_pretrained(
-                self.model_config.local_path, trust_remote_code=self.model_config.trust_remote_code
+                hf_src, trust_remote_code=self.model_config.trust_remote_code
             )
             # Get Megatron provider and configure it
             provider = bridge.to_megatron_provider(load_weights=False)
@@ -508,7 +518,9 @@ class MegatronEngine(BaseEngine):
                 if self.is_value_model:
                     allowed_mismatched_params = ["output_layer.weight"]
                 self.bridge.load_hf_weights(
-                    module, self.model_config.local_path, allowed_mismatched_params=allowed_mismatched_params
+                    module,
+                    getattr(self, "_megatron_hf_src", self.model_config.local_path),
+                    allowed_mismatched_params=allowed_mismatched_params,
                 )
 
         if torch.distributed.get_rank() == 0:


### PR DESCRIPTION
### What does this PR do?

`AutoBridge.from_hf_pretrained` / `load_hf_weights` look for `.safetensors` on a **filesystem path**. Passing a Hub id is not a directory, and Bridge does not honor `revision` on that id, so Megatron init fails (missing `model_type` / no weights).

`snapshot_download` the Hub id (optional `model.revision` if present) and load from the local snapshot. Hits the HF cache when already present.

Related: https://github.com/verl-project/verl/pull/7658 threads `revision` through FSDP/vLLM but not Megatron-Bridge.

Search: https://github.com/verl-project/verl/pulls?q=is%3Apr+Megatron-Bridge+snapshot_download

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+Megatron-Bridge+from_hf_pretrained
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

2-node Megatron-FSDP OPD with Hub ids + revisions. No new GPU CI in this environment.

### API and Usage Example

```yaml
actor_rollout_ref.model.path: org/name
actor_rollout_ref.model.revision: abcdef  # optional; ignored for local paths
```

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] pre-commit not run in this environment.


Made with [Cursor](https://cursor.com)