### PR TITLE
[rollout] fix: default IPC weight transfer on Ascend A5 hardware

### DIFF
--- a/tests/utils/test_check_ipc_version_support_on_npu.py
+++ b/tests/utils/test_check_ipc_version_support_on_npu.py
@@ -15,7 +15,7 @@
 import logging
 import sys
 import unittest
-from unittest.mock import Mock, MagicMock, mock_open, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 from verl.utils.device import AscendHardwareVersion, check_ipc_version_support, get_npu_versions
 

--- a/tests/utils/test_check_ipc_version_support_on_npu.py
+++ b/tests/utils/test_check_ipc_version_support_on_npu.py
@@ -13,10 +13,18 @@
 # limitations under the License.
 
 import logging
+import sys
 import unittest
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, MagicMock, mock_open, patch
 
-from verl.utils.device import check_ipc_version_support, get_npu_versions
+from verl.utils.device import AscendHardwareVersion, check_ipc_version_support, get_npu_versions
+
+
+def _fake_torch_npu(device_name):
+    """Build a fake torch_npu module whose get_device_name returns device_name."""
+    fake = MagicMock()
+    fake.npu.get_device_name.return_value = device_name
+    return fake
 
 
 class TestCheckIPCVersionSupport(unittest.TestCase):
@@ -154,7 +162,7 @@ class TestGetNPUVersions(unittest.TestCase):
         # Mock path exists
         mock_exists.return_value = True
 
-        software_version, cann_version = get_npu_versions()
+        _, software_version, cann_version = get_npu_versions()
 
         self.assertEqual(software_version, "25.5.0")
         self.assertEqual(cann_version, "8.3.rc1")
@@ -234,6 +242,124 @@ class TestGetNPUVersions(unittest.TestCase):
             get_npu_versions()
 
         self.assertIn("Could not find version in CANN toolkit info file", str(context.exception))
