### PR TITLE
[fsdp] fix: backport gradient-sync configuration to v0.9.0

### DIFF
--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -198,10 +198,9 @@ Reduce FSDP gradient synchronization during gradient accumulation
 
 When a PPO mini-batch is split into multiple micro-batches, the optimizer only
 steps after the final micro-batch, so gradients only need to be synchronized
-once per mini-batch. The FSDP engine automatically defers gradient
-synchronization on the non-final micro-batches and synchronizes only before the
-final backward. This applies to both the actor and the critic, and requires no
-configuration.
+once per mini-batch. By default, the FSDP engine defers gradient synchronization
+on the non-final micro-batches and synchronizes only before the final backward.
+This applies to both the actor and the critic.
 
 With :math:`M` micro-batches per mini-batch, this reduces gradient
 synchronization from :math:`M` rounds to one round. It does not remove parameter
@@ -211,9 +210,12 @@ numerically identical to synchronizing every micro-batch.
 
 .. note::
     Deferring synchronization retains unsharded gradients until the final
-    micro-batch, which slightly increases peak device memory during gradient
-    accumulation. Forward-only passes are unaffected and always keep the default
-    behavior.
+    micro-batch, which can substantially increase peak device memory during
+    gradient accumulation for large models or long packed sequences. Set
+    ``actor_rollout_ref.actor.fsdp_config.use_no_sync_for_gradient_accumulation=False``
+    (or the corresponding critic FSDP setting) to synchronize and reshard after
+    every micro-batch when memory headroom is limited. Forward-only passes are
+    unaffected.
 
 Migrating to FSDP2
 ----------------------

--- a/tests/workers/config/test_engine_config_on_cpu.py
+++ b/tests/workers/config/test_engine_config_on_cpu.py
@@ -51,6 +51,11 @@ class TestFSDPEngineConfigCPU:
         assert config.param_offload is False
         assert config.optimizer_offload is False
         assert config.fsdp_size == -1
