### PR TITLE
[doc] fix: point GKD paths at recipe/gkd/megatron/

### DIFF
--- a/docs/advance/async-on-policy-distill.md
+++ b/docs/advance/async-on-policy-distill.md
@@ -156,10 +156,10 @@ There are 3 arguments can be set for vllm backend `--tp-size`, `--n-logprobs` an
 
 We also provide a toy multi-node teacher server. You can start the main node using `start_server.sh` and start the slave nodes using `join_server.sh`. Still remember to set args in `join_server.sh`, especially the `$PROXY_IP` and `$PROXY_BACKEND_PORT` of main node.
 
-When training, student will automatically use the teacher's topk (n-logprobs) to set its own topk argument at line 83 of `recipe/gkd/megatron_kl_loss.py`, so you don't need to set student's topk argument.
+When training, student will automatically use the teacher's topk (n-logprobs) to set its own topk argument at line 83 of `recipe/gkd/megatron/megatron_kl_loss.py`, so you don't need to set student's topk argument.
 
 ```bash
-cd recipe/gkd/teacher
+cd recipe/gkd/megatron/teacher
 bash start_server.sh
 # Exports ports and launches proxy + worker (default vLLM backend)
 ```
@@ -173,8 +173,8 @@ telnet localhost 15555
 ### 7.2 Minimal Local (Megatron + vLLM) Run
 
 ```bash
-python3 -m recipe.gkd.main_gkd \
-  --config-path=recipe/gkd/config \
+python3 -m recipe.gkd.megatron.main_gkd \
+  --config-path=recipe/gkd/megatron/config \
   --config-name=on_policy_distill_trainer \
   actor_rollout_ref.model.path=/path/to/MODEL \
   data.train_files=/path/to/train.parquet \
@@ -199,7 +199,7 @@ See `run_moonlight_dsv3_training.sh` for a full script including:
 Submit (after adjusting paths):
 
 ```bash
-bash recipe/gkd/run_moonlight_dsv3_training.sh
+bash recipe/gkd/megatron/run_moonlight_dsv3_training.sh
 ```
 
 ## 8. Metrics & Monitoring


### PR DESCRIPTION
## Summary
`docs/advance/async-on-policy-distill.md` still points GKD examples at top-level `recipe/gkd/…`. On current `verl-recipe` tip (submodule `recipe` @ `e7f889574b8301cc0f0fc1d57c6d67f31ffeb689`), `gkd/` only contains `megatron/`, so those paths 404.

Update file and module paths to `recipe/gkd/megatron/…` / `recipe.gkd.megatron…`.

## Repro
```bash
SHA=$(gh api repos/verl-project/verl/contents/recipe --jq .sha)
# stale (404)
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/megatron_kl_loss.py" | head -1
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/teacher/start_server.sh" | head -1
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/main_gkd.py" | head -1
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/run_moonlight_dsv3_training.sh" | head -1
# live (200)
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/megatron/megatron_kl_loss.py" | head -1
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/megatron/teacher/start_server.sh" | head -1
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/megatron/main_gkd.py" | head -1
curl -sI "https://raw.githubusercontent.com/verl-project/verl-recipe/${SHA}/gkd/megatron/run_moonlight_dsv3_training.sh" | head -1
# module layout: file is gkd/megatron/main_gkd.py; scripts invoke `python3 -m main_gkd` from that dir
```

## Changes
- `recipe/gkd/megatron_kl_loss.py` → `recipe/gkd/megatron/megatron_kl_loss.py`
- `cd recipe/gkd/teacher` → `cd recipe/gkd/megatron/teacher`
- `python3 -m recipe.gkd.main_gkd` → `python3 -m recipe.gkd.megatron.main_gkd`
- `--config-path=recipe/gkd/config` → `--config-path=recipe/gkd/megatron/config`
- `bash recipe/gkd/run_moonlight_dsv3_training.sh` → `bash recipe/gkd/megatron/run_moonlight_dsv3_training.sh`

## Test plan
- [x] Confirmed top-level GKD paths 404 and `gkd/megatron/…` paths 200 against submodule tip
- [x] Confirmed `main_gkd.py` / `run_moonlight_dsv3_training.sh` live under `gkd/megatron/`
- [x] Diff limited to `docs/advance/async-on-policy-distill.md`
- [x] No open covering PR for this doc path fix