### PR TITLE
[doc] fix: correct remax sync script name in README

### DIFF
--- a/examples/remax_trainer/README.md
+++ b/examples/remax_trainer/README.md
@@ -9,7 +9,7 @@ Reference: [ReMax: A Simple, Effective, and Efficient Reinforcement Learning Met
 | Script                                    | Infer | Train     | Platform |
 |-------------------------------------------|-------|-----------|----------|
 | `run_qwen3_8b_fsdp.sh`                   | vLLM  | FSDP      | NVIDIA   |
-| `run_qwen2.5_math_7b_fsdp_sync.sh`       | vLLM  | FSDP+Sync | NVIDIA   |
+| `run_qwen2.5_math_7b_sync_fsdp.sh`       | vLLM  | FSDP+Sync | NVIDIA   |
 
 Override any argument via env vars at the top of the script.
 


### PR DESCRIPTION
## Summary
- `examples/remax_trainer/README.md` listed `run_qwen2.5_math_7b_fsdp_sync.sh`, which is not in the tree.
- The checked-in script is `run_qwen2.5_math_7b_sync_fsdp.sh` (sync before fsdp).
- Update the Canonical Scripts table to match the filename on main.

## Test plan
- [x] Confirmed `examples/remax_trainer/run_qwen2.5_math_7b_sync_fsdp.sh` exists on main
- [x] Confirmed old `..._fsdp_sync.sh` name does not exist