### PR TITLE
[doc] fix: drop dead Yuanrong usage-guide link in transfer_queue

### DIFF
--- a/docs/data/transfer_queue.md
+++ b/docs/data/transfer_queue.md
@@ -73,7 +73,7 @@ This class encapsulates the core interaction logic within the TransferQueue syst
 Currently, we support the following storage backends:
 
 - SimpleStorage: A basic CPU memory storage with minimal data format constraints and ease of use.
-- [Yuanrong](https://gitee.com/openeuler/yuanrong-datasystem) ([usage guide](docs/storage_backends/openyuanrong_datasystem.md), beta, [#PR107](https://github.com/TransferQueue/TransferQueue/pull/107), [#PR96](https://github.com/TransferQueue/TransferQueue/pull/96)): An Ascend native data system that provides hierarchical storage interfaces including HBM/DRAM/SSD.
+- [Yuanrong](https://gitee.com/openeuler/yuanrong-datasystem) (beta, [#PR107](https://github.com/TransferQueue/TransferQueue/pull/107), [#PR96](https://github.com/TransferQueue/TransferQueue/pull/96)): An Ascend native data system that provides hierarchical storage interfaces including HBM/DRAM/SSD.
 - [MooncakeStore](https://github.com/kvcache-ai/Mooncake) (beta, [#PR162](https://github.com/TransferQueue/TransferQueue/pull/162)): A high-performance, KV-based hierarchical storage that supports RDMA transport between GPU and DRAM.
 - [RayRDT](https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html) (alpha, [#PR167](https://github.com/TransferQueue/TransferQueue/pull/167)): Ray's new feature that allows Ray to store and pass objects directly between Ray actors.
 


### PR DESCRIPTION
## Summary
- `docs/data/transfer_queue.md` linked to `docs/storage_backends/openyuanrong_datasystem.md`, which does not exist in the tree (and as a relative link under `docs/data/` would nest incorrectly).
- Drop the dead usage-guide parenthetical; keep the live gitee Yuanrong project link plus the existing beta / TransferQueue PR references.

## Test plan
- [x] Confirmed `docs/storage_backends/openyuanrong_datasystem.md` is absent on main (`d096498d`)
- [x] Confirmed no other in-tree hit for that path
- [x] Diff is a single-line docs-only change