### PR TITLE
[training_utils] fix: keep FusedLinearForPPO on the chunked path unde…

### DIFF
--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -181,7 +181,7 @@ LigerKernel provides fused Triton kernels (RMSNorm, SwiGLU, RoPE) that can impro
       model:
         use_liger: True  # Enable LigerKernel
 
-2. The default value is ``False``. When enabled, verl applies Liger's fused RMSNorm, SwiGLU, and RoPE kernels to the model. The model-level ``fused_linear_cross_entropy`` patch remains disabled because verl computes log-probabilities through its output-head path. With ``use_fused_kernels`` and the ``torch`` backend, that path uses Liger's fused scaled linear cross entropy from v0.8.2 or newer and falls back to verl's existing chunked ``FusedLinearForPPOFunction`` when Liger is not installed.
+2. The default value is ``False``. When enabled, verl applies Liger's fused RMSNorm, SwiGLU, and RoPE kernels to the model. The model-level ``fused_linear_cross_entropy`` patch remains disabled because verl computes log-probabilities through its output-head path. With ``use_fused_kernels`` and the ``torch`` backend, that path uses Liger's fused scaled linear cross entropy from v0.8.2 or newer and falls back to verl's existing chunked ``FusedLinearForPPOFunction`` when Liger is not installed. It also falls back to the chunked path while ``torch.use_deterministic_algorithms(True)`` is in effect, since the Liger kernel's reduction order differs from ``torch.matmul`` and it bypasses ``torch.library`` overrides of ``aten::mm`` (for example batch-invariant kernels).
 
 3. ``use_liger`` is compatible with ``use_fused_kernels``. The former controls model-internal kernels, while the latter controls the output head and can use Liger's scaled cross entropy independently when ``liger-kernel>=0.8.2`` is installed.
 

--- a/tests/utils/test_experimental_torch_functional_on_cpu.py
+++ b/tests/utils/test_experimental_torch_functional_on_cpu.py
@@ -97,6 +97,41 @@ def test_fused_linear_for_ppo_dispatches_to_liger(monkeypatch):
     torch.testing.assert_close(entropy, (torch.arange(6, dtype=hidden.dtype) + 10).reshape(2, 3))
 
 
+def test_fused_linear_for_ppo_skips_liger_under_deterministic_algorithms(monkeypatch):
+    calls = []
+
+    class FakeLigerFusedLinearScaledCrossEntropyFunction:
+        @staticmethod
+        def apply(*args):
+            calls.append(args)
+            raise AssertionError("Liger must not be used when deterministic algorithms are enabled")
+
+    monkeypatch.setattr(
+        experimental_F,
+        "_LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY",
+        FakeLigerFusedLinearScaledCrossEntropyFunction,
+    )
+    monkeypatch.setattr(experimental_F, "_FLASH_ATTN_CROSS_ENTROPY_AVAILABLE", False)
+    torch.manual_seed(42)
+    hidden = torch.randn(2, 3, 5)
+    weight = torch.randn(7, 5)
+    labels = torch.randint(7, (2, 3))
+
+    was_deterministic = torch.are_deterministic_algorithms_enabled()
+    warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    torch.use_deterministic_algorithms(True)
+    try:
+        log_probs, entropy = experimental_F.FusedLinearForPPO()(hidden, weight, labels)
+    finally:
+        torch.use_deterministic_algorithms(was_deterministic, warn_only=warn_only)
+
+    assert calls == []
+    logits = (hidden @ weight.t()).float()
+    expected_log_probs = logits.log_softmax(dim=-1).gather(-1, labels.unsqueeze(-1)).squeeze(-1)
+    torch.testing.assert_close(log_probs, expected_log_probs)
+    assert entropy.shape == labels.shape
+
+
 def test_fused_linear_for_ppo_fallback_preserves_chunking(monkeypatch):
     monkeypatch.setattr(experimental_F, "_LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY", None)
     monkeypatch.setattr(experimental_F, "_FLASH_ATTN_CROSS_ENTROPY_AVAILABLE", False)

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -217,6 +217,20 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
         )
 
 
+def _use_liger_fused_linear_for_ppo() -> bool:
+    """Whether FusedLinearForPPO should dispatch to Liger's fused scaled cross entropy.
+
+    Liger is faster, but it is a Triton kernel with its own tiling and reduction order, so
+    its log-probs are not bit-identical to the chunked ``torch.matmul`` path and it does not
+    see ``torch.library`` overrides of ``aten::mm`` (e.g. batch-invariant kernels). When the
+    user has asked PyTorch for deterministic algorithms, keep the chunked path so the
+    output head follows the same numerics as the rest of the model.
+    """
+    if _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY is None:
+        return False
+    return not torch.are_deterministic_algorithms_enabled()
+
+
 class FusedLinearForPPO(torch.nn.Module):
     def __init__(self, chunk_size: int = 512):
         super().__init__()
@@ -231,7 +245,7 @@ class FusedLinearForPPO(torch.nn.Module):
         temperature: float = 1.0,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
         input_ids = input_ids.to(torch.int64)
-        if _LIGER_FUSED_LINEAR_SCALED_CROSS_ENTROPY is None:
+        if not _use_liger_fused_linear_for_ppo():
             return FusedLinearForPPOFunction.apply(
                 hidden_states,
                 vocab_weights,


### PR DESCRIPTION
…r deterministic algorithms

#7461 routes FusedLinearForPPO through Liger's
LigerFusedLinearScaledCrossEntropyFunction whenever liger_kernel is importable. The Liger kernel has its own tiling and reduction order and does not go through torch.library overrides of aten::mm, so its log-probs are not bit-identical to the chunked torch.matmul path. Batch-invariant setups (e.g. vexact, which overrides aten::mm and enables
torch.use_deterministic_algorithms(True)) lost the exact match between training-side and inference-side log-probs: 98.9% of elements differ, max abs diff 0.6875, on verl 8e4a572 + liger-kernel 0.8.2.

Keep the Liger dispatch as the default fast path, but fall back to the chunked FusedLinearForPPOFunction while torch deterministic algorithms are enabled. Add a CPU test for the gate and a note in the perf tuning docs.

Verified on 1xH100 with liger-kernel 0.8.2: vexact tests/batch_invariant_ops/ 67 passed (previously 2 failed in test_verl_fused_linear_for_ppo.py).

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