+
+    @patch.dict(sys.modules, {"torch_npu": _fake_torch_npu("Ascend910_95")})
+    @patch("subprocess.run")
+    @patch("platform.machine")
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open, read_data="version=8.3.rc1\n")
+    def test_hardware_version_a5_910_95(self, mock_file, mock_exists, mock_machine, mock_run):
+        mock_run.return_value = Mock(stdout="Software Version : 25.5.0\n", check=True)
+        mock_machine.return_value = "x86_64"
+        mock_exists.return_value = True
+        hardware_version, _, _ = get_npu_versions()
+        self.assertEqual(hardware_version, AscendHardwareVersion.A5)
+
+    @patch.dict(sys.modules, {"torch_npu": _fake_torch_npu("Ascend950")})
+    @patch("subprocess.run")
+    @patch("platform.machine")
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open, read_data="version=8.3.rc1\n")
+    def test_hardware_version_a5_950(self, mock_file, mock_exists, mock_machine, mock_run):
+        mock_run.return_value = Mock(stdout="Software Version : 25.5.0\n", check=True)
+        mock_machine.return_value = "x86_64"
+        mock_exists.return_value = True
+        hardware_version, _, _ = get_npu_versions()
+        self.assertEqual(hardware_version, AscendHardwareVersion.A5)
+
+    @patch.dict(sys.modules, {"torch_npu": _fake_torch_npu("Ascend910_93")})
+    @patch("subprocess.run")
+    @patch("platform.machine")
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open, read_data="version=8.3.rc1\n")
+    def test_hardware_version_a3(self, mock_file, mock_exists, mock_machine, mock_run):
+        mock_run.return_value = Mock(stdout="Software Version : 25.5.0\n", check=True)
+        mock_machine.return_value = "x86_64"
+        mock_exists.return_value = True
+        hardware_version, _, _ = get_npu_versions()
+        self.assertEqual(hardware_version, AscendHardwareVersion.A3)
+
+    @patch.dict(sys.modules, {"torch_npu": _fake_torch_npu("Ascend910B3")})
+    @patch("subprocess.run")
+    @patch("platform.machine")
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open, read_data="version=8.3.rc1\n")
+    def test_hardware_version_a2_910b(self, mock_file, mock_exists, mock_machine, mock_run):
+        mock_run.return_value = Mock(stdout="Software Version : 25.5.0\n", check=True)
+        mock_machine.return_value = "x86_64"
+        mock_exists.return_value = True
+        hardware_version, _, _ = get_npu_versions()
+        self.assertEqual(hardware_version, AscendHardwareVersion.A2)
+
+    @patch.dict(sys.modules, {"torch_npu": _fake_torch_npu("A2G")})
+    @patch("subprocess.run")
+    @patch("platform.machine")
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open, read_data="version=8.3.rc1\n")
+    def test_hardware_version_a2_a2g(self, mock_file, mock_exists, mock_machine, mock_run):
+        mock_run.return_value = Mock(stdout="Software Version : 25.5.0\n", check=True)
+        mock_machine.return_value = "x86_64"
+        mock_exists.return_value = True
+        hardware_version, _, _ = get_npu_versions()
+        self.assertEqual(hardware_version, AscendHardwareVersion.A2)
+
+    @patch.dict(sys.modules, {"torch_npu": _fake_torch_npu("Ascend910_99")})
+    @patch("subprocess.run")
+    @patch("platform.machine")
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open, read_data="version=8.3.rc1\n")
+    def test_hardware_version_max_version(self, mock_file, mock_exists, mock_machine, mock_run):
+        mock_run.return_value = Mock(stdout="Software Version : 25.5.0\n", check=True)
+        mock_machine.return_value = "x86_64"
+        mock_exists.return_value = True
+        hardware_version, _, _ = get_npu_versions()
+        self.assertEqual(hardware_version, AscendHardwareVersion.MAX_VERSION)
+
+    @patch.dict(sys.modules, {"torch_npu": None})
+    @patch("subprocess.run")
+    @patch("platform.machine")
+    @patch("os.path.exists")
+    @patch("builtins.open", new_callable=mock_open, read_data="version=8.3.rc1\n")
+    def test_hardware_version_none_when_torch_npu_unavailable(self, mock_file, mock_exists, mock_machine, mock_run):
+        mock_run.return_value = Mock(stdout="Software Version : 25.5.0\n", check=True)
+        mock_machine.return_value = "x86_64"
+        mock_exists.return_value = True
+        hardware_version, _, _ = get_npu_versions()
+        self.assertEqual(hardware_version, AscendHardwareVersion.NONE)
+
+
+class TestIsIPCSupported(unittest.TestCase):
+    """Test PlatformNPU.is_ipc_supported A5 short-circuit behavior."""
+
+    @patch("verl.utils.device.check_ipc_version_support")
+    @patch("verl.utils.device.get_npu_versions")
+    def test_a5_short_circuit_returns_true(self, mock_get_versions, mock_check):
+        mock_get_versions.return_value = (AscendHardwareVersion.A5, "24.0.0", "7.0.0")
+        from verl.plugin.platform.platform_npu import PlatformNPU
+
+        platform = PlatformNPU()
+        self.assertTrue(platform.is_ipc_supported())
+        mock_check.assert_not_called()
+
+    @patch("verl.utils.device.check_ipc_version_support", return_value=True)
+    @patch("verl.utils.device.get_npu_versions")
+    def test_non_a5_delegates_to_version_check_true(self, mock_get_versions, mock_check):
+        mock_get_versions.return_value = (AscendHardwareVersion.A3, "25.5.0", "8.3.0")
+        from verl.plugin.platform.platform_npu import PlatformNPU
+
+        platform = PlatformNPU()
+        self.assertTrue(platform.is_ipc_supported())
+        mock_check.assert_called_once_with("25.5.0", "8.3.0")
+
+    @patch("verl.utils.device.check_ipc_version_support", return_value=False)
+    @patch("verl.utils.device.get_npu_versions")
+    def test_non_a5_delegates_to_version_check_false(self, mock_get_versions, mock_check):
+        mock_get_versions.return_value = (AscendHardwareVersion.A3, "24.0.0", "7.0.0")
+        from verl.plugin.platform.platform_npu import PlatformNPU
+
+        platform = PlatformNPU()
+        self.assertFalse(platform.is_ipc_supported())
+        mock_check.assert_called_once_with("24.0.0", "7.0.0")
 
 
 if __name__ == "__main__":

