### PR TITLE
[doc] fix: correct gamma and rollout.n Hydra keys in ppo.md

### DIFF
--- a/docs/algo/ppo.md
+++ b/docs/algo/ppo.md
@@ -29,7 +29,7 @@ Most critic configs are similar to those of actors. Note that the critic model i
 
 ![image](https://github.com/user-attachments/assets/16aebad1-0da6-4eb3-806d-54a74e712c2d)
 
-- `data.train_batch_size`: The global batch size of prompts used to generate a set of sampled trajectories/rollouts. The number of responses/trajectories is `data.train_batch_size * actor_rollout.ref.rollout.n`
+- `data.train_batch_size`: The global batch size of prompts used to generate a set of sampled trajectories/rollouts. The number of responses/trajectories is `data.train_batch_size * actor_rollout_ref.rollout.n`
 
 - `actor_rollout_ref.actor.ppo_mini_batch_size`: The set of sampled trajectories is split into multiple mini-batches with batch_size=ppo_mini_batch_size for PPO actor updates. The ppo_mini_batch_size is a global size across all workers
 
@@ -41,7 +41,7 @@ Most critic configs are similar to those of actors. Note that the critic model i
 
 - `critic.ppo_epochs`: Number of epochs for PPO updates on one set of sampled trajectories for critic. Defaults to `actor_rollout_ref.actor.ppo_epochs`
 
-- `algorithm.gemma`: discount factor
+- `algorithm.gamma`: discount factor
 
 - `algorithm.lam`: The lambda term that trades off between bias and variance in the GAE estimator
 


### PR DESCRIPTION
### What does this PR do?

Fixes two incorrect Hydra config keys in `docs/algo/ppo.md`:

1. `algorithm.gemma` → `algorithm.gamma` (discount factor). `AlgoConfig` in `verl/trainer/config/algorithm.py` defines `gamma`, not `gemma`. Same typo class was previously corrected in `config.rst` (#2369).
2. `actor_rollout.ref.rollout.n` → `actor_rollout_ref.rollout.n` in the train-batch × n formula. The real Hydra path is under `actor_rollout_ref.rollout`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+algorithm.gemma+OR+actor_rollout.ref.rollout.n+doc
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Docs-only wording fix; verified keys against `AlgoConfig.gamma` and `actor_rollout_ref.rollout.n` usage in trainer configs. No runtime change.

### API and Usage Example

No API change. Docs now match the Hydra keys users actually pass:

```bash
algorithm.gamma=1.0
actor_rollout_ref.rollout.n=4
```

### Design & Code Changes

- `docs/algo/ppo.md`: two Hydra key typos only.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Docs-only change; pre-commit N/A for this single markdown typo fix.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Unit/e2e tests not applicable (docs typo).
- [ ] CI request N/A for docs-only.
- [x] Not a recipe submodule change.