### PR TITLE
[sglang, rollout] feat: support fixed-token prompt logprobs

### DIFF
--- a/tests/workers/rollout/rollout_sglang/test_token_ids_logprob.py
+++ b/tests/workers/rollout/rollout_sglang/test_token_ids_logprob.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+pytest.importorskip("sglang")
+
+from sglang.srt.managers.io_struct import GenerateReqInput
+
+from verl.workers.rollout.sglang_rollout.async_sglang_server import (
+    _extract_token_ids_logprobs_sglang,
+    _pop_token_ids_logprob_request_sglang,
+)
+
+
+def test_token_ids_logprob_request_and_response():
+    sampling_params = {
+        "temperature": 0,
+        "logprob_start_len": 1,
+        "token_ids_logprob": [3, 4],
+    }
+
+    token_ids_logprob, request = _pop_token_ids_logprob_request_sglang(sampling_params)
+
+    assert token_ids_logprob == [3, 4]
+    assert request == {
+        "return_logprob": True,
+        "logprob_start_len": 1,
+        "token_ids_logprob": [3, 4],
+    }
+    assert sampling_params == {"temperature": 0}
+
+    generate_request = GenerateReqInput(input_ids=[1, 2], sampling_params=sampling_params, **request)
+    generate_request.normalize_batch_and_arguments()
+    assert generate_request.return_logprob is True
+    assert generate_request.logprob_start_len == 1
+    assert generate_request.token_ids_logprob == [3, 4]
+
+    input_token_ids_logprobs = [
+        [],
+        [[-1.0, 3, None], [-2.0, 4, None]],
+    ]
+    result = {}
+    _extract_token_ids_logprobs_sglang(
+        meta_info={"input_token_ids_logprobs": input_token_ids_logprobs}, result_dict=result
+    )
+    assert result == {"input_token_ids_logprobs": input_token_ids_logprobs}

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -70,6 +70,23 @@ logger.setLevel(logging.INFO)
 visible_devices_keyword = get_visible_devices_keyword()
 
 
+def _pop_token_ids_logprob_request_sglang(
+    sampling_params: dict[str, Any],
+) -> tuple[Optional[list[int]], dict[str, Any]]:
+    """Translate fixed-token logprob parameters into SGLang request fields."""
+    token_ids_logprob = sampling_params.pop("token_ids_logprob", None)
+    logprob_start_len = sampling_params.pop("logprob_start_len", 0)
+    if logprob_start_len and not token_ids_logprob:
+        raise ValueError("logprob_start_len is only supported with token_ids_logprob.")
+    if not token_ids_logprob:
+        return token_ids_logprob, {}
+    return token_ids_logprob, {
+        "return_logprob": True,
+        "logprob_start_len": logprob_start_len,
+        "token_ids_logprob": token_ids_logprob,
+    }
+
+
 def _extract_prompt_logprobs_sglang(
     meta_info: dict,
     num_prompt_logprobs: int,
@@ -118,6 +135,14 @@ def _extract_prompt_logprobs_sglang(
     )
     result_dict["prompt_ids"] = prompt_ids_ls
     result_dict["prompt_logprobs"] = prompt_logprobs_ls
+
+
+def _extract_token_ids_logprobs_sglang(meta_info: dict, result_dict: dict[str, Any]) -> None:
+    """Expose SGLang's fixed-token input logprobs through ``TokenOutput``."""
+    input_token_ids_logprobs = meta_info.get("input_token_ids_logprobs")
+    if input_token_ids_logprobs is None:
+        raise ValueError("SGLang did not return input_token_ids_logprobs for a token_ids_logprob request.")
+    result_dict["input_token_ids_logprobs"] = input_token_ids_logprobs
 
 
 class SGLangHttpServer:
@@ -618,6 +643,7 @@ class SGLangHttpServer:
         # input-token logprobs for every position (top-K when K>0, sampled-token
         # logprob only when K==0). Translate to SGLang's per-request logprob API.
         prompt_logprobs = sampling_params.pop("prompt_logprobs", None)
+        token_ids_logprob, token_ids_logprob_request = _pop_token_ids_logprob_request_sglang(sampling_params)
         if prompt_logprobs is not None:
             return_logprob = True
 
@@ -635,6 +661,8 @@ class SGLangHttpServer:
             request["logprob_start_len"] = 0
             if prompt_logprobs > 0:
                 request["top_logprobs_num"] = prompt_logprobs
+        request.update(token_ids_logprob_request)
+        return_logprob = request["return_logprob"]
 
         if self.config.enable_rollout_routing_replay:
             request.update({"return_routed_experts": True})
@@ -704,6 +732,8 @@ class SGLangHttpServer:
                 sequence_length=len(prompt_ids),
                 result_dict=extra_fields,
             )
