### PR TITLE
[fsdp] fix: backport unit-temperature logits reuse to v0.9.0

### DIFF
--- a/tests/workers/test_fsdp_temperature_scaling_on_cpu.py
+++ b/tests/workers/test_fsdp_temperature_scaling_on_cpu.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0(the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from verl.workers.engine.fsdp.transformer_impl import (
+    _is_scalar_unit_temperature,
+    _scale_logits_by_temperature,
+)
+
+
+@pytest.mark.parametrize("temperature", [1, 1.0])
+def test_scalar_unit_temperature_is_detected(temperature):
+    assert _is_scalar_unit_temperature(temperature) is True
+
+
+@pytest.mark.parametrize("temperature", [0.7, 2.0, torch.tensor(1.0)])
+def test_non_unit_or_tensor_temperature_uses_general_path(temperature):
+    assert _is_scalar_unit_temperature(temperature) is False
+
+
+def test_unit_temperature_preserves_logits_storage_and_gradient():
+    base = torch.randn(1, 4, 8, requires_grad=True)
+    logits_view = base.squeeze(0)
+
+    scaled = _scale_logits_by_temperature(
+        logits_view,
+        torch.ones(4, 1),
+        is_unit_temperature=True,
+    )
+
+    assert scaled is logits_view
+    scaled.sum().backward()
+    torch.testing.assert_close(base.grad, torch.ones_like(base))
+
+
+def test_non_unit_temperature_is_out_of_place_and_has_correct_gradient():
+    logits = torch.randn(4, 8, requires_grad=True)
+    temperature = torch.full((4, 1), 0.5)
+
+    scaled = _scale_logits_by_temperature(
+        logits,
+        temperature,
+        is_unit_temperature=False,
+    )
+
+    assert scaled is not logits
+    torch.testing.assert_close(scaled, logits * 2)
+    scaled.sum().backward()
+    torch.testing.assert_close(logits.grad, torch.full_like(logits, 2))

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -84,6 +84,20 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 device_name = get_device_name()
 
 
+def _is_scalar_unit_temperature(temperature) -> bool:
+    """Return whether a host scalar temperature makes scaling a no-op."""
+
+    return not isinstance(temperature, torch.Tensor) and float(temperature) == 1.0
+
+
+def _scale_logits_by_temperature(logits, temperature, *, is_unit_temperature: bool):
+    """Scale logits without copying the full vocabulary tensor for temperature 1."""
+
+    if is_unit_temperature:
+        return logits
+    return logits / temperature.clamp(min=1e-8).to(logits.dtype)
+
+
 class FSDPEngine(BaseEngine):
     """
     Concrete Engine implementation using PyTorch FullyShardedDataParallel (FSDP).
@@ -1130,6 +1144,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
         temperature = micro_batch["temperature"]
         temperature_item = temperature
+        temperature_is_one = _is_scalar_unit_temperature(temperature)
         if use_fused_kernels:
             assert not isinstance(temperature, torch.Tensor), (
                 "use_fused_kernels does not support per sample temperature yet"
@@ -1148,7 +1163,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
         assert temperature.shape[0] == input_ids.shape[0]
 
         # args used to get outputs
-        output_args = {}
+        output_args = {"temperature_is_one": temperature_is_one}
 
         if use_remove_padding:
             # support per sample temperature
@@ -1319,6 +1334,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
         model_output = {}
 
+        # Some internal callers construct output_args directly instead of going
+        # through prepare_model_inputs. Without the optimization metadata, fall
+        # back to the original out-of-place scaling path.
+        temperature_is_one = output_args.get("temperature_is_one", False)
+
         input_ids = micro_batch["input_ids"]
 
         if use_remove_padding:
@@ -1349,7 +1369,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 # With TP, logits are DTensors sharded on vocab dim; gather for log_softmax.
                 if isinstance(logits_rmpad, DTensor):
                     logits_rmpad = logits_rmpad.full_tensor()
-                logits_rmpad = logits_rmpad / temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype)
+                logits_rmpad = _scale_logits_by_temperature(
+                    logits_rmpad,
+                    temperature_rmpad.unsqueeze(-1),
+                    is_unit_temperature=temperature_is_one,
+                )
 
                 log_probs = None
 
@@ -1442,7 +1466,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 # With TP, logits are DTensors sharded on vocab dim; gather for log_softmax.
                 if isinstance(logits, DTensor):
                     logits = logits.full_tensor()
-                logits = logits / temperature.clamp(min=1e-8).to(logits.dtype)
+                logits = _scale_logits_by_temperature(
+                    logits,
+                    temperature,
+                    is_unit_temperature=temperature_is_one,
+                )
 
                 if calculate_entropy:
                     if not self.engine_config.entropy_checkpointing:


### PR DESCRIPTION
### What does this PR do

Backport #7428, upstream commit `978e2cc1b80347a2b3d759d235fb4396f9db5861`, to `release/v0.9.0`.

The FSDP eager logits path currently allocates another full-vocabulary tensor even when temperature is the host scalar `1`. Reuse the original logits in that case while preserving the safe out-of-place operation for non-unit and tensor temperatures. The prerequisite view-tensor fix from #6935 is already present in this release.

### Checklist Before Starting

- [x] Checked for existing backports to `release/v0.9.0`; none found on 2026-09-03. The source PR targets main and is already merged.
- [x] Used the repository PR title format.
- [x] Verified the backport applies cleanly to release commit `88512193628b95f24916c0898d51a8a877d09203`.

### Test

The backport was tested independently on its release-based branch:

```bash
python -m pytest tests/workers/test_fsdp_temperature_scaling_on_cpu.py -q --disable-warnings
```

Result: `7 passed` on Windows with Python 3.12 and PyTorch 2.13.0+cpu. A prior combined check with the independent #7458 backport also passed (`28 passed, 1 deselected`).

Ruff 0.12.2 lint and format checks passed for the changed Python files, as did `git diff --cached --check`. Both patches apply independently and in either order without conflicts. GPU/NPU training and peak-memory validation have not been run. Full pre-commit and full CI are not claimed.

### API and Usage Example

No public API or configuration changes. Existing host-scalar temperature `1` / `1.0` uses the optimization. Tensor and per-sample temperatures retain the general path. Fused-kernel execution is not optimized by this change.

### Design and Code Changes

- Preserve the final upstream implementation, including the fallback for callers that construct output arguments without the optimization metadata.
- Apply the helper to both remove-padding and padded FSDP eager paths.
- Backport the upstream CPU tests for tensor reuse, non-unit scaling and gradients.
- No dependency, checkpoint-format or recipe changes.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Included and ran the focused CPU tests described above.
- [x] Ran changed-file Ruff lint/format and whitespace checks.
- [x] Confirmed the recipe submodule is unaffected.
- [ ] Run complete pre-commit and required CI.
- [ ] Run GPU/NPU FSDP validation and measure peak memory.
- [ ] Human submitter reviewed every changed line and can explain the change.
