### PR TITLE
[training_utils] fix: honor fused output-head backend

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -248,8 +248,10 @@ Actor/Rollout/Reference Policy
   used.
 
   - ``actor_rollout_ref.model.fused_kernel_options.impl_backend``: The
-    implementation backend for fused kernels. Options: "triton" or
-    "torch". Default is "torch".
+    implementation backend for fused kernels. Options: "triton", "torch", or
+    "liger". The "torch" backend always uses verl's native output-head implementation;
+    select "liger" explicitly to use Liger's fused output-head kernel.
+    Default is "torch".
     While in megatron, we only support "triton" as the
     implementation backend, so there is no need for this option.
 

--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -181,9 +181,9 @@ LigerKernel provides fused Triton kernels (RMSNorm, SwiGLU, RoPE) that can impro
       model:
         use_liger: True  # Enable LigerKernel
 
-2. The default value is ``False``. When enabled, verl applies Liger's fused RMSNorm, SwiGLU, and RoPE kernels to the model. The model-level ``fused_linear_cross_entropy`` patch remains disabled because verl computes log-probabilities through its output-head path. With ``use_fused_kernels`` and the ``torch`` backend, that path uses Liger's fused scaled linear cross entropy from v0.8.2 or newer and falls back to verl's existing chunked ``FusedLinearForPPOFunction`` when Liger is not installed.
+2. The default value is ``False``. When enabled, verl applies Liger's fused RMSNorm, SwiGLU, and RoPE kernels to the model. The model-level ``fused_linear_cross_entropy`` patch remains disabled because verl computes log-probabilities through its output-head path.
 
-3. ``use_liger`` is compatible with ``use_fused_kernels``. The former controls model-internal kernels, while the latter controls the output head and can use Liger's scaled cross entropy independently when ``liger-kernel>=0.8.2`` is installed.
+3. ``use_liger`` is compatible with ``use_fused_kernels``. The former controls model-internal kernels, while the latter controls the output head. Set ``fused_kernel_options.impl_backend`` to ``liger`` to use Liger's fused scaled cross entropy, or keep the default ``torch`` backend to use verl's native chunked ``FusedLinearForPPOFunction``. The ``liger`` backend falls back to the native implementation when Liger is not installed.
 
 Forward prefetch in FSDP training backend
 ----------------------

--- a/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
+++ b/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
@@ -40,6 +40,7 @@ exercises the full path on 2 GPUs.
 """
 
 import contextlib
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -157,7 +158,7 @@ def _patch_fused_kernels():
     so the CPU test exercises only the routing layer. Yields a dict that
     captures the `input_ids` arg the kernel would have received.
     """
-    captured: dict[str, torch.Tensor] = {}
+    captured: dict[str, Any] = {}
 
     def _fake_log_probs_and_entropy(input_ids: torch.Tensor):
         if input_ids.dim() == 1:
@@ -170,6 +171,7 @@ def _patch_fused_kernels():
 
     def fake_fused_linear_forward(self, hidden_states, vocab_weights, input_ids, temperature=1.0):
         captured["input_ids"] = input_ids.detach().clone()
+        captured["impl_backend"] = self.impl_backend
         return _fake_log_probs_and_entropy(input_ids)
 
     def fake_linear_ce(hidden_states, vocab_weights, input_ids, temperature, reduction):
@@ -218,9 +220,29 @@ ALL_ADAPTERS = [
     glm4v.forward_with_triton_backend,
 ]
 
+TORCH_ADAPTERS = [
+    dense_common.forward_with_torch_backend,
+    qwen3_5.forward_with_torch_backend,
+    qwen3_vl.forward_with_torch_backend,
+    qwen2_vl.forward_with_torch_backend,
+    glm4v.forward_with_torch_backend,
+]
+
 
 def _adapter_id(forward_fn) -> str:
     return f"{forward_fn.__module__.rsplit('.', 1)[-1]}.{forward_fn.__name__}"
