### PR TITLE
[doc] fix: correct actor_rollout_ref.rollout.n Hydra key in grpo.md

### DIFF
--- a/docs/algo/grpo.md
+++ b/docs/algo/grpo.md
@@ -26,9 +26,9 @@ Despite that many configurations start with the `ppo_` prefix, they work across 
 
 ![image](https://github.com/user-attachments/assets/16aebad1-0da6-4eb3-806d-54a74e712c2d)
 
-- `actor_rollout.ref.rollout.n`: For each prompt, sample n times. Default to 1. For GRPO, please set it to a value larger than 1 for group sampling.
+- `actor_rollout_ref.rollout.n`: For each prompt, sample n times. Default to 1. For GRPO, please set it to a value larger than 1 for group sampling.
 
-- `data.train_batch_size`: The global batch size of prompts used to generate a set of sampled trajectories/rollouts. The number of responses/trajectories is `data.train_batch_size * actor_rollout.ref.rollout.n`
+- `data.train_batch_size`: The global batch size of prompts used to generate a set of sampled trajectories/rollouts. The number of responses/trajectories is `data.train_batch_size * actor_rollout_ref.rollout.n`
 
 - `actor_rollout_ref.actor.ppo_mini_batch_size`: The set of sampled trajectories is split into multiple mini-batches with batch_size=ppo_mini_batch_size for PPO actor updates. The ppo_mini_batch_size is a global size across all workers.
 


### PR DESCRIPTION
## Summary

`docs/algo/grpo.md` documents the group-sampling Hydra override as `actor_rollout.ref.rollout.n` (dot between `actor_rollout` and `ref`). The real config group is `actor_rollout_ref`, so the override must be `actor_rollout_ref.rollout.n` (underscore), matching sibling docs and GRPO example scripts.

This PR updates the two drifted occurrences in `docs/algo/grpo.md` only.

## Repro

```bash
# Typo still present on main
curl -fsSL https://raw.githubusercontent.com/verl-project/verl/main/docs/algo/grpo.md \
  | rg -n 'actor_rollout\.ref\.rollout\.n'
# -> lines documenting actor_rollout.ref.rollout.n

# Correct key used elsewhere
curl -fsSL https://raw.githubusercontent.com/verl-project/verl/main/examples/grpo_trainer/run_glm4_1v_9b_fsdp.sh \
  | rg -n 'actor_rollout_ref\.rollout\.n'
# -> actor_rollout_ref.rollout.n=${ROLLOUT_N}

curl -fsSL https://raw.githubusercontent.com/verl-project/verl/main/docs/algo/otb.md \
  | rg -n 'actor_rollout_ref\.rollout\.n'
# -> Group sampling (`actor_rollout_ref.rollout.n > 1`) ...
```

## Test plan

- [x] Diff limited to `docs/algo/grpo.md`
- [x] Both typo sites now read `actor_rollout_ref.rollout.n`
- [x] No other files changed