### PR TITLE
[doc] fix: correct actor_rollout_ref.rollout.n Hydra key in ppo_trainer README

### DIFF
--- a/examples/ppo_trainer/README.md
+++ b/examples/ppo_trainer/README.md
@@ -27,7 +27,7 @@ Most critic configs are similar to those of actors. Note that the critic model i
 
 ![image](https://github.com/user-attachments/assets/16aebad1-0da6-4eb3-806d-54a74e712c2d)
 
-- `data.train_batch_size`: The global batch size of prompts used to generate a set of sampled trajectories/rollouts. The number of responses/trajectories is `data.train_batch_size * actor_rollout.ref.rollout.n`
+- `data.train_batch_size`: The global batch size of prompts used to generate a set of sampled trajectories/rollouts. The number of responses/trajectories is `data.train_batch_size * actor_rollout_ref.rollout.n`
 
 - `actor_rollout_ref.actor.ppo_mini_batch_size`: The set of sampled trajectories is split into multiple mini-batches with batch_size=ppo_mini_batch_size for PPO actor updates. The ppo_mini_batch_size is a global size across all workers
 


### PR DESCRIPTION
## Summary

`examples/ppo_trainer/README.md` still documents the Hydra key as `actor_rollout.ref.rollout.n` when describing how `data.train_batch_size` scales with per-prompt samples. On `main`, the live key is `actor_rollout_ref.rollout.n` (`n` under `actor_rollout_ref.rollout` in `verl/trainer/config/rollout/rollout.yaml` / `_generated_ppo_trainer.yaml`).

This is the same typo class as open docs fixes in `docs/algo/grpo.md` / `docs/algo/ppo.md`, but in the examples PPO README (not covered by those PRs).

## Reproduction

```bash
SHA=$(gh api repos/verl-project/verl/commits/HEAD --jq .sha)
curl -fsSL "https://raw.githubusercontent.com/verl-project/verl/${SHA}/examples/ppo_trainer/README.md" | rg 'actor_rollout\.ref\.rollout\.n'
# expect a hit on the train_batch_size bullet

curl -fsSL "https://raw.githubusercontent.com/verl-project/verl/${SHA}/verl/trainer/config/rollout/rollout.yaml" | rg -n '^n:'
# n: 1  # number of responses (i.e. num sample times)

# Wrong key fails Hydra overrides; correct key is actor_rollout_ref.rollout.n
# (see examples/grpo_trainer/README.md which already uses the correct form)
```

## Test plan

- [x] Confirmed single wrong occurrence in `examples/ppo_trainer/README.md`
- [x] Confirmed `n` lives under `actor_rollout_ref.rollout` in rollout config
- [x] Confirmed open #7707/#7709 only touch `docs/algo/grpo.md` / `docs/algo/ppo.md`