### PR TITLE
[perf, tool] fix: Avoid overlapping rollout and training profilers in Trainer V1

### DIFF
--- a/.github/workflows/e2e_ascend.yml
+++ b/.github/workflows/e2e_ascend.yml
@@ -120,7 +120,8 @@ jobs:
         run: |
           ray stop --force
           bash tests/special_npu/run_qwen3_8b_grpo_profiling.sh
-          python3 "tests/utils/test_check_profiler_output.py" --profiler_dir="./profiler_data-dis" --device="npu"
+          python3 "tests/utils/test_check_profiler_output.py" --profiler_dir="./profiler_data-dis" --device="npu" \
+            --stage actor_update actor_compute_log_prob '*_rollout_*'
           rm -rf ./profiler_data-dis
           rm -rf $HOME/ckpts
       - name: Running gsm8k e2e training tests with GRPO on ASCEND NPU (MindSpeed backend)

--- a/tests/special_e2e/run_ppo_trainer_veomni.sh
+++ b/tests/special_e2e/run_ppo_trainer_veomni.sh
@@ -122,7 +122,8 @@ if [ -n "$device_name" ] && [ "$device_name" == "cuda" ]; then
         global_profiler.tool=torch $@
 
     assert_finish_hook_ran
-    python3 "tests/utils/test_check_profiler_output.py" --profiler_dir="$SAVE_PATH" --device="gpu"
+    python3 "tests/utils/test_check_profiler_output.py" --profiler_dir="$SAVE_PATH" --device="gpu" \
+        --stage actor_update 'rollout?replica*' ref_compute_log_prob
     
 elif [ -n "$device_name" ] && [ "$device_name" == "npu" ]; then
     CONTENTS=['npu','cpu']

--- a/tests/special_e2e/run_ppo_trainer_veomni.sh
+++ b/tests/special_e2e/run_ppo_trainer_veomni.sh
@@ -123,7 +123,7 @@ if [ -n "$device_name" ] && [ "$device_name" == "cuda" ]; then
 
     assert_finish_hook_ran
     python3 "tests/utils/test_check_profiler_output.py" --profiler_dir="$SAVE_PATH" --device="gpu" \
-        --stage actor_update 'rollout?replica*' ref_compute_log_prob
+        --stage actor-update 'rollout?replica*' ref-compute-log-prob
     
 elif [ -n "$device_name" ] && [ "$device_name" == "npu" ]; then
     CONTENTS=['npu','cpu']

--- a/tests/trainer/ppo/v1/test_rollout_profiling_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_rollout_profiling_on_cpu.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The V1 trainer must drive the rollout engines' profiler, not just the worker groups."""
+"""Tests for the rollout profiler lifecycle across V1 trainer modes."""
 
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 from omegaconf import OmegaConf
 
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+from verl.trainer.ppo.v1.trainer_colocate_async import PPOTrainerColocateAsync
 from verl.trainer.ppo.v1.trainer_separate_async import PPOTrainerSeparateAsync
+from verl.trainer.ppo.v1.trainer_sync import PPOTrainerSync
 
 
 class _StubTrainer(PPOTrainer):
@@ -34,29 +37,36 @@ def _trainer(cls, **managers):
     trainer = cls.__new__(cls)
     trainer.config = OmegaConf.create({"global_profiler": {"profile_continuous_steps": False, "steps": [1]}})
     trainer.global_steps = 1
+    trainer.trainer_mode = "sync" if cls in (PPOTrainerSync, PPOTrainerColocateAsync) else "separate_async"
     # The finish command fires only on the last profiled step; total_training_steps lets
     # _stop_profiling decide whether this is it (here step 1 is the largest profiled step).
     trainer.total_training_steps = 10
     trainer.prev_step_profile = False
     trainer.curr_step_profile = True
     trainer.next_step_profile = False
+    trainer.local_trigger_step = 0
     trainer.use_reference_policy = False
     trainer.use_critic = False
     trainer.actor_rollout_wg = MagicMock()
+    trainer.checkpoint_manager = MagicMock()
     for name, manager in managers.items():
         setattr(trainer, name, manager)
     return trainer
 
 
