### PR TITLE
[megatron] feat: add memory-efficient chunked top-k KL computation

### DIFF
--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -55,10 +55,102 @@ def vocab_parallel_log_softmax(
     return vp_logits - log_sum_exp_logits.unsqueeze(dim=-1)
 
 
+def _chunked_student_topk_stats(
+    vp_logits: torch.Tensor,
+    target_topk_indices_local: torch.Tensor,
+    chunk_size: int,
+    local_topk: int,
+    vocab_start_index: int,
+):
+    """Chunked, low-peak-memory computation of the vocab-parallel student statistics.
+
+    This is the memory-optimized replacement for the full ``[N, V_local]`` fp32
+    log-softmax + probs that the baseline materializes. Softmax is per-token
+    (normalized over the vocab dim), so we split along the TOKEN dim into chunks
+    of ``chunk_size`` rows and, per chunk, do the two TP reductions (MAX then SUM
+    over the local vocab shard) to obtain the *global* log-normalizer ``logZ``.
+    We never materialize the full ``[N, V_local]`` fp32 log-softmax / probs; the
+    largest fp32 vocab workspace is a single ``[chunk_size, V_local]`` temporary.
+
+    Returns (all in fp32, shaped like the (b, s, ...) inputs):
+      - vp_source_topk_logps  : student log p at the teacher top-k *local* indices, (b, s, topk)
+      - global_log_z          : per-token global log-normalizer logZ,               (b, s)
+      - local_student_topk_logps : this rank's top-k student log p,                 (b, s, local_topk)
+      - local_student_topk_ids   : this rank's top-k *global* vocab ids,            (b, s, local_topk)
+
+    NOTE: `vp_logits` is NOT modified in place (each chunk works on a fresh float
+    copy), so it can be safely saved for backward and re-used to recompute p.
+    """
+    from megatron.core.parallel_state import get_tensor_model_parallel_group
+
+    tp_group = get_tensor_model_parallel_group()
+
+    partition_vocab_size = vp_logits.size(-1)
+    prefix_shape = target_topk_indices_local.shape[:-1]  # (b, s)
+    topk = target_topk_indices_local.size(-1)
+
+    logits_2d = vp_logits.reshape(-1, partition_vocab_size)  # (N, V_local) view, never written
+    tgt_idx_2d = target_topk_indices_local.reshape(-1, topk)  # (N, topk) local indices, dummy 0 off-shard
+    n_tokens = logits_2d.size(0)
+    device = logits_2d.device
+
+    vp_source_topk_logps_2d = torch.empty(n_tokens, topk, dtype=torch.float32, device=device)
+    global_log_z_1d = torch.empty(n_tokens, dtype=torch.float32, device=device)
+    local_student_topk_logps_2d = torch.empty(n_tokens, local_topk, dtype=torch.float32, device=device)
+    local_student_topk_ids_2d = torch.empty(n_tokens, local_topk, dtype=torch.long, device=device)
+
+    for start in range(0, n_tokens, chunk_size):
+        end = min(start + chunk_size, n_tokens)
+        zc = logits_2d[start:end].float()  # (C, V_local) fresh fp32 copy
+
+        # Global max over the full vocab for numerical stability (same as baseline).
+        local_max = zc.amax(dim=-1)  # (C,)
+        torch.distributed.all_reduce(local_max, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+
+        # Global sum-exp of the shifted logits. The exp temporary is freed right after the sum.
+        exp_shifted = (zc - local_max.unsqueeze(-1)).exp()  # (C, V_local)
+        local_sum_exp = exp_shifted.sum(dim=-1)  # (C,)
+        del exp_shifted
+        torch.distributed.all_reduce(local_sum_exp, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+
+        # logZ = m + log(sum_j exp(z_j - m)); log p_j = z_j - logZ.
+        logZ = local_max + local_sum_exp.log()  # (C,)
+        global_log_z_1d[start:end] = logZ
+
+        rows = torch.arange(end - start, device=device).unsqueeze(-1)  # (C, 1)
+        # Student log p at the teacher top-k local indices (off-shard entries use dummy idx 0;
+        # they are zeroed by the shared post-processing via topk_indices_in_vocab_mask).
+        vp_source_topk_logps_2d[start:end] = zc[rows, tgt_idx_2d[start:end]] - logZ.unsqueeze(-1)
+
+        # This rank's local top-k student candidates (log p and global ids) for the overlap diagnostic.
+        vals, ids = torch.topk(zc, k=local_topk, dim=-1)
+        local_student_topk_logps_2d[start:end] = vals - logZ.unsqueeze(-1)
+        local_student_topk_ids_2d[start:end] = ids + vocab_start_index
+
+        del zc
+
+    return (
+        vp_source_topk_logps_2d.view(*prefix_shape, topk),
+        global_log_z_1d.view(*prefix_shape),
+        local_student_topk_logps_2d.view(*prefix_shape, local_topk),
+        local_student_topk_ids_2d.view(*prefix_shape, local_topk),
+    )
+
+
 class _VocabParallelKLDivergence(torch.autograd.Function):
     """
     Adapted from:
       https://github.com/verl-project/verl-recipe/blob/ccdb8d140dfc540761a9b209b854dbd2c0011e7e/gkd/megatron/megatron_kl_loss.py.
+
+    When ``use_chunked_topk`` is True, the forward computes the per-token global
+    log-normalizer logZ in TOKEN chunks and saves only ``vp_logits`` (its own
+    dtype) + ``logZ`` (fp32, [N]) + the small [N, topk] support tensors for
+    backward, instead of the full fp32 ``[N, V_local]`` student probs. Backward
+    then recomputes p_j = exp(z_j - logZ) in chunks (no TP collective — logZ is
+    already the global normalizer). This lowers the peak of the two full fp32
+    vocab tensors that the baseline materializes, at the cost of more (but
+    smaller) TP collectives. The math and all returned values are identical to
+    the non-chunked path up to fp reduction-order rounding.
     """
 
     @staticmethod
@@ -68,6 +160,8 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
         target_topk_logps: torch.Tensor,
         target_topk_indices: torch.Tensor,
         log_prob_min_clamp: Optional[float],
+        use_chunked_topk: bool = False,
+        chunk_size: int = 4096,
     ):
         """
         NOTE:
@@ -81,10 +175,6 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
             get_tensor_model_parallel_world_size,
         )
         from megatron.core.tensor_parallel.utils import VocabUtility
-
-        # Compute softmax over vocab-parallel logits
-        vp_source_logps = vocab_parallel_log_softmax(vp_logits).float()
-        vp_source_probs = torch.exp(vp_source_logps)
 
         # Find the vocab range owned by this partition
         rank = get_tensor_model_parallel_rank()
@@ -119,14 +209,40 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
         target_topk_probs[~topk_indices_in_vocab_mask] = 0
         target_topk_logps[~topk_indices_in_vocab_mask] = 0
 
-        # Gather source log probabilities at the target top-k indices (local indices)
         topk = target_topk_indices.size(-1)
-        vp_source_logps_2d = vp_source_logps.view(-1, partition_vocab_size)  # (b*s, vocab_shard)
-        arange_1d = torch.arange(start=0, end=vp_source_logps_2d.size(0), device=vp_source_logps_2d.device)  # (b*s,)
-        vp_source_topk_logps_2d = vp_source_logps_2d[
-            arange_1d.unsqueeze(-1), target_topk_indices.view(-1, topk)
-        ]  # (b*s, topk)
-        vp_source_topk_logps = vp_source_topk_logps_2d.view(target_topk_indices.shape)  # (b, s, topk)
+        local_topk = min(topk, partition_vocab_size)
+
+        # ---- Student-side stats: gather student log p at teacher top-k, plus local student top-k. ----
+        # The chunked path never materializes the full [N, V_local] fp32 log-softmax/probs.
+        if use_chunked_topk:
+            (
+                vp_source_topk_logps,
+                global_log_z,
+                local_student_topk_logps,
+                local_student_topk_ids,
+            ) = _chunked_student_topk_stats(
+                vp_logits, target_topk_indices, chunk_size, local_topk, vocab_start_index
+            )
+            vp_source_probs = None
+        else:
+            # Compute softmax over vocab-parallel logits
+            vp_source_logps = vocab_parallel_log_softmax(vp_logits).float()
+            vp_source_probs = torch.exp(vp_source_logps)
+            global_log_z = None
+
+            # Gather source log probabilities at the target top-k indices (local indices)
+            vp_source_logps_2d = vp_source_logps.view(-1, partition_vocab_size)  # (b*s, vocab_shard)
+            arange_1d = torch.arange(
+                start=0, end=vp_source_logps_2d.size(0), device=vp_source_logps_2d.device
+            )  # (b*s,)
+            vp_source_topk_logps_2d = vp_source_logps_2d[
+                arange_1d.unsqueeze(-1), target_topk_indices.view(-1, topk)
+            ]  # (b*s, topk)
+            vp_source_topk_logps = vp_source_topk_logps_2d.view(target_topk_indices.shape)  # (b, s, topk)
+
+            # Compute the student's global top-k ids from per-rank vocab-shard candidates.
+            local_student_topk_logps, local_student_topk_ids = torch.topk(vp_source_logps, k=local_topk, dim=-1)
+            local_student_topk_ids = local_student_topk_ids + vocab_start_index
 
         # `active_mask` tracks entries that should receive gradient.
         # If clamping is enabled, entries with log p_i <= clamp have zero gradient w.r.t. logits.
@@ -162,7 +278,18 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
             group=get_tensor_model_parallel_group(),
         )
 
-        ctx.save_for_backward(vp_source_probs, target_topk_probs, target_topk_indices, active_mask, target_active_mass)
+        # Save for backward. The chunked path saves the (bf16/fp16) logits + logZ and recomputes
+        # p_j = exp(z_j - logZ); the baseline path saves the full fp32 probs directly.
+        if use_chunked_topk:
+            ctx.save_for_backward(
+                vp_logits, global_log_z, target_topk_probs, target_topk_indices, active_mask, target_active_mass
+            )
+        else:
+            ctx.save_for_backward(
+                vp_source_probs, target_topk_probs, target_topk_indices, active_mask, target_active_mass
+            )
+        ctx.use_chunked_topk = use_chunked_topk
+        ctx.chunk_size = chunk_size
 
         # For logging: mass of student probs that lands on the teacher's top-k indices.
         vp_source_topk_probs = vp_source_topk_logps.exp() * topk_indices_in_vocab_mask  # (b, s, topk)
@@ -173,10 +300,7 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
             group=get_tensor_model_parallel_group(),
         )
 
-        # Compute the student's global top-k ids from per-rank vocab-shard candidates.
-        local_topk = min(topk, partition_vocab_size)
-        local_student_topk_logps, local_student_topk_ids = torch.topk(vp_source_logps, k=local_topk, dim=-1)
-        local_student_topk_ids = local_student_topk_ids + vocab_start_index
+        # Student's global top-k ids: all-gather the per-rank local top-k candidates, then top-k again.
         gathered_student_topk_logps = [torch.empty_like(local_student_topk_logps) for _ in range(world_size)]
         gathered_student_topk_ids = [torch.empty_like(local_student_topk_ids) for _ in range(world_size)]
         torch.distributed.all_gather(
@@ -241,10 +365,33 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
         Then for any vocab index j on this shard (with p = softmax(logits)):
             dL/dz_j = m_A * p_j - q_j * 1[j in A]
         """
-        vp_source_probs, target_topk_probs, target_topk_indices, active_mask, target_active_mass = ctx.saved_tensors
+        if ctx.use_chunked_topk:
+            vp_logits, global_log_z, target_topk_probs, target_topk_indices, active_mask, target_active_mass = (
+                ctx.saved_tensors
+            )
+            partition_vocab_size = vp_logits.size(-1)
+            logits_2d = vp_logits.reshape(-1, partition_vocab_size)  # (N, V_local) view, never written
+            n_tokens = logits_2d.size(0)
 
-        # Scale by m_A: grad starts as m_A * p_j for all j on this shard.
-        grad_input = vp_source_probs * target_active_mass.unsqueeze(-1)  # [b, s, vocab_shard]
+            # Allocate the (unavoidable) full [N, V_local] fp32 gradient once and fill it chunk by chunk,
+            # recomputing p_j = exp(z_j - logZ). This avoids holding a second full fp32 vocab tensor
+            # (the baseline keeps the saved fp32 probs AND the fresh fp32 grad alive simultaneously).
+            grad_input = torch.empty(n_tokens, partition_vocab_size, dtype=torch.float32, device=logits_2d.device)
+            m_A_1d = target_active_mass.reshape(-1)  # (N,)
+            logZ_1d = global_log_z.reshape(-1)  # (N,)
+            chunk_size = ctx.chunk_size
+            for start in range(0, n_tokens, chunk_size):
+                end = min(start + chunk_size, n_tokens)
+                p_c = (logits_2d[start:end].float() - logZ_1d[start:end].unsqueeze(-1)).exp()  # (C, V_local)
+                grad_input[start:end] = p_c * m_A_1d[start:end].unsqueeze(-1)  # m_A * p_j
+                del p_c
+            grad_input = grad_input.view(*target_active_mass.shape, partition_vocab_size)
+        else:
+            vp_source_probs, target_topk_probs, target_topk_indices, active_mask, target_active_mass = (
+                ctx.saved_tensors
+            )
+            # Scale by m_A: grad starts as m_A * p_j for all j on this shard.
+            grad_input = vp_source_probs * target_active_mass.unsqueeze(-1)  # [b, s, vocab_shard]
 
         topk = target_topk_indices.size(-1)
         grad_input_2d = grad_input.view(-1, grad_input.size(-1))
@@ -258,7 +405,7 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
         grad_input_2d.scatter_add_(dim=1, index=target_topk_indices_flat, src=-sub)
 
         grad_input.mul_(grad_loss.unsqueeze(dim=-1))
-        return grad_input, None, None, None
+        return grad_input, None, None, None, None, None
 
 
 def compute_forward_kl_topk(
@@ -300,6 +447,8 @@ def compute_forward_kl_topk(
             teacher_topk_log_probs_cp_split,
             teacher_topk_ids_cp_split,
             distillation_loss_config.log_prob_min_clamp,
+            distillation_loss_config.use_chunked_topk,
+            distillation_loss_config.chunked_topk_chunk_size,
         )
     )
 


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in, memory-efficient chunked path for Megatron vocab-parallel top-k forward KL. It extends the FSDP chunking approach from #6593 to tensor-parallel vocabulary shards, avoiding full fp32 `[N, V_local]` log-softmax/probability buffers while preserving the existing outputs and gradients.

With chunked loss implemented, small student models (e.g., 4B or smaller) can reduce GPU memory via an FSDP-like chunked loss approach, eliminating the need to increase TP to lower peak memory usage. This prevents GPU idleness and significantly improves utilization. We previously used a 4B student model, but the trainer OOM'd during loss computation. The original approach required TP=4 to avoid OOM; with chunked loss enabled, we can now run at TP=1 without OOM, greatly improving GPU utilization and reducing idle time.

### Test

Results (b=2, s=96, V=2048, K=32; d_* denotes the maximum absolute error):

| Config | Comparison | d_loss | d_grad | d_smass | d_ocount | Verdict |
|---|---|---|---|---|---|---|
| fp32, clamp=-10 | baseline vs **reference** | 8.9e-8 | **1.2e-9** | — | — | ✅ |
| fp32, clamp=-10 | chunked(cs=7/64/4096) vs baseline | ≤1.2e-7 | ≤1.3e-9 | 1.9e-8 | 0 | ✅ |
| fp32, clamp=None | baseline vs reference | 8.9e-8 | 1.2e-9 | — | — | ✅ |
| fp32, clamp=None | chunked vs baseline | ≤1.2e-7 | ≤1.3e-9 | 1.9e-8 | 0 | ✅ |
| bf16, clamp=-10 | chunked vs baseline | ≤8.9e-8 | **1.9e-6** | 1.9e-8 | 0 | ✅ |

- Under fp32, chunked and baseline are nearly bit-for-bit identical (same floating-point operators and reduction order when TP=1);
- overlap_count is exactly identical (diff=0);
- For bf16 (storing bf16 logits and recomputing p in backward), the additional rounding is only ~1.9e-6;
- chunk_size=7 (many odd-sized chunks + a residual chunk) produces results consistent with 4096 → chunk boundary handling is correct.

Actual Qwen3.5-4B distillation dimensions: V=248320, K=128, TP=1, N=4096 tokens, clamp=-10.
Individually compared the maximum absolute/relative differences across 5 forward outputs + gradients.

**bf16 logits（actual online dtype）：**

| chunk_size | overlap_count diff | per_token_kl | student_mass | teacher_mass | overlap_adv | grad | Conclusion |
|---|---|---|---|---|---|---|---|
| 2048 | 0 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | **Bit-for-bit identical** |
| 4096 | 0 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | **Bit-for-bit identical** |
| 8192 | 0 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | **Bit-for-bit identical** |

**fp32 logits（stricter rounding observation）：**

| chunk_size | overlap_count diff | per_token_kl (abs/rel) | grad (abs/rel) | worst_rel | Conclusion |
|---|---|---|---|---|---|
| 2048 | 0 | 9.31e-10 / 8.13e-08 | 8.53e-14 / 2.96e-10 | 8.22e-07 | OK |
| 4096 | 0 | 9.31e-10 / 8.13e-08 | 8.53e-14 / 2.96e-10 | 8.22e-07 | OK |
| 8192 | 0 | 9.31e-10 / 8.13e-08 | 8.53e-14 / 2.96e-10 | 8.22e-07 | OK |

#### Peak memory

End-to-end forward/backward peak memory with `chunk_size=4,096`:

**TP=1 (`V_local=248,320`)**

| tokens (`N`) | logits size | baseline peak | chunked peak | saved | reduction |
|---:|---:|---:|---:|---:|---:|
| 4,096 | 1.90G | 13.28 GiB | 13.29 GiB | -0.01 GiB | -0.1% |
| 8,192 | 3.80G | 26.56 GiB | 18.97 GiB | 7.59 GiB | 28.6% |
| 16,384 | 7.60G | 53.12 GiB | 30.36 GiB | 22.76 GiB | 42.8% |
| 24,576 | 11.40G | 79.68 GiB | 45.54 GiB | 34.14 GiB | 42.8% |

**TP=4 (`V_local=62,080` per rank, matching the E20 launch)**

| tokens (`N`) | logits size per rank | baseline peak | chunked peak | saved per rank | reduction |
|---:|---:|---:|---:|---:|---:|
| 16,384 | 1.92G | 13.33 GiB | 7.63 GiB | 5.71 GiB | 42.8% |
| 32,768 | 3.84G | 26.67 GiB | 15.25 GiB | 11.41 GiB | 42.8% |
| 49,152 | 5.75G | 40.00 GiB | 22.88 GiB | 17.12 GiB | 42.8% |

At small token counts the chunk workspace makes peak memory effectively unchanged. The benefit grows with sequence length, reaching a stable `42.8%` reduction; for the TP=4 E20-scale case at `N=49,152`, this saves `17.12 GiB` per rank.

### API and Usage Example

No new API is introduced; this uses the existing distillation configuration added for the FSDP path:

```yaml
distillation_loss:
  use_chunked_topk: true
  chunked_topk_chunk_size: 4096
```

The feature remains disabled by default.

### Design & Code Changes

- Forward processes tokens in chunks, performs TP `MAX`/`SUM` reductions to compute the global `logZ`, and gathers only teacher top-k plus local student top-k statistics.
- Backward saves the original low-precision logits and per-token fp32 `logZ`, then recomputes probabilities chunk by chunk.
- This removes the persistent full fp32 probability tensor and limits temporary fp32 vocabulary storage to `[chunk_size, V_local]`, at the cost of additional TP collectives and recomputation.
- The baseline path is unchanged when chunking is disabled.

### Checklist Before Submitting

- [x] Searched for similar PRs; this implementation follows #6593.
- [x] PR title follows the required format.
- [x] Added targeted numerical validation, including chunk boundaries and realistic model dimensions.
- [x] No documentation update is required; the existing FSDP configuration is reused without API changes.
