### PR TITLE
[doc] fix: use fsdp_config.ulysses_sequence_parallel_size in ppo_lora.rst

### DIFF
--- a/docs/advance/ppo_lora.rst
+++ b/docs/advance/ppo_lora.rst
@@ -197,7 +197,7 @@ Best Practices and Notes
     actor_rollout_ref.rollout.load_format=safetensors \
     actor_rollout_ref.rollout.layered_summon=True \
     actor_rollout_ref.ref.fsdp_config.param_offload=True \
-    actor_rollout_ref.actor.ulysses_sequence_parallel_size=1 \
+    actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=1 \
 
 Example Scripts
 -------------------


### PR DESCRIPTION
## Summary
- In `docs/advance/ppo_lora.rst` FSDP reference config, replace deprecated `actor_rollout_ref.actor.ulysses_sequence_parallel_size` with `actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size`.
- Matches `verl/trainer/config/actor/dp_actor.yaml` (`[DEPRECATED] use fsdp_config.ulysses_sequence_parallel_size instead`) and the LoRA example scripts under `examples/tuning/lora/`.

## Test plan
- [x] Confirmed top-level key marked deprecated in `dp_actor.yaml` / `FSDPActorConfig`
- [x] Confirmed example `examples/tuning/lora/run_qwen3_8b_fsdp.sh` already uses `fsdp_config.ulysses_sequence_parallel_size`
- [x] Single-line docs change only