### PR TITLE
[doc] fix: drop ghost sandbox_fusion e2e script path

### DIFF
--- a/docs/sglang_multiturn/sandbox_fusion.rst
+++ b/docs/sglang_multiturn/sandbox_fusion.rst
@@ -218,7 +218,10 @@ Unit Tests
 
 e2e Tests
 ----------
-we provide e2e test scripts in `tests/special_e2e` folder, named `tests/special_e2e/run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh`
+The former SandboxFusion e2e script under ``tests/special_e2e/``
+(``run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh``) was removed together with the
+in-tree ``SandboxFusionTool``. Unit tests above still cover the multiturn tool
+rollout pattern. For general PPO e2e scripts see ``tests/special_e2e/``.
 
 by setting 'trainer.rollout_data_dir' you can dump the rollout data to local disk. here is an sample taken from the rollout data:
 


### PR DESCRIPTION
## Summary
`docs/sglang_multiturn/sandbox_fusion.rst` still pointed e2e readers at `tests/special_e2e/run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh`, which 404s on main (removed with the in-tree `SandboxFusionTool`). Reword that section to match the existing removal note; keep the rollout dump sample and `scripts/rollout_viewer.py` guidance.

## Reproduction
```bash
# on main tip
curl -sI "https://raw.githubusercontent.com/verl-project/verl/main/tests/special_e2e/run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh" | head -1
# → 404 Not Found

# directory listing has no *sf_tool* script
gh api repos/verl-project/verl/contents/tests/special_e2e --jq '.[].name' | grep -i sf || echo "no sf_tool script"

# docs still cite it
curl -sL "https://raw.githubusercontent.com/verl-project/verl/main/docs/sglang_multiturn/sandbox_fusion.rst" | grep -n "run_gsm8k_fsdp_sgl_multiturn_sf_tool"
# → line with the ghost path

# rollout_viewer still exists (kept)
gh api repos/verl-project/verl/contents/scripts/rollout_viewer.py --jq .path
```

## Test plan
- [ ] Confirm the e2e section no longer links a missing path
- [ ] Confirm sample dump + `rollout_viewer.py` instructions remain