### PR TITLE
fix(reward): replace eval with whitelisted AST evaluation in prime_math grader (CVE-2026-6878)

### DIFF
--- a/tests/utils/reward_score/test_prime_math_safe_eval.py
+++ b/tests/utils/reward_score/test_prime_math_safe_eval.py
@@ -1,0 +1,66 @@
+"""Regression tests for CVE-2026-6878: prime_math grader safe evaluation.
+
+The grader evaluates model-authored strings. Before the fix, both
+evaluation sites used builtins eval, so an answer could execute
+arbitrary code inside the reward worker. The fixes:
+
+- handle_pi evaluates only whitelisted numeric arithmetic ASTs
+- the pmatrix path parses prediction with ast.literal_eval
+
+Behavior on legitimate inputs is unchanged.
+"""
+
+import ast
+import math
+
+import pytest
+
+from verl.utils.reward_score.prime_math.grader import (
+    _safe_arith_eval,
+    handle_pi,
+)
+
+
+class TestSafeArithEval:
+    def test_numeric_arithmetic_evaluates(self):
+        assert _safe_arith_eval("2*3.141592653589793 + 1") == pytest.approx(2 * math.pi + 1)
+
+    def test_unary_and_precedence(self):
+        assert _safe_arith_eval("-2*3") == -6
+        assert _safe_arith_eval("1+2*3") == 7
+
+    def test_names_rejected(self):
+        with pytest.raises(ValueError):
+            _safe_arith_eval("pi")
+
+    def test_calls_rejected(self):
+        with pytest.raises(ValueError):
+            _safe_arith_eval("__import__('os').system('true') or 5")
+
+    def test_attribute_access_rejected(self):
+        with pytest.raises(ValueError):
+            _safe_arith_eval("(1).__class__")
+
+    def test_subscript_rejected(self):
+        with pytest.raises(ValueError):
+            _safe_arith_eval("[1, 2][0]")
+
+    def test_comprehension_rejected(self):
+        with pytest.raises(ValueError):
+            _safe_arith_eval("[x for x in (1, 2)]")
+
+
+class TestHandlePiAttackSurface:
+    def test_import_attack_string_is_not_evaluated(self, tmp_path):
+        marker = tmp_path / "pwned"
+        attack = f"__import__('os').system('touch {marker}') or 5"
+        result = handle_pi(attack, math.pi)
+        assert not marker.exists()
+        assert isinstance(result, str)
+
+    def test_legitimate_pi_expression_evaluates(self):
+        assert handle_pi("2\\pi", math.pi) == pytest.approx(2 * math.pi)
+        assert handle_pi("\\pi/2", math.pi) == pytest.approx(math.pi / 2)
+
+    def test_string_without_pi_untouched(self):
+        assert handle_pi("1+2*3", math.pi) == "1+2*3"

--- a/verl/utils/reward_score/prime_math/grader.py
+++ b/verl/utils/reward_score/prime_math/grader.py
@@ -105,6 +105,30 @@ from sympy.parsing.sympy_parser import parse_expr
 # verl related
 from verl.utils.py_functional import timeout_limit
 
+import ast
+
+_ARITHMETIC_NODES = frozenset(
+    [ast.Expression, ast.BinOp, ast.UnaryOp, ast.Constant, ast.Load]
+    + list(ast.operator.__subclasses__())
+    + list(ast.unaryop.__subclasses__())
+)
+
+
+def _safe_arith_eval(expression: str):
+    r"""Evaluate a purely numeric arithmetic expression.
+
+    The input string is model-authored text after \pi substitution, so it
+    must never reach a general-purpose eval. Only numeric constants,
+    arithmetic operators, and unary signs are permitted; names, calls,
+    attributes, subscripts, and comprehensions raise before evaluation.
+    """
+    tree = ast.parse(expression, mode="eval")
+    for node in ast.walk(tree):
+        if type(node) not in _ARITHMETIC_NODES:
+            raise ValueError(f"disallowed node in arithmetic expression: {type(node).__name__}")
+    code = compile(tree, "<prime_math>", "eval")
+    return eval(code, {"__builtins__": {}}, {})
+
 
 def is_digit(s):
     try:
@@ -164,9 +188,11 @@ def handle_pi(string, pi):
             # Find the next occurrence of "\pi"
             idx = string.find("\\pi", idx + 1)
 
-        # Evaluate the expression using eval() function
+        # Evaluate the arithmetic expression with a whitelisted AST
+        # (CVE-2026-6878): the string is model-authored and must never
+        # reach a general-purpose eval.
         with contextlib.suppress(Exception):
-            string = eval(string)
+            string = _safe_arith_eval(string)
 
     return string
 
@@ -296,9 +322,12 @@ def math_equal(
         except Exception:
             pass
     elif r"\begin{pmatrix}" in reference and prediction.startswith("[") and prediction.endswith("]"):
-        if isinstance(eval(prediction), list):
+        try:
+            pred_matrix = ast.literal_eval(prediction)
+        except (ValueError, SyntaxError):
+            pred_matrix = None
+        if isinstance(pred_matrix, list):
             try:
-                pred_matrix = eval(prediction)
                 # ref_matrix_items = reference.split()[1:-1:2]
                 ref_matrix_items = (
                     reference.removeprefix(r"\\begin{pmatrix}")


### PR DESCRIPTION
## Summary

Both evaluation sites in the prime_math grader run `eval` on model-authored strings inside the reward worker:

- `handle_pi` evals the string after pi substitution (`grader.py`, the `string = eval(string)` under `contextlib.suppress`)
- the pmatrix path evals the prediction to obtain a matrix literal (`eval(prediction)`)

Either site allows a submitted answer to execute arbitrary code during reward computation. This is CVE-2026-6878 / GHSA-h57c-v2v3-5v3v, published 2026-04-23 with no patched version; the sinks are still live on main today (re-verified at 8df88be and again at the current tip while preparing this PR).

## The fix

- `handle_pi` evaluates through a whitelisted numeric AST (`_safe_arith_eval`): numeric constants, arithmetic operators, and unary signs only. Names, calls, attributes, subscripts, and comprehensions raise before evaluation, and the compiled node runs with empty builtins. The check runs before `compile`, so rejected strings never reach code generation.
- The pmatrix path parses the prediction with `ast.literal_eval`; non-literal input fails the comparison instead of executing.

## Behavior preservation

- pi expressions evaluate to identical values (`2\pi` -> 6.283185307179586, before and after)
- strings without pi pass through untouched (never were evaluated)
- non-literal matrix predictions already failed the comparison upstream; they now fail without executing
- verified input-by-input against the pre-fix grader loaded side by side

## Testing

`tests/utils/reward_score/test_prime_math_safe_eval.py`: whitelisted evaluation accepts arithmetic and rejects five attack shapes (name, import call, attribute, subscript, comprehension); `handle_pi` neutralizes an `os.system` import attempt without executing it while preserving legitimate pi arithmetic. All bodies validated locally against the module.

## Scope note

The persistent-forgery chain described in the advisory write-up (monkeypatching `grade_answer` to affect later samples) needs reward-worker isolation to address fully and is intentionally out of scope for this PR; this closes the arbitrary-execution sinks.