-def test_profiled_step_starts_and_stops_rollout_engines():
+def _prepare_separate_step_end(trainer):
+    trainer.hybrid_rollout_config = SimpleNamespace(enable_switch=False)
+    trainer.timing_raw = {}
+    trainer.standalone_checkpoint_manager = MagicMock()
+    trainer.standalone_checkpoint_manager.update_weights.return_value = {}
+
+
+def test_profiled_step_starts_rollout_engines():
     manager = MagicMock()
     trainer = _trainer(_StubTrainer, llm_server_manager=manager)
 
     trainer._start_profiling()
     manager.start_profile.assert_called_once()
-
-    trainer._stop_profiling()
-    manager.stop_profile.assert_called_once()
 
 
 def test_unprofiled_step_leaves_rollout_engines_alone():
@@ -86,6 +96,36 @@ def test_continuous_steps_leave_the_open_collection_running():
     trainer.actor_rollout_wg.step_profile.assert_not_called()
     trainer.actor_rollout_wg.start_profile.assert_not_called()
     manager.start_profile.assert_not_called()
+
+
+def test_sync_stops_rollout_after_sampling():
+    manager = MagicMock()
+    trainer = _trainer(PPOTrainerSync, llm_server_manager=manager)
+    calls = MagicMock()
+    calls.attach_mock(trainer.checkpoint_manager.sleep_replicas, "sleep")
+    calls.attach_mock(manager.stop_profile, "stop")
+
+    with patch.object(PPOTrainer, "_add_batch_to_generate") as submit:
+        calls.attach_mock(submit, "submit")
+        trainer._add_batch_to_generate()
+        trainer.on_sample_end()
+
+    assert calls.mock_calls == [call.submit(), call.sleep(), call.stop()]
+    manager.start_profile.assert_not_called()
+
+
+def test_sync_skips_rollout_stop_on_unprofiled_step():
+    manager = MagicMock()
+    trainer = _trainer(PPOTrainerSync, llm_server_manager=manager)
+    trainer.curr_step_profile = False
+    calls = MagicMock()
+    calls.attach_mock(trainer.checkpoint_manager.sleep_replicas, "sleep")
+    calls.attach_mock(manager.stop_profile, "stop")
+
+    trainer.on_sample_end()
+
+    assert calls.mock_calls == [call.sleep()]
+    manager.stop_profile.assert_not_called()
 
 
 def test_shared_worker_group_is_profiled_once():
@@ -126,17 +166,69 @@ def test_distinct_worker_groups_are_each_profiled_once():
         wg.stop_profile.assert_called_once()
 
 
-def test_separate_async_also_profiles_standalone_replicas():
+def test_separate_async_closes_hybrid_and_standalone_rollout_once():
     hybrid, standalone = MagicMock(), MagicMock()
     trainer = _trainer(
         PPOTrainerSeparateAsync,
         llm_server_manager=hybrid,
         standalone_server_manager=standalone,
     )
+    _prepare_separate_step_end(trainer)
 
     trainer._start_profiling()
     trainer._stop_profiling()
+    trainer.on_step_end()
 
     for manager in (hybrid, standalone):
         manager.start_profile.assert_called_once()
         manager.stop_profile.assert_called_once()
