### PR TITLE
[doc] fix: point prepare_dapo_data.sh at recipe/dapo/

### DIFF
--- a/docs/algo/dapo.md
+++ b/docs/algo/dapo.md
@@ -15,7 +15,7 @@ Last updated: 06/19/2025.
 1. Prepare the datasets **on the Ray cluster**:
 
 ```bash
-bash prepare_dapo_data.sh # This downloads the datasets to ${HOME}/verl/data by default
+bash recipe/dapo/prepare_dapo_data.sh # This downloads the datasets to ${HOME}/verl/data by default
 ```
 
 2. Submit the job to the Ray cluster **from any machine**:

--- a/docs/algo/dppo.md
+++ b/docs/algo/dppo.md
@@ -19,7 +19,7 @@ Last updated: 02/25/2026.
 1. Prepare the datasets by running [prepare_dapo_data.sh](https://github.com/verl-project/verl-recipe/blob/3490a22a0a3adeb7e4787fe70b1060b642efbae4/dapo/prepare_dapo_data.sh):
 
 ```bash
-bash prepare_dapo_data.sh # This downloads the datasets to ${HOME}/verl/data by default
+bash recipe/dapo/prepare_dapo_data.sh # This downloads the datasets to ${HOME}/verl/data by default
 ```
 
 2. Prepare the model:

--- a/examples/dppo_trainer/README.md
+++ b/examples/dppo_trainer/README.md
@@ -17,7 +17,7 @@
 1. Prepare the datasets by running [prepare_dapo_data.sh](https://github.com/verl-project/verl-recipe/blob/3490a22a0a3adeb7e4787fe70b1060b642efbae4/dapo/prepare_dapo_data.sh):
 
 ```bash
-bash prepare_dapo_data.sh # This downloads the datasets to ${HOME}/verl/data by default
+bash recipe/dapo/prepare_dapo_data.sh # This downloads the datasets to ${HOME}/verl/data by default
 ```
 
 2. Prepare the model:


### PR DESCRIPTION
## Summary
- Quickstart / Getting-started snippets still ran `bash prepare_dapo_data.sh` from the repo root.
- That script lives under the `recipe` submodule at `recipe/dapo/prepare_dapo_data.sh`.
- Update `docs/algo/dapo.md`, `docs/algo/dppo.md`, and `examples/dppo_trainer/README.md` so the prepare command matches the neighboring `recipe/dapo/` run paths.

## Test plan
- [x] Confirmed `prepare_dapo_data.sh` is 404 at repo root on `main`
- [x] Confirmed script exists at `dapo/prepare_dapo_data.sh` in the pinned `recipe` submodule (`verl-recipe`)
- [x] Diff limited to the three bash path lines above