+        assert config.use_no_sync_for_gradient_accumulation is True
+
+    def test_gradient_accumulation_sync_can_be_restored_per_micro_batch(self):
+        config = FSDPEngineConfig(use_no_sync_for_gradient_accumulation=False)
+        assert config.use_no_sync_for_gradient_accumulation is False
 
     @pytest.mark.parametrize(
         "offload_params",

--- a/tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
+++ b/tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -48,9 +49,12 @@ class _FSDP2Module:
         self.events.append(enabled)
 
 
-def _make_engine(module):
+def _make_engine(module, *, use_no_sync_for_gradient_accumulation=True):
     engine = object.__new__(FSDPEngine)
     engine.module = module
+    engine.engine_config = SimpleNamespace(
+        use_no_sync_for_gradient_accumulation=use_no_sync_for_gradient_accumulation,
+    )
     return engine
 
 
@@ -88,6 +92,36 @@ def test_gradient_sync_context_keeps_sync_for_final_micro_batch(monkeypatch):
         module.events.append("backward")
 
     assert module.events == ["backward"]
+
+
+@pytest.mark.parametrize("version,module_cls", [(1, _FSDP1Module), (2, _FSDP2Module)])
+def test_gradient_sync_context_keeps_sync_when_disabled(monkeypatch, version, module_cls):
+    module = module_cls()
+    engine = _make_engine(module, use_no_sync_for_gradient_accumulation=False)
+    monkeypatch.setattr(transformer_impl, "fsdp_version", lambda _: version)
+
+    with engine._gradient_sync_context(is_last_micro_batch=False):
+        module.events.append("backward")
+
+    assert module.events == ["backward"]
+
+
+@pytest.mark.parametrize("version,module_cls", [(1, _FSDP1Module), (2, _FSDP2Module)])
+def test_gradient_sync_context_defaults_to_deferred_sync_for_legacy_config(
+    monkeypatch,
+    version,
+    module_cls,
+):
+    module = module_cls()
+    engine = _make_engine(module)
+    engine.engine_config = SimpleNamespace()
+    monkeypatch.setattr(transformer_impl, "fsdp_version", lambda _: version)
+
+    with engine._gradient_sync_context(is_last_micro_batch=False):
+        module.events.append("backward")
+
+    expected = ["enter", "backward", "exit"] if version == 1 else [False, "backward", True]
+    assert module.events == expected
 
 
 def test_forward_backward_batch_syncs_only_final_micro_batch(monkeypatch):

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -43,6 +43,7 @@ actor_rollout_ref:
       entropy_from_logits_chunk_size: ${oc.select:actor_rollout_ref.actor.entropy_from_logits_chunk_size,2048}
       use_torch_compile: true
       entropy_checkpointing: ${oc.select:actor_rollout_ref.actor.entropy_checkpointing,False}
+      use_no_sync_for_gradient_accumulation: false
       pad_to_length: ${oc.select:actor_rollout_ref.actor.pad_to_length,False}
       pad_to_length_bucket: 1024
       forward_only: false
@@ -236,6 +237,7 @@ actor_rollout_ref:
       entropy_from_logits_chunk_size: ${oc.select:actor_rollout_ref.ref.entropy_from_logits_chunk_size,2048}
       use_torch_compile: true
       entropy_checkpointing: ${oc.select:actor_rollout_ref.ref.entropy_checkpointing,False}
+      use_no_sync_for_gradient_accumulation: false
       pad_to_length: ${oc.select:actor_rollout_ref.ref.pad_to_length,False}
       pad_to_length_bucket: ${oc.select:actor_rollout_ref.actor.fsdp_config.pad_to_length_bucket,1024}
       forward_only: true
@@ -538,6 +540,7 @@ critic:
     entropy_from_logits_chunk_size: 2048
     use_torch_compile: true
     entropy_checkpointing: false
+    use_no_sync_for_gradient_accumulation: false
     pad_to_length: false
     pad_to_length_bucket: 1024
     forward_only: false

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -56,6 +56,10 @@ use_torch_compile: true
 # Whether to use entropy checkpointing in fsdp.
 entropy_checkpointing: false
 
+# Whether to defer gradient synchronization until the final micro-batch. Disable this when the extra peak memory
+# from retaining unsharded gradients outweighs the communication savings.
+use_no_sync_for_gradient_accumulation: false
+
 # Round every packed micro-batch up to a multiple of `pad_to_length_bucket` tokens, so the packed
 # shape only takes a few distinct values instead of a new one per micro-batch (avoids kernel
 # recompilation / re-autotuning). Requires use_remove_padding=True. Pad tokens are stripped before

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -261,6 +261,9 @@ class FSDPEngineConfig(EngineConfig):
             debugging.
         mixed_precision (Optional[dict[str, Any]]): Mixed precision configuration for FSDP, default None
         dtype (str): Mixed precision training param dtype, default "bfloat16"
+        use_no_sync_for_gradient_accumulation (bool): Whether to defer FSDP gradient synchronization until the
+            final micro-batch. Disabling this reduces peak memory by synchronizing and resharding gradients after
+            every micro-batch. default True
         pad_to_length (bool): Round every packed micro-batch up to a multiple of
             ``pad_to_length_bucket`` tokens, so the packed shape only takes a handful of distinct
             values instead of a new one per micro-batch, which avoids repeated kernel
@@ -294,6 +297,7 @@ class FSDPEngineConfig(EngineConfig):
     entropy_from_logits_chunk_size: int = 2048
     use_torch_compile: bool = True
     entropy_checkpointing: bool = False
+    use_no_sync_for_gradient_accumulation: bool = True
     strategy: str = "fsdp"
     pad_to_length: bool = False
     pad_to_length_bucket: int = 1024

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -680,7 +680,12 @@ class FSDPEngine(BaseEngine):
         micro-batch to a single round, at the cost of temporarily retaining
         unsharded gradients until the final backward.
         """
-        if is_last_micro_batch:
+        defer_sync = getattr(
+            self.engine_config,
+            "use_no_sync_for_gradient_accumulation",
+            True,
+        )
+        if is_last_micro_batch or not defer_sync:
             yield
             return
 


### PR DESCRIPTION
### What does this PR do

Backport #7458, upstream commit `a0feb78fe8229fde644aec3bbec20b5dc4583509`, to `release/v0.9.0`.

The release already contains deferred FSDP gradient synchronization from #7095, but has no option to disable it. This backport allows memory-constrained jobs to synchronize after each micro-batch instead of retaining unsharded gradients until the final backward.

The final upstream defaults are preserved: **Hydra FSDP YAML defaults to `false`; direct `FSDPEngineConfig()` construction and legacy configuration objects without the field default to `true`.** For normal Hydra-configured jobs, the release default therefore changes from deferred synchronization to synchronization on every micro-batch. This can reduce peak memory at the cost of more gradient communication. Explicitly set the option to `true` to retain the original release behavior.

### Checklist Before Starting

- [x] Checked for existing backports to `release/v0.9.0`; none found on 2026-09-03. The source PR targets main and is already merged.
- [x] Used the repository PR title format.
- [x] Verified the prerequisite #7095 is already in the release history.
- [x] Verified the backport applies cleanly to release commit `88512193628b95f24916c0898d51a8a877d09203`.

### Test

The backport was tested independently on its release-based branch:

```bash
python -m pytest tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py tests/workers/config/test_engine_config_on_cpu.py -q -k "not distributed_accumulation_matches_per_micro_batch_sync" --disable-warnings
```

Result: `21 passed, 1 deselected` on Windows with Python 3.12 and PyTorch 2.13.0+cpu. The two-rank distributed equivalence test was excluded and remains available for Linux execution. A prior combined check with the independent #7428 backport also passed (`28 passed, 1 deselected`).

Additional completed checks:

- Hydra composition: actor, reference model and critic resolve to `false`; actor and critic explicit `true` overrides resolve correctly.
- PPO generated reference configuration matches `scripts/print_cfg.py --cfg job` output.
- Ruff 0.12.2 lint and format checks for changed Python files.
- `git diff --cached --check`.
- Independent and combined patch application, including both application orders.

GPU/NPU training, multi-rank correctness and communication/memory performance measurements have not been run. Full pre-commit and full CI are not claimed.

### API and Usage Example

```bash
# Synchronize each micro-batch: final upstream Hydra default.
actor_rollout_ref.actor.fsdp_config.use_no_sync_for_gradient_accumulation=False
critic.fsdp.use_no_sync_for_gradient_accumulation=False

# Retain the original v0.9.0 deferred synchronization behavior.
actor_rollout_ref.actor.fsdp_config.use_no_sync_for_gradient_accumulation=True
critic.fsdp.use_no_sync_for_gradient_accumulation=True
```

The setting applies to FSDP1 and FSDP2. Forward-only execution bypasses the gradient synchronization context. With a single micro-batch, both values take the normal synchronized path.

### Design and Code Changes

- Add the upstream engine-config field and Hydra setting.
- Gate the existing FSDP1 `no_sync()` and FSDP2 `set_requires_gradient_sync(False)` paths.
- Preserve the upstream `getattr(..., True)` fallback for older or subclass-specific configuration objects.
- Include the upstream configuration, context-manager tests and documentation changes.
- Preserve the upstream default split rather than silently changing Python construction semantics. The upstream performance documentation still describes deferred synchronization as the default; the actual Hydra and Python defaults are stated explicitly above.
- No third-party dependency, model-weight, checkpoint-format or recipe changes.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Included and ran the focused CPU tests described above.
- [x] Verified Hydra defaults, explicit overrides and the generated PPO reference configuration.
- [x] Ran changed-file Ruff lint/format and whitespace checks.
- [x] Confirmed the recipe submodule is unaffected.
- [ ] Run complete pre-commit and required CI.
- [ ] Run Linux multi-rank and GPU/NPU FSDP validation.
- [ ] Human submitter reviewed every changed line, including the change to Hydra defaults.
