### PR TITLE
[doc] fix: point Ascend SGLang practice at live ascend_extras script

### DIFF
--- a/docs/ascend_tutorial/zh/model_support/examples/ascend_sglang_best_practices.rst
+++ b/docs/ascend_tutorial/zh/model_support/examples/ascend_sglang_best_practices.rst
@@ -94,7 +94,7 @@ SGLang 是当前主流的高性能开源推理引擎, 昇腾已经全面原生�
 
 .. code-block:: bash 
 
-  bash examples/grpo_trainer/run_qwen3moe-30b_sglang_megatron_npu.sh
+  bash examples/ascend_extras/grpo_trainer/run_qwen3_30b_a3b_megatron.sh
 如果您想扩展至多节点，我们推荐使用以下脚本进行大规模多节点训练拉起
 
 .. code-block:: bash


### PR DESCRIPTION
## Summary
`docs/ascend_tutorial/zh/model_support/examples/ascend_sglang_best_practices.rst` tells readers to run:

```bash
bash examples/grpo_trainer/run_qwen3moe-30b_sglang_megatron_npu.sh
```

That path is gone after the Ascend script cleanup/rename. The same doc's `Qwen3-30B` table link already points at the live replacement:

`examples/ascend_extras/grpo_trainer/run_qwen3_30b_a3b_megatron.sh`

(which sets `actor_rollout_ref.rollout.name=sglang`).

## Reproduction
```bash
SHA=$(gh api repos/verl-project/verl/commits/main --jq .sha)
curl -sL -o /dev/null -w '%{http_code}\n' \
  https://raw.githubusercontent.com/verl-project/verl/$SHA/examples/grpo_trainer/run_qwen3moe-30b_sglang_megatron_npu.sh
# -> 404
curl -sL -o /dev/null -w '%{http_code}\n' \
  https://raw.githubusercontent.com/verl-project/verl/$SHA/examples/ascend_extras/grpo_trainer/run_qwen3_30b_a3b_megatron.sh
# -> 200
curl -fsSL https://raw.githubusercontent.com/verl-project/verl/$SHA/examples/ascend_extras/grpo_trainer/run_qwen3_30b_a3b_megatron.sh \
  | rg 'rollout.name=sglang'
```

## Change
One path update in `ascend_sglang_best_practices.rst` so the single-node bash example matches the live `ascend_extras` script (and this doc's own table link). Historical checkout notes left untouched.