+
+
+def test_colocate_async_stops_rollout_only_after_replicas_sleep():
+    manager = MagicMock()
+    trainer = _trainer(PPOTrainerColocateAsync, llm_server_manager=manager)
+    calls = MagicMock()
+    calls.attach_mock(trainer.checkpoint_manager.abort_replicas, "abort")
+    calls.attach_mock(trainer.checkpoint_manager.sleep_replicas, "sleep")
+    calls.attach_mock(manager.stop_profile, "stop")
+
+    trainer.on_sample_end()
+    trainer._stop_profiling()
+
+    assert calls.mock_calls == [call.abort(), call.sleep(), call.stop()]
+    manager.stop_profile.assert_called_once()
+
+
+def test_rollout_stops_before_the_first_training_stage():
+    manager = MagicMock()
+    trainer = _trainer(PPOTrainerSync, llm_server_manager=manager)
+    calls = MagicMock()
+    calls.attach_mock(manager.start_profile, "rollout_start")
+    calls.attach_mock(manager.stop_profile, "rollout_stop")
+
+    batch = SimpleNamespace(extra_info={})
+    trainer.config.actor_rollout_ref = OmegaConf.create({"rollout": {"temperature": 1.0}})
+    trainer.config.trainer = OmegaConf.create({"critic_warmup": 0})
+    trainer.replay_buffer = MagicMock()
+    trainer.replay_buffer.sample.return_value = (batch, {})
+    trainer.reward_loop_manager = SimpleNamespace(reward_loop_worker_handles=object())
+
+    for name in ("_balance_batch", "_compute_old_log_prob", "_compute_advantage", "_update_actor"):
+        stage = MagicMock(return_value=batch)
+        setattr(trainer, name, stage)
+        calls.attach_mock(stage, name.removeprefix("_"))
+
+    trainer._start_profiling()
+    trainer._step_once({}, {}, sample_batch_size=1)
+
+    assert [item[0] for item in calls.mock_calls] == [
+        "rollout_start",
+        "rollout_stop",
+        "balance_batch",
+        "compute_old_log_prob",
+        "compute_advantage",
+        "update_actor",
+    ]
+
+    trainer._stop_profiling()
+    manager.stop_profile.assert_called_once()

