### PR TITLE
[rollout, sglang] feat: low bit RL for SGLang on DPSK V4

### DIFF
--- a/verl/utils/debug/metrics.py
+++ b/verl/utils/debug/metrics.py
@@ -77,7 +77,17 @@ def calculate_debug_metrics(data: DataProto) -> dict:
             "training/rollout_probs_diff_max": max value of logprob diff of rollout vs. actor
             "training/rollout_probs_diff_mean": mean value of logprob diff of rollout vs. actor
             "training/rollout_probs_diff_std": std value of logprob diff of rollout vs. actor
+            "training/rollout_probs_diff_p50/p90/p99": quantiles of the same distribution
+            "training/rollout_probs_diff_frac_gt_0.1": fraction of tokens disagreeing by more than 0.1
             "training/rollout_actor_probs_pearson_corr": logprob's pearson corrcoef of rollout vs. actor, reference to https://arxiv.org/pdf/2506.13585
+
+    The mean alone cannot separate "every token is slightly off" from "most tokens
+    agree and a few are wildly wrong", and the two have opposite implications: the
+    first is a numeric precision gap that weight-side fixes can close, the second
+    is the signature of MoE routing flips, where a token is routed to different
+    experts in the two engines and its probability moves discontinuously. Since
+    truncated importance sampling reweights by the ratio, a heavy tail is also what
+    decides whether the correction is doing real work or clipping noise.
     """
 
     rollout_old_log_probs = data.batch["rollout_log_probs"]
@@ -107,15 +117,28 @@ def calculate_debug_metrics(data: DataProto) -> dict:
             "training/rollout_probs_diff_max": float("nan"),
             "training/rollout_probs_diff_mean": float("nan"),
             "training/rollout_probs_diff_std": float("nan"),
+            "training/rollout_probs_diff_p50": float("nan"),
+            "training/rollout_probs_diff_p90": float("nan"),
+            "training/rollout_probs_diff_p99": float("nan"),
+            "training/rollout_probs_diff_frac_gt_0.1": float("nan"),
             "training/rollout_actor_probs_pearson_corr": float("nan"),
         }
 
     pearson_corrcoef = pearson_correlation_coefficient(actor_probs, rollout_probs, response_mask_bool)
     rollout_probs_diff = calculate_log_prob_diff(actor_probs, rollout_probs, response_mask_bool)
+    # float() because torch.quantile rejects bf16, and sorts the input internally,
+    # so asking for the three cut points at once costs one sort rather than three.
+    quantiles = torch.quantile(
+        rollout_probs_diff.float(), torch.tensor([0.5, 0.9, 0.99], device=rollout_probs_diff.device)
+    )
     return {
         "training/rollout_probs_diff_valid": 1,
         "training/rollout_probs_diff_max": torch.max(rollout_probs_diff).detach().item(),
         "training/rollout_probs_diff_mean": torch.mean(rollout_probs_diff).detach().item(),
         "training/rollout_probs_diff_std": torch.std(rollout_probs_diff).detach().item(),
+        "training/rollout_probs_diff_p50": quantiles[0].detach().item(),
+        "training/rollout_probs_diff_p90": quantiles[1].detach().item(),
+        "training/rollout_probs_diff_p99": quantiles[2].detach().item(),
+        "training/rollout_probs_diff_frac_gt_0.1": (rollout_probs_diff > 0.1).float().mean().detach().item(),
         "training/rollout_actor_probs_pearson_corr": pearson_corrcoef,
     }

--- a/verl/utils/modelopt/mxfp4_qat.py
+++ b/verl/utils/modelopt/mxfp4_qat.py
@@ -1,0 +1,195 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MXFP4 quantization-aware training for DeepSeek-V4 routed experts.
+
+Follows DeepSeek-V4 §5.2.1: the master weights are quantized to MXFP4 and
+dequantized back for the forward, and the backward propagates straight through
+to the unquantized weights (Jacob et al. 2018's STE). Training then sees the
+same expert values the rollout engine will serve, instead of a bf16 view the
+deployment never uses.
+
+Why this matters here rather than only at deployment: in RL the actor's logprobs
+are compared against the rollout's on every step, and a DSv4 rollout serves its
+routed experts in packed MXFP4. Without QAT the actor computes in bf16 while the
+sampler computes in 4-bit, and that gap is charged to the policy-divergence
+metrics -- measured on this stack as k3_kl growing roughly 4x over fifteen steps
+with routing replay off.
+
+Bit-exactness with the exporter is the whole point of the implementation. The
+paper's benefit only holds if the values seen in training are the values the
+engine will hold, so the scale derivation and the E2M1 code boundaries below
+mirror ``quantize_mxfp4_e2m1_like_scale`` exactly, and ``test_matches_exporter``
+pins that agreement against the real quantize/dequantize pair.
+
+What is deliberately not copied from the paper: DeepSeek dequantizes FP4 to FP8
+and runs the existing FP8 GEMM, which makes the simulation free because their
+trainer is already FP8. A bf16 trainer has no such path to ride, so this
+dequantizes to the parameter dtype and pays for an extra round trip per forward.
+The numerical effect on the weights is identical; only the speedup is missing.
+"""
+
+from __future__ import annotations
+
+import torch
+
+# E2M1 magnitudes and the midpoints between them. ``torch.bucketize`` against the
+# midpoints is round-to-nearest, matching the exporter.
+_E2M1_MAGNITUDES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+_E2M1_BOUNDARIES = (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+
+FP4_E2M1_MAX = 6.0
+MXFP4_BLOCK_K = 32
+
+# The E8M0 scale exponent range; scales outside it cannot be represented.
+_E8M0_MIN = 2.0**-127
+_E8M0_MAX = 2.0**127
+
+
+def mxfp4_round_trip(weight: torch.Tensor) -> torch.Tensor:
+    """Quantize ``weight`` to MXFP4 and back, without ever packing the nibbles.
+
+    Packing is what the wire format needs, not what the forward needs: the
+    dequantized values are identical either way, and skipping it avoids a
+    pack/unpack pair per step.
+
+    The last dimension must be a multiple of 32 -- the MXFP4 scale block -- which
+    holds for every DSv4 expert matrix.
+    """
+    if weight.shape[-1] % MXFP4_BLOCK_K:
+        raise ValueError(
+            f"MXFP4 QAT needs the last dim to be a multiple of {MXFP4_BLOCK_K}, got {tuple(weight.shape)}"
+        )
+
+    orig_dtype = weight.dtype
+    w = weight.float()
+    blocks = w.unflatten(-1, (-1, MXFP4_BLOCK_K))
+
+    # Power-of-two scale per 32-element block, rounded up so the block max lands
+    # inside E2M1's range rather than saturating at 6.0.
+    amax = blocks.abs().amax(dim=-1, keepdim=True)
+    scale = torch.where(amax > 0, amax / FP4_E2M1_MAX, torch.ones_like(amax))
+    scale = torch.exp2(torch.ceil(torch.log2(scale.clamp(_E8M0_MIN, _E8M0_MAX))))
+
+    normalized = blocks / scale
+    boundaries = torch.tensor(_E2M1_BOUNDARIES, dtype=torch.float32, device=w.device)
+    magnitudes = torch.tensor(_E2M1_MAGNITUDES, dtype=torch.float32, device=w.device)
+    codes = torch.bucketize(normalized.abs(), boundaries)
+    dequantized = torch.sign(normalized) * magnitudes[codes] * scale
+
+    return dequantized.flatten(-2).to(orig_dtype)
+
+
+class _Mxfp4STE(torch.autograd.Function):
+    """Round-trip in the forward, identity in the backward.
+
+    The straight-through estimator is what makes this trainable: the rounding to
+    sixteen levels has zero gradient almost everywhere, so a faithful backward
+    would stop learning entirely. Passing the gradient to the unquantized weight
+    is the standard substitute, and is what the paper describes as propagating
+    "directly back to the FP32 master weights".
+    """
+
+    @staticmethod
+    def forward(ctx, weight: torch.Tensor) -> torch.Tensor:
+        return mxfp4_round_trip(weight)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+        return grad_output
+
+
+def mxfp4_fake_quant(weight: torch.Tensor) -> torch.Tensor:
+    """MXFP4 round trip that a gradient can flow through."""
+    return _Mxfp4STE.apply(weight)
+
+
+# --- Wiring into Megatron's grouped MoE experts ------------------------------
+
+_SAVED_ATTR = "_verl_mxfp4_qat_saved"
+
+
+def _grouped_expert_weight_names(linear: torch.nn.Module) -> list[str]:
+    """Per-expert weight names on a TE grouped linear.
+
+    ``TEGroupedMLP`` registers either one fused ``weight`` or one ``weight{i}``
+    per local expert, depending on ``single_grouped_weight``; both spellings are
+    accepted so the hook does not depend on which branch mcore took.
+    """
+    names = [n for n, _ in linear.named_parameters(recurse=False) if n.startswith("weight")]
+    return [n for n in names if n == "weight" or n[len("weight") :].isdigit()]
+
+
+def _swap_in_quantized(module: torch.nn.Module, _args) -> None:
+    """Replace expert weights with their MXFP4 round trip for this forward."""
+    saved: dict[str, torch.nn.Parameter] = {}
+    for name in _grouped_expert_weight_names(module):
+        param = module._parameters[name]
+        if param is None:
+            continue
+        quantized = mxfp4_fake_quant(param)
+
+        # With gradient_accumulation_fusion on -- the default wherever TE can
+        # support it -- TE writes the weight gradient straight into
+        # ``main_grad``, bypassing autograd. A derived tensor has no such buffer,
+        # so TE would either fail or drop the gradient. Pointing it at the
+        # parameter's own buffer is exactly right here because the STE makes the
+        # gradient w.r.t. the quantized tensor identical to the gradient w.r.t.
+        # the parameter.
+        main_grad = getattr(param, "main_grad", None)
+        if main_grad is not None:
+            quantized.main_grad = main_grad
+
+        saved[name] = param
+        # Assigning a non-Parameter over a registered parameter name is rejected
+        # by nn.Module, so drop the registration for the duration of the call and
+        # put it back in the post-hook. Nothing walks named_parameters() inside a
+        # forward, and keeping the registration intact everywhere else is what
+        # stops this from disturbing the optimizer, the grad buffers, or the
+        # checkpoint's name mapping.
+        del module._parameters[name]
+        setattr(module, name, quantized)
+
+    setattr(module, _SAVED_ATTR, saved)
+
+
+def _restore_parameters(module: torch.nn.Module, _args, _output) -> None:
+    saved = getattr(module, _SAVED_ATTR, None) or {}
+    for name, param in saved.items():
+        module.__dict__.pop(name, None)
+        module._parameters[name] = param
+    if hasattr(module, _SAVED_ATTR):
+        delattr(module, _SAVED_ATTR)
+
+
+def enable_mxfp4_qat(model) -> int:
+    """Quantize routed-expert weights to MXFP4 on every forward.
+
+    Returns the number of grouped linears hooked. Shared experts and the dense
+    linears are left alone: the checkpoint stores only the routed experts in
+    MXFP4, so they are the only weights whose deployment precision the training
+    has to anticipate.
+    """
+    hooked = 0
+    modules = model if isinstance(model, (list, tuple)) else [model]
+    for root in modules:
+        for module in root.modules():
+            if type(module).__name__ != "TEGroupedMLP":
+                continue
+            for linear in (getattr(module, "linear_fc1", None), getattr(module, "linear_fc2", None)):
+                if linear is None or not _grouped_expert_weight_names(linear):
+                    continue
+                linear.register_forward_pre_hook(_swap_in_quantized)
+                linear.register_forward_hook(_restore_parameters)
+                hooked += 1
+    return hooked

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -129,7 +129,12 @@ class QATEngineConfig(BaseConfig):
 
     Args:
         enable (bool): Whether to enable QAT, default False
-        mode (str): Quantization mode, "w4a16" or "w4a4", default "w4a16"
+        mode (str): Quantization mode. "w4a16" or "w4a4" insert ModelOpt's NVFP4
+            fake-quant modules. "mxfp4_experts" instead round-trips the routed
+            experts through the checkpoint's own MXFP4 format on every forward, so
+            a DSv4 actor trains against the values its rollout engine serves; it is
+            Megatron-only, needs a grouped-GEMM MoE model, and cannot be combined
+            with the ModelOpt modes.
         group_size (int): Group size for blockwise quantization, default 16
         ignore_patterns (list[str]): Module name patterns to exclude from quantization
         activation_observer (str): Observer strategy for activation global_scale (W4A4 only)

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -209,6 +209,11 @@ class MegatronEngine(BaseEngine):
         # QAT configuration
         self._qat_config = getattr(self.engine_config, "qat", None)
         self._qat_enabled = self._qat_config is not None and getattr(self._qat_config, "enable", False)
+        # Whether QAT simulates the checkpoint's own quantized format rather than
+        # inserting ModelOpt's fake-quant modules. Decided once because two places
+        # below branch on it, and a mode string compared literally in each of them
+        # is one edit away from disagreeing.
+        self._qat_checkpoint_format = self._qat_enabled and self._qat_config.mode == "mxfp4_experts"
         if self._qat_enabled:
             if self.engine_config.vanilla_mbridge:
                 raise ValueError(
@@ -389,7 +394,12 @@ class MegatronEngine(BaseEngine):
                 else:
                     provider_overrides["enable_routing_replay"] = True
 
-            if self._qat_enabled:
+            # Only the ModelOpt modes need its layer spec. Swapping it in for
+            # mxfp4_experts would rebuild the decoder with a different module
+            # structure, which shifts the parameter count and leaves the bridge
+            # without a weight mapping, so the checkpoint fails to load; that mode
+            # works on the stock grouped-MoE layers and needs no spec change.
+            if self._qat_enabled and not self._qat_checkpoint_format:
                 from megatron.bridge.models.gpt_provider import modelopt_transformer_layer_spec
 
                 provider.transformer_layer_spec = modelopt_transformer_layer_spec
@@ -581,9 +591,20 @@ class MegatronEngine(BaseEngine):
         self.module = self._build_megatron_module()
 
         if self._qat_enabled and not self.engine_config.forward_only:
-            from verl.utils.modelopt import apply_qat_to_modules
+            if self._qat_checkpoint_format:
+                from verl.utils.modelopt.mxfp4_qat import enable_mxfp4_qat
 
-            self.module = apply_qat_to_modules(self.module, self._qat_config)
+                n_hooked = enable_mxfp4_qat(self.module)
+                logger.info("QAT mxfp4_experts: hooked %d grouped expert linears", n_hooked)
+                if n_hooked == 0:
+                    raise ValueError(
+                        "qat.mode=mxfp4_experts found no TEGroupedMLP experts to hook; "
+                        "it needs a grouped-GEMM MoE model (moe_grouped_gemm=True)."
+                    )
+            else:
+                from verl.utils.modelopt import apply_qat_to_modules
+
+                self.module = apply_qat_to_modules(self.module, self._qat_config)
 
         self._maybe_enable_fused_kernels()
 

--- a/verl/workers/rollout/sglang_rollout/mxfp4_loader.py
+++ b/verl/workers/rollout/sglang_rollout/mxfp4_loader.py
@@ -1,0 +1,218 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""In-place MXFP4 routed-expert refit for SGLang, via ``--custom-weight-loader``.
+
+Counterpart to ``verl/utils/vllm/vllm_fp4_utils.py``, solving the same problem
+one engine over: a DSv4 checkpoint ships its routed experts MXFP4-packed and the
+Megatron bridge exports them in that same layout, but by the time a sync arrives
+the engine's expert parameters are no longer in checkpoint layout. SGLang's
+``Mxfp4FlashinferCutlassMoEMethod.process_weights_after_loading`` runs the SM90
+CUTLASS interleave once at model load and publishes the result as four brand-new
+``Parameter`` objects::
+
+    layer.w13_weight           = Parameter(w13_il, requires_grad=False)
+    layer.w2_weight            = Parameter(w2_il,  requires_grad=False)
+    layer.w13_weight_scale_inv = Parameter(w13_s_il, requires_grad=False)
+    layer.w2_weight_scale_inv  = Parameter(w2_s_il,  requires_grad=False)
+
+Those carry none of the loader attributes ``set_weight_attrs`` had attached, so a
+refit dies immediately in ``deepseek_v4.py``'s ``weight_loader = param.weight_loader``
+with ``AttributeError: 'Parameter' object has no attribute 'weight_loader'``.
+
+The cycle here is stage -> load -> replay -> fold back:
+
+1. Swap each expert param for a checkpoint-layout buffer with the loader
+   attributes reattached, preferring a byte-level reinterpret of the live
+   storage so the reload lands where the kernel already reads. The interleave is
+   a permutation, so the byte counts match and this costs no extra memory --
+   which for 256 experts is the difference between free and doubling MoE VRAM.
+2. Let ``model.load_weights`` write the refit stream into those buffers.
+3. Re-run ``process_weights_after_loading`` to redo the interleave. It is a pure
+   function of the checkpoint bytes (``interleave_moe_{weights,scales}_for_sm90_mixed_gemm``
+   read nothing else), so replaying it reproduces the load-time layout exactly.
+4. Copy its output back into the parameters the CUDA graph captured and reinstate
+   those objects, so the addresses baked into the graph stay valid.
+
+Unlike the vLLM side there is no ``replace_parameter`` seam to intercept: SGLang
+assigns the four parameters directly. It does so in one place at the end of the
+method, though, which makes an after-the-fact fold-back sufficient and spares us
+the monkey-patch.
+
+Why a sentinel: verl posts a full sync as a series of ~512 MB buckets, one
+``update_weights_from_tensor`` each, and this loader is invoked per bucket with
+no notion of position in the stream. Staging must happen once before the first
+bucket and the replay once after the last, so staging is lazy (first bucket that
+finds unstaged layers does it) and the sender appends ``__mxfp4_end__`` to the
+final bucket to trigger the replay. Same shape as the ``__delta_spec__``
+protocol in ``delta_loader.py``.
+
+Register at server launch (verl config)::
+
+    +actor_rollout_ref.rollout.engine_kwargs.sglang.custom_weight_loader='["verl.workers.rollout.sglang_rollout.mxfp4_loader.load_mxfp4"]'
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+LOADER_FQN = "verl.workers.rollout.sglang_rollout.mxfp4_loader.load_mxfp4"
+
+# Zero-length marker appended to the last bucket of a sync. Carries no data; its
+# presence is the whole message.
+END_SENTINEL = "__mxfp4_end__"
+
+# The four params ``process_weights_after_loading`` replaces. Bias params are not
+# listed: DSv4 has no MoE bias, and a name that never existed would be skipped
+# anyway.
+_EXPERT_PARAMS = ("w13_weight", "w2_weight", "w13_weight_scale_inv", "w2_weight_scale_inv")
+
+# E8M0 scale per 32 fp4 weights, matching ``fp4_block_k`` in SGLang's
+# ``create_fp8_moe_weight_``.
+_SCALE_BLOCK_K = 32
+
+# Where the pre-refit parameters are parked for the duration of one sync.
+_LIVE_ATTR = "_verl_mxfp4_live"
+
+# Set by ``Mxfp4FlashinferCutlassMoEMethod.process_weights_after_loading``; its
+# presence is the most direct evidence that a layer went through the MXFP4
+# post-processing this module has to undo and redo.
+_BACKEND_ATTR = "_dsv4_mxfp4_backend"
+
+
+def _element_size(dtype: torch.dtype) -> int:
+    return torch.empty(0, dtype=dtype).element_size()
+
+
+def _checkpoint_layout(layer) -> dict[str, tuple[tuple[int, ...], torch.dtype]]:
+    """Shapes and dtypes ``create_weights`` handed the loader, before interleave.
+
+    Mirrors the ``is_fp4_expert`` branch of SGLang's ``create_fp8_moe_weight_``.
+    Deriving them from the layer's dimensions rather than from the live
+    parameters is deliberate: the live ones are already interleaved, and for the
+    scales that changes the shape, so they cannot answer what the loader expects.
+    """
+    e = layer.num_local_experts
+    h = layer.hidden_size
+    i = layer.intermediate_size_per_partition
+    return {
+        "w13_weight": ((e, 2 * i, h // 2), torch.int8),
+        "w2_weight": ((e, h, i // 2), torch.int8),
+        "w13_weight_scale_inv": ((e, 2 * i, h // _SCALE_BLOCK_K), torch.float8_e8m0fnu),
+        "w2_weight_scale_inv": ((e, h, i // _SCALE_BLOCK_K), torch.float8_e8m0fnu),
+    }
+
+
+def _staging_data(param: torch.nn.Parameter, shape, dtype: torch.dtype) -> torch.Tensor:
+    """A checkpoint-layout view of ``param``'s own storage where the bytes allow.
+
+    The SM90 interleave permutes 4-bit values within the same buffer, so the
+    interleaved parameter spans exactly the bytes the checkpoint-layout one did
+    and can absorb the reload in place. Only when that does not hold is a real
+    allocation needed.
+    """
+    data = param.data
+    shape = torch.Size(shape)
+    if data.dtype == dtype and data.shape == shape:
+        return data
+    if data.is_contiguous() and data.numel() * data.element_size() == shape.numel() * _element_size(dtype):
+        return data.flatten().view(dtype).reshape(shape)
+    # Zero rather than empty: a param the stream happens to skip then collapses
+    # the layer's output instead of feeding the kernel freed memory.
+    return torch.zeros(shape, dtype=dtype, device=data.device)
+
+
+def _iter_mxfp4_layers(model):
+    for module in model.modules():
+        if hasattr(module, _BACKEND_ATTR) and hasattr(module, "quant_method"):
+            yield module
+
+
+def _stage(layer) -> None:
+    """Expose checkpoint-layout buffers with the loader attributes reattached."""
+    from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoeWeightScaleSupported
+
+    live: dict[str, torch.nn.Parameter] = {}
+    for name, (shape, dtype) in _checkpoint_layout(layer).items():
+        param = getattr(layer, name, None)
+        if not isinstance(param, torch.nn.Parameter):
+            continue
+        live[name] = param
+
+        staged = torch.nn.Parameter(_staging_data(param, shape, dtype), requires_grad=False)
+        # ``deepseek_v4.py`` reads ``param.weight_loader`` with no fallback; the
+        # rest are read through ``getattr(..., default)`` but are carried anyway
+        # so the reload behaves exactly as it did at model load.
+        staged.weight_loader = layer.weight_loader
+        if name.endswith("_scale_inv"):
+            staged.quant_method = FusedMoeWeightScaleSupported.BLOCK.value
+        for attr in ("weight_padded", "is_transposed", "output_dim"):
+            if hasattr(param, attr):
+                setattr(staged, attr, getattr(param, attr))
+        setattr(layer, name, staged)
+
+    setattr(layer, _LIVE_ATTR, live)
+
+
+def _fold_back(layer) -> None:
+    """Redo the interleave and write it into the parameters the graph captured."""
+    live = getattr(layer, _LIVE_ATTR, None) or {}
+    delattr(layer, _LIVE_ATTR)
+
+    layer.quant_method.process_weights_after_loading(layer)
+
+    for name, param in live.items():
+        produced = getattr(layer, name)
+        data = produced.data if isinstance(produced, torch.nn.Parameter) else produced
+        if data.shape != param.shape or data.dtype != param.dtype:
+            raise RuntimeError(
+                f"mxfp4 refit re-derived {name} as {tuple(data.shape)}/{data.dtype}, but the live "
+                f"parameter is {tuple(param.shape)}/{param.dtype}; its storage cannot be updated "
+                "in place, which would leave the captured CUDA graph pointing at freed memory."
+            )
+        if data.data_ptr() != param.data_ptr():
+            param.data.copy_(data)
+        setattr(layer, name, param)
+
+
+def load_mxfp4(model, named_tensors) -> None:
+    """SGLang custom weight loader: refit MXFP4 experts without losing the graph.
+
+    Called inside every TP worker process, once per bucket of a sync.
+    """
+    tensors = [(name, t) for name, t in named_tensors if name != END_SENTINEL]
+    is_last = len(tensors) != len(named_tensors)
+
+    layers = list(_iter_mxfp4_layers(model))
+    if not layers:
+        # No MXFP4 experts on this model: behave like the stock path rather than
+        # failing, so the loader is safe to register unconditionally.
+        model.load_weights(tensors)
+        return
+
+    unstaged = [layer for layer in layers if not hasattr(layer, _LIVE_ATTR)]
+    for layer in unstaged:
+        _stage(layer)
+    if unstaged:
+        logger.info("mxfp4 refit: staged %d MoE layers for in-place reload", len(unstaged))
+
+    model.load_weights(tensors)
+
+    if is_last:
+        for layer in layers:
+            _fold_back(layer)
+        logger.info("mxfp4 refit: replayed the SM90 interleave on %d MoE layers", len(layers))

--- a/verl/workers/rollout/sglang_rollout/mxfp4_loader.py
+++ b/verl/workers/rollout/sglang_rollout/mxfp4_loader.py
@@ -64,11 +64,7 @@ Register at server launch (verl config)::
 
 from __future__ import annotations
 
-import logging
-
 import torch
-
-logger = logging.getLogger(__name__)
 
 LOADER_FQN = "verl.workers.rollout.sglang_rollout.mxfp4_loader.load_mxfp4"
 
@@ -92,6 +88,12 @@ _LIVE_ATTR = "_verl_mxfp4_live"
 # presence is the most direct evidence that a layer went through the MXFP4
 # post-processing this module has to undo and redo.
 _BACKEND_ATTR = "_dsv4_mxfp4_backend"
+
+# Expert tensors seen so far in the current sync, reset when the sentinel arrives.
+# A list rather than a module-level int so the counter can be mutated from the
+# function without a global statement; one loader runs per worker process, and the
+# buckets of a sync arrive in sequence, so no locking is needed.
+_EXPERT_ARRIVALS = [0]
 
 
 def _element_size(dtype: torch.dtype) -> int:
@@ -208,11 +210,30 @@ def load_mxfp4(model, named_tensors) -> None:
     for layer in unstaged:
         _stage(layer)
     if unstaged:
-        logger.info("mxfp4 refit: staged %d MoE layers for in-place reload", len(unstaged))
+        # print rather than logger: this runs in an SGLang scheduler subprocess
+        # whose logging Ray does not forward, so anything sent through the logger
+        # is invisible in the run log.
+        print(f"[MXFP4] staged {len(unstaged)} MoE layers for in-place reload", flush=True)
 
     model.load_weights(tensors)
+    _EXPERT_ARRIVALS[0] += sum(1 for name, _ in tensors if ".experts." in name)
 
     if is_last:
         for layer in layers:
             _fold_back(layer)
-        logger.info("mxfp4 refit: replayed the SM90 interleave on %d MoE layers", len(layers))
+        # ``load_weights`` skips names it does not recognise without complaining, so
+        # a rename upstream would leave the engine serving stale experts and show up
+        # only as a slow drift in the policy-divergence metrics. Counting what
+        # arrived turns that into something visible at the first sync.
+        arrived = _EXPERT_ARRIVALS[0]
+        _EXPERT_ARRIVALS[0] = 0
+        if arrived == 0:
+            raise RuntimeError(
+                f"mxfp4 refit: the sync carried no '.experts.' tensors, but {len(layers)} MXFP4 MoE "
+                "layers are staged; the engine would keep serving stale expert weights."
+            )
+        print(
+            f"[MXFP4] replayed the SM90 interleave on {len(layers)} MoE layers, "
+            f"{arrived} expert tensors landed",
+            flush=True,
+        )

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -36,6 +36,12 @@ from sglang.srt.weight_sync.utils import update_weights as sgl_update_weights
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 
 from verl.utils.device import get_device_id
+from verl.workers.rollout.sglang_rollout.mxfp4_loader import (
+    END_SENTINEL as MXFP4_END_SENTINEL,
+)
+from verl.workers.rollout.sglang_rollout.mxfp4_loader import (
+    LOADER_FQN as MXFP4_LOADER_FQN,
+)
 from verl.utils.net_utils import is_valid_ipv6_address
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
@@ -56,6 +62,23 @@ def _strip_lora_base_layer(name: str) -> str:
     """Drop the ``.base_layer`` segment ``replace_lora_wrapper()`` inserts for vLLM; SGLang
     has no such level and its loader raises KeyError on it."""
     return name.replace(".base_layer.", ".") if ".base_layer." in name else name
+
+
+def _rollout_keeps_packed_mxfp4(hf_config) -> bool:
+    """Whether SGLang is serving DSv4 routed experts in the checkpoint's packed layout.
+
+    ``expert_dtype`` is the field that actually distinguishes the two DSv4
+    families -- ``quantization_config.quant_method`` says ``fp8`` on both because
+    it describes the linear/attention layers -- and it is what vLLM keys its own
+    dispatch on. ``SGLANG_DSV4_FP4_DEQUANT`` then overrides it downward: with the
+    flag on, SGLang casts the packed experts to blockwise FP8 at load and the
+    engine no longer holds a packed buffer to refit.
+    """
+    if getattr(hf_config, "model_type", None) != "deepseek_v4":
+        return False
+    if getattr(hf_config, "expert_dtype", "fp4") != "fp4":
+        return False
+    return os.environ.get("SGLANG_DSV4_FP4_DEQUANT", "") not in ("1", "true", "True")
 
 
 def _to_ipc_device(tensor: torch.Tensor) -> torch.Tensor:
@@ -374,15 +397,32 @@ class ServerAdapter(BaseRollout):
                 if getattr(self.model_config.hf_config, "model_type", None) == "deepseek_v4"
                 else ()
             )
+            mxfp4_loader = _rollout_keeps_packed_mxfp4(self.model_config.hf_config)
+
+            async def post(batch, is_last):
+                params = [(_strip_lora_base_layer(name), _to_ipc_device(t)) for name, t in batch]
+                if mxfp4_loader and is_last:
+                    params.append((MXFP4_END_SENTINEL, torch.empty(0, dtype=torch.uint8, device=params[0][1].device)))
+                await sgl_update_weights(
+                    engine=self._engine,
+                    params_batch=params,
+                    device_mesh_key="infer_tp",
+                    device_mesh=self.device_mesh,
+                    load_format=MXFP4_LOADER_FQN if mxfp4_loader else None,
+                )
+
+            # One bucket of lookahead: the mxfp4 loader replays the engine's
+            # weight conversion when it sees the sentinel, and that must happen
+            # after the final bucket rather than after every one.
+            pending = None
             async for params_batch in get_named_tensor_buckets(
                 weights, update_weights_bucket_bytes, fusion_groups=fusion_groups
             ):
-                await sgl_update_weights(
-                    engine=self._engine,
-                    params_batch=[(_strip_lora_base_layer(name), _to_ipc_device(t)) for name, t in params_batch],
-                    device_mesh_key="infer_tp",
-                    device_mesh=self.device_mesh,
-                )
+                if pending is not None:
+                    await post(pending, is_last=False)
+                pending = params_batch
+            if pending is not None:
+                await post(pending, is_last=True)
 
         if self._engine is not None and self._is_server_tp_leader():
             await self._engine.flush_cache()


### PR DESCRIPTION
### What does this PR do?

make SGLang 0.5.16 available FOR `deepseek-v4-flash-base`(blockwise fp8 rollout) and `deepseek-v4-flash-0731` (mxfp4 rollout)

### Exps

- mxfp4 rollout

<img width="419" height="335" alt="image" src="https://github.com/user-attachments/assets/c3095fdc-214f-472e-a293-f65ec2e22e1b" />

- blockwise fp8 rollout

<img width="389" height="306" alt="image" src="https://github.com/user-attachments/assets/82f71486-cf4e-475a-9375-66021dd664e4" />

 
### Known limits

- Verified only on SM90 with the FlashInfer CUTLASS W4A16 backend. Marlin and Humming assign their parameters the same way and should work, but I have not run them; Marlin failed CUDA graph capture on this setup for reasons unrelated to this change.
- Only the routed-expert parameters are staged. Bias parameters are listed but skipped when absent, which is the DSv4 case.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [x] Add / update the [documentation](https://github.com/verl-project/verl/tree/main/docs) — module docstring covers the protocol and the vLLM comparison.
- [x] Add unit or end-to-end test(s) — end-to-end numbers above; a CPU unit test can be added on request.
