### PR TITLE
[cfg, trainer] fix: prevent multi-teacher OPD from using dummy weights

### DIFF
--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -251,9 +251,12 @@ auto-fills it as `pool_size // per_replica_world_size`.
 ### `distillation.teacher_models.<name>.inference.*`
 
 Inference-engine config for this teacher; see [`RolloutConfig`](../../verl/workers/config/rollout.py). Same shape as
-`actor_rollout_ref.rollout.*`. Notable defaults inherited from the YAML:
+`actor_rollout_ref.rollout.*`. Teacher inference uses checkpoint-loading defaults rather than the actor rollout's
+weight-sync defaults. Notable settings include:
 
 - `inference.name` — e.g. `vllm` or `sglang`.
+- `inference.load_format` — defaults to `auto`. Dummy load formats are rejected because teacher weights are loaded once
+  at startup and are not synchronized from the actor later.
 - `inference.tensor_model_parallel_size` — default `2`.
 - `inference.gpu_memory_utilization` — default `0.5`.
 - `inference.max_model_len` — must accommodate `student_prompt_length +

--- a/tests/workers/config/test_distillation_config_on_cpu.py
+++ b/tests/workers/config/test_distillation_config_on_cpu.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.utils.config import omega_conf_to_dataclass
+from verl.workers.config import DistillationTeacherModelConfig, RolloutConfig
+
+
+def test_sparse_teacher_inference_defaults_to_checkpoint_loading():
+    config = omega_conf_to_dataclass(
+        {
+            "key": "general",
+            "model_path": "/tmp/teacher",
+            "num_replicas": 1,
+            "inference": {"name": "vllm"},
+        },
+        dataclass_type=DistillationTeacherModelConfig,
+    )
+
+    assert config.inference.load_format == "auto"
+    config.check_configured()
+
+
+@pytest.mark.parametrize("load_format", ["dummy", "dummy_hf", "dummy_megatron"])
+def test_teacher_rejects_dummy_load_format(load_format):
+    config = DistillationTeacherModelConfig(
+        key="general",
+        model_path="/tmp/teacher",
+        num_replicas=1,
+        inference=RolloutConfig(name="vllm", load_format=load_format),
+    )
+
+    with pytest.raises(ValueError, match="must load checkpoint weights at startup"):
+        config.check_configured()
+
+
+def test_actor_rollout_default_load_format_remains_dummy():
+    assert RolloutConfig().load_format == "dummy"

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -124,6 +124,10 @@ class DistillationLossConfig(BaseConfig):
             )
 
 
+def _default_teacher_inference_config() -> RolloutConfig:
+    return RolloutConfig(load_format="auto")
+
+
 @dataclass
 class DistillationTeacherModelConfig(BaseConfig):
     """Configuration for on-policy distillation teacher.
@@ -146,7 +150,7 @@ class DistillationTeacherModelConfig(BaseConfig):
 
     key: Optional[str] = None
     model_path: Optional[str] = None
-    inference: RolloutConfig = field(default_factory=RolloutConfig)
+    inference: RolloutConfig = field(default_factory=_default_teacher_inference_config)
     num_replicas: Optional[int] = 0
 
     @property
@@ -168,6 +172,13 @@ class DistillationTeacherModelConfig(BaseConfig):
             raise ValueError("key must be specified for distillation teacher model config.")
         if self.num_replicas is None:
             raise ValueError("num_replicas must be specified for distillation teacher model config.")
+        if self.inference.load_format.startswith("dummy"):
+            raise ValueError(
+                "Distillation teachers must load checkpoint weights at startup; "
+                "dummy load formats initialize random weights and teacher weights "
+                "are not synchronized later. Set inference.load_format=auto or "
+                "another checkpoint-loading format."
+            )
 
     def validate_and_prepare_for_distillation(self, use_topk: bool, topk: Optional[int]) -> None:
         # Prompt + Response from student are fed into teacher as context


### PR DESCRIPTION
### What does this PR do?

Multi-teacher OPD entries created through sparse Hydra overrides are converted independently into `DistillationTeacherModelConfig`. Missing inference fields previously inherited `RolloutConfig.load_format="dummy"` instead of the single-teacher YAML value `"auto"`.

Unlike actor rollout engines, teacher engines do not receive a later weight synchronization. As a result, affected teachers silently used randomly initialized weights throughout training.

This PR:

- Defaults distillation teacher inference to `load_format="auto"`.
- Rejects explicit `dummy*` load formats for teachers before server startup.
- Keeps the actor rollout default unchanged at `"dummy"`.
- Adds CPU regression coverage and documents the different teacher/actor loading lifecycles.

AI assistance was used for root-cause analysis, implementation review, tests, and documentation.

### Test

```bash
PYTHONPATH=. /private/tmp/opd-guard-venv/bin/python -m pytest -q tests/workers/config/test_distillation_config_on_cpu.py
# 5 passed

ruff check verl/workers/config/distillation.py tests/workers/config/test_distillation_config_on_cpu.py
ruff format --check verl/workers/config/distillation.py tests/workers/config/test_distillation_config_on_cpu.py
git diff --check

![image/png](https://code.byted.org/api/v2/api/2022-06-01/DownloadFile?FileId=794771738115676)