### PR TITLE
[doc] fix: point one-step-off docs at main_ppo entry point

### DIFF
--- a/docs/advance/one_step_off.md
+++ b/docs/advance/one_step_off.md
@@ -236,7 +236,7 @@ Instead, we have switched to AgentLoop mode, which also supports multi-turn tool
 ### FSDP2 Configuration Example
 
 ```shell
-python3 -m verl.experimental.one_step_off_policy.async_main_ppo \
+python3 -m verl.experimental.one_step_off_policy.main_ppo \
     --config-path=config \
     --config-name='one_step_off_ppo_trainer.yaml' \
     actor_rollout_ref.actor.strategy=fsdp2 \
@@ -252,7 +252,7 @@ python3 -m verl.experimental.one_step_off_policy.async_main_ppo \
 ### Megatron Configuration Example
 
 ```shell
-python3 -m verl.experimental.one_step_off_policy.async_main_ppo \
+python3 -m verl.experimental.one_step_off_policy.main_ppo \
     --config-path=config \
     --config-name='one_step_off_ppo_megatron_trainer.yaml' \
     actor_rollout_ref.actor.strategy=megatron \

--- a/verl/experimental/one_step_off_policy/README.md
+++ b/verl/experimental/one_step_off_policy/README.md
@@ -226,7 +226,7 @@ Instead, we have switched to AgentLoop mode, which also supports multi-turn tool
 ### FSDP2 Configuration Example
 
 ```shell
-python3 -m verl.experimental.one_step_off_policy.async_main_ppo \
+python3 -m verl.experimental.one_step_off_policy.main_ppo \
     --config-path=config \
     --config-name='one_step_off_ppo_trainer.yaml' \
     actor_rollout_ref.actor.strategy=fsdp2 \
@@ -242,7 +242,7 @@ python3 -m verl.experimental.one_step_off_policy.async_main_ppo \
 ### Megatron Configuration Example
 
 ```shell
-python3 -m verl.experimental.one_step_off_policy.async_main_ppo \
+python3 -m verl.experimental.one_step_off_policy.main_ppo \
     --config-path=config \
     --config-name='one_step_off_ppo_megatron_trainer.yaml' \
     actor_rollout_ref.actor.strategy=megatron \


### PR DESCRIPTION
## Summary
`docs/advance/one_step_off.md` and `verl/experimental/one_step_off_policy/README.md` still invoke removed `async_main_ppo`. The real module is `main_ppo.py` (shell scripts already use it). Replace the four stale entry points.

## Repro
```bash
gh api repos/verl-project/verl/contents/verl/experimental/one_step_off_policy/async_main_ppo.py
# → 404
gh api repos/verl-project/verl/contents/verl/experimental/one_step_off_policy/main_ppo.py --jq .name
# → main_ppo.py
rg -n 'async_main_ppo' docs/advance/one_step_off.md verl/experimental/one_step_off_policy/README.md
# → 4 hits of python3 -m ...async_main_ppo
rg -n 'one_step_off_policy\.main_ppo' verl/experimental/one_step_off_policy/shell/
# → shell scripts already use main_ppo
```

## Test plan
- [x] Confirmed `async_main_ppo.py` 404 and `main_ppo.py` exists on default branch
- [x] Replaced all 4 `async_main_ppo` invocations in the two docs (2 files)
- [x] Left shell scripts and other files untouched