### PR TITLE
[doc] fix: point Ascend vLLM Qwen3-MoE example at release/v0.7.1 script

### DIFF
--- a/docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst
+++ b/docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst
@@ -91,7 +91,7 @@ vLLM 是当前主流的高性能开源推理引擎, 昇腾已经全面原生支�
     #保存频率，-1默认不保存，如需评测请修改此参数
     trainer.save_freq=-1
 
-对于单机任务 `Qwen3-30B`_ , 可以直接bash执行verl仓上示例脚本，如:
+对于单机任务 `Qwen3-30B`_ , 可在 ``release/v0.7.1`` 分支直接 bash 执行该示例脚本（见上方链接；该路径不在当前 main）。在已 ``git checkout release/v0.7.1`` 的仓库中可运行:
 
 .. code-block:: bash 
 


### PR DESCRIPTION
## Summary
The Ascend **vLLM** best-practices page cites `examples/grpo_trainer/run_qwen3moe-30b_grpo_megatron_vllm_npu.sh` as if it lived on current `main`. That path 404s on `main` / `3d36367e` and only exists on `release/v0.7.1`. The same page already pins `_Qwen3-30B` to `release/v0.7.1`; this change only qualifies the bash/example prose so it matches that pin.

This is **not** the SGLang Ascend practice page (open #7739 retargets that to `examples/ascend_extras/...`). Do not retarget this vLLM doc to `ascend_extras`.

## Repro
```bash
# main / tip: 404
curl -sI https://raw.githubusercontent.com/verl-project/verl/main/examples/grpo_trainer/run_qwen3moe-30b_grpo_megatron_vllm_npu.sh | head -1
curl -sI https://raw.githubusercontent.com/verl-project/verl/3d36367e/examples/grpo_trainer/run_qwen3moe-30b_grpo_megatron_vllm_npu.sh | head -1

# release/v0.7.1: 200
curl -sI https://raw.githubusercontent.com/verl-project/verl/release/v0.7.1/examples/grpo_trainer/run_qwen3moe-30b_grpo_megatron_vllm_npu.sh | head -1
```

## Change
In `docs/ascend_tutorial/zh/model_support/examples/ascend_vllm_best_practices.rst`, note that the single-node script is on `release/v0.7.1` (align with `_Qwen3-30B` and the existing `git checkout release/v0.7.1` step). Keep the bash command itself; do not invent a nonexistent main Ascend vLLM 30B script.
