### PR TITLE
[doc] fix: point fully_async example at verl/experimental path

### DIFF
--- a/docs/advance/fully_async.md
+++ b/docs/advance/fully_async.md
@@ -529,7 +529,7 @@ specifying `multi_turn` configurations in the config file.
      staleness_threshold: 0.5
      # Other async parameters
    ```
-4. **Example**: See `recipe/fully_async_policy/shell/dapo_7b_async_retool.sh`.
+4. **Example**: See `verl/experimental/fully_async_policy/shell/dapo_7b_async_retool.sh`.
 
 ### Experimental Results
 


### PR DESCRIPTION
## Summary
- Update `docs/advance/fully_async.md` example path from `recipe/fully_async_policy/shell/dapo_7b_async_retool.sh` to `verl/experimental/fully_async_policy/shell/dapo_7b_async_retool.sh` (script location on main).

## Test plan
- [x] Confirmed `recipe/fully_async_policy/shell/dapo_7b_async_retool.sh` is 404 on upstream main
- [x] Confirmed `verl/experimental/fully_async_policy/shell/dapo_7b_async_retool.sh` exists on main
- [x] Left `recipe/retool/...` references unchanged (present in verl-recipe submodule)