### PR TITLE
[doc] fix: point entropy kl_cov scripts at recipe/entropy/

### DIFF
--- a/docs/algo/entropy.md
+++ b/docs/algo/entropy.md
@@ -42,7 +42,7 @@ After preparing the training data, for training Qwen2.5-7B on a single node, tak
 ```
 cd verl
 conda activate your_env
-bash recipe/dapo/7b_kl_cov.sh
+bash recipe/entropy/7b_kl_cov.sh
 ```
 
 While for training Qwen2.5-32B on multi nodes, you can run the following commands:
@@ -50,7 +50,7 @@ While for training Qwen2.5-32B on multi nodes, you can run the following command
 ```
 cd verl
 conda activate your_env
-bash recipe/dapo/32b_kl_cov.sh
+bash recipe/entropy/32b_kl_cov.sh
 ```
 
 ## 📖Introduction
@@ -112,4 +112,3 @@ For questions, discussion, or collaboration opportunities, feel free to contact:
 - Yuchen Zhang: yuchen.zhang2003@gmail.com
 - Jiacheng Chen: jackchan9345@gmail.com
 - Ning Ding: ningding.cs@gmail.com
-


### PR DESCRIPTION
## Summary
`docs/algo/entropy.md` told readers to run:

- `bash recipe/dapo/7b_kl_cov.sh`
- `bash recipe/dapo/32b_kl_cov.sh`

Those scripts are not under `recipe/dapo/` in the current [verl-recipe](https://github.com/verl-project/verl-recipe) tip (`e7f8895`). The live paths are:

- `recipe/entropy/7b_kl_cov.sh`
- `recipe/entropy/32b_kl_cov.sh`

## Reproduction
```bash
curl -fsSL https://raw.githubusercontent.com/verl-project/verl/main/docs/algo/entropy.md | rg 'kl_cov'
SHA=$(gh api repos/verl-project/verl/contents/recipe --jq .sha)
curl -sL -o /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/verl-project/verl-recipe/$SHA/dapo/7b_kl_cov.sh   # 404
curl -sL -o /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/verl-project/verl-recipe/$SHA/entropy/7b_kl_cov.sh # 200
```

## Change
Two path updates in `docs/algo/entropy.md` only.