--- a/tests/trainer/ppo/v1/test_separate_async_step_switch_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_separate_async_step_switch_on_cpu.py
@@ -108,6 +108,9 @@ def _trainer(
     trainer.parameter_sync_step = parameter_sync_step
     trainer.global_steps = global_steps
     trainer.total_training_steps = total_training_steps
+    trainer.prev_step_profile = False
+    trainer.curr_step_profile = False
+    trainer.next_step_profile = False
     trainer.timing_raw = {}
     trainer.current_mode = HybridEngineMode.ROLLOUT
     trainer.replay_buffer = _RecordingReplayBuffer(eviction_metrics, sampleable_count)

--- a/tests/utils/test_check_profiler_output.py
+++ b/tests/utils/test_check_profiler_output.py
@@ -68,8 +68,8 @@ class ProfilerChecker:
             self.config = DeviceCheckConfig(
                 # NPU search pattern: match ascend subdirectory under stage
                 search_pattern=os.path.join(self.profiler_dir, "{stage}", "*_ascend_*"),
-                # NPU: rollout requires >1 dir, others require exactly 1 dir
-                dir_count_validator=lambda stage, dirs: (len(dirs) > 1 if stage == "*_rollout_*" else len(dirs) == 1),
+                # Each stage needs output; multiple ranks or windows may produce multiple directories.
+                dir_count_validator=lambda stage, dirs: len(dirs) > 0,
                 # NPU: PROF_* subdirectory must exist and be a valid directory
                 prof_validator=lambda d: (
                     len(glob.glob(os.path.join(d, "PROF_*"))) > 0
@@ -81,11 +81,16 @@ class ProfilerChecker:
         """Generic stage directory validation: extracted common logic for GPU/NPU"""
         # 1. Generate search path and match directories
         search_pattern = self.config.search_pattern.format(stage=stage)
-        dirs = glob.glob(search_pattern, recursive=True)
+        dirs = [path for path in glob.glob(search_pattern, recursive=True) if os.path.isdir(path)]
 
         # 2. Log found directories
+        logger.info(f"[{stage}] Found {len(dirs)} profiler directories (pattern: {search_pattern})")
         for d in dirs:
             logger.info(f"[{stage}] Found: {d}")
+
+        if not self.config.dir_count_validator(stage, dirs):
+            logger.error(f"[{stage}] Unexpected profiler directory count: {len(dirs)} (pattern: {search_pattern})")
+            return False
 
         # 3. Validate PROF files/directories
         for target_dir in dirs:

--- a/tests/utils/test_check_profiler_output.py
+++ b/tests/utils/test_check_profiler_output.py
@@ -29,26 +29,27 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 class DeviceCheckConfig:
     """Device check configuration: encapsulates device-specific validation rules"""
 
-    # Search path pattern
-    search_pattern: str
-    # Directory count validation function: takes stage and dir list, returns bool
-    dir_count_validator: Callable[[str, list[str]], bool]
-    # PROF file/dir validation function: takes directory path, returns bool
+    search_patterns: Callable[[str], list[str]]
+    path_filter: Callable[[str], bool]
+    count_validator: Callable[[str, list[str]], bool]
     prof_validator: Callable[[str], bool]
 
 
 class ProfilerChecker:
     """Unified Profiler checker supporting GPU/NPU devices"""
 
-    TARGET_STAGES = ["actor_update", "*_rollout_*", "ref_*"]
+    TARGET_STAGES = ["actor_update", "*rollout*", "ref_*"]
 
-    def __init__(self, device_type: str, profiler_dir: str):
+    def __init__(self, device_type: str, profiler_dir: str, stages: list[str] | None = None):
         self.device_type = device_type.lower()
         self.profiler_dir = profiler_dir
 
         # Validate device type
         if self.device_type not in ["gpu", "npu"]:
             raise ValueError(f"Unsupported device type: {device_type}, only gpu/npu are supported")
+        self.stages = stages if stages is not None else self.TARGET_STAGES
+        if not self.stages:
+            raise ValueError("At least one profiler stage is required")
 
         # Initialize device-specific configuration
         self._init_device_config()
@@ -57,19 +58,20 @@ class ProfilerChecker:
         """Initialize validation rules for different devices (core: device differences as config)"""
         if self.device_type == "gpu":
             self.config = DeviceCheckConfig(
-                # GPU search pattern: match stage directory directly
-                search_pattern=os.path.join(self.profiler_dir, "{stage}"),
-                # GPU: all stages must have exactly 1 directory
-                dir_count_validator=lambda stage, dirs: len(dirs) == 1,
-                # GPU: any file/subdirectory exists under the directory
-                prof_validator=lambda d: len(glob.glob(os.path.join(d, "*"))) > 0,
+                search_patterns=lambda stage: [
+                    os.path.join(f"*{stage}*", "**", "*.json*"), f"*{stage}*.json*"
+                ],
+                path_filter=lambda p: os.path.isfile(p) and p.endswith((".json", ".json.gz")),
+                count_validator=lambda stage, paths: len(paths) > 0,
+                prof_validator=lambda p: os.path.getsize(p) > 0,
             )
         else:  # NPU
             self.config = DeviceCheckConfig(
                 # NPU search pattern: match ascend subdirectory under stage
-                search_pattern=os.path.join(self.profiler_dir, "{stage}", "*_ascend_*"),
+                search_patterns=lambda stage: [os.path.join(stage, "*_ascend_*")],
+                path_filter=os.path.isdir,
                 # Each stage needs output; multiple ranks or windows may produce multiple directories.
-                dir_count_validator=lambda stage, dirs: len(dirs) > 0,
+                count_validator=lambda stage, paths: len(paths) > 0,
                 # NPU: PROF_* subdirectory must exist and be a valid directory
                 prof_validator=lambda d: (
                     len(glob.glob(os.path.join(d, "PROF_*"))) > 0
@@ -77,25 +79,24 @@ class ProfilerChecker:
                 ),
             )
 
-    def _validate_stage_dirs(self, stage: str) -> bool:
-        """Generic stage directory validation: extracted common logic for GPU/NPU"""
-        # 1. Generate search path and match directories
-        search_pattern = self.config.search_pattern.format(stage=stage)
-        dirs = [path for path in glob.glob(search_pattern, recursive=True) if os.path.isdir(path)]
+    def _validate_stage(self, stage: str) -> bool:
+        """Match, log and validate the stage's profiler output."""
+        patterns = [os.path.join(self.profiler_dir, p) for p in self.config.search_patterns(stage)]
+        paths = sorted({
+            path for pattern in patterns for path in glob.glob(pattern, recursive=True)
+            if self.config.path_filter(path)
+        })
+        logger.info(f"[{stage}] Found {len(paths)} profiler paths (patterns: {patterns})")
+        for path in paths:
+            logger.info(f"[{stage}] Found: {path}")
 
-        # 2. Log found directories
-        logger.info(f"[{stage}] Found {len(dirs)} profiler directories (pattern: {search_pattern})")
-        for d in dirs:
-            logger.info(f"[{stage}] Found: {d}")
-
-        if not self.config.dir_count_validator(stage, dirs):
-            logger.error(f"[{stage}] Unexpected profiler directory count: {len(dirs)} (pattern: {search_pattern})")
+        if not self.config.count_validator(stage, paths):
+            logger.error(f"[{stage}] Unexpected profiler output count: {len(paths)}")
             return False
 
-        # 3. Validate PROF files/directories
-        for target_dir in dirs:
-            if not self.config.prof_validator(target_dir):
-                logger.error(f"[{stage}] PROF not found in {target_dir}")
+        for path in paths:
+            if not self.config.prof_validator(path):
+                logger.error(f"[{stage}] Missing or empty profiler output: {path}")
                 return False
 
         return True
@@ -110,8 +111,8 @@ class ProfilerChecker:
             return False
 
         # Run validation for all target stages
-        for stage in self.TARGET_STAGES:
-            if not self._validate_stage_dirs(stage):
+        for stage in self.stages:
+            if not self._validate_stage(stage):
                 return False
 
         logger.info(f"All {self.device_type.upper()} validation stages passed")
@@ -134,6 +135,12 @@ def parse_args():
         default="./profiler_data",
         help="Path to profiler data directory (default: ./profiler_data)",
     )
+    parser.add_argument(
+        "--stage",
+        nargs="+",
+        default=None,
+        help=f"Stage patterns to check (default: {ProfilerChecker.TARGET_STAGES})",
+    )
     return parser.parse_args()
 
 
@@ -141,7 +148,7 @@ def main():
     args = parse_args()
 
     try:
-        checker = ProfilerChecker(device_type=args.device, profiler_dir=args.profiler_dir)
+        checker = ProfilerChecker(device_type=args.device, profiler_dir=args.profiler_dir, stages=args.stage)
         if checker.check():
             logger.info(f"All {args.device.upper()} profiler deliverables check passed!")
             sys.exit(0)

--- a/tests/utils/test_check_profiler_output.py
+++ b/tests/utils/test_check_profiler_output.py
@@ -58,9 +58,7 @@ class ProfilerChecker:
         """Initialize validation rules for different devices (core: device differences as config)"""
         if self.device_type == "gpu":
             self.config = DeviceCheckConfig(
-                search_patterns=lambda stage: [
-                    os.path.join(f"*{stage}*", "**", "*.json*"), f"*{stage}*.json*"
-                ],
+                search_patterns=lambda stage: [os.path.join(f"*{stage}*", "**", "*.json*"), f"*{stage}*.json*"],
                 path_filter=lambda p: os.path.isfile(p) and p.endswith((".json", ".json.gz")),
                 count_validator=lambda stage, paths: len(paths) > 0,
                 prof_validator=lambda p: os.path.getsize(p) > 0,
@@ -82,10 +80,14 @@ class ProfilerChecker:
     def _validate_stage(self, stage: str) -> bool:
         """Match, log and validate the stage's profiler output."""
         patterns = [os.path.join(self.profiler_dir, p) for p in self.config.search_patterns(stage)]
-        paths = sorted({
-            path for pattern in patterns for path in glob.glob(pattern, recursive=True)
-            if self.config.path_filter(path)
-        })
+        paths = sorted(
+            {
+                path
+                for pattern in patterns
+                for path in glob.glob(pattern, recursive=True)
+                if self.config.path_filter(path)
+            }
+        )
         logger.info(f"[{stage}] Found {len(paths)} profiler paths (patterns: {patterns})")
         for path in paths:
             logger.info(f"[{stage}] Found: {path}")

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1298,6 +1298,16 @@ class PPOTrainer(ABC):
         managers = [getattr(self, "llm_server_manager", None)]
         return [manager for manager in managers if manager is not None]
 
+    def _start_rollout_profiling(self) -> None:
+        """Start rollout profiling."""
+        for manager in self._rollout_server_managers():
+            manager.start_profile()
+
+    def _stop_rollout_profiling(self) -> None:
+        """Stop rollout profiling."""
+        for manager in self._rollout_server_managers():
+            manager.stop_profile()
+
     def _start_profiling(self) -> None:
         """Start profiling for all worker groups if profiling is enabled."""
         do_profile = (
@@ -1325,11 +1335,7 @@ class PPOTrainer(ABC):
             if self.use_critic and id(self.critic_wg) not in seen:
                 seen.add(id(self.critic_wg))
                 self.critic_wg.start_profile(profile_step=self.global_steps)
-            # Rollout generation is decoupled from the training step in V1 (prompts are served
-            # asynchronously and consumed from the replay buffer), so the inference engines are
-            # profiled across the whole step rather than around a single generation call.
-            for manager in self._rollout_server_managers():
-                manager.start_profile()
+            self._start_rollout_profiling()
 
     def _stop_profiling(self) -> None:
         """Stop profiling for all worker groups if profiling is enabled."""
@@ -1367,8 +1373,6 @@ class PPOTrainer(ABC):
             if self.use_critic and id(self.critic_wg) not in seen:
                 seen.add(id(self.critic_wg))
                 self.critic_wg.stop_profile(run_command=run_command)
-            for manager in self._rollout_server_managers():
-                manager.stop_profile()
 
     def _fetch_one_gen_batch(self) -> TensorDict:
         """Fetch one ``gen_batch_size`` chunk from the dataloader."""

--- a/verl/trainer/ppo/v1/trainer_colocate_async.py
+++ b/verl/trainer/ppo/v1/trainer_colocate_async.py
@@ -57,3 +57,5 @@ class PPOTrainerColocateAsync(PPOTrainer):
         self.checkpoint_manager.abort_replicas()
         # sleep all replicas to discard weights and kv cache
         self.checkpoint_manager.sleep_replicas()
+        if self.curr_step_profile:
+            self._stop_rollout_profiling()

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -295,6 +295,9 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         )
 
     def on_step_end(self):
+        if self.prev_step_profile:
+            self._stop_rollout_profiling()
+
         config = self.hybrid_rollout_config
         should_switch = False
         prepare_seconds = 0.0

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -295,6 +295,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         )
 
     def on_step_end(self):
+        # _stop_profiling() already moved this step's flag to prev_step_profile.
         if self.prev_step_profile:
             self._stop_rollout_profiling()
 

--- a/verl/trainer/ppo/v1/trainer_sync.py
+++ b/verl/trainer/ppo/v1/trainer_sync.py
@@ -40,3 +40,5 @@ class PPOTrainerSync(PPOTrainer):
     def on_sample_end(self):
         # sleep all replicas to discard weights and kv cache
         self.checkpoint_manager.sleep_replicas()
+        if self.curr_step_profile:
+            self._stop_rollout_profiling()


### PR DESCRIPTION
### What does this PR do?

This PR separates rollout and training profiling windows in Trainer V1.

Previously, rollout profiling could remain active when training profiling started, causing **multiple processes on the same device to collect profiling data simultaneously** in colocated workloads. This can lead to **missing profiling data with the NPU profiler** and **conflicts in GPU metrics collection with Nsight Systems (`nsys`)** https://docs.nvidia.com/nsight-systems/UserGuide/index.html#gpu-metrics.

For `sync` and `colocate_async`, rollout profiling stops in `on_sample_end()` after generation and sleep, before training stages begin:

```mermaid
flowchart LR
    A[Start rollout profiling] --> B[Generation and sleep]
    B --> C[Stop rollout profiling]
    C --> D[Start training profiling]
    D --> E[Compute log prob and update actor]
    E --> F[Stop training profiling]
```

For `separate_async`, hybrid and standalone rollout profilers are managed together and stopped in `on_step_end()`.

The change preserves the shared profiling lifecycle in Trainer V1 and avoids duplicate rollout profiler stops.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

End-to-end profiling tests were run on both GPU and NPU platforms.

| Platform | Sync | Colocate Async | Separate Async |
|----------|------|----------------|----------------|
| GPU      | ✅ Passed | ✅ Passed | ✅ Passed |
| NPU      | ✅ Passed | ✅ Passed | ✅ Passed |

The traces below show that inference-stage profiling captures only generation and sleep operations, without simultaneously collecting training-stage operations in the same trace.

**torch.profiler:**
<img width="607" height="304" alt="image" src="https://github.com/user-attachments/assets/23b6d537-95f7-400d-886b-31dd01c4916f" />



**torch_npu.profiler:**

<img width="1567" height="904" alt="image" src="https://github.com/user-attachments/assets/7c47767d-96d7-4ac5-bd30-938b7da2acd7" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