--- a/verl/plugin/platform/platform_npu.py
+++ b/verl/plugin/platform/platform_npu.py
@@ -164,15 +164,18 @@ class PlatformNPU(PlatformBase):
     def is_ipc_supported(self) -> bool:
         import subprocess
 
-        from verl.utils.device import check_ipc_version_support, get_npu_versions
+        from verl.utils.device import AscendHardwareVersion, check_ipc_version_support, get_npu_versions
 
         try:
-            software_version, cann_version = get_npu_versions()
-            return check_ipc_version_support(software_version, cann_version)
+            hardware_version, software_version, cann_version = get_npu_versions()
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to execute npu-smi command: {e}") from e
         except Exception as e:
             raise RuntimeError(f"Error checking IPC support: {e}") from e
+
+        if hardware_version == AscendHardwareVersion.A5:
+            return True
+        return check_ipc_version_support(software_version, cann_version)
 
     # ------------------------------------------------------------------
     # Profiling helpers

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -19,6 +19,7 @@ import logging
 import os
 import platform
 import subprocess
+from enum import IntEnum, unique
 
 import torch
 from packaging import version
@@ -182,15 +183,41 @@ def get_device_capability(device_id: int = 0) -> tuple[int | None, int | None]:
     return get_platform().get_device_capability(device_id)
 
 
-def get_npu_versions() -> tuple[str, str]:
-    """Get the software version and CANN toolkit version for NPU devices.
+@unique
+class AscendHardwareVersion(IntEnum):
+    NONE = 0
+    A2 = 2
+    A3 = 3
+    A5 = 5
+    MAX_VERSION = 999
+
+
+def get_npu_versions() -> tuple[AscendHardwareVersion, str, str]:
+    """Get the NPU chip generation, software version and CANN toolkit version.
 
     Returns:
-        tuple[str, str]: A tuple of (software_version, cann_version)
+        tuple[AscendHardwareVersion, str, str]: A tuple of
+        (hardware_version, software_version, cann_version)
 
     Raises:
         RuntimeError: If unable to retrieve version information
     """
+    try:
+        import torch_npu
+
+        device_name = torch_npu.npu.get_device_name()
+    except Exception:
+        hardware_version = AscendHardwareVersion.NONE
+    else:
+        if "Ascend910_95" in device_name or "Ascend950" in device_name:
+            hardware_version = AscendHardwareVersion.A5
+        elif "Ascend910_93" in device_name:
+            hardware_version = AscendHardwareVersion.A3
+        elif "Ascend910B" in device_name or "A2G" in device_name:
+            hardware_version = AscendHardwareVersion.A2
+        else:
+            hardware_version = AscendHardwareVersion.MAX_VERSION
+
     # Check npu-smi software version
     try:
         result = subprocess.run(
@@ -263,7 +290,7 @@ def get_npu_versions() -> tuple[str, str]:
     if not cann_version:
         raise RuntimeError("Could not find version in CANN toolkit info file")
 
-    return software_version, cann_version
+    return hardware_version, software_version, cann_version
 
 
 def check_ipc_version_support(software_version: str, cann_version: str) -> bool:


### PR DESCRIPTION
### What does this PR do?

Fix the issue of A5 being unable to open IPC due to the HDK version problem.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

```bash
python -m unittest tests.utils.test_check_ipc_version_support_on_npu -v
```

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
