### PR TITLE
[misc] fix: handle strict system-message chat templates

### DIFF
--- a/tests/utils/test_chat_template_on_cpu.py
+++ b/tests/utils/test_chat_template_on_cpu.py
@@ -1,0 +1,152 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.utils.tokenizer.chat_template import apply_chat_template
+
+
+def _text_of(message):
+    content = message["content"]
+    if isinstance(content, list):
+        return "".join(part.get("text", "") for part in content)
+    return content
+
+
+class StrictTokenizer:
+    """Chat template with the Qwen3.5 constraints that trigger the fallback path.
+
+    * at least one user message is required,
+    * a system message must come first,
+    * only the *last* assistant message keeps its ``reasoning_content``,
+      like Qwen3 / DeepSeek-R1 templates do.
+    """
+
+    def render(self, messages, add_generation_prompt=False, tools=None):
+        rendered = ""
+        if tools:
+            rendered += f"<|tools|>{','.join(tools)}"
+        for i, message in enumerate(messages):
+            role = message["role"]
+            rendered += f"<|{role}|>"
+            if role == "assistant" and i == len(messages) - 1 and message.get("reasoning_content"):
+                rendered += f"<think>{message['reasoning_content']}</think>"
+            rendered += _text_of(message)
+        if add_generation_prompt:
+            rendered += "<|assistant|>"
+        return rendered
+
+    def apply_chat_template(
+        self, messages, tokenize=True, add_generation_prompt=True, tools=None, return_dict=False, **kwargs
+    ):
+        if not any(m["role"] == "user" for m in messages):
+            raise ValueError("chat template requires at least one user message")
+        if any(m["role"] == "system" for m in messages[1:]):
+            raise ValueError("System message must be at the beginning.")
+        text = self.render(messages, add_generation_prompt=add_generation_prompt, tools=tools)
+        if not tokenize:
+            return text
+        return [ord(c) for c in text]
+
+
+@pytest.fixture
+def tokenizer():
+    return StrictTokenizer()
+
+
+def _expected(tokenizer, messages, add_generation_prompt, tools=None, tokenize=False):
+    text = tokenizer.render(messages, add_generation_prompt=add_generation_prompt, tools=tools)
+    return [ord(c) for c in text] if tokenize else text
+
+
+@pytest.mark.parametrize("add_generation_prompt", [False, True])
+@pytest.mark.parametrize("tokenize", [False, True])
+def test_single_system_message(tokenizer, add_generation_prompt, tokenize):
+    """A lone system message must not raise, and must not carry a dummy user."""
+    messages = [{"role": "system", "content": "you are a helpful assistant"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=tokenize, add_generation_prompt=add_generation_prompt)
+    assert got == _expected(tokenizer, messages, add_generation_prompt, tokenize=tokenize)
+
+
+def test_system_message_keeps_tools(tokenizer):
+    messages = [{"role": "system", "content": "sys"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=False, tools=["get_time"])
+    assert got == _expected(tokenizer, messages, False, tools=["get_time"])
+
+
+@pytest.mark.parametrize("tokenize", [False, True])
+def test_trailing_assistant_keeps_reasoning_content(tokenizer, tokenize):
+    """The dummy user must not shift the last assistant message out of last place."""
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "hello", "reasoning_content": "thinking hard"},
+    ]
+    got = apply_chat_template(tokenizer, messages, tokenize=tokenize, add_generation_prompt=False)
+    expected = _expected(tokenizer, messages, False, tokenize=tokenize)
+    assert got == expected
+    if not tokenize:
+        assert "<think>thinking hard</think>" in got
+
+
+def test_no_system_message_uses_prefix_path(tokenizer):
+    """Messages without a system prefix keep the original prepend-and-strip behaviour."""
+    messages = [{"role": "assistant", "content": "hello", "reasoning_content": "why"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=False)
+    assert got == _expected(tokenizer, messages, False)
+
+
+def test_no_fallback_when_template_accepts_messages(tokenizer):
+    messages = [{"role": "user", "content": "hi"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=True)
+    assert got == _expected(tokenizer, messages, True)
+
+
+@pytest.mark.parametrize(
+    "messages, expected",
+    [
+        (
+            [
+                {"role": "user", "content": "question"},
+                {"role": "system", "content": "late instruction"},
+            ],
+            "<|system|>late instruction<|user|>question",
+        ),
+        (
+            [
+                {"role": "system", "content": "first"},
+                {"role": "system", "content": "second"},
+                {"role": "user", "content": "question"},
+            ],
+            "<|system|>first\n\nsecond<|user|>question",
+        ),
+    ],
+)
+def test_inline_system_messages_are_normalized(tokenizer, messages, expected):
+    original = [dict(message) for message in messages]
+
+    assert apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=False) == expected
+    assert messages == original
+
+
+def test_system_content_parts_are_merged(tokenizer):
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "first"}]},
+        {"role": "system", "content": [{"type": "text", "text": "second"}]},
+        {"role": "user", "content": "question"},
+    ]
+
+    assert apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=False) == (
+        "<|system|>first\n\nsecond<|user|>question"
+    )
+