+
+
+@pytest.mark.parametrize("forward_fn", TORCH_ADAPTERS, ids=_adapter_id)
+def test_torch_adapter_propagates_fused_linear_backend(forward_fn):
+    model = _make_fake_lm()
+    model._verl_fused_kernels_backend = "liger"
+    input_ids = torch.tensor([[10, 20, 30, 40]], dtype=torch.long)
+
+    with _patch_fused_kernels() as captured:
+        forward_fn(model, input_ids=input_ids, labels=None, temperature=1.0, return_dict=True)
+
+    assert captured["impl_backend"] == "liger"
 
 
 @pytest.mark.parametrize("forward_fn", ALL_ADAPTERS, ids=_adapter_id)

--- a/tests/utils/test_experimental_torch_functional_on_cpu.py
+++ b/tests/utils/test_experimental_torch_functional_on_cpu.py
@@ -81,7 +81,7 @@ def test_fused_linear_for_ppo_dispatches_to_liger(monkeypatch):
     weight = torch.randn(7, 5)
     labels = torch.randint(7, (2, 3), dtype=torch.int32)
 
-    log_probs, entropy = experimental_F.FusedLinearForPPO()(hidden, weight, labels, temperature=0.8)
+    log_probs, entropy = experimental_F.FusedLinearForPPO(impl_backend="liger")(hidden, weight, labels, temperature=0.8)
 
     assert len(calls) == 1
     liger_hidden, liger_weight, liger_labels, temperature, ignore_index, m_tiles, return_entropy = calls[0]
@@ -95,6 +95,38 @@ def test_fused_linear_for_ppo_dispatches_to_liger(monkeypatch):
     assert return_entropy is True
     torch.testing.assert_close(log_probs, -torch.arange(6, dtype=torch.float32).reshape(2, 3))
     torch.testing.assert_close(entropy, (torch.arange(6, dtype=hidden.dtype) + 10).reshape(2, 3))
+
+
+def test_fused_linear_for_ppo_torch_backend_does_not_dispatch_to_liger(monkeypatch):
+    class UnexpectedLigerFusedLinearScaledCrossEntropyFunction:
+        @staticmethod
+        def apply(*args):
+            raise AssertionError("The torch backend must not dispatch to Liger")
+
+    monkeypatch.setattr(
+        experimental_F,
+        "_LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY",
+        UnexpectedLigerFusedLinearScaledCrossEntropyFunction,
+    )
+    monkeypatch.setattr(experimental_F, "_FLASH_ATTN_CROSS_ENTROPY_AVAILABLE", False)
+
+    hidden = torch.randn(2, 3, 5)
+    weight = torch.randn(7, 5)
+    labels = torch.randint(7, (2, 3))
+
+    log_probs, entropy = experimental_F.FusedLinearForPPO()(hidden, weight, labels)
+
+    logits = (hidden @ weight.t()).float()
+    expected_log_probs = logits.log_softmax(dim=-1).gather(-1, labels.unsqueeze(-1)).squeeze(-1)
+    probs = logits.softmax(dim=-1)
+    expected_entropy = torch.logsumexp(logits, dim=-1) - torch.sum(probs * logits, dim=-1)
+    torch.testing.assert_close(log_probs, expected_log_probs)
+    torch.testing.assert_close(entropy, expected_entropy)
+
+
+def test_fused_linear_for_ppo_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="Unsupported FusedLinearForPPO backend"):
+        experimental_F.FusedLinearForPPO(impl_backend="unknown")
 
 
 def test_fused_linear_for_ppo_fallback_preserves_chunking(monkeypatch):

