### PR TITLE
[doc] fix: note removed Dockerfile.uv.cu129 in docker README

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -190,9 +190,10 @@ uv run --frozen --all-packages --extra sglang --extra megatron \
 ```
 
 Optional named stages: `--target=prefetch` builds just the baked cache (every
-backend, no source), and `--target=lock` regenerates `uv.lock`. A companion
-`docker/Dockerfile.uv.cu129` builds the cu12.9 / torch-2.9.1 backends (veomni,
-nemoautomodel) the same way; trtllm stays deferred. For the full story — the
+backend, no source), and `--target=lock` regenerates `uv.lock`. The former
+cu12.9 / torch-2.9.1 companion image (`docker/Dockerfile.uv.cu129`, for veomni /
+nemoautomodel) was removed and is deferred in `pyproject.toml` — recover it from
+git history if needed; trtllm stays deferred as well. For the full story — the
 launch flow, the baked-cache mechanics, and re-locking — see
 **"Install with uv"** in
 [`docs/start/install.rst`](../docs/start/install.rst).


### PR DESCRIPTION
## Summary
- `docker/README.md` still said a companion `docker/Dockerfile.uv.cu129` builds the cu12.9 / torch-2.9.1 backends (veomni, nemoautomodel).
- That Dockerfile was removed; `docker/Dockerfile.uv.cu130` comments and `docs/start/install.rst` document the cu130-only uv image, with the cu12.9 stack deferred in `pyproject.toml`.
- Update the README to state the cu129 companion was removed / deferred (recover from git history if needed), matching live tree + install docs.

## Test plan
- [x] Confirm `docker/Dockerfile.uv.cu129` is absent at HEAD while `docker/Dockerfile.uv.cu130` exists
- [x] Confirm `docs/start/install.rst` only references `Dockerfile.uv.cu130`
- [x] Confirm no other open docs PR already covers this sentence