--- a/tests/utils/test_chat_template_on_cpu.py
+++ b/tests/utils/test_chat_template_on_cpu.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
+import numpy as np
 import pytest
 
 from verl.utils.tokenizer.chat_template import apply_chat_template
@@ -20,7 +23,7 @@ from verl.utils.tokenizer.chat_template import apply_chat_template
 def _text_of(message):
     content = message["content"]
     if isinstance(content, list):
-        return "".join(part.get("text", "") for part in content)
+        return "".join(part["text"] if "text" in part else f"<{part.get('type', 'content')}>" for part in content)
     return content
 
 
@@ -48,7 +51,13 @@ class StrictTokenizer:
         return rendered
 
     def apply_chat_template(
-        self, messages, tokenize=True, add_generation_prompt=True, tools=None, return_dict=False, **kwargs
+        self,
+        messages,
+        tokenize=True,
+        add_generation_prompt=True,
+        tools=None,
+        return_dict=False,
+        **kwargs,
     ):
         if not any(m["role"] == "user" for m in messages):
             raise ValueError("chat template requires at least one user message")
@@ -58,6 +67,51 @@ class StrictTokenizer:
         if not tokenize:
             return text
         return [ord(c) for c in text]
+
+
+class StructuredTokenizer(StrictTokenizer):
+    """Strict tokenizer stub that exposes transformers' return shapes."""
+
+    def __init__(self, nested=False):
+        self.nested = nested
+
+    def apply_chat_template(
+        self, messages, tokenize=True, add_generation_prompt=True, tools=None, return_dict=False, **kwargs
+    ):
+        if not return_dict:
+            output = super().apply_chat_template(
+                messages,
+                tokenize=tokenize,
+                add_generation_prompt=add_generation_prompt,
+                tools=tools,
+                return_dict=False,
+                **kwargs,
+            )
+            if tokenize and self.nested:
+                return [output]
+            return output
+
+        ids = super().apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+            return_dict=False,
+            **kwargs,
+        )
+        return_tensors = kwargs.get("return_tensors")
+        values = {
+            "input_ids": [ids],
+            "attention_mask": [[1] * len(ids)],
+            "mm_token_type_ids": [[2] * len(ids)],
+            "pixel_values": ["preserved"],
+        }
+        if return_tensors == "np":
+            values.update({key: np.asarray(value) for key, value in values.items() if key != "pixel_values"})
+        elif return_tensors == "pt":
+            torch = pytest.importorskip("torch")
+            values.update({key: torch.tensor(value) for key, value in values.items() if key != "pixel_values"})
+        return values
 
 
 @pytest.fixture
@@ -150,3 +204,65 @@ def test_system_content_parts_are_merged(tokenizer):
         "<|system|>first\n\nsecond<|user|>question"
     )
 