--- a/verl/models/transformers/dense_common.py
+++ b/verl/models/transformers/dense_common.py
@@ -119,7 +119,7 @@ def forward_with_torch_backend(
     else:
         raise RuntimeError("To use forward_with_torch_backend, either labels or input_ids must be provided.")
 
-    fused_linear_for_ppo = FusedLinearForPPO()
+    fused_linear_for_ppo = FusedLinearForPPO(impl_backend=getattr(self, "_verl_fused_kernels_backend", "torch"))
     log_probs, entropy = fused_linear_for_ppo.forward(
         hidden_states=hidden_states,
         vocab_weights=self.lm_head.weight,

--- a/verl/models/transformers/glm4v.py
+++ b/verl/models/transformers/glm4v.py
@@ -489,7 +489,7 @@ def forward_with_torch_backend(
     else:
         raise RuntimeError("To use forward_with_torch_backend, either labels or input_ids must be provided.")
 
-    fused_linear_for_ppo = FusedLinearForPPO()
+    fused_linear_for_ppo = FusedLinearForPPO(impl_backend=getattr(self, "_verl_fused_kernels_backend", "torch"))
     log_probs, entropy = fused_linear_for_ppo.forward(
         hidden_states=hidden_states,
         vocab_weights=self.lm_head.weight,

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -243,7 +243,7 @@ def patch_forward_with_backends(
         use_fused_kernels (bool): Whether to use fused kernels.
         fused_kernels_backend (str): The backend to use for fused kernels.
     """
-    if not use_fused_kernels or fused_kernels_backend not in ["triton", "torch"]:
+    if not use_fused_kernels or fused_kernels_backend not in ["triton", "torch", "liger"]:
         print(
             f"Skipping monkey patch for {model.__class__.__name__} as use_fused_kernels is "
             f"{use_fused_kernels} or fused_kernels_backend is {fused_kernels_backend}"
@@ -278,14 +278,17 @@ def patch_forward_with_backends(
         forward_with_torch_backend_function = forward_with_torch_backend
         forward_with_triton_backend_function = forward_with_triton_backend
 
+    model._verl_fused_kernels_backend = fused_kernels_backend
     if fused_kernels_backend == "triton":
         model.__class__.forward = forward_with_triton_backend_function
         print(f"Using Triton backend for fused kernels in {model.__class__.__name__}")
-    elif fused_kernels_backend == "torch":
+    elif fused_kernels_backend in ("torch", "liger"):
         model.__class__.forward = forward_with_torch_backend_function
-        print(f"Using Torch backend for fused kernels in {model.__class__.__name__}")
+        print(f"Using {fused_kernels_backend.capitalize()} backend for fused kernels in {model.__class__.__name__}")
     else:
-        raise ValueError(f"Unsupported fused_kernels_backend: {fused_kernels_backend}. Choose 'triton' or 'torch'.")
+        raise ValueError(
+            f"Unsupported fused_kernels_backend: {fused_kernels_backend}. Choose 'triton', 'torch', or 'liger'."
+        )
 
 
 def apply_monkey_patch(

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -511,7 +511,7 @@ def forward_with_torch_backend(
     else:
         raise RuntimeError("To use forward_with_torch_backend, either labels or input_ids must be provided.")
 
-    fused_linear_for_ppo = FusedLinearForPPO()
+    fused_linear_for_ppo = FusedLinearForPPO(impl_backend=getattr(self, "_verl_fused_kernels_backend", "torch"))
     log_probs, entropy = fused_linear_for_ppo.forward(
         hidden_states=hidden_states,
         vocab_weights=self.lm_head.weight,

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -583,7 +583,7 @@ def forward_with_torch_backend(
     else:
         raise RuntimeError("To use forward_with_torch_backend, either labels or input_ids must be provided.")
 
-    fused_linear_for_ppo = FusedLinearForPPO()
+    fused_linear_for_ppo = FusedLinearForPPO(impl_backend=getattr(self, "_verl_fused_kernels_backend", "torch"))
     vocab_weights = self.lm_head.weight
     if isinstance(vocab_weights, DTensor):
         vocab_weights = vocab_weights.full_tensor()

--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -370,7 +370,7 @@ def forward_with_torch_backend(
     if isinstance(vocab_weights, DTensor):
         vocab_weights = vocab_weights.full_tensor().to(hidden_states.device)
 
-    fused_linear_for_ppo = FusedLinearForPPO()
+    fused_linear_for_ppo = FusedLinearForPPO(impl_backend=getattr(self, "_verl_fused_kernels_backend", "torch"))
     log_probs, entropy = fused_linear_for_ppo.forward(
         hidden_states=hidden_states,
         vocab_weights=vocab_weights,

--- a/verl/trainer/config/model/hf_model.yaml
+++ b/verl/trainer/config/model/hf_model.yaml
@@ -63,7 +63,8 @@ use_fused_kernels: False
 # fused kernel options.
 fused_kernel_options:
 
-  # the implementation backend for fused kernels.
+  # the implementation backend for fused kernels: torch, triton, or liger.
+  # Megatron only supports triton.
   impl_backend: torch
 
 # TiledMLP configuration for memory-efficient MLP computation.

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -218,10 +218,13 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
 
 
 class FusedLinearForPPO(torch.nn.Module):
-    def __init__(self, chunk_size: int = 512):
+    def __init__(self, chunk_size: int = 512, impl_backend: str = "torch"):
         super().__init__()
 
+        if impl_backend not in ("torch", "liger"):
+            raise ValueError(f"Unsupported FusedLinearForPPO backend: {impl_backend}. Choose 'torch' or 'liger'.")
         self.chunk_size = chunk_size
+        self.impl_backend = impl_backend
 
     def forward(
         self,
@@ -231,7 +234,7 @@ class FusedLinearForPPO(torch.nn.Module):
         temperature: float = 1.0,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
         input_ids = input_ids.to(torch.int64)
-        if _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY is None:
+        if self.impl_backend == "torch" or _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY is None:
             return FusedLinearForPPOFunction.apply(
                 hidden_states,
                 vocab_weights,


### PR DESCRIPTION
### What does this PR do?

Makes `fused_kernel_options.impl_backend` authoritative for the PPO output head:

- `torch` always uses verl's native chunked `FusedLinearForPPOFunction`.
- `liger` explicitly opts into `LigerFusedLinearScaledCrossEntropyFunction` and retains the native fallback when Liger is unavailable.
- The selected backend is propagated through all five Hugging Face fused-forward adapters.

This fixes a regression introduced by #7461. That change selected Liger whenever it was importable, even when the configured backend was `torch`. Besides violating the backend contract, the implicit Liger dispatch bypasses PyTorch operator overrides used by exactness integrations such as vexact, forcing vexact to modify verl's private module state as proposed in verl-project/vexact#48.

This does not duplicate an existing PR. Before implementation, open PRs and issues were searched for `FusedLinearForPPO Liger batch invariant`, `LigerFusedLinearScaledCrossEntropyFunction`, `fused linear PPO exactness`, and `disable Liger fused linear`; no matching open work was found.

AI assistance: OpenAI Codex assisted with implementation and test execution. The human submitter reviewed every changed line and understands the change end-to-end. The relevant tests listed below were run in the shared development workspace before submission.

### Test

- `python -m pytest -q tests/utils/test_experimental_torch_functional_on_cpu.py` — 6 passed.
- `python -m pytest -q tests/models/test_fused_kernels_ulysses_sp_on_cpu.py` — 26 passed.
- `pre-commit run --files <all changed files>` — all hooks passed.
- vexact `test_fused_linear_for_ppo_batch_invariance_forward` on 1x H20, without a vexact monkey patch or environment override — 2 passed.

Additional H20 diagnostic: the full vexact file has two existing strict bitwise comparison failures between the native chunked 2D matmul path and the 3D reference matmul, with maximum absolute differences of `1.52587890625e-05` and `1.9073486328125e-06`. This is separate from the implicit Liger dispatch fixed here; verl-project/vexact#48 reports 68 passing tests on H100 when using the same native fallback path.

### API and Usage Example

The default remains the native torch backend:

```yaml
actor_rollout_ref:
  model:
    use_fused_kernels: true
    fused_kernel_options:
      impl_backend: torch
```

Select Liger explicitly when desired:

```yaml
actor_rollout_ref:
  model:
    use_fused_kernels: true
    fused_kernel_options:
      impl_backend: liger
```

### Design & Code Changes

- Add an explicit `impl_backend` argument to `FusedLinearForPPO`, defaulting to `torch`.
- Route to Liger only when `impl_backend="liger"`.
- Store the selected fused backend on each model instance and pass it through dense, Qwen2-VL, Qwen3-VL, Qwen3.5, and GLM4V torch forward adapters.
- Document `liger` as an explicit backend and clarify the `torch` backend behavior.
- Add unit coverage for backend dispatch, validation, and adapter propagation.

### Checklist Before Submitting

- [x] Read the contribution and agent instructions.
- [x] Search for duplicate issues and PRs.
- [x] Add/update tests and documentation.
- [x] Run pre-commit checks.
- [x] Disclose AI assistance.
