### PR TITLE
[training_utils] fix: finalize MLflow run on finish to record end time

### DIFF
--- a/tests/utils/test_mlflow_key_sanitization.py
+++ b/tests/utils/test_mlflow_key_sanitization.py
@@ -59,6 +59,20 @@ class TestMlflowLoggingAdapter(unittest.TestCase):
             self.assertTrue(any("val-core///acc/best_at_5" in msg for msg in warning_msgs))
             self.assertTrue(any("metric////with/many////slashes" in msg for msg in warning_msgs))
 
+    def test_finish_ends_active_run(self):
+        """Test that finish() calls mlflow.end_run() when a run is active."""
+        adapter = _MlflowLoggingAdapter()
+        with patch("mlflow.active_run", return_value=object()), patch("mlflow.end_run") as mock_end_run:
+            adapter.finish()
+        mock_end_run.assert_called_once()
+
+    def test_finish_skips_when_no_active_run(self):
+        """Test that finish() does not call mlflow.end_run() when no run is active."""
+        adapter = _MlflowLoggingAdapter()
+        with patch("mlflow.active_run", return_value=None), patch("mlflow.end_run") as mock_end_run:
+            adapter.finish()
+        mock_end_run.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -30,6 +30,17 @@ def test_tracking_finish_finalizes_wandb_once():
     tracking.logger["wandb"].finish.assert_called_once_with(exit_code=1)
 
 
+def test_tracking_finish_finalizes_mlflow_once():
+    tracking = Tracking.__new__(Tracking)
+    tracking.logger = {"mlflow": MagicMock()}
+    tracking._finished = False
+
+    tracking.finish()
+    tracking.finish()
+
+    tracking.logger["mlflow"].finish.assert_called_once()
+
+
 def test_dapo_filtered_reward_table_logs_incremental_rows():
     mock_wandb = MagicMock()
     mock_wandb.run = object()

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -210,6 +210,8 @@ class Tracking:
             loggers["tensorboard"].finish()
         if "clearml" in loggers:
             loggers["clearml"].finish()
+        if "mlflow" in loggers:
+            loggers["mlflow"].finish()
         if "trackio" in loggers:
             loggers["trackio"].finish()
         if "file" in loggers:
@@ -615,6 +617,12 @@ class _MlflowLoggingAdapter:
                     self.logger.info(msg, *args)
                 else:
                     self.logger.warning(msg, *args)
+
+    def finish(self):
+        import mlflow
+
+        if mlflow.active_run() is not None:
+            mlflow.end_run()
 
 
 def _compute_mlflow_params_from_objects(params) -> dict[str, Any]:


### PR DESCRIPTION
### What does this PR do?

Finalize MLflow runs on trainer shutdown so the UI records End Time / Duration.

verl starts MLflow runs with a bare `mlflow.start_run()` (not the context-manager
`with mlflow.start_run():` form), so without an explicit `mlflow.end_run()` the run
stays in the `RUNNING` state and the UI shows `(unknown)` for End Time and Duration.
This PR adds `_MlflowLoggingAdapter.finish()` and wires it into `Tracking.finish()`
alongside the other backends.

No related issue / PR found (searched `mlflow end_run` and `mlflow finish`).


#### Current problem: Even after the job finished, MlFlow status is "Running"

<img width="1140" height="596" alt="image" src="https://github.com/user-attachments/assets/0fb54a7a-6be7-4a34-8ccb-63838447f53a" />


End time and duration are "unknown":
<img width="1519" height="315" alt="Clipboard_Screenshot_1788505907" src="https://github.com/user-attachments/assets/73d83ad5-f227-4684-9a31-c875c3263fcf" />


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+mlflow+finish
- [x] Format the PR title as `[{modules}] {type}: {description}` ...  → `[training_utils] fix: ...`

### Test

python3 -m pytest tests/utils/test_tracking_on_cpu.py tests/utils/test_mlflow_key_sanitization.py -q

#### status fixed and Duration shows correctly:
<img width="1726" height="417" alt="Clipboard_Screenshot_1788513291" src="https://github.com/user-attachments/assets/d3d3f859-bf7e-49c0-8d0c-8a870bc38801" />

Covers:
- `Tracking.finish()` finalizes the mlflow backend exactly once (idempotent).
- `_MlflowLoggingAdapter.finish()` calls `mlflow.end_run()` only when a run is active.

### API and Usage Example

No public API change. Users who pass `trainer.logger=["console","mlflow"]` will now see
the run transition to `FINISHED` with a populated End Time / Duration after training
completes normally. No configuration change required.

### Design & Code Changes

- `verl/utils/tracking.py`
  -  Add `if "mlflow" in loggers: loggers["mlflow"].finish()` to `Tracking.finish()`.
  - Add `_MlflowLoggingAdapter.finish()` that calls `mlflow.end_run()` guarded by
    `mlflow.active_run() is not None`.
- `tests/utils/test_tracking_on_cpu.py`
  - Add `test_tracking_finish_finalizes_mlflow_once`.
- `tests/utils/test_mlflow_key_sanitization.py`
  - Add `test_finish_ends_active_run` and `test_finish_skips_when_no_active_run`.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks: `pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation — N/A (no user-facing config change).
- [x] Add unit or end-to-end test(s) to the CI workflow — tests added to existing
      `test_tracking_on_cpu.py` / `test_mlflow_key_sanitization.py`, which are already
      collected by `cpu_unit_tests.yml` / existing unit-test workflow.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