+
+@pytest.mark.parametrize("return_tensors", [None, "np", "pt"])
+def test_leading_system_dictionary_output_preserves_backend(return_tensors):
+    tokenizer = StructuredTokenizer()
+    if return_tensors == "pt":
+        pytest.importorskip("torch")
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "answer", "reasoning_content": "think"},
+    ]
+    expected_text = tokenizer.render(messages, add_generation_prompt=False)
+    expected_ids = [ord(c) for c in expected_text]
+
+    got = apply_chat_template(
+        tokenizer,
+        messages,
+        tokenize=True,
+        add_generation_prompt=False,
+        return_dict=True,
+        return_tensors=return_tensors,
+    )
+
+    if return_tensors == "np":
+        np.testing.assert_array_equal(got["input_ids"], np.asarray([expected_ids]))
+        np.testing.assert_array_equal(got["attention_mask"], np.ones((1, len(expected_ids)), dtype=int))
+        np.testing.assert_array_equal(got["mm_token_type_ids"], np.full((1, len(expected_ids)), 2, dtype=int))
+    elif return_tensors == "pt":
+        torch = pytest.importorskip("torch")
+        assert torch.equal(got["input_ids"], torch.tensor([expected_ids]))
+        assert got["attention_mask"].shape == (1, len(expected_ids))
+        assert got["mm_token_type_ids"].shape == (1, len(expected_ids))
+    else:
+        assert got["input_ids"] == [expected_ids]
+        assert got["attention_mask"] == [[1] * len(expected_ids)]
+        assert got["mm_token_type_ids"] == [[2] * len(expected_ids)]
+    assert got["pixel_values"] == ["preserved"]
+
+
+def test_nested_token_output_is_unwrapped():
+    tokenizer = StructuredTokenizer(nested=True)
+    messages = [{"role": "system", "content": "sys"}]
+    expected = [ord(c) for c in tokenizer.render(messages, add_generation_prompt=False)]
+    assert apply_chat_template(tokenizer, messages, tokenize=True, add_generation_prompt=False) == expected
+
+
+def test_multimodal_content_is_preserved_during_normalization(tokenizer):
+    messages = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "system",
+            "content": [
+                {"type": "image", "image": "image-placeholder"},
+                {"type": "text", "text": "late instruction"},
+            ],
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    assert apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=False) == (
+        "<|system|><image>late instruction<|user|>question"
+    )
+    assert messages == original

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -138,6 +138,30 @@ def extract_system_prompt_and_generation(tokenizer, **apply_chat_template_kwargs
     return system_prompt, generate_prompt
 
 
+def _normalize_system_messages(messages: list[dict]) -> list[dict]:
+    """Move system content to the first turn when a template requires it."""
+    system_messages = [message for message in messages if message.get("role") == "system"]
+    if not system_messages or (len(system_messages) == 1 and messages[0].get("role") == "system"):
+        return messages
+
+    first_system = dict(system_messages[0])
+    contents = [message.get("content", "") for message in system_messages]
+    if all(isinstance(content, str) for content in contents):
+        first_system["content"] = "\n\n".join(content for content in contents if content)
+    else:
+        merged_content: list[dict] = []
+        for index, content in enumerate(contents):
+            if index and merged_content:
+                merged_content.append({"type": "text", "text": "\n\n"})
+            if isinstance(content, list):
+                merged_content.extend(content)
+            elif content is not None:
+                merged_content.append({"type": "text", "text": str(content)})
+        first_system["content"] = merged_content
+
+    return [first_system] + [message for message in messages if message.get("role") != "system"]
+
+
 def apply_chat_template(
     processor: PreTrainedTokenizerBase | ProcessorMixin,
     messages: list[dict],
@@ -173,8 +197,89 @@ def apply_chat_template(
             **kwargs,
         )
     except Exception:
-        # Qwen3.5 apply_chat_template needs messages with at least one user message
+        # Qwen3.5 apply_chat_template needs messages with at least one user message.
+        # A leading system block must stay first, so the dummy user cannot be prepended
+        # in that case. It is not appended either: templates that keep the reasoning
+        # content of the *last* assistant message only (Qwen3, DeepSeek-R1, ...) would
+        # drop it once another message follows. Instead the dummy user is inserted right
+        # after the leading system block and its span is cut back out of the middle of
+        # the output, which keeps both the system message first and the last assistant
+        # message last.
+        normalized_messages = _normalize_system_messages(messages)
+        if normalized_messages != messages:
+            try:
+                return processor.apply_chat_template(
+                    normalized_messages,
+                    tokenize=tokenize,
+                    add_generation_prompt=add_generation_prompt,
+                    tools=tools,
+                    return_dict=return_dict,
+                    **kwargs,
+                )
+            except Exception:
+                messages = normalized_messages
         dummy_user_message = [{"role": "user", "content": [{"type": "text", "text": ""}]}]
+        num_leading_system = 0
+        while num_leading_system < len(messages) and messages[num_leading_system].get("role") == "system":
+            num_leading_system += 1
+
+        if num_leading_system:
+            head = list(messages[:num_leading_system])
+            tail = list(messages[num_leading_system:])
+            # The difference trick gives the length of one dummy-user span; subtracting it
+            # from the head+dummy rendering gives the length of the head block itself.
+            one_user = processor.apply_chat_template(
+                head + dummy_user_message,
+                tokenize=tokenize,
+                add_generation_prompt=False,
+                tools=tools,
+                return_dict=return_dict,
+                **kwargs,
+            )
+            two_users = processor.apply_chat_template(
+                head + dummy_user_message * 2,
+                tokenize=tokenize,
+                add_generation_prompt=False,
+                tools=tools,
+                return_dict=return_dict,
+                **kwargs,
+            )
+            output = processor.apply_chat_template(
+                head + dummy_user_message + tail,
+                tokenize=tokenize,
+                add_generation_prompt=add_generation_prompt,
+                tools=tools,
+                return_dict=return_dict,
+                **kwargs,
+            )
+
+            if not tokenize:  # tokenize=False
+                user_len = len(two_users) - len(one_user)
+                head_len = len(one_user) - user_len
+                return output[:head_len] + output[head_len + user_len :]
+            elif not return_dict:  # tokenize=True and return_dict=False
+                if isinstance(output[0], list):  # transformers>=5
+                    assert len(output) == 1, "output must be a list[int] or list[list[int]]"
+                    one_user = one_user[0]
+                    two_users = two_users[0]
+                    output = output[0]
+                user_len = len(two_users) - len(one_user)
+                head_len = len(one_user) - user_len
+                return output[:head_len] + output[head_len + user_len :]
+            else:  # tokenize=True and return_dict=True and return_tensors="pt"
+                import torch
+
+                one_user = dict(one_user)
+                two_users = dict(two_users)
+                output = dict(output)
+                user_len = two_users["input_ids"].shape[1] - one_user["input_ids"].shape[1]
+                head_len = one_user["input_ids"].shape[1] - user_len
+                for key in ("input_ids", "attention_mask", "mm_token_type_ids"):
+                    if key not in output:
+                        continue
+                    output[key] = torch.cat([output[key][:, :head_len], output[key][:, head_len + user_len :]], dim=1)
+                return output
+
         dummy_user_prefix = processor.apply_chat_template(
             dummy_user_message,
             tokenize=tokenize,
@@ -209,3 +314,4 @@ def apply_chat_template(
             if "mm_token_type_ids" in output:
                 output["mm_token_type_ids"] = output["mm_token_type_ids"][:, prefix_len:]
             return output
+

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -162,6 +162,59 @@ def _normalize_system_messages(messages: list[dict]) -> list[dict]:
     return [first_system] + [message for message in messages if message.get("role") != "system"]
 
 
+def _sequence_length(value) -> int:
+    """Return the token-axis length for a tokenizer output value."""
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        if len(shape) == 1:
+            return int(shape[0])
+        return int(shape[-1])
+    if isinstance(value, list):
+        if value and isinstance(value[0], list):
+            return len(value[0])
+        return len(value)
+    raise TypeError(f"Unsupported token output type: {type(value)!r}")
+
+
+def _remove_sequence_span(value, start: int, length: int):
+    """Remove a token span while retaining the output array's backend and shape."""
+    stop = start + length
+    if isinstance(value, list):
+        if value and isinstance(value[0], list):
+            return [row[:start] + row[stop:] for row in value]
+        return value[:start] + value[stop:]
+
+    module = type(value).__module__.split(".", 1)[0]
+    head = value[..., :start]
+    tail = value[..., stop:]
+    if module == "torch":
+        import torch
+
+        return torch.cat((head, tail), dim=-1)
+    if module == "numpy":
+        import numpy as np
+
+        return np.concatenate((head, tail), axis=-1)
+    if module == "tensorflow":
+        import tensorflow as tf
+
+        return tf.concat((head, tail), axis=-1)
+    if module in ("jax", "jaxlib"):
+        import jax.numpy as jnp
+
+        return jnp.concatenate((head, tail), axis=-1)
+    raise TypeError(f"Unsupported token output backend: {type(value)!r}")
+
+
+def _unwrap_token_sequence(value):
+    """Unwrap the single batch returned by transformers 5 tokenization."""
+    if isinstance(value, list) and value and isinstance(value[0], list):
+        if len(value) != 1:
+            raise ValueError("apply_chat_template must return one tokenized sequence")
+        return value[0]
+    return value
+
+
 def apply_chat_template(
     processor: PreTrainedTokenizerBase | ProcessorMixin,
     messages: list[dict],
@@ -258,26 +311,22 @@ def apply_chat_template(
                 head_len = len(one_user) - user_len
                 return output[:head_len] + output[head_len + user_len :]
             elif not return_dict:  # tokenize=True and return_dict=False
-                if isinstance(output[0], list):  # transformers>=5
-                    assert len(output) == 1, "output must be a list[int] or list[list[int]]"
-                    one_user = one_user[0]
-                    two_users = two_users[0]
-                    output = output[0]
+                one_user = _unwrap_token_sequence(one_user)
+                two_users = _unwrap_token_sequence(two_users)
+                output = _unwrap_token_sequence(output)
                 user_len = len(two_users) - len(one_user)
                 head_len = len(one_user) - user_len
                 return output[:head_len] + output[head_len + user_len :]
-            else:  # tokenize=True and return_dict=True and return_tensors="pt"
-                import torch
-
+            else:  # tokenize=True and return_dict=True
                 one_user = dict(one_user)
                 two_users = dict(two_users)
                 output = dict(output)
-                user_len = two_users["input_ids"].shape[1] - one_user["input_ids"].shape[1]
-                head_len = one_user["input_ids"].shape[1] - user_len
+                user_len = _sequence_length(two_users["input_ids"]) - _sequence_length(one_user["input_ids"])
+                head_len = _sequence_length(one_user["input_ids"]) - user_len
                 for key in ("input_ids", "attention_mask", "mm_token_type_ids"):
                     if key not in output:
                         continue
-                    output[key] = torch.cat([output[key][:, :head_len], output[key][:, head_len + user_len :]], dim=1)
+                    output[key] = _remove_sequence_span(output[key], head_len, user_len)
                 return output
 
         dummy_user_prefix = processor.apply_chat_template(
@@ -300,18 +349,15 @@ def apply_chat_template(
         if not tokenize:  # tokenize=False
             return output[len(dummy_user_prefix) :]
         elif not return_dict:  # tokenize=True and return_dict=False
-            if isinstance(output[0], list):  # transformers>=5
-                assert len(output) == 1, "output must be a list[int] or list[list[int]]"
-                dummy_user_prefix = dummy_user_prefix[0]
-                output = output[0]
+            dummy_user_prefix = _unwrap_token_sequence(dummy_user_prefix)
+            output = _unwrap_token_sequence(output)
             return output[len(dummy_user_prefix) :]
-        else:  # tokenize=True and return_dict=True and return_tensors="pt"
+        else:  # tokenize=True and return_dict=True
             dummy_user_prefix = dict(dummy_user_prefix)
             output = dict(output)
-            prefix_len = dummy_user_prefix["input_ids"].shape[1]
-            output["input_ids"] = output["input_ids"][:, prefix_len:]
-            output["attention_mask"] = output["attention_mask"][:, prefix_len:]
-            if "mm_token_type_ids" in output:
-                output["mm_token_type_ids"] = output["mm_token_type_ids"][:, prefix_len:]
+            prefix_len = _sequence_length(dummy_user_prefix["input_ids"])
+            for key in ("input_ids", "attention_mask", "mm_token_type_ids"):
+                if key not in output:
+                    continue
+                output[key] = _remove_sequence_span(output[key], 0, prefix_len)
             return output
-


### PR DESCRIPTION
## Summary

Qwen3.5 chat templates require a user message and allow a system message only at the beginning. verl's compatibility fallback currently injects a synthetic user before the input, so system-only and system-constrained histories can fail with `TemplateError: System message must be at the beginning.`

Fixes #7725.

## Changes

- Keep a leading system block first while inserting the synthetic user needed by strict templates.
- Remove the synthetic-user span from the rendered text or token sequence without dropping trailing assistant reasoning content.
- Normalize inline and repeated system messages only after native rendering fails, while preserving the original input messages and content parts.
- Preserve generation prompts, tool schemas, and sequence-aligned fields across the return shapes supported by the wrapper; add explicit PyTorch and NumPy coverage.
- Add CPU-only regression coverage for text and token output, nested token batches, dictionary returns, backend-preserving sequence masks, generation prompts, tools, reasoning content, system normalization, and non-text content parts.

## Validation

- Clean `verl/main` reproduces the three reported Qwen3.5 failures: `system_only`, `late_system`, and `multiple_system`.
- The patched wrapper passes the same six-case Qwen3.5 regression plus generation-prompt and tool-schema cases using the existing local Qwen3.5-9B processor.
- The real processor output matches independently tokenized rendered text for both `return_dict=True, return_tensors="pt"` and `return_tensors="np"`.
- `python -m pytest -q tests/utils/test_chat_template_on_cpu.py tests/utils/test_turn_separator_on_cpu.py`: 25 passed.
- Targeted pre-commit hooks, including ruff, ruff format, mypy, configuration generation, and compile-all, passed.

The validation is tokenizer/processor-only; no full model generation or distributed training is needed for this change.

AI assistance was used for investigation, implementation, and test execution; the submitting maintainer should review every changed line and the reproduction evidence.
