### PR TITLE
[doc] fix: drop ghost flowgrpo_trainer / vllm_omni from examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -119,7 +119,6 @@ under `recipe/` instead.
 | `otb_trainer/`                     | OTB                            | `adv_estimator=optimal_token_baseline`              |
 | `mtp_trainer/`                     | DAPO + MTP (MiMo-7B)           | `adv_estimator=grpo`, MTP flags                     |
 | `on_policy_distillation_trainer/`  | on-policy distillation         | GRPO + distillation loss                            |
-| `flowgrpo_trainer/`                | Flow-GRPO (diffusion)          | image-gen specific                                  |
 
 ### Feature / infra
 
@@ -129,7 +128,6 @@ under `recipe/` instead.
 | `profile/`           | NPU profiler / torch-memory profiler runs.                                               |
 | `sft/`               | Supervised fine-tuning examples.                                                         |
 | `generation/`        | Rollout-only inference launches.                                                         |
-| `vllm_omni/`         | vLLM omni backend examples.                                                              |
 | `data_preprocess/`   | Scripts that produce the `$HOME/data/<dataset>/*.parquet` layout the run scripts expect. |
 | `prefix_grouper/`    | Prefix-grouped rollout examples.                                                         |
 | `rollout_correction/`| Rollout correction examples.                                                             |


### PR DESCRIPTION
## Summary
`examples/README.md` lists `flowgrpo_trainer/` (algorithm table) and `vllm_omni/` (feature/infra table), but neither directory exists on `main`. Drop the two ghost rows.

## Repro
```bash
gh api repos/verl-project/verl/contents/examples --jq '.[].name'
gh api repos/verl-project/verl/contents/examples/flowgrpo_trainer
gh api repos/verl-project/verl/contents/examples/vllm_omni
gh api repos/verl-project/verl/contents/examples/README.md \
  -H 'Accept: application/vnd.github.raw' | rg -n 'flowgrpo_trainer|vllm_omni'
```

## Test plan
- [x] Confirmed both paths 404 on default branch
- [x] Removed only those two table rows