+        if token_ids_logprob:
+            _extract_token_ids_logprobs_sglang(meta_info=meta_info, result_dict=extra_fields)
 
         # Re-key backend spec-decoding stats to the rollout-common names.
         if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:


### PR DESCRIPTION
### What does this PR do?

Expose SGLang's native `token_ids_logprob` request capability through `SGLangHttpServer.generate()`.

Callers can request prompt logprobs for a fixed set of token IDs without returning a vocabulary-sized distribution. The native SGLang response is available through `output.extra_fields["input_token_ids_logprobs"]`.

This can be used by OPD and reverse-KL implementations to send selected top-k candidate token IDs, such as the student's top-k tokens, to a teacher SGLang server and retrieve the teacher logprobs for only those candidates instead of returning a full-vocabulary distribution. It does not ask SGLang to select the teacher's own top-k tokens.

SGLang 0.5.12 applies one request-wide `token_ids_logprob` list to every scored prompt position. This PR does not add per-position token-ID lists.

Related PR #5897 adds SGLang teacher support using `top_logprobs_num`. It does not expose `token_ids_logprob`, so this PR does not duplicate it.

This reduces the response size across the inference API boundary. It does not claim to eliminate SGLang's internal full-vocabulary logits or log-softmax computation.

### Checklist Before Starting

- [x] Searched for similar open PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+sglang+token_ids_logprob
- [x] PR title follows `[sglang, rollout] feat: ...`

### Test

Static and pre-commit checks:

```bash
uvx --with hydra-core pre-commit run --files verl/workers/rollout/sglang_rollout/async_sglang_server.py tests/workers/rollout/rollout_sglang/test_token_ids_logprob.py
git diff --check
```

All checks passed.

Unit test against SGLang 0.5.12:

```bash
pytest -q tests/workers/rollout/rollout_sglang/test_token_ids_logprob.py
```

Result:

```text
1 passed
```

The test constructs a real SGLang `GenerateReqInput`, calls `normalize_batch_and_arguments()`, and verifies the normalized fixed-token logprob fields and response extraction.

A real `/generate` request was also tested with SGLang 0.5.12 and Qwen3.5-4B. For a 13-token prompt and 4 requested token IDs, every scored prompt position returned exactly those 4 IDs. Four overlapping scores were compared against `input_token_logprobs`, and all matched within `1e-5`.

### API and Usage Example

```python
output = await server.generate(
    prompt_ids=prompt_ids,
    sampling_params={
        "max_tokens": 1,
        "temperature": 0,
        "token_ids_logprob": candidate_token_ids,
        "logprob_start_len": 0,
    },
    request_id=request_id,
)

input_token_ids_logprobs = output.extra_fields["input_token_ids_logprobs"]
```

### Checklist Before Submitting

- [ ] Human submitter reviewed and understands every changed line.
- [ ] Read the contribution guide.
- [x] Applied pre-commit checks to the changed files.
- [x] Added a focused unit test.
- [x] Documentation update is not required because this exposes an engine-specific sampling parameter and does not add a public config.
- [x] No new CI workflow is required; the test is collected by the existing rollout/SGLang test setup.

### AI Assistance Disclosure

This change and its tests were developed with assistance from OpenAI Codex. The human submitter will review every changed line and is responsible for the final implementation and PR.
