### PR TITLE
[perf] Add topology cells for communication policy selection

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -112,6 +112,7 @@ verl is fast with:
    perf/verl_profiler_system.md
    perf/nsight_profiling.md
    perf/torch_profiling.md
+   perf/communication_phase_autotuning.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -16,8 +16,8 @@ Pass every rank shard from every candidate run. Each JSONL record must contain:
 
 - `framework`, `run_id`, `rank`, `operation`, `message_bytes`, `transport`, and
   `topology_class`;
-- `world_size` when available, so an accidentally omitted highest-rank shard is
-  detected directly;
+- `world_size`, so an accidentally omitted highest-rank shard is detected
+  directly;
 - `gpu_start_timestamp_ns` and `gpu_end_timestamp_ns` from a common monotonic
   time domain across ranks;
 - `gpu_timestamp_semantics=kernel-observed`, the shared `timestamp_domain`, and
@@ -28,6 +28,8 @@ Pass every rank shard from every candidate run. Each JSONL record must contain:
 - `requested_offset_us` for an offset experiment, and optionally `policy`;
 - semantic context fields that pair operation A and B, such as `iteration`,
   `microbatch`, and `layer`;
+- stable `process_group_id` and non-negative `communicator_sequence_id` values
+  for both operations;
 - `metadata.completion_observed=true` for asynchronous operations;
 - `sequence_consistent=false` when launch-order validation detects divergence.
 

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -20,6 +20,8 @@ Pass every rank shard from every candidate run. Each JSONL record must contain:
   detected directly;
 - `gpu_start_timestamp_ns` and `gpu_end_timestamp_ns` from a common monotonic
   time domain across ranks;
+- `gpu_timestamp_semantics=kernel-observed`, the shared `timestamp_domain`, and
+  a measured non-negative `clock_sync_error_bound_us` for that domain;
 - `consumer_timestamp_ns` for operation B;
 - optionally, `critical_path_duration_us` on both records for the enclosing
   step's slowest-rank critical-path duration;
@@ -33,6 +35,10 @@ The default pairing fields also cover weight-version and bucket traces. Override
 them with `--pair-by` when a framework uses a different semantic boundary.
 Every selected run must contain a complete, contiguous rank set beginning at
 rank zero. The implementation has no topology-specific rank-count branch.
+CUDA-event eligibility/completion brackets may be inspected with the same tool,
+but they are rejected as policy evidence and produce `insufficient_evidence`.
+Likewise, evidence whose measured clock error exceeds
+`--max-clock-sync-error-us` cannot select or refine a policy.
 
 ## Decision rules
 

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -1,0 +1,98 @@
+# Evidence-driven communication phase autotuning
+
+Last updated: 09/04/2026.
+
+`scripts/autotune_communication_phase.py` turns semantic communication traces
+into a conservative policy recommendation. It is an offline analysis tool: it
+does not add sleeps, timers, or scheduling behavior to a training process.
+
+The recommendation is keyed by framework, topology, operation pair, transport,
+message sizes, and observed world size. Results from different workload keys
+are never pooled.
+
+## Required trace evidence
+
+Pass every rank shard from every candidate run. Each JSONL record must contain:
+
+- `framework`, `run_id`, `rank`, `operation`, `message_bytes`, `transport`, and
+  `topology_class`;
+- `world_size` when available, so an accidentally omitted highest-rank shard is
+  detected directly;
+- `gpu_start_timestamp_ns` and `gpu_end_timestamp_ns` from a common monotonic
+  time domain across ranks;
+- `consumer_timestamp_ns` for operation B;
+- optionally, `critical_path_duration_us` on both records for the enclosing
+  step's slowest-rank critical-path duration;
+- `requested_offset_us` for an offset experiment, and optionally `policy`;
+- semantic context fields that pair operation A and B, such as `iteration`,
+  `microbatch`, and `layer`;
+- `metadata.completion_observed=true` for asynchronous operations;
+- `sequence_consistent=false` when launch-order validation detects divergence.
+
+The default pairing fields also cover weight-version and bucket traces. Override
+them with `--pair-by` when a framework uses a different semantic boundary.
+Every selected run must contain a complete, contiguous rank set beginning at
+rank zero. The implementation has no topology-specific rank-count branch.
+
+## Decision rules
+
+For each global A/B trial, the tuner derives:
+
+```text
+realized offset = gpu_start(B) - gpu_start(A)
+consumer slack = consumer(B) - gpu_end(B)
+pair completion = max_rank(end(A), end(B)) - min_rank(start(A), start(B))
+rank skew = max launch/finish skew over A and B
+```
+
+When `critical_path_duration_us` is present on every rank and candidate, it is
+the optimization objective. Otherwise the tuner uses pair completion as the
+explicitly labelled fallback. Candidates using different objective sources are
+not compared.
+
+Negative consumer slack means B was still incomplete when its consumer arrived.
+A candidate is rejected if its lower-tail slack is worse than the baseline
+deadline guard, if added rank skew exceeds the remaining measured slack, if
+logical sequence validation failed, if the requested and realized directions
+disagree, or if it has too few complete trials.
+
+Among the remaining candidates, the objective is lexicographic: minimize p95
+critical path, then consumer wait, then rank skew. A non-baseline policy is
+recommended only when a deterministic bootstrap confidence interval says its
+critical-path improvement is positive. Trials with a unique shared semantic
+context use paired mean improvement; otherwise the reported fallback is an
+independent p95 comparison. This makes the tool fail closed under ambiguous or
+noisy evidence.
+
+## Adaptive refinement without a fixed delay
+
+The tuner may propose another requested offset. Every proposal is the midpoint
+of an already measured request interval. Its interpolated consumer slack must
+remain inside the baseline-derived deadline guard, and the tuner never
+extrapolates beyond the measured envelope. Run the proposed points, append the
+new trace shards, and invoke the tuner again.
+
+No default millisecond offset exists. The scale comes entirely from the
+observed workload, GPU realization, and consumer deadline.
+
+## Usage
+
+```bash
+python scripts/autotune_communication_phase.py \
+  --trace-jsonl traces/candidate-*/rank-*.jsonl \
+  --operation-a ep_dispatch_tokens \
+  --operation-b dp_grad_reduce_scatter \
+  --output-json phase-policy.json
+```
+
+The output includes all candidate summaries and rejection reasons, the baseline
+and recommended settings, the realized offset of the recommendation, and any
+data-derived refinement points with their interpolated realized offset and
+deadline slack. A `keep_baseline` or `insufficient_evidence`
+decision is a valid result and must not be converted into a phase shift by the
+caller.
+
+An aggregate phase-sweep summary may record isolated/contended latency and
+GPU-realized offsets, but it has no consumer timestamp. Feed semantic trace
+records to this tool; do not infer consumer slack from aggregate collective
+latency.

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -100,6 +100,42 @@ deadline slack. A `keep_baseline` or `insufficient_evidence`
 decision is a valid result and must not be converted into a phase shift by the
 caller.
 
+## Topology policy cells
+
+Every recommendation also contains a content-addressed `topology_cell_id` and
+its canonical `topology_fingerprint`. The fingerprint includes:
+
+- single-node or multi-node scope;
+- local PCIe, NVLink, or unknown fabric;
+- world size and the exact rank-to-node placement, without embedding ephemeral
+  hostnames;
+- accelerator model by rank;
+- an optional opaque topology inventory signature.
+
+Single-node PCIe, single-node NVLink, and multi-node measurements therefore
+land in separate cells. Multi-node evidence must include a consistent
+`topology_signature`; node count alone is not sufficient to identify a cluster
+topology. Runs with missing ranks, partially missing node identities, or a
+declared class that disagrees with observed host placement are rejected.
+
+Use the selector before applying a stored policy to a new run:
+
+```bash
+python scripts/communication_topology_policy.py \
+  --policy-json phase-policy.json \
+  --target-trace-jsonl current-run/rank-*.jsonl \
+  --output-json compatible-policy.json
+```
+
+Selection is exact: every fingerprint field must match. There is no nearest
+topology, model-family fallback, or cross-topology extrapolation. If no cell
+matches, the command exits unsuccessfully and the workload must collect a new
+baseline and candidate traces for its own cell.
+
+NIC traffic classes, rail assignment, and route selection are outside this
+policy layer. `topology_signature` is only an opaque compatibility identity; it
+does not configure or infer any NIC behavior.
+
 An aggregate phase-sweep summary may record isolated/contended latency and
 GPU-realized offsets, but it has no consumer timestamp. Feed semantic trace
 records to this tool; do not infer consumer slack from aggregate collective

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -34,6 +34,21 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+if __package__:
+    from scripts.communication_topology_policy import (
+        TopologyEvidenceError,
+        TopologyFingerprint,
+        fingerprint_trace_runs,
+        topology_run_key,
+    )
+else:
+    from communication_topology_policy import (
+        TopologyEvidenceError,
+        TopologyFingerprint,
+        fingerprint_trace_runs,
+        topology_run_key,
+    )
+
 SCHEMA_VERSION = 2
 DEFAULT_PAIR_FIELDS = (
     "step",
@@ -66,6 +81,8 @@ class RankPair:
     timestamp_domain: str
     gpu_timestamp_semantics: str
     clock_sync_error_bound_us: float
+    topology_cell_id: str
+    topology_fingerprint_json: str
     operation_a: str
     operation_b: str
     message_bytes_a: int
@@ -95,6 +112,8 @@ class RankPair:
             self.topology_class,
             self.timestamp_domain,
             self.gpu_timestamp_semantics,
+            self.topology_cell_id,
+            self.topology_fingerprint_json,
             self.operation_a,
             self.operation_b,
             self.message_bytes_a,
@@ -299,6 +318,7 @@ def _pair_records(
     ordinal: int,
     operation_a: str,
     operation_b: str,
+    topology: TopologyFingerprint,
 ) -> RankPair:
     a_start, a_end = _validate_timestamps(record_a)
     b_start, b_end = _validate_timestamps(record_b)
@@ -397,10 +417,12 @@ def _pair_records(
         rank=rank,
         declared_world_size=declared_world_size,
         framework=framework,
-        topology_class=topology_class,
+        topology_class=topology.topology_class,
         timestamp_domain=timestamp_domain,
         gpu_timestamp_semantics=gpu_timestamp_semantics,
         clock_sync_error_bound_us=float(clock_sync_error_bound_us),
+        topology_cell_id=topology.cell_id,
+        topology_fingerprint_json=topology.canonical_json,
         operation_a=operation_a,
         operation_b=operation_b,
         message_bytes_a=message_bytes_a,
@@ -431,6 +453,11 @@ def pair_trace_records(
 ) -> list[RankPair]:
     """Pair A/B trace records by run, rank, semantic context, and launch order."""
 
+    records = list(records)
+    try:
+        topology_by_run = fingerprint_trace_runs(records, (operation_a, operation_b))
+    except TopologyEvidenceError as exc:
+        raise TraceFormatError(str(exc)) from exc
     grouped: defaultdict[tuple[Any, ...], dict[str, list[Mapping[str, Any]]]] = defaultdict(
         lambda: {operation_a: [], operation_b: []}
     )
@@ -475,6 +502,7 @@ def pair_trace_records(
                     ordinal=ordinal,
                     operation_a=operation_a,
                     operation_b=operation_b,
+                    topology=topology_by_run[topology_run_key(record_a)],
                 )
             )
     return pairs
@@ -676,6 +704,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
         topology_class,
         timestamp_domain,
         gpu_timestamp_semantics,
+        topology_cell_id,
+        topology_fingerprint_json,
         operation_a,
         operation_b,
         message_bytes_a,
@@ -689,6 +719,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
         "topology_class": topology_class,
         "timestamp_domain": timestamp_domain,
         "gpu_timestamp_semantics": gpu_timestamp_semantics,
+        "topology_cell_id": topology_cell_id,
+        "topology_fingerprint": json.loads(topology_fingerprint_json),
         "operation_a": operation_a,
         "operation_b": operation_b,
         "message_bytes_a": message_bytes_a,

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -234,15 +234,6 @@ def _integer(record: Mapping[str, Any], name: str) -> int:
     return int(value)
 
 
-def _optional_integer(record: Mapping[str, Any], name: str) -> int | None:
-    value = _number(record, name, required=False)
-    if value is None:
-        return None
-    if not value.is_integer():
-        raise TraceFormatError(f"{name} must be an integer or null")
-    return int(value)
-
-
 def _string(record: Mapping[str, Any], name: str, *, default: str | None = None) -> str:
     value = _record_value(record, name)
     if value is None and default is not None:
@@ -282,14 +273,21 @@ def _required_common_value(records: Sequence[Mapping[str, Any]], name: str) -> A
     return _common_value(records, name)
 
 
+def _optional_common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
+    values = [_record_value(record, name) for record in records]
+    if any(value is None for value in values) and not all(value is None for value in values):
+        raise TraceFormatError(f"{name} must be present on both paired records or neither")
+    return _common_value(records, name)
+
+
 def _validate_timestamps(record: Mapping[str, Any]) -> tuple[int, int]:
     start = _integer(record, "gpu_start_timestamp_ns")
     end = _integer(record, "gpu_end_timestamp_ns")
     if end < start:
         raise TraceFormatError("gpu_end_timestamp_ns precedes gpu_start_timestamp_ns")
     completion_observed = _record_value(record, "completion_observed")
-    if completion_observed is False:
-        raise TraceFormatError("trace contains an operation without observed completion")
+    if completion_observed is not True:
+        raise TraceFormatError("completion_observed=true is required for every operation")
     return start, end
 
 
@@ -313,25 +311,24 @@ def _pair_records(
         raise TraceFormatError("paired records disagree on rank")
     if rank < 0:
         raise TraceFormatError("rank must be non-negative")
-    declared_world_size = _common_value((record_a, record_b), "world_size")
-    if declared_world_size is not None:
-        if (
-            isinstance(declared_world_size, bool)
-            or not isinstance(declared_world_size, int | float)
-            or not float(declared_world_size).is_integer()
-            or declared_world_size < 2
-        ):
-            raise TraceFormatError("world_size must be an integer of at least two")
-        declared_world_size = int(declared_world_size)
-        if rank >= declared_world_size:
-            raise TraceFormatError("rank must be smaller than world_size")
+    declared_world_size = _required_common_value((record_a, record_b), "world_size")
+    if (
+        isinstance(declared_world_size, bool)
+        or not isinstance(declared_world_size, int | float)
+        or not float(declared_world_size).is_integer()
+        or declared_world_size < 2
+    ):
+        raise TraceFormatError("world_size must be an integer of at least two")
+    declared_world_size = int(declared_world_size)
+    if rank >= declared_world_size:
+        raise TraceFormatError("rank must be smaller than world_size")
 
-    framework = _common_value((record_a, record_b), "framework")
+    framework = _required_common_value((record_a, record_b), "framework")
     if not isinstance(framework, str) or not framework:
         raise TraceFormatError("framework must be a non-empty string")
-    topology_class = _common_value((record_a, record_b), "topology_class") or "unknown"
-    if not isinstance(topology_class, str):
-        raise TraceFormatError("topology_class must be a string")
+    topology_class = _required_common_value((record_a, record_b), "topology_class")
+    if not isinstance(topology_class, str) or not topology_class:
+        raise TraceFormatError("topology_class must be a non-empty string")
     timestamp_domain = _required_common_value((record_a, record_b), "timestamp_domain")
     if not isinstance(timestamp_domain, str) or not timestamp_domain:
         raise TraceFormatError("timestamp_domain must be a non-empty string")
@@ -351,14 +348,14 @@ def _pair_records(
     if message_bytes_a <= 0 or message_bytes_b <= 0:
         raise TraceFormatError("message_bytes must be positive")
 
-    requested_offset = _common_value((record_a, record_b), "requested_offset_us")
+    requested_offset = _optional_common_value((record_a, record_b), "requested_offset_us")
     if requested_offset is not None:
         if isinstance(requested_offset, bool) or not isinstance(requested_offset, int | float):
             raise TraceFormatError("requested_offset_us must be numeric or null")
         requested_offset = float(requested_offset)
         if not math.isfinite(requested_offset):
             raise TraceFormatError("requested_offset_us must be finite")
-    policy = _common_value((record_a, record_b), "policy")
+    policy = _optional_common_value((record_a, record_b), "policy")
     if policy is None:
         if requested_offset == 0:
             policy = "eager"
@@ -369,7 +366,7 @@ def _pair_records(
     if not isinstance(policy, str) or not policy:
         raise TraceFormatError("policy must be a non-empty string")
 
-    critical_path_duration_us = _common_value((record_a, record_b), "critical_path_duration_us")
+    critical_path_duration_us = _optional_common_value((record_a, record_b), "critical_path_duration_us")
     if critical_path_duration_us is not None:
         if (
             isinstance(critical_path_duration_us, bool)
@@ -386,6 +383,13 @@ def _pair_records(
         if explicit is False:
             sequence_consistent = False
 
+    process_group_id_a = _string(record_a, "process_group_id")
+    process_group_id_b = _string(record_b, "process_group_id")
+    sequence_id_a = _integer(record_a, "communicator_sequence_id")
+    sequence_id_b = _integer(record_b, "communicator_sequence_id")
+    if sequence_id_a < 0 or sequence_id_b < 0:
+        raise TraceFormatError("communicator_sequence_id must be non-negative")
+
     return RankPair(
         run_id=run_id,
         context=context,
@@ -401,12 +405,12 @@ def _pair_records(
         operation_b=operation_b,
         message_bytes_a=message_bytes_a,
         message_bytes_b=message_bytes_b,
-        transport_a=_string(record_a, "transport", default="unknown"),
-        transport_b=_string(record_b, "transport", default="unknown"),
-        process_group_id_a=_string(record_a, "process_group_id", default="unknown-a"),
-        process_group_id_b=_string(record_b, "process_group_id", default="unknown-b"),
-        sequence_id_a=_optional_integer(record_a, "communicator_sequence_id"),
-        sequence_id_b=_optional_integer(record_b, "communicator_sequence_id"),
+        transport_a=_string(record_a, "transport"),
+        transport_b=_string(record_b, "transport"),
+        process_group_id_a=process_group_id_a,
+        process_group_id_b=process_group_id_b,
+        sequence_id_a=sequence_id_a,
+        sequence_id_b=sequence_id_b,
         policy=policy,
         requested_offset_us=requested_offset,
         a_start_ns=a_start,
@@ -440,7 +444,16 @@ def pair_trace_records(
         rank = _integer(record, "rank")
         context = _context(record, pair_fields)
         declared_world_size = _record_value(record, "world_size")
-        grouped[(run_id, rank, declared_world_size, context)][operation].append(record)
+        if declared_world_size is None:
+            raise TraceFormatError("world_size must be present on every selected record")
+        if (
+            isinstance(declared_world_size, bool)
+            or not isinstance(declared_world_size, int | float)
+            or not float(declared_world_size).is_integer()
+            or declared_world_size < 2
+        ):
+            raise TraceFormatError("world_size must be an integer of at least two")
+        grouped[(run_id, rank, int(declared_world_size), context)][operation].append(record)
     if not selected:
         raise TraceFormatError(f"no records matched operations {operation_a!r} and {operation_b!r}")
 

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -34,7 +34,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DEFAULT_PAIR_FIELDS = (
     "step",
     "iteration",
@@ -63,6 +63,9 @@ class RankPair:
     declared_world_size: int | None
     framework: str
     topology_class: str
+    timestamp_domain: str
+    gpu_timestamp_semantics: str
+    clock_sync_error_bound_us: float
     operation_a: str
     operation_b: str
     message_bytes_a: int
@@ -90,6 +93,8 @@ class RankPair:
         return (
             self.framework,
             self.topology_class,
+            self.timestamp_domain,
+            self.gpu_timestamp_semantics,
             self.operation_a,
             self.operation_b,
             self.message_bytes_a,
@@ -270,6 +275,13 @@ def _common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
     return next(iter(values)) if values else None
 
 
+def _required_common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
+    values = [_record_value(record, name) for record in records]
+    if any(value is None for value in values):
+        raise TraceFormatError(f"{name} must be present on both paired records")
+    return _common_value(records, name)
+
+
 def _validate_timestamps(record: Mapping[str, Any]) -> tuple[int, int]:
     start = _integer(record, "gpu_start_timestamp_ns")
     end = _integer(record, "gpu_end_timestamp_ns")
@@ -320,6 +332,20 @@ def _pair_records(
     topology_class = _common_value((record_a, record_b), "topology_class") or "unknown"
     if not isinstance(topology_class, str):
         raise TraceFormatError("topology_class must be a string")
+    timestamp_domain = _required_common_value((record_a, record_b), "timestamp_domain")
+    if not isinstance(timestamp_domain, str) or not timestamp_domain:
+        raise TraceFormatError("timestamp_domain must be a non-empty string")
+    gpu_timestamp_semantics = _required_common_value((record_a, record_b), "gpu_timestamp_semantics")
+    if gpu_timestamp_semantics not in {"kernel-observed", "event-bracket"}:
+        raise TraceFormatError("gpu_timestamp_semantics must be 'kernel-observed' or 'event-bracket'")
+    clock_sync_error_bound_us = _required_common_value((record_a, record_b), "clock_sync_error_bound_us")
+    if (
+        isinstance(clock_sync_error_bound_us, bool)
+        or not isinstance(clock_sync_error_bound_us, int | float)
+        or not math.isfinite(clock_sync_error_bound_us)
+        or clock_sync_error_bound_us < 0
+    ):
+        raise TraceFormatError("clock_sync_error_bound_us must be finite and non-negative")
     message_bytes_a = _integer(record_a, "message_bytes")
     message_bytes_b = _integer(record_b, "message_bytes")
     if message_bytes_a <= 0 or message_bytes_b <= 0:
@@ -368,6 +394,9 @@ def _pair_records(
         declared_world_size=declared_world_size,
         framework=framework,
         topology_class=topology_class,
+        timestamp_domain=timestamp_domain,
+        gpu_timestamp_semantics=gpu_timestamp_semantics,
+        clock_sync_error_bound_us=float(clock_sync_error_bound_us),
         operation_a=operation_a,
         operation_b=operation_b,
         message_bytes_a=message_bytes_a,
@@ -534,6 +563,7 @@ def summarize_candidate(candidate: Candidate) -> dict[str, Any]:
         "consumer_slack_us_p50": _rounded(percentile(consumer_slacks, 50)),
         "consumer_wait_us_p95": _rounded(percentile(consumer_waits, 95)),
         "rank_skew_us_p95": _rounded(percentile(rank_skews, 95)),
+        "clock_sync_error_bound_us": _rounded(max(pair.clock_sync_error_bound_us for pair in rank_pairs)),
         "sequence_consistent": all(trial.sequence_consistent for trial in candidate.trials),
     }
 
@@ -631,6 +661,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
     (
         framework,
         topology_class,
+        timestamp_domain,
+        gpu_timestamp_semantics,
         operation_a,
         operation_b,
         message_bytes_a,
@@ -642,6 +674,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
     return {
         "framework": framework,
         "topology_class": topology_class,
+        "timestamp_domain": timestamp_domain,
+        "gpu_timestamp_semantics": gpu_timestamp_semantics,
         "operation_a": operation_a,
         "operation_b": operation_b,
         "message_bytes_a": message_bytes_a,
@@ -697,6 +731,7 @@ def tune_workload(
     confidence: float = 0.95,
     bootstrap_resamples: int = 2000,
     min_trials: int = 2,
+    max_clock_sync_error_us: float = 50.0,
 ) -> dict[str, Any]:
     """Choose a safe policy and data-derived refinement offsets for one workload."""
 
@@ -712,6 +747,10 @@ def tune_workload(
     eligible = []
     for index, (candidate, summary) in enumerate(zip(candidates, summaries, strict=True)):
         reasons = []
+        if candidate.rank_pairs[0].gpu_timestamp_semantics != "kernel-observed":
+            reasons.append("kernel_observed_gpu_timestamps_required")
+        if float(summary["clock_sync_error_bound_us"]) > max_clock_sync_error_us:
+            reasons.append("clock_sync_error_bound_exceeded")
         if summary["trial_count"] < min_trials:
             reasons.append("insufficient_trials")
         if not summary["sequence_consistent"]:
@@ -769,9 +808,11 @@ def tune_workload(
     else:
         decision = "switch_policy"
 
-    focus_pool = eligible or [baseline_index]
-    focus_index = min(focus_pool, key=lambda index: _candidate_sort_key(summaries[index]))
-    next_candidates = _refinement_points(summaries, focus_index, minimum_slack_us)
+    if evidence_ready:
+        focus_index = min(eligible, key=lambda index: _candidate_sort_key(summaries[index]))
+        next_candidates = _refinement_points(summaries, focus_index, minimum_slack_us)
+    else:
+        next_candidates = []
     return {
         "workload_key": _workload_dict(workload),
         "decision": decision,
@@ -810,6 +851,7 @@ def tune_traces(
     confidence: float = 0.95,
     bootstrap_resamples: int = 2000,
     min_trials: int = 2,
+    max_clock_sync_error_us: float = 50.0,
 ) -> dict[str, Any]:
     """Build recommendations from framework-neutral semantic trace records."""
 
@@ -819,6 +861,8 @@ def tune_traces(
         raise ValueError("bootstrap_resamples must be non-negative")
     if min_trials <= 0:
         raise ValueError("min_trials must be positive")
+    if not math.isfinite(max_clock_sync_error_us) or max_clock_sync_error_us < 0:
+        raise ValueError("max_clock_sync_error_us must be finite and non-negative")
     if not pair_fields:
         raise ValueError("at least one pair field is required")
     pairs = pair_trace_records(records, operation_a, operation_b, pair_fields)
@@ -830,6 +874,7 @@ def tune_traces(
             confidence=confidence,
             bootstrap_resamples=bootstrap_resamples,
             min_trials=min_trials,
+            max_clock_sync_error_us=max_clock_sync_error_us,
         )
         for workload, candidates in sorted(by_workload.items(), key=lambda item: repr(item[0]))
     ]
@@ -838,6 +883,7 @@ def tune_traces(
         "operation_a": operation_a,
         "operation_b": operation_b,
         "pair_fields": list(pair_fields),
+        "max_clock_sync_error_us": max_clock_sync_error_us,
         "recommendations": recommendations,
     }
 
@@ -875,6 +921,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--confidence", type=float, default=0.95)
     parser.add_argument("--bootstrap-resamples", type=int, default=2000)
     parser.add_argument("--min-trials", type=int, default=2)
+    parser.add_argument(
+        "--max-clock-sync-error-us",
+        type=float,
+        default=50.0,
+        help="largest measured cross-rank clock error allowed for a policy recommendation",
+    )
     parser.add_argument("--output-json", type=Path, required=True)
     return parser
 
@@ -890,6 +942,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             confidence=args.confidence,
             bootstrap_resamples=args.bootstrap_resamples,
             min_trials=args.min_trials,
+            max_clock_sync_error_us=args.max_clock_sync_error_us,
         )
     except (OSError, TraceFormatError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -1,0 +1,905 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Select and refine communication phase policies from semantic traces.
+
+The tuner is deliberately offline: it never sleeps in a training process and
+never invents a hardware-specific delay.  It compares observed policies using
+GPU-realized offset, consumer slack, rank skew, and the global pair critical
+path.  Refinement points are midpoints of the measured request intervals and
+are rejected when interpolated slack would cross the baseline deadline guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+import random
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_PAIR_FIELDS = (
+    "step",
+    "iteration",
+    "microbatch",
+    "virtual_pipeline_stage",
+    "layer",
+    "bucket_id",
+    "weight_version",
+    "rollout_id",
+)
+BASELINE_POLICIES = {"baseline", "concurrent", "eager"}
+
+
+class TraceFormatError(ValueError):
+    """Raised when trace evidence cannot be compared safely."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RankPair:
+    """Two communication operations observed on one rank."""
+
+    run_id: str
+    context: tuple[tuple[str, Any], ...]
+    ordinal: int
+    rank: int
+    declared_world_size: int | None
+    framework: str
+    topology_class: str
+    operation_a: str
+    operation_b: str
+    message_bytes_a: int
+    message_bytes_b: int
+    transport_a: str
+    transport_b: str
+    process_group_id_a: str
+    process_group_id_b: str
+    sequence_id_a: int | None
+    sequence_id_b: int | None
+    policy: str
+    requested_offset_us: float | None
+    a_start_ns: int
+    a_end_ns: int
+    b_start_ns: int
+    b_end_ns: int
+    b_consumer_ns: int
+    critical_path_duration_us: float | None
+    sequence_consistent: bool
+
+    @property
+    def workload_base(self) -> tuple[Any, ...]:
+        """Return fields that must not be mixed in one recommendation."""
+
+        return (
+            self.framework,
+            self.topology_class,
+            self.operation_a,
+            self.operation_b,
+            self.message_bytes_a,
+            self.message_bytes_b,
+            self.transport_a,
+            self.transport_b,
+        )
+
+    @property
+    def realized_offset_us(self) -> float:
+        """Return operation B's GPU start relative to operation A."""
+
+        return (self.b_start_ns - self.a_start_ns) / 1000
+
+    @property
+    def consumer_slack_us(self) -> float:
+        """Return positive slack, or negative time spent waiting for B."""
+
+        return (self.b_consumer_ns - self.b_end_ns) / 1000
+
+
+@dataclasses.dataclass(frozen=True)
+class Trial:
+    """One globally complete operation pair across all participating ranks."""
+
+    run_id: str
+    context: tuple[tuple[str, Any], ...]
+    ordinal: int
+    ranks: tuple[RankPair, ...]
+
+    @property
+    def pair_completion_us(self) -> float:
+        """Return the global communication-pair completion window."""
+
+        start_ns = min(min(pair.a_start_ns, pair.b_start_ns) for pair in self.ranks)
+        end_ns = max(max(pair.a_end_ns, pair.b_end_ns) for pair in self.ranks)
+        return (end_ns - start_ns) / 1000
+
+    @property
+    def critical_path_us(self) -> float:
+        """Return the slowest-rank step critical path, or pair completion fallback."""
+
+        values = [pair.critical_path_duration_us for pair in self.ranks]
+        present = [value for value in values if value is not None]
+        if present and len(present) != len(values):
+            raise TraceFormatError("critical_path_duration_us is missing on only some ranks")
+        return max(present) if present else self.pair_completion_us
+
+    @property
+    def critical_path_source(self) -> str:
+        """Return which trace signal supplies the optimization objective."""
+
+        return "trace_critical_path" if self.ranks[0].critical_path_duration_us is not None else "pair_completion"
+
+    @property
+    def rank_skew_us(self) -> float:
+        """Return the largest launch or finish skew of the two operations."""
+
+        timestamp_sets = (
+            [pair.a_start_ns for pair in self.ranks],
+            [pair.a_end_ns for pair in self.ranks],
+            [pair.b_start_ns for pair in self.ranks],
+            [pair.b_end_ns for pair in self.ranks],
+        )
+        return max((max(values) - min(values)) / 1000 for values in timestamp_sets)
+
+    @property
+    def sequence_consistent(self) -> bool:
+        """Return whether every communicator has one logical sequence ID."""
+
+        if not all(pair.sequence_consistent for pair in self.ranks):
+            return False
+        for group_field, sequence_field in (
+            ("process_group_id_a", "sequence_id_a"),
+            ("process_group_id_b", "sequence_id_b"),
+        ):
+            by_group: defaultdict[str, set[int]] = defaultdict(set)
+            for pair in self.ranks:
+                sequence_id = getattr(pair, sequence_field)
+                if sequence_id is not None:
+                    by_group[getattr(pair, group_field)].add(sequence_id)
+            if any(len(sequence_ids) > 1 for sequence_ids in by_group.values()):
+                return False
+        return True
+
+
+@dataclasses.dataclass(frozen=True)
+class Candidate:
+    """Aggregate trace evidence for one observed policy setting."""
+
+    policy: str
+    requested_offset_us: float | None
+    trials: tuple[Trial, ...]
+
+    @property
+    def rank_pairs(self) -> tuple[RankPair, ...]:
+        """Flatten per-trial rank observations."""
+
+        return tuple(pair for trial in self.trials for pair in trial.ranks)
+
+
+def percentile(values: Sequence[float], percent: float) -> float:
+    """Return a linearly interpolated percentile."""
+
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * percent / 100
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] * (upper - position) + ordered[upper] * (position - lower)
+
+
+def _record_value(record: Mapping[str, Any], name: str) -> Any:
+    value = record.get(name)
+    if value is not None:
+        return value
+    metadata = record.get("metadata")
+    return metadata.get(name) if isinstance(metadata, Mapping) else None
+
+
+def _number(record: Mapping[str, Any], name: str, *, required: bool = True) -> float | None:
+    value = _record_value(record, name)
+    if value is None and not required:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value):
+        raise TraceFormatError(f"{name} must be a finite number")
+    return float(value)
+
+
+def _integer(record: Mapping[str, Any], name: str) -> int:
+    value = _number(record, name)
+    if value is None or not value.is_integer():
+        raise TraceFormatError(f"{name} must be an integer")
+    return int(value)
+
+
+def _optional_integer(record: Mapping[str, Any], name: str) -> int | None:
+    value = _number(record, name, required=False)
+    if value is None:
+        return None
+    if not value.is_integer():
+        raise TraceFormatError(f"{name} must be an integer or null")
+    return int(value)
+
+
+def _string(record: Mapping[str, Any], name: str, *, default: str | None = None) -> str:
+    value = _record_value(record, name)
+    if value is None and default is not None:
+        return default
+    if not isinstance(value, str) or not value:
+        raise TraceFormatError(f"{name} must be a non-empty string")
+    return value
+
+
+def _context(record: Mapping[str, Any], pair_fields: Sequence[str]) -> tuple[tuple[str, Any], ...]:
+    values = []
+    for field in pair_fields:
+        value = _record_value(record, field)
+        if isinstance(value, dict | list):
+            raise TraceFormatError(f"pair field {field!r} must be scalar")
+        values.append((field, value))
+    return tuple(values)
+
+
+def _sort_key(record: Mapping[str, Any]) -> tuple[float, float]:
+    start = _number(record, "gpu_start_timestamp_ns")
+    sequence = _number(record, "communicator_sequence_id", required=False)
+    return float(start), -1 if sequence is None else sequence
+
+
+def _common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
+    values = {_record_value(record, name) for record in records if _record_value(record, name) is not None}
+    if len(values) > 1:
+        raise TraceFormatError(f"paired records disagree on {name}: {sorted(values, key=str)!r}")
+    return next(iter(values)) if values else None
+
+
+def _validate_timestamps(record: Mapping[str, Any]) -> tuple[int, int]:
+    start = _integer(record, "gpu_start_timestamp_ns")
+    end = _integer(record, "gpu_end_timestamp_ns")
+    if end < start:
+        raise TraceFormatError("gpu_end_timestamp_ns precedes gpu_start_timestamp_ns")
+    completion_observed = _record_value(record, "completion_observed")
+    if completion_observed is False:
+        raise TraceFormatError("trace contains an operation without observed completion")
+    return start, end
+
+
+def _pair_records(
+    record_a: Mapping[str, Any],
+    record_b: Mapping[str, Any],
+    *,
+    context: tuple[tuple[str, Any], ...],
+    ordinal: int,
+    operation_a: str,
+    operation_b: str,
+) -> RankPair:
+    a_start, a_end = _validate_timestamps(record_a)
+    b_start, b_end = _validate_timestamps(record_b)
+    consumer = _integer(record_b, "consumer_timestamp_ns")
+    run_id = _string(record_a, "run_id")
+    if _string(record_b, "run_id") != run_id:
+        raise TraceFormatError("paired records disagree on run_id")
+    rank = _integer(record_a, "rank")
+    if _integer(record_b, "rank") != rank:
+        raise TraceFormatError("paired records disagree on rank")
+    if rank < 0:
+        raise TraceFormatError("rank must be non-negative")
+    declared_world_size = _common_value((record_a, record_b), "world_size")
+    if declared_world_size is not None:
+        if (
+            isinstance(declared_world_size, bool)
+            or not isinstance(declared_world_size, int | float)
+            or not float(declared_world_size).is_integer()
+            or declared_world_size < 2
+        ):
+            raise TraceFormatError("world_size must be an integer of at least two")
+        declared_world_size = int(declared_world_size)
+        if rank >= declared_world_size:
+            raise TraceFormatError("rank must be smaller than world_size")
+
+    framework = _common_value((record_a, record_b), "framework")
+    if not isinstance(framework, str) or not framework:
+        raise TraceFormatError("framework must be a non-empty string")
+    topology_class = _common_value((record_a, record_b), "topology_class") or "unknown"
+    if not isinstance(topology_class, str):
+        raise TraceFormatError("topology_class must be a string")
+    message_bytes_a = _integer(record_a, "message_bytes")
+    message_bytes_b = _integer(record_b, "message_bytes")
+    if message_bytes_a <= 0 or message_bytes_b <= 0:
+        raise TraceFormatError("message_bytes must be positive")
+
+    requested_offset = _common_value((record_a, record_b), "requested_offset_us")
+    if requested_offset is not None:
+        if isinstance(requested_offset, bool) or not isinstance(requested_offset, int | float):
+            raise TraceFormatError("requested_offset_us must be numeric or null")
+        requested_offset = float(requested_offset)
+        if not math.isfinite(requested_offset):
+            raise TraceFormatError("requested_offset_us must be finite")
+    policy = _common_value((record_a, record_b), "policy")
+    if policy is None:
+        if requested_offset == 0:
+            policy = "eager"
+        elif requested_offset is None:
+            policy = "unspecified"
+        else:
+            policy = "phase_shifted"
+    if not isinstance(policy, str) or not policy:
+        raise TraceFormatError("policy must be a non-empty string")
+
+    critical_path_duration_us = _common_value((record_a, record_b), "critical_path_duration_us")
+    if critical_path_duration_us is not None:
+        if (
+            isinstance(critical_path_duration_us, bool)
+            or not isinstance(critical_path_duration_us, int | float)
+            or not math.isfinite(critical_path_duration_us)
+            or critical_path_duration_us <= 0
+        ):
+            raise TraceFormatError("critical_path_duration_us must be positive and finite")
+        critical_path_duration_us = float(critical_path_duration_us)
+
+    sequence_consistent = True
+    for record in (record_a, record_b):
+        explicit = _record_value(record, "sequence_consistent")
+        if explicit is False:
+            sequence_consistent = False
+
+    return RankPair(
+        run_id=run_id,
+        context=context,
+        ordinal=ordinal,
+        rank=rank,
+        declared_world_size=declared_world_size,
+        framework=framework,
+        topology_class=topology_class,
+        operation_a=operation_a,
+        operation_b=operation_b,
+        message_bytes_a=message_bytes_a,
+        message_bytes_b=message_bytes_b,
+        transport_a=_string(record_a, "transport", default="unknown"),
+        transport_b=_string(record_b, "transport", default="unknown"),
+        process_group_id_a=_string(record_a, "process_group_id", default="unknown-a"),
+        process_group_id_b=_string(record_b, "process_group_id", default="unknown-b"),
+        sequence_id_a=_optional_integer(record_a, "communicator_sequence_id"),
+        sequence_id_b=_optional_integer(record_b, "communicator_sequence_id"),
+        policy=policy,
+        requested_offset_us=requested_offset,
+        a_start_ns=a_start,
+        a_end_ns=a_end,
+        b_start_ns=b_start,
+        b_end_ns=b_end,
+        b_consumer_ns=consumer,
+        critical_path_duration_us=critical_path_duration_us,
+        sequence_consistent=sequence_consistent,
+    )
+
+
+def pair_trace_records(
+    records: Iterable[Mapping[str, Any]],
+    operation_a: str,
+    operation_b: str,
+    pair_fields: Sequence[str] = DEFAULT_PAIR_FIELDS,
+) -> list[RankPair]:
+    """Pair A/B trace records by run, rank, semantic context, and launch order."""
+
+    grouped: defaultdict[tuple[Any, ...], dict[str, list[Mapping[str, Any]]]] = defaultdict(
+        lambda: {operation_a: [], operation_b: []}
+    )
+    selected = 0
+    for record in records:
+        operation = _record_value(record, "operation")
+        if operation not in (operation_a, operation_b):
+            continue
+        selected += 1
+        run_id = _string(record, "run_id")
+        rank = _integer(record, "rank")
+        context = _context(record, pair_fields)
+        declared_world_size = _record_value(record, "world_size")
+        grouped[(run_id, rank, declared_world_size, context)][operation].append(record)
+    if not selected:
+        raise TraceFormatError(f"no records matched operations {operation_a!r} and {operation_b!r}")
+
+    pairs = []
+    for (run_id, rank, _, context), by_operation in grouped.items():
+        records_a = sorted(by_operation[operation_a], key=_sort_key)
+        records_b = sorted(by_operation[operation_b], key=_sort_key)
+        if len(records_a) != len(records_b) or not records_a:
+            raise TraceFormatError(
+                f"run {run_id!r} rank {rank} context {dict(context)!r} has "
+                f"{len(records_a)} {operation_a!r} records and {len(records_b)} {operation_b!r} records"
+            )
+        for ordinal, (record_a, record_b) in enumerate(zip(records_a, records_b, strict=True)):
+            pairs.append(
+                _pair_records(
+                    record_a,
+                    record_b,
+                    context=context,
+                    ordinal=ordinal,
+                    operation_a=operation_a,
+                    operation_b=operation_b,
+                )
+            )
+    return pairs
+
+
+def build_candidates(rank_pairs: Sequence[RankPair]) -> dict[tuple[Any, ...], list[Candidate]]:
+    """Build complete global trials and group them by portable workload key."""
+
+    trials_by_key: defaultdict[tuple[Any, ...], list[RankPair]] = defaultdict(list)
+    ranks_by_run: defaultdict[tuple[Any, ...], set[int]] = defaultdict(set)
+    ranks_by_workload: defaultdict[tuple[Any, ...], set[int]] = defaultdict(set)
+    declared_sizes_by_workload: defaultdict[tuple[Any, ...], set[int]] = defaultdict(set)
+    for pair in rank_pairs:
+        grouping_key = (pair.workload_base, pair.declared_world_size)
+        candidate_key = (pair.policy, pair.requested_offset_us)
+        run_key = (pair.run_id, grouping_key, candidate_key)
+        ranks_by_run[run_key].add(pair.rank)
+        ranks_by_workload[grouping_key].add(pair.rank)
+        if pair.declared_world_size is not None:
+            declared_sizes_by_workload[grouping_key].add(pair.declared_world_size)
+        trials_by_key[(run_key, pair.context, pair.ordinal)].append(pair)
+
+    expected_by_workload: dict[tuple[Any, ...], tuple[int, ...]] = {}
+    for grouping_key, observed_ranks in ranks_by_workload.items():
+        declared_sizes = declared_sizes_by_workload[grouping_key]
+        if len(declared_sizes) > 1:
+            raise TraceFormatError(f"workload has conflicting declared world sizes: {sorted(declared_sizes)}")
+        world_size = next(iter(declared_sizes)) if declared_sizes else max(observed_ranks) + 1
+        expected_by_workload[grouping_key] = tuple(range(world_size))
+
+    for run_key, observed_ranks in ranks_by_run.items():
+        expected = expected_by_workload[run_key[1]]
+        if tuple(sorted(observed_ranks)) != expected:
+            raise TraceFormatError(f"run {run_key[0]!r} has ranks {tuple(sorted(observed_ranks))}, expected {expected}")
+
+    candidate_trials: defaultdict[tuple[Any, ...], list[Trial]] = defaultdict(list)
+    for (run_key, context, ordinal), pairs in trials_by_key.items():
+        run_id, grouping_key, candidate_key = run_key
+        workload_base, _ = grouping_key
+        expected = expected_by_workload[grouping_key]
+        observed = tuple(sorted(pair.rank for pair in pairs))
+        if observed != expected:
+            raise TraceFormatError(
+                f"run {run_id!r} context {dict(context)!r} has ranks {observed}, expected {expected}"
+            )
+        workload_key = (*workload_base, len(expected))
+        candidate_trials[(workload_key, candidate_key)].append(
+            Trial(run_id, context, ordinal, tuple(sorted(pairs, key=lambda pair: pair.rank)))
+        )
+
+    by_workload: defaultdict[tuple[Any, ...], list[Candidate]] = defaultdict(list)
+    for (workload_key, candidate_key), trials in candidate_trials.items():
+        policy, requested_offset_us = candidate_key
+        by_workload[workload_key].append(
+            Candidate(policy, requested_offset_us, tuple(sorted(trials, key=_trial_sort_key)))
+        )
+    return dict(by_workload)
+
+
+def _trial_sort_key(trial: Trial) -> tuple[str, str, int]:
+    return trial.run_id, json.dumps(trial.context, sort_keys=True), trial.ordinal
+
+
+def _rounded(value: float | None) -> float | None:
+    return round(value, 6) if value is not None else None
+
+
+def summarize_candidate(candidate: Candidate) -> dict[str, Any]:
+    """Summarize one candidate without discarding tail or safety signals."""
+
+    rank_pairs = candidate.rank_pairs
+    critical_path_sources = {trial.critical_path_source for trial in candidate.trials}
+    if len(critical_path_sources) != 1:
+        raise TraceFormatError("critical_path_duration_us is missing on only some trials")
+    critical_paths = [trial.critical_path_us for trial in candidate.trials]
+    pair_completions = [trial.pair_completion_us for trial in candidate.trials]
+    realized_offsets = [pair.realized_offset_us for pair in rank_pairs]
+    consumer_slacks = [pair.consumer_slack_us for pair in rank_pairs]
+    consumer_waits = [max(0.0, -slack) for slack in consumer_slacks]
+    rank_skews = [trial.rank_skew_us for trial in candidate.trials]
+    realized_p50 = percentile(realized_offsets, 50)
+    requested = candidate.requested_offset_us
+    return {
+        "policy": candidate.policy,
+        "requested_offset_us": requested,
+        "trial_count": len(candidate.trials),
+        "rank_observation_count": len(rank_pairs),
+        "critical_path_source": next(iter(critical_path_sources)),
+        "critical_path_us_p50": _rounded(percentile(critical_paths, 50)),
+        "critical_path_us_p95": _rounded(percentile(critical_paths, 95)),
+        "critical_path_us_p99": _rounded(percentile(critical_paths, 99)),
+        "pair_completion_us_p50": _rounded(percentile(pair_completions, 50)),
+        "pair_completion_us_p95": _rounded(percentile(pair_completions, 95)),
+        "realized_gpu_offset_us_p50": _rounded(realized_p50),
+        "realized_gpu_offset_us_p05": _rounded(percentile(realized_offsets, 5)),
+        "realized_gpu_offset_us_p95": _rounded(percentile(realized_offsets, 95)),
+        "realized_offset_error_us_p50": (_rounded(abs(realized_p50 - requested)) if requested is not None else None),
+        "consumer_slack_us_p05": _rounded(percentile(consumer_slacks, 5)),
+        "consumer_slack_us_p50": _rounded(percentile(consumer_slacks, 50)),
+        "consumer_wait_us_p95": _rounded(percentile(consumer_waits, 95)),
+        "rank_skew_us_p95": _rounded(percentile(rank_skews, 95)),
+        "sequence_consistent": all(trial.sequence_consistent for trial in candidate.trials),
+    }
+
+
+def _bootstrap_improvement_interval(
+    baseline: Sequence[float],
+    candidate: Sequence[float],
+    *,
+    confidence: float,
+    resamples: int,
+    seed_material: str,
+) -> tuple[float, float] | None:
+    if len(baseline) < 2 or len(candidate) < 2 or resamples <= 0:
+        return None
+    seed = int.from_bytes(hashlib.sha256(seed_material.encode()).digest()[:8], "big")
+    generator = random.Random(seed)
+    differences = []
+    for _ in range(resamples):
+        baseline_sample = [baseline[generator.randrange(len(baseline))] for _ in baseline]
+        candidate_sample = [candidate[generator.randrange(len(candidate))] for _ in candidate]
+        differences.append(percentile(baseline_sample, 95) - percentile(candidate_sample, 95))
+    tail_percent = (1 - confidence) * 50
+    return percentile(differences, tail_percent), percentile(differences, 100 - tail_percent)
+
+
+def _paired_improvement_interval(
+    baseline: Sequence[Trial],
+    candidate: Sequence[Trial],
+    *,
+    confidence: float,
+    resamples: int,
+    seed_material: str,
+) -> tuple[tuple[float, float] | None, str]:
+    baseline_by_context: defaultdict[tuple[Any, ...], list[Trial]] = defaultdict(list)
+    candidate_by_context: defaultdict[tuple[Any, ...], list[Trial]] = defaultdict(list)
+    for trial in baseline:
+        baseline_by_context[(trial.context, trial.ordinal)].append(trial)
+    for trial in candidate:
+        candidate_by_context[(trial.context, trial.ordinal)].append(trial)
+
+    contexts = set(baseline_by_context) & set(candidate_by_context)
+    unambiguous = (
+        contexts
+        and contexts == set(baseline_by_context) == set(candidate_by_context)
+        and all(len(baseline_by_context[context]) == len(candidate_by_context[context]) == 1 for context in contexts)
+    )
+    if unambiguous and len(contexts) >= 2 and resamples > 0:
+        differences = [
+            baseline_by_context[context][0].critical_path_us - candidate_by_context[context][0].critical_path_us
+            for context in sorted(contexts, key=repr)
+        ]
+        seed = int.from_bytes(hashlib.sha256(seed_material.encode()).digest()[:8], "big")
+        generator = random.Random(seed)
+        estimates = []
+        for _ in range(resamples):
+            sample = [differences[generator.randrange(len(differences))] for _ in differences]
+            estimates.append(sum(sample) / len(sample))
+        tail_percent = (1 - confidence) * 50
+        return (
+            percentile(estimates, tail_percent),
+            percentile(estimates, 100 - tail_percent),
+        ), "paired_mean"
+
+    interval = _bootstrap_improvement_interval(
+        [trial.critical_path_us for trial in baseline],
+        [trial.critical_path_us for trial in candidate],
+        confidence=confidence,
+        resamples=resamples,
+        seed_material=seed_material,
+    )
+    return interval, "independent_p95"
+
+
+def _candidate_sort_key(summary: Mapping[str, Any]) -> tuple[float, float, float]:
+    return (
+        float(summary["critical_path_us_p95"]),
+        float(summary["consumer_wait_us_p95"]),
+        float(summary["rank_skew_us_p95"]),
+    )
+
+
+def _baseline_index(summaries: Sequence[Mapping[str, Any]]) -> int:
+    explicit = [index for index, item in enumerate(summaries) if item["policy"] in BASELINE_POLICIES]
+    candidates = explicit or list(range(len(summaries)))
+    return min(
+        candidates,
+        key=lambda index: (
+            abs(float(summaries[index]["realized_gpu_offset_us_p50"])),
+            _candidate_sort_key(summaries[index]),
+        ),
+    )
+
+
+def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
+    (
+        framework,
+        topology_class,
+        operation_a,
+        operation_b,
+        message_bytes_a,
+        message_bytes_b,
+        transport_a,
+        transport_b,
+        world_size,
+    ) = workload
+    return {
+        "framework": framework,
+        "topology_class": topology_class,
+        "operation_a": operation_a,
+        "operation_b": operation_b,
+        "message_bytes_a": message_bytes_a,
+        "message_bytes_b": message_bytes_b,
+        "transport_a": transport_a,
+        "transport_b": transport_b,
+        "world_size": world_size,
+    }
+
+
+def _refinement_points(
+    summaries: Sequence[Mapping[str, Any]],
+    focus_index: int,
+    minimum_slack_us: float,
+) -> list[dict[str, float]]:
+    observed = sorted(
+        (float(item["requested_offset_us"]), index)
+        for index, item in enumerate(summaries)
+        if item["requested_offset_us"] is not None
+    )
+    position = next((position for position, (_, index) in enumerate(observed) if index == focus_index), None)
+    if position is None:
+        return []
+    proposals = []
+    for neighbor_position in (position - 1, position + 1):
+        if not 0 <= neighbor_position < len(observed):
+            continue
+        request_a, index_a = observed[position]
+        request_b, index_b = observed[neighbor_position]
+        midpoint = (request_a + request_b) / 2
+        if midpoint in {request for request, _ in observed}:
+            continue
+        slack_a = float(summaries[index_a]["consumer_slack_us_p05"])
+        slack_b = float(summaries[index_b]["consumer_slack_us_p05"])
+        predicted_slack = (slack_a + slack_b) / 2
+        if predicted_slack >= minimum_slack_us:
+            realized_a = float(summaries[index_a]["realized_gpu_offset_us_p50"])
+            realized_b = float(summaries[index_b]["realized_gpu_offset_us_p50"])
+            proposals.append(
+                {
+                    "requested_offset_us": midpoint,
+                    "predicted_realized_gpu_offset_us": (realized_a + realized_b) / 2,
+                    "predicted_consumer_slack_us_p05": predicted_slack,
+                }
+            )
+    return sorted(proposals, key=lambda proposal: proposal["requested_offset_us"])
+
+
+def tune_workload(
+    workload: tuple[Any, ...],
+    candidates: Sequence[Candidate],
+    *,
+    confidence: float = 0.95,
+    bootstrap_resamples: int = 2000,
+    min_trials: int = 2,
+) -> dict[str, Any]:
+    """Choose a safe policy and data-derived refinement offsets for one workload."""
+
+    summaries = [summarize_candidate(candidate) for candidate in candidates]
+    critical_path_sources = {summary["critical_path_source"] for summary in summaries}
+    if len(critical_path_sources) != 1:
+        raise TraceFormatError("all candidates for a workload must use the same critical-path source")
+    baseline_index = _baseline_index(summaries)
+    baseline = summaries[baseline_index]
+    minimum_slack_us = min(0.0, float(baseline["consumer_slack_us_p05"]))
+    baseline_rank_skew_us = float(baseline["rank_skew_us_p95"])
+
+    eligible = []
+    for index, (candidate, summary) in enumerate(zip(candidates, summaries, strict=True)):
+        reasons = []
+        if summary["trial_count"] < min_trials:
+            reasons.append("insufficient_trials")
+        if not summary["sequence_consistent"]:
+            reasons.append("communicator_sequence_divergence")
+        if float(summary["consumer_slack_us_p05"]) < minimum_slack_us:
+            reasons.append("consumer_deadline_regression")
+        rank_skew_growth_us = max(0.0, float(summary["rank_skew_us_p95"]) - baseline_rank_skew_us)
+        rank_skew_headroom_us = max(0.0, float(summary["consumer_slack_us_p05"]) - minimum_slack_us)
+        summary["rank_skew_growth_us"] = _rounded(rank_skew_growth_us)
+        summary["rank_skew_slack_headroom_us"] = _rounded(rank_skew_headroom_us)
+        if rank_skew_growth_us > rank_skew_headroom_us:
+            reasons.append("rank_skew_exceeds_slack_headroom")
+        requested = summary["requested_offset_us"]
+        realized = float(summary["realized_gpu_offset_us_p50"])
+        if requested not in (None, 0) and math.copysign(1, float(requested)) != math.copysign(1, realized):
+            reasons.append("realized_offset_direction_mismatch")
+        elif requested is not None and requested > 0 and summary["realized_gpu_offset_us_p05"] <= 0:
+            reasons.append("realized_offset_direction_unstable")
+        elif requested is not None and requested < 0 and summary["realized_gpu_offset_us_p95"] >= 0:
+            reasons.append("realized_offset_direction_unstable")
+
+        interval = (0.0, 0.0)
+        confidence_method = "identity"
+        if index != baseline_index:
+            interval, confidence_method = _paired_improvement_interval(
+                candidates[baseline_index].trials,
+                candidate.trials,
+                confidence=confidence,
+                resamples=bootstrap_resamples,
+                seed_material=f"{workload!r}/{candidate.policy}/{candidate.requested_offset_us}",
+            )
+        summary["critical_path_improvement_ci_us"] = (
+            [_rounded(interval[0]), _rounded(interval[1])] if interval is not None else None
+        )
+        summary["confidence_method"] = confidence_method
+        summary["eligible"] = not reasons
+        summary["rejection_reasons"] = reasons
+        if not reasons:
+            eligible.append(index)
+
+    improving = []
+    for index in eligible:
+        interval = summaries[index]["critical_path_improvement_ci_us"]
+        if index != baseline_index and interval is not None and interval[0] > 0:
+            improving.append(index)
+    selected_index = (
+        min(improving, key=lambda index: _candidate_sort_key(summaries[index])) if improving else baseline_index
+    )
+
+    evidence_ready = baseline["trial_count"] >= min_trials and baseline_index in eligible
+    if not evidence_ready:
+        decision = "insufficient_evidence"
+    elif selected_index == baseline_index:
+        decision = "keep_baseline"
+    else:
+        decision = "switch_policy"
+
+    focus_pool = eligible or [baseline_index]
+    focus_index = min(focus_pool, key=lambda index: _candidate_sort_key(summaries[index]))
+    next_candidates = _refinement_points(summaries, focus_index, minimum_slack_us)
+    return {
+        "workload_key": _workload_dict(workload),
+        "decision": decision,
+        "baseline_candidate": {
+            "policy": baseline["policy"],
+            "requested_offset_us": baseline["requested_offset_us"],
+        },
+        "recommended_candidate": {
+            "policy": summaries[selected_index]["policy"],
+            "requested_offset_us": summaries[selected_index]["requested_offset_us"],
+            "realized_gpu_offset_us_p50": summaries[selected_index]["realized_gpu_offset_us_p50"],
+        },
+        "consumer_deadline_guard_us": _rounded(minimum_slack_us),
+        "refinement": {
+            "next_requested_offsets_us": [candidate["requested_offset_us"] for candidate in next_candidates],
+            "next_candidates": next_candidates,
+            "method": "measured-interval midpoint bounded by consumer slack; no extrapolation",
+        },
+        "candidates": sorted(
+            summaries,
+            key=lambda item: (
+                item["requested_offset_us"] is None,
+                0 if item["requested_offset_us"] is None else item["requested_offset_us"],
+                item["policy"],
+            ),
+        ),
+    }
+
+
+def tune_traces(
+    records: Iterable[Mapping[str, Any]],
+    operation_a: str,
+    operation_b: str,
+    *,
+    pair_fields: Sequence[str] = DEFAULT_PAIR_FIELDS,
+    confidence: float = 0.95,
+    bootstrap_resamples: int = 2000,
+    min_trials: int = 2,
+) -> dict[str, Any]:
+    """Build recommendations from framework-neutral semantic trace records."""
+
+    if not 0 < confidence < 1:
+        raise ValueError("confidence must be between zero and one")
+    if bootstrap_resamples < 0:
+        raise ValueError("bootstrap_resamples must be non-negative")
+    if min_trials <= 0:
+        raise ValueError("min_trials must be positive")
+    if not pair_fields:
+        raise ValueError("at least one pair field is required")
+    pairs = pair_trace_records(records, operation_a, operation_b, pair_fields)
+    by_workload = build_candidates(pairs)
+    recommendations = [
+        tune_workload(
+            workload,
+            candidates,
+            confidence=confidence,
+            bootstrap_resamples=bootstrap_resamples,
+            min_trials=min_trials,
+        )
+        for workload, candidates in sorted(by_workload.items(), key=lambda item: repr(item[0]))
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "operation_a": operation_a,
+        "operation_b": operation_b,
+        "pair_fields": list(pair_fields),
+        "recommendations": recommendations,
+    }
+
+
+def load_jsonl(paths: Sequence[Path]) -> list[dict[str, Any]]:
+    """Load JSON objects from one or more JSONL trace shards."""
+
+    records = []
+    for path in paths:
+        with path.open(encoding="utf-8") as trace_file:
+            for line_number, line in enumerate(trace_file, 1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise TraceFormatError(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
+                if not isinstance(record, dict):
+                    raise TraceFormatError(f"{path}:{line_number}: each line must contain a JSON object")
+                records.append(record)
+    return records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--trace-jsonl", nargs="+", type=Path, required=True, help="all rank shards for all candidates")
+    parser.add_argument("--operation-a", required=True)
+    parser.add_argument("--operation-b", required=True)
+    parser.add_argument(
+        "--pair-by",
+        nargs="+",
+        default=list(DEFAULT_PAIR_FIELDS),
+        help="scalar trace fields identifying one semantic A/B pair",
+    )
+    parser.add_argument("--confidence", type=float, default=0.95)
+    parser.add_argument("--bootstrap-resamples", type=int, default=2000)
+    parser.add_argument("--min-trials", type=int, default=2)
+    parser.add_argument("--output-json", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = tune_traces(
+            load_jsonl(args.trace_jsonl),
+            args.operation_a,
+            args.operation_b,
+            pair_fields=args.pair_by,
+            confidence=args.confidence,
+            bootstrap_resamples=args.bootstrap_resamples,
+            min_trials=args.min_trials,
+        )
+    except (OSError, TraceFormatError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    payload["trace_files"] = [str(path) for path in args.trace_jsonl]
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/communication_topology_policy.py
+++ b/scripts/communication_topology_policy.py
@@ -1,0 +1,474 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fingerprint communication topology and select only exact policy cells.
+
+This module intentionally does not configure NIC traffic classes, rails, or
+routing.  It creates a stable compatibility boundary for measured policies so
+that a recommendation from one topology is never extrapolated to another.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+TOPOLOGY_SCHEMA_VERSION = 1
+_FINGERPRINT_FIELDS = {
+    "schema_version",
+    "scope",
+    "local_fabric",
+    "node_count",
+    "world_size",
+    "rank_groups",
+    "ranks_per_node",
+    "accelerator_models_by_rank",
+    "topology_signature",
+}
+
+
+class TopologyEvidenceError(ValueError):
+    """Raised when trace records cannot form a safe topology fingerprint."""
+
+
+class IncompatibleTopologyError(ValueError):
+    """Raised when no measured policy cell exactly matches a target topology."""
+
+
+@dataclasses.dataclass(frozen=True)
+class TopologyCompatibility:
+    """Exact compatibility result between two topology fingerprints."""
+
+    compatible: bool
+    reasons: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class TopologyFingerprint:
+    """Portable topology identity for one distributed run.
+
+    Hostnames are deliberately excluded from the identity. ``rank_groups``
+    preserves placement while allowing the same layout on different hosts.
+    ``topology_signature`` is an opaque inventory hash, required for multi-node
+    traces because a node count alone cannot identify an inter-node topology.
+    """
+
+    scope: str
+    local_fabric: str
+    node_count: int
+    world_size: int
+    rank_groups: tuple[tuple[int, ...], ...]
+    accelerator_models_by_rank: tuple[str, ...]
+    topology_signature: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+
+        return {
+            "schema_version": TOPOLOGY_SCHEMA_VERSION,
+            "scope": self.scope,
+            "local_fabric": self.local_fabric,
+            "node_count": self.node_count,
+            "world_size": self.world_size,
+            "rank_groups": [list(group) for group in self.rank_groups],
+            "ranks_per_node": [len(group) for group in self.rank_groups],
+            "accelerator_models_by_rank": list(self.accelerator_models_by_rank),
+            "topology_signature": self.topology_signature,
+        }
+
+    @property
+    def canonical_json(self) -> str:
+        """Return a stable serialization suitable for hashing and storage."""
+
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+    @property
+    def topology_class(self) -> str:
+        """Return a coarse human-readable class without weakening identity."""
+
+        if self.scope == "multi_node":
+            return "multi-node"
+        return f"single-node-{self.local_fabric}"
+
+    @property
+    def cell_id(self) -> str:
+        """Return the content-addressed topology cell identifier."""
+
+        return f"topology-v{TOPOLOGY_SCHEMA_VERSION}:{hashlib.sha256(self.canonical_json.encode()).hexdigest()}"
+
+    def compare(self, other: TopologyFingerprint) -> TopologyCompatibility:
+        """Compare every scheduling-relevant field without fuzzy matching."""
+
+        reasons = []
+        for field in (
+            "scope",
+            "local_fabric",
+            "node_count",
+            "world_size",
+            "rank_groups",
+            "accelerator_models_by_rank",
+            "topology_signature",
+        ):
+            if getattr(self, field) != getattr(other, field):
+                reasons.append(field)
+        return TopologyCompatibility(not reasons, tuple(reasons))
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> TopologyFingerprint:
+        """Validate and deserialize a stored fingerprint."""
+
+        if value.get("schema_version") != TOPOLOGY_SCHEMA_VERSION:
+            raise TopologyEvidenceError("unsupported topology fingerprint schema_version")
+        unexpected = set(value) - _FINGERPRINT_FIELDS
+        if unexpected:
+            raise TopologyEvidenceError(f"unexpected topology fingerprint fields: {sorted(unexpected)}")
+        try:
+            scope = value["scope"]
+            local_fabric = value["local_fabric"]
+            node_count = value["node_count"]
+            world_size = value["world_size"]
+            raw_groups = value["rank_groups"]
+            raw_models = value["accelerator_models_by_rank"]
+            if not isinstance(scope, str) or not isinstance(local_fabric, str):
+                raise TypeError
+            if isinstance(node_count, bool) or not isinstance(node_count, int):
+                raise TypeError
+            if isinstance(world_size, bool) or not isinstance(world_size, int):
+                raise TypeError
+            if not isinstance(raw_groups, list) or not all(isinstance(group, list) for group in raw_groups):
+                raise TypeError
+            if not all(not isinstance(rank, bool) and isinstance(rank, int) for group in raw_groups for rank in group):
+                raise TypeError
+            if not isinstance(raw_models, list) or not all(isinstance(model, str) for model in raw_models):
+                raise TypeError
+            rank_groups = tuple(tuple(group) for group in raw_groups)
+            models = tuple(raw_models)
+            signature = value.get("topology_signature")
+            if signature is not None and not isinstance(signature, str):
+                raise TypeError
+            fingerprint = cls(
+                scope=scope,
+                local_fabric=local_fabric,
+                node_count=node_count,
+                world_size=world_size,
+                rank_groups=rank_groups,
+                accelerator_models_by_rank=models,
+                topology_signature=signature,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise TopologyEvidenceError("malformed topology fingerprint") from exc
+        fingerprint.validate()
+        raw_ranks_per_node = value.get("ranks_per_node")
+        if not isinstance(raw_ranks_per_node, list) or not all(
+            not isinstance(count, bool) and isinstance(count, int) for count in raw_ranks_per_node
+        ):
+            raise TopologyEvidenceError("ranks_per_node must contain integer counts")
+        if raw_ranks_per_node != [len(group) for group in fingerprint.rank_groups]:
+            raise TopologyEvidenceError("ranks_per_node disagrees with rank_groups")
+        return fingerprint
+
+    def validate(self) -> None:
+        """Validate internal topology invariants."""
+
+        if isinstance(self.node_count, bool) or not isinstance(self.node_count, int):
+            raise TopologyEvidenceError("node_count must be an integer")
+        if isinstance(self.world_size, bool) or not isinstance(self.world_size, int):
+            raise TopologyEvidenceError("world_size must be an integer")
+        if self.scope not in {"single_node", "multi_node"}:
+            raise TopologyEvidenceError("scope must be single_node or multi_node")
+        if self.local_fabric not in {"pcie", "nvlink", "unknown"}:
+            raise TopologyEvidenceError("local_fabric must be pcie, nvlink, or unknown")
+        if self.node_count <= 0 or self.world_size < 2:
+            raise TopologyEvidenceError("invalid node_count or world_size")
+        if len(self.rank_groups) != self.node_count:
+            raise TopologyEvidenceError("rank_groups does not match node_count")
+        if any(not group for group in self.rank_groups):
+            raise TopologyEvidenceError("rank_groups cannot contain an empty node")
+        if any(isinstance(rank, bool) or not isinstance(rank, int) for group in self.rank_groups for rank in group):
+            raise TopologyEvidenceError("rank_groups must contain integer ranks")
+        flattened = tuple(sorted(rank for group in self.rank_groups for rank in group))
+        if flattened != tuple(range(self.world_size)):
+            raise TopologyEvidenceError("rank_groups must contain every rank exactly once")
+        if len(self.accelerator_models_by_rank) != self.world_size:
+            raise TopologyEvidenceError("accelerator model vector does not match world_size")
+        if any(not isinstance(model, str) or not model for model in self.accelerator_models_by_rank):
+            raise TopologyEvidenceError("accelerator models must be non-empty strings")
+        if self.scope == "single_node" and self.node_count != 1:
+            raise TopologyEvidenceError("single_node scope must contain exactly one node")
+        if self.scope == "multi_node" and self.node_count < 2:
+            raise TopologyEvidenceError("multi_node scope must contain at least two nodes")
+        if self.scope == "multi_node" and not self.topology_signature:
+            raise TopologyEvidenceError("multi-node traces require an opaque topology_signature")
+        if self.topology_signature is not None and (
+            not isinstance(self.topology_signature, str) or not self.topology_signature.strip()
+        ):
+            raise TopologyEvidenceError("topology_signature must be a non-empty string")
+
+
+def _value(record: Mapping[str, Any], name: str) -> Any:
+    value = record.get(name)
+    if value is not None:
+        return value
+    metadata = record.get("metadata")
+    return metadata.get(name) if isinstance(metadata, Mapping) else None
+
+
+def topology_run_key(record: Mapping[str, Any]) -> tuple[str, int | None]:
+    """Return a run key that keeps explicitly different world sizes separate."""
+
+    run_id = _value(record, "run_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise TopologyEvidenceError("run_id must be a non-empty string")
+    declared_world_size = _value(record, "world_size")
+    if declared_world_size is None:
+        return run_id, None
+    if (
+        isinstance(declared_world_size, bool)
+        or not isinstance(declared_world_size, int | float)
+        or not math.isfinite(declared_world_size)
+        or not float(declared_world_size).is_integer()
+    ):
+        raise TopologyEvidenceError("world_size must be an integer")
+    return run_id, int(declared_world_size)
+
+
+def _rank(record: Mapping[str, Any]) -> int:
+    value = _value(record, "rank")
+    if isinstance(value, bool) or not isinstance(value, int | float) or not float(value).is_integer():
+        raise TopologyEvidenceError("rank must be an integer")
+    rank = int(value)
+    if rank < 0:
+        raise TopologyEvidenceError("rank must be non-negative")
+    return rank
+
+
+def _consistent_scalar(records: Sequence[Mapping[str, Any]], names: Sequence[str]) -> Any:
+    values = set()
+    for record in records:
+        for name in names:
+            value = _value(record, name)
+            if value is not None:
+                if isinstance(value, dict | list):
+                    raise TopologyEvidenceError(f"{name} must be scalar")
+                values.add(value)
+                break
+    if len(values) > 1:
+        raise TopologyEvidenceError(f"conflicting {names[0]} values: {sorted(values, key=str)!r}")
+    return next(iter(values)) if values else None
+
+
+def _scope_and_fabric(topology_class: str | None, node_count: int) -> tuple[str, str]:
+    normalized = (topology_class or "unknown").strip().lower().replace("_", "-")
+    declared_scope = None
+    if "multi-node" in normalized or "multinode" in normalized:
+        declared_scope = "multi_node"
+    elif "single-node" in normalized or "singlenode" in normalized:
+        declared_scope = "single_node"
+    inferred_scope = "single_node" if node_count == 1 else "multi_node"
+    if declared_scope is not None and declared_scope != inferred_scope:
+        raise TopologyEvidenceError("declared topology class disagrees with observed node placement")
+    if "nvlink" in normalized:
+        local_fabric = "nvlink"
+    elif "pcie" in normalized or "pci-e" in normalized:
+        local_fabric = "pcie"
+    else:
+        local_fabric = "unknown"
+    return inferred_scope, local_fabric
+
+
+def fingerprint_trace_run(records: Sequence[Mapping[str, Any]]) -> TopologyFingerprint:
+    """Build one fingerprint from all selected rank records of a run."""
+
+    if not records:
+        raise TopologyEvidenceError("cannot fingerprint an empty trace run")
+    _consistent_scalar(records, ("run_id",))
+    ranks = sorted({_rank(record) for record in records})
+    declared_sizes = {key[1] for key in (topology_run_key(record) for record in records) if key[1] is not None}
+    if len(declared_sizes) > 1:
+        raise TopologyEvidenceError("trace run has conflicting world_size values")
+    world_size = next(iter(declared_sizes)) if declared_sizes else max(ranks) + 1
+    if world_size < 2 or ranks != list(range(world_size)):
+        raise TopologyEvidenceError(f"trace ranks {tuple(ranks)} do not cover world_size {world_size}")
+
+    records_by_rank: defaultdict[int, list[Mapping[str, Any]]] = defaultdict(list)
+    for record in records:
+        records_by_rank[_rank(record)].append(record)
+
+    topology_class = _consistent_scalar(records, ("topology_class",))
+    if topology_class is not None and not isinstance(topology_class, str):
+        raise TopologyEvidenceError("topology_class must be a string")
+
+    node_by_rank = []
+    for rank in range(world_size):
+        node = _consistent_scalar(records_by_rank[rank], ("node_id", "node", "hostname"))
+        node_by_rank.append(str(node) if node is not None else "__unspecified_node__")
+    explicit_nodes = {node for node in node_by_rank if node != "__unspecified_node__"}
+    if explicit_nodes and "__unspecified_node__" in node_by_rank:
+        raise TopologyEvidenceError("node identity is missing on only some ranks")
+    if not explicit_nodes:
+        if isinstance(topology_class, str) and ("multi-node" in topology_class or "multinode" in topology_class):
+            raise TopologyEvidenceError("multi-node traces require hostname or node_id on every rank")
+        node_by_rank = ["__single_node__"] * world_size
+
+    ranks_by_node: defaultdict[str, list[int]] = defaultdict(list)
+    for rank, node in enumerate(node_by_rank):
+        ranks_by_node[node].append(rank)
+    rank_groups = tuple(sorted((tuple(group) for group in ranks_by_node.values()), key=lambda group: group[0]))
+    scope, local_fabric = _scope_and_fabric(topology_class, len(rank_groups))
+
+    models = []
+    for rank in range(world_size):
+        model = _consistent_scalar(records_by_rank[rank], ("accelerator_model", "device_name", "device"))
+        models.append(str(model) if model is not None else "unknown")
+    signatures_by_rank = [
+        _consistent_scalar(records_by_rank[rank], ("topology_signature",)) for rank in range(world_size)
+    ]
+    present_signatures = {signature for signature in signatures_by_rank if signature is not None}
+    if present_signatures and any(signature is None for signature in signatures_by_rank):
+        raise TopologyEvidenceError("topology_signature is missing on only some ranks")
+    if len(present_signatures) > 1:
+        raise TopologyEvidenceError("conflicting topology_signature values across ranks")
+    topology_signature = next(iter(present_signatures)) if present_signatures else None
+    if topology_signature is not None and not isinstance(topology_signature, str):
+        raise TopologyEvidenceError("topology_signature must be a string")
+
+    fingerprint = TopologyFingerprint(
+        scope=scope,
+        local_fabric=local_fabric,
+        node_count=len(rank_groups),
+        world_size=world_size,
+        rank_groups=rank_groups,
+        accelerator_models_by_rank=tuple(models),
+        topology_signature=topology_signature,
+    )
+    fingerprint.validate()
+    return fingerprint
+
+
+def fingerprint_trace_runs(
+    records: Iterable[Mapping[str, Any]], operations: Sequence[str] | None = None
+) -> dict[tuple[str, int | None], TopologyFingerprint]:
+    """Fingerprint every run represented in a trace collection."""
+
+    selected_operations = set(operations) if operations is not None else None
+    by_run: defaultdict[tuple[str, int | None], list[Mapping[str, Any]]] = defaultdict(list)
+    for record in records:
+        if selected_operations is not None and _value(record, "operation") not in selected_operations:
+            continue
+        by_run[topology_run_key(record)].append(record)
+    if not by_run:
+        raise TopologyEvidenceError("no trace records matched the topology request")
+    fingerprints = {}
+    for run_key, run_records in by_run.items():
+        try:
+            fingerprints[run_key] = fingerprint_trace_run(run_records)
+        except TopologyEvidenceError as exc:
+            raise TopologyEvidenceError(f"run {run_key[0]!r}: {exc}") from exc
+    return fingerprints
+
+
+def select_compatible_policy_cells(
+    recommendations: Sequence[Mapping[str, Any]], target: TopologyFingerprint
+) -> list[Mapping[str, Any]]:
+    """Return exact topology matches and reject every cross-topology fallback."""
+
+    target.validate()
+    matches = []
+    mismatch_counts: Counter[str] = Counter()
+    for recommendation in recommendations:
+        workload_key = recommendation.get("workload_key")
+        if not isinstance(workload_key, Mapping):
+            raise TopologyEvidenceError("recommendation is missing workload_key")
+        stored = workload_key.get("topology_fingerprint")
+        if not isinstance(stored, Mapping):
+            raise TopologyEvidenceError("recommendation is missing topology_fingerprint")
+        fingerprint = TopologyFingerprint.from_dict(stored)
+        if workload_key.get("topology_cell_id") != fingerprint.cell_id:
+            raise TopologyEvidenceError("stored topology_cell_id does not match its fingerprint")
+        compatibility = fingerprint.compare(target)
+        if compatibility.compatible:
+            matches.append(recommendation)
+        else:
+            mismatch_counts.update(compatibility.reasons)
+    if matches:
+        return matches
+    mismatch_summary = ", ".join(f"{field} ({count})" for field, count in sorted(mismatch_counts.items()))
+    raise IncompatibleTopologyError(
+        f"no exact policy cell for {target.cell_id}; mismatched fields: {mismatch_summary or 'no measured cells'}"
+    )
+
+
+def load_jsonl(paths: Sequence[Path]) -> list[dict[str, Any]]:
+    """Load topology evidence from JSONL trace shards."""
+
+    records = []
+    for path in paths:
+        with path.open(encoding="utf-8") as trace_file:
+            for line_number, line in enumerate(trace_file, 1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise TopologyEvidenceError(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
+                if not isinstance(record, dict):
+                    raise TopologyEvidenceError(f"{path}:{line_number}: each line must be a JSON object")
+                records.append(record)
+    return records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--policy-json", type=Path, required=True)
+    parser.add_argument("--target-trace-jsonl", nargs="+", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        policy_payload = json.loads(args.policy_json.read_text(encoding="utf-8"))
+        if not isinstance(policy_payload, dict) or not isinstance(policy_payload.get("recommendations"), list):
+            raise TopologyEvidenceError("policy JSON must contain a recommendations list")
+        fingerprints = fingerprint_trace_runs(load_jsonl(args.target_trace_jsonl))
+        unique_targets = {fingerprint.cell_id: fingerprint for fingerprint in fingerprints.values()}
+        if len(unique_targets) != 1:
+            raise TopologyEvidenceError("target traces contain more than one topology cell")
+        target = next(iter(unique_targets.values()))
+        matches = select_compatible_policy_cells(policy_payload["recommendations"], target)
+        output = {
+            "schema_version": TOPOLOGY_SCHEMA_VERSION,
+            "topology_cell_id": target.cell_id,
+            "topology_fingerprint": target.to_dict(),
+            "recommendations": matches,
+        }
+    except (OSError, json.JSONDecodeError, TopologyEvidenceError, IncompatibleTopologyError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(output, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from scripts.autotune_communication_phase import TraceFormatError, main, tune_traces
+
+
+def _candidate_records(
+    world_size,
+    *,
+    run_id,
+    policy,
+    requested_offset_us,
+    realized_offset_us,
+    duration_a_us,
+    duration_b_us,
+    consumer_slack_us,
+    critical_path_duration_us=None,
+    trial_count=4,
+):
+    records = []
+    for trial in range(trial_count):
+        trial_origin_ns = 1_000_000_000 + trial * 10_000_000
+        for rank in range(world_size):
+            rank_skew_ns = rank * 1000
+            a_start_ns = trial_origin_ns + rank_skew_ns
+            b_start_ns = a_start_ns + int((realized_offset_us + rank) * 1000)
+            common = {
+                "framework": "fixture",
+                "run_id": run_id,
+                "rank": rank,
+                "world_size": world_size,
+                "iteration": trial,
+                "microbatch": 0,
+                "layer": 3,
+                "requested_offset_us": requested_offset_us,
+                "topology_class": "logical-fixture",
+                "transport": "fixture",
+                "metadata": {
+                    "policy": policy,
+                    "completion_observed": True,
+                    "sequence_consistent": True,
+                },
+            }
+            if critical_path_duration_us is not None:
+                common["critical_path_duration_us"] = critical_path_duration_us + trial + rank
+            records.extend(
+                [
+                    {
+                        **common,
+                        "operation": "comm_a",
+                        "message_bytes": 8192,
+                        "communicator_sequence_id": trial,
+                        "gpu_start_timestamp_ns": a_start_ns,
+                        "gpu_end_timestamp_ns": a_start_ns + int(duration_a_us * 1000),
+                        "consumer_timestamp_ns": a_start_ns + int(duration_a_us * 1000),
+                    },
+                    {
+                        **common,
+                        "operation": "comm_b",
+                        "message_bytes": 4096,
+                        "communicator_sequence_id": trial,
+                        "gpu_start_timestamp_ns": b_start_ns,
+                        "gpu_end_timestamp_ns": b_start_ns + int(duration_b_us * 1000),
+                        "consumer_timestamp_ns": b_start_ns + int((duration_b_us + consumer_slack_us) * 1000),
+                    },
+                ]
+            )
+    return records
+
+
+def _trace_fixture(world_size):
+    baseline = _candidate_records(
+        world_size,
+        run_id="baseline",
+        policy="eager",
+        requested_offset_us=0,
+        realized_offset_us=0,
+        duration_a_us=1200,
+        duration_b_us=1100,
+        consumer_slack_us=300,
+    )
+    safe = _candidate_records(
+        world_size,
+        run_id="safe-shift",
+        policy="phase_shifted",
+        requested_offset_us=200,
+        realized_offset_us=180,
+        duration_a_us=800,
+        duration_b_us=650,
+        consumer_slack_us=120,
+    )
+    deadline_regression = _candidate_records(
+        world_size,
+        run_id="late-shift",
+        policy="phase_shifted",
+        requested_offset_us=400,
+        realized_offset_us=380,
+        duration_a_us=700,
+        duration_b_us=500,
+        consumer_slack_us=-40,
+    )
+    return baseline + safe + deadline_regression
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_tuner_uses_trace_evidence_for_any_logical_rank_count(world_size):
+    payload = tune_traces(
+        _trace_fixture(world_size),
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=400,
+    )
+
+    assert len(payload["recommendations"]) == 1
+    recommendation = payload["recommendations"][0]
+    assert recommendation["workload_key"]["world_size"] == world_size
+    assert recommendation["decision"] == "switch_policy"
+    assert recommendation["recommended_candidate"] == {
+        "policy": "phase_shifted",
+        "requested_offset_us": 200.0,
+        "realized_gpu_offset_us_p50": pytest.approx(180 + (world_size - 1) / 2),
+    }
+    by_offset = {candidate["requested_offset_us"]: candidate for candidate in recommendation["candidates"]}
+    assert by_offset[200.0]["eligible"]
+    assert by_offset[200.0]["confidence_method"] == "paired_mean"
+    assert by_offset[200.0]["critical_path_improvement_ci_us"][0] > 0
+    assert by_offset[400.0]["rejection_reasons"] == ["consumer_deadline_regression"]
+    assert recommendation["refinement"]["next_requested_offsets_us"] == [100.0, 300.0]
+    assert recommendation["refinement"]["next_candidates"][0] == {
+        "requested_offset_us": 100.0,
+        "predicted_realized_gpu_offset_us": pytest.approx(90 + (world_size - 1) / 2),
+        "predicted_consumer_slack_us_p05": pytest.approx(210),
+    }
+
+
+def test_sequence_divergence_fails_closed_on_two_rank_trace():
+    records = _trace_fixture(2)
+    for record in records:
+        if record["run_id"] == "safe-shift" and record["rank"] == 1:
+            record["metadata"]["sequence_consistent"] = False
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "keep_baseline"
+    safe_candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "communicator_sequence_divergence" in safe_candidate["rejection_reasons"]
+
+
+def test_raw_communicator_sequence_ids_are_checked_on_four_ranks():
+    records = _trace_fixture(4)
+    record = next(
+        record
+        for record in records
+        if record["run_id"] == "safe-shift"
+        and record["rank"] == 2
+        and record["iteration"] == 1
+        and record["operation"] == "comm_b"
+    )
+    record["communicator_sequence_id"] += 1
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "communicator_sequence_divergence" in candidate["rejection_reasons"]
+
+
+def test_rank_skew_must_fit_inside_measured_slack_on_four_ranks():
+    records = _trace_fixture(4)
+    for record in records:
+        if record["run_id"] == "safe-shift" and record["rank"] == 3:
+            record["gpu_start_timestamp_ns"] += 250_000
+            record["gpu_end_timestamp_ns"] += 250_000
+            record["consumer_timestamp_ns"] += 250_000
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "rank_skew_exceeds_slack_headroom" in candidate["rejection_reasons"]
+
+
+def test_incomplete_four_rank_trial_is_rejected():
+    records = _trace_fixture(4)
+    records = [
+        record
+        for record in records
+        if not (
+            record["run_id"] == "safe-shift"
+            and record["rank"] == 3
+            and record["iteration"] == 1
+            and record["operation"] == "comm_b"
+        )
+    ]
+
+    with pytest.raises(TraceFormatError, match="has 1 'comm_a' records and 0 'comm_b' records"):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_declared_world_size_detects_an_entire_missing_rank_shard():
+    records = [record for record in _trace_fixture(4) if not (record["run_id"] == "safe-shift" and record["rank"] == 3)]
+
+    with pytest.raises(TraceFormatError, match=r"run 'safe-shift' has ranks \(0, 1, 2\), expected \(0, 1, 2, 3\)"):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_two_and_four_rank_workloads_are_tuned_independently():
+    records = _trace_fixture(2) + _trace_fixture(4)
+
+    payload = tune_traces(records, "comm_a", "comm_b", bootstrap_resamples=200)
+
+    assert [item["workload_key"]["world_size"] for item in payload["recommendations"]] == [2, 4]
+
+
+def test_negative_offset_uses_the_same_measured_policy_path():
+    records = _candidate_records(
+        2,
+        run_id="baseline",
+        policy="eager",
+        requested_offset_us=0,
+        realized_offset_us=0,
+        duration_a_us=1200,
+        duration_b_us=1100,
+        consumer_slack_us=100,
+    ) + _candidate_records(
+        2,
+        run_id="negative-shift",
+        policy="phase_shifted",
+        requested_offset_us=-200,
+        realized_offset_us=-180,
+        duration_a_us=700,
+        duration_b_us=800,
+        consumer_slack_us=80,
+    )
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "switch_policy"
+    assert recommendation["recommended_candidate"]["requested_offset_us"] == -200.0
+    assert recommendation["refinement"]["next_requested_offsets_us"] == [-100.0]
+
+
+def test_full_step_critical_path_overrides_pair_completion_fallback():
+    records = _candidate_records(
+        2,
+        run_id="baseline",
+        policy="eager",
+        requested_offset_us=0,
+        realized_offset_us=0,
+        duration_a_us=1200,
+        duration_b_us=1100,
+        consumer_slack_us=200,
+        critical_path_duration_us=2000,
+    ) + _candidate_records(
+        2,
+        run_id="shorter-pair-slower-step",
+        policy="phase_shifted",
+        requested_offset_us=200,
+        realized_offset_us=180,
+        duration_a_us=700,
+        duration_b_us=600,
+        consumer_slack_us=100,
+        critical_path_duration_us=2500,
+    )
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "keep_baseline"
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert candidate["critical_path_source"] == "trace_critical_path"
+    assert candidate["pair_completion_us_p95"] < recommendation["candidates"][0]["pair_completion_us_p95"]
+    assert candidate["critical_path_improvement_ci_us"][1] < 0
+
+
+def test_cli_writes_machine_readable_recommendation(tmp_path):
+    trace = tmp_path / "trace.jsonl"
+    output = tmp_path / "recommendation.json"
+    records = _trace_fixture(2)
+    trace.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "--trace-jsonl",
+                str(trace),
+                "--operation-a",
+                "comm_a",
+                "--operation-b",
+                "comm_b",
+                "--bootstrap-resamples",
+                "200",
+                "--output-json",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["recommendations"][0]["workload_key"]["world_size"] == 2
+
+
+def test_realized_offset_direction_mismatch_is_not_recommended():
+    records = deepcopy(_trace_fixture(2))
+    for record in records:
+        if record["run_id"] == "safe-shift" and record["operation"] == "comm_b":
+            a_record = next(
+                candidate
+                for candidate in records
+                if candidate["run_id"] == record["run_id"]
+                and candidate["rank"] == record["rank"]
+                and candidate["iteration"] == record["iteration"]
+                and candidate["operation"] == "comm_a"
+            )
+            duration_ns = record["gpu_end_timestamp_ns"] - record["gpu_start_timestamp_ns"]
+            slack_ns = record["consumer_timestamp_ns"] - record["gpu_end_timestamp_ns"]
+            record["gpu_start_timestamp_ns"] = a_record["gpu_start_timestamp_ns"] - 20_000
+            record["gpu_end_timestamp_ns"] = record["gpu_start_timestamp_ns"] + duration_ns
+            record["consumer_timestamp_ns"] = record["gpu_end_timestamp_ns"] + slack_ns
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "realized_offset_direction_mismatch" in candidate["rejection_reasons"]

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -238,7 +238,10 @@ def test_incomplete_four_rank_trial_is_rejected():
 def test_declared_world_size_detects_an_entire_missing_rank_shard():
     records = [record for record in _trace_fixture(4) if not (record["run_id"] == "safe-shift" and record["rank"] == 3)]
 
-    with pytest.raises(TraceFormatError, match=r"run 'safe-shift' has ranks \(0, 1, 2\), expected \(0, 1, 2, 3\)"):
+    with pytest.raises(
+        TraceFormatError,
+        match=r"run 'safe-shift': trace ranks \(0, 1, 2\) do not cover world_size 4",
+    ):
         tune_traces(records, "comm_a", "comm_b")
 
 

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -51,6 +51,9 @@ def _candidate_records(
                 "requested_offset_us": requested_offset_us,
                 "topology_class": "logical-fixture",
                 "transport": "fixture",
+                "timestamp_domain": "fixture-global-monotonic",
+                "gpu_timestamp_semantics": "kernel-observed",
+                "clock_sync_error_bound_us": 1.0,
                 "metadata": {
                     "policy": policy,
                     "completion_observed": True,
@@ -341,7 +344,8 @@ def test_cli_writes_machine_readable_recommendation(tmp_path):
         == 0
     )
     payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
+    assert payload["max_clock_sync_error_us"] == 50.0
     assert payload["recommendations"][0]["workload_key"]["world_size"] == 2
 
 
@@ -373,3 +377,65 @@ def test_realized_offset_direction_mismatch_is_not_recommended():
         candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
     )
     assert "realized_offset_direction_mismatch" in candidate["rejection_reasons"]
+
+
+def test_event_brackets_are_diagnostic_only_and_do_not_refine():
+    records = deepcopy(_trace_fixture(2))
+    for record in records:
+        record["gpu_timestamp_semantics"] = "event-bracket"
+
+    recommendation = tune_traces(records, "comm_a", "comm_b", bootstrap_resamples=200)["recommendations"][0]
+
+    assert recommendation["decision"] == "insufficient_evidence"
+    assert recommendation["refinement"]["next_candidates"] == []
+    assert all(
+        "kernel_observed_gpu_timestamps_required" in candidate["rejection_reasons"]
+        for candidate in recommendation["candidates"]
+    )
+
+
+def test_clock_sync_error_bound_fails_closed():
+    records = deepcopy(_trace_fixture(4))
+    for record in records:
+        record["clock_sync_error_bound_us"] = 75.0
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+        max_clock_sync_error_us=50.0,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "insufficient_evidence"
+    assert recommendation["refinement"]["next_candidates"] == []
+    assert all(
+        "clock_sync_error_bound_exceeded" in candidate["rejection_reasons"]
+        for candidate in recommendation["candidates"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("gpu_timestamp_semantics", "assumed-kernel", "gpu_timestamp_semantics"),
+        ("timestamp_domain", "", "timestamp_domain"),
+        ("clock_sync_error_bound_us", -1.0, "clock_sync_error_bound_us"),
+    ],
+)
+def test_timing_provenance_contract_rejects_invalid_values(field, value, message):
+    records = deepcopy(_trace_fixture(2))
+    for record in records:
+        record[field] = value
+
+    with pytest.raises(TraceFormatError, match=message):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_timing_provenance_is_required_on_both_pair_members():
+    records = deepcopy(_trace_fixture(2))
+    record = next(item for item in records if item["operation"] == "comm_b")
+    del record["gpu_timestamp_semantics"]
+
+    with pytest.raises(TraceFormatError, match="must be present on both paired records"):
+        tune_traces(records, "comm_a", "comm_b")

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -67,6 +67,7 @@ def _candidate_records(
                     {
                         **common,
                         "operation": "comm_a",
+                        "process_group_id": "group-a",
                         "message_bytes": 8192,
                         "communicator_sequence_id": trial,
                         "gpu_start_timestamp_ns": a_start_ns,
@@ -76,6 +77,7 @@ def _candidate_records(
                     {
                         **common,
                         "operation": "comm_b",
+                        "process_group_id": "group-b",
                         "message_bytes": 4096,
                         "communicator_sequence_id": trial,
                         "gpu_start_timestamp_ns": b_start_ns,
@@ -438,4 +440,34 @@ def test_timing_provenance_is_required_on_both_pair_members():
     del record["gpu_timestamp_semantics"]
 
     with pytest.raises(TraceFormatError, match="must be present on both paired records"):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("world_size", "world_size"),
+        ("process_group_id", "process_group_id must be a non-empty string"),
+        ("communicator_sequence_id", "communicator_sequence_id must be a finite number"),
+        ("completion_observed", "completion_observed=true is required"),
+    ],
+)
+def test_required_safety_evidence_cannot_be_omitted(field, message):
+    records = deepcopy(_trace_fixture(2))
+    record = next(item for item in records if item["operation"] == "comm_b")
+    if field == "completion_observed":
+        del record["metadata"][field]
+    else:
+        del record[field]
+
+    with pytest.raises(TraceFormatError, match=message):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_optional_pair_evidence_cannot_be_present_on_only_one_member():
+    records = deepcopy(_trace_fixture(2))
+    record = next(item for item in records if item["operation"] == "comm_b")
+    del record["requested_offset_us"]
+
+    with pytest.raises(TraceFormatError, match="present on both paired records or neither"):
         tune_traces(records, "comm_a", "comm_b")

--- a/tests/special_sanity/test_communication_topology_policy.py
+++ b/tests/special_sanity/test_communication_topology_policy.py
@@ -1,0 +1,306 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from scripts.autotune_communication_phase import tune_traces
+from scripts.communication_topology_policy import (
+    IncompatibleTopologyError,
+    TopologyEvidenceError,
+    TopologyFingerprint,
+    fingerprint_trace_run,
+    main,
+    select_compatible_policy_cells,
+)
+
+
+def _topology_records(world_size, topology_class, hosts, *, run_id="run", signature=None):
+    records = []
+    for rank in range(world_size):
+        record = {
+            "run_id": run_id,
+            "rank": rank,
+            "world_size": world_size,
+            "hostname": hosts[rank],
+            "topology_class": topology_class,
+            "accelerator_model": "logical-device",
+        }
+        if signature is not None:
+            record["topology_signature"] = signature
+        records.append(record)
+    return records
+
+
+def _tuning_records(
+    world_size,
+    topology_class,
+    *,
+    run_id,
+    policy,
+    requested_offset_us,
+    duration_us,
+):
+    records = []
+    for trial in range(3):
+        for rank in range(world_size):
+            a_start_ns = 1_000_000_000 + trial * 10_000_000 + rank * 1000
+            b_start_ns = a_start_ns + int((requested_offset_us * 0.8 + rank) * 1000)
+            common = {
+                "framework": "fixture",
+                "run_id": run_id,
+                "rank": rank,
+                "world_size": world_size,
+                "hostname": "host-a",
+                "accelerator_model": "logical-device",
+                "topology_class": topology_class,
+                "topology_signature": f"{topology_class}-layout",
+                "iteration": trial,
+                "microbatch": 0,
+                "layer": 1,
+                "requested_offset_us": requested_offset_us,
+                "transport": "fixture",
+                "timestamp_domain": "fixture-global-monotonic",
+                "gpu_timestamp_semantics": "kernel-observed",
+                "clock_sync_error_bound_us": 1.0,
+                "process_group_id": "group",
+                "communicator_sequence_id": trial,
+                "metadata": {"policy": policy, "completion_observed": True},
+            }
+            records.extend(
+                [
+                    {
+                        **common,
+                        "operation": "comm_a",
+                        "message_bytes": 8192,
+                        "gpu_start_timestamp_ns": a_start_ns,
+                        "gpu_end_timestamp_ns": a_start_ns + duration_us * 1000,
+                        "consumer_timestamp_ns": a_start_ns + duration_us * 1000,
+                    },
+                    {
+                        **common,
+                        "operation": "comm_b",
+                        "message_bytes": 4096,
+                        "gpu_start_timestamp_ns": b_start_ns,
+                        "gpu_end_timestamp_ns": b_start_ns + duration_us * 1000,
+                        "consumer_timestamp_ns": b_start_ns + (duration_us + 200) * 1000,
+                    },
+                ]
+            )
+    return records
+
+
+def test_single_node_pcie_and_nvlink_have_distinct_stable_cells():
+    pcie_records = _topology_records(4, "single-node-pcie", ["host-a"] * 4)
+    nvlink_records = _topology_records(4, "single-node-nvlink", ["host-b"] * 4)
+
+    pcie = fingerprint_trace_run(pcie_records)
+    reordered = fingerprint_trace_run(list(reversed(pcie_records)))
+    nvlink = fingerprint_trace_run(nvlink_records)
+
+    assert pcie.scope == "single_node"
+    assert pcie.local_fabric == "pcie"
+    assert pcie.rank_groups == ((0, 1, 2, 3),)
+    assert pcie.cell_id == reordered.cell_id
+    assert pcie.cell_id != nvlink.cell_id
+    assert pcie.compare(nvlink).reasons == ("local_fabric",)
+
+
+def test_multi_node_fingerprint_preserves_rank_placement():
+    records = _topology_records(
+        4,
+        "multi-node",
+        ["host-a", "host-a", "host-b", "host-b"],
+        signature="opaque-cluster-layout",
+    )
+
+    fingerprint = fingerprint_trace_run(records)
+
+    assert fingerprint.scope == "multi_node"
+    assert fingerprint.node_count == 2
+    assert fingerprint.rank_groups == ((0, 1), (2, 3))
+    assert fingerprint.to_dict()["ranks_per_node"] == [2, 2]
+
+
+def test_multi_node_rank_placements_are_different_cells():
+    contiguous = fingerprint_trace_run(
+        _topology_records(
+            4,
+            "multi-node",
+            ["host-a", "host-a", "host-b", "host-b"],
+            signature="same-cluster",
+        )
+    )
+    interleaved = fingerprint_trace_run(
+        _topology_records(
+            4,
+            "multi-node",
+            ["host-a", "host-b", "host-a", "host-b"],
+            signature="same-cluster",
+        )
+    )
+
+    assert contiguous.compare(interleaved).reasons == ("rank_groups",)
+    assert contiguous.cell_id != interleaved.cell_id
+
+
+def test_multi_node_without_topology_signature_fails_closed():
+    records = _topology_records(2, "multi-node", ["host-a", "host-b"])
+
+    with pytest.raises(TopologyEvidenceError, match="require an opaque topology_signature"):
+        fingerprint_trace_run(records)
+
+
+def test_partial_topology_signature_fails_closed():
+    records = _topology_records(
+        2,
+        "multi-node",
+        ["host-a", "host-b"],
+        signature="opaque-cluster-layout",
+    )
+    del records[1]["topology_signature"]
+
+    with pytest.raises(TopologyEvidenceError, match="missing on only some ranks"):
+        fingerprint_trace_run(records)
+
+
+def test_declared_single_node_class_cannot_hide_multiple_hosts():
+    records = _topology_records(2, "single-node-pcie", ["host-a", "host-b"])
+
+    with pytest.raises(TopologyEvidenceError, match="disagrees with observed node placement"):
+        fingerprint_trace_run(records)
+
+
+def test_stored_fingerprint_rejects_non_integer_rank():
+    fingerprint = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2)).to_dict()
+    fingerprint["rank_groups"] = [[0, 1.5]]
+
+    with pytest.raises(TopologyEvidenceError, match="malformed topology fingerprint"):
+        TopologyFingerprint.from_dict(fingerprint)
+
+
+def test_policy_cell_selection_rejects_cross_topology_fallback():
+    pcie = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2))
+    nvlink = fingerprint_trace_run(_topology_records(2, "single-node-nvlink", ["host-b"] * 2))
+    pcie_cell = {
+        "workload_key": {
+            "topology_cell_id": pcie.cell_id,
+            "topology_fingerprint": pcie.to_dict(),
+        },
+        "decision": "keep_baseline",
+    }
+
+    assert select_compatible_policy_cells([pcie_cell], pcie) == [pcie_cell]
+    with pytest.raises(IncompatibleTopologyError, match="local_fabric"):
+        select_compatible_policy_cells([pcie_cell], nvlink)
+
+
+def test_policy_cell_rejects_a_mismatched_stored_digest():
+    pcie = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2))
+    cell = {
+        "workload_key": {
+            "topology_cell_id": "topology-v1:not-the-fingerprint",
+            "topology_fingerprint": pcie.to_dict(),
+        }
+    }
+
+    with pytest.raises(TopologyEvidenceError, match="does not match its fingerprint"):
+        select_compatible_policy_cells([cell], pcie)
+
+
+def test_autotuner_selects_independently_inside_four_rank_topology_cells():
+    records = []
+    for topology_class, shifted_duration in (("single-node-pcie", 600), ("single-node-nvlink", 1200)):
+        records.extend(
+            _tuning_records(
+                4,
+                topology_class,
+                run_id=f"{topology_class}-baseline",
+                policy="eager",
+                requested_offset_us=0,
+                duration_us=1000,
+            )
+        )
+        records.extend(
+            _tuning_records(
+                4,
+                topology_class,
+                run_id=f"{topology_class}-shifted",
+                policy="phase_shifted",
+                requested_offset_us=100,
+                duration_us=shifted_duration,
+            )
+        )
+
+    recommendations = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"]
+
+    assert len(recommendations) == 2
+    by_topology = {item["workload_key"]["topology_class"]: item for item in recommendations}
+    assert by_topology["single-node-pcie"]["decision"] == "switch_policy"
+    assert by_topology["single-node-pcie"]["recommended_candidate"]["requested_offset_us"] == 100.0
+    assert by_topology["single-node-nvlink"]["decision"] == "keep_baseline"
+    assert (
+        by_topology["single-node-pcie"]["workload_key"]["topology_cell_id"]
+        != by_topology["single-node-nvlink"]["workload_key"]["topology_cell_id"]
+    )
+
+
+def test_selector_cli_uses_two_rank_target_trace(tmp_path):
+    pcie = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2))
+    policy = tmp_path / "policy.json"
+    traces = tmp_path / "target.jsonl"
+    output = tmp_path / "selected.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "recommendations": [
+                    {
+                        "workload_key": {
+                            "topology_cell_id": pcie.cell_id,
+                            "topology_fingerprint": pcie.to_dict(),
+                        },
+                        "decision": "keep_baseline",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    traces.write_text(
+        "".join(json.dumps(record) + "\n" for record in _topology_records(2, "single-node-pcie", ["new"] * 2)),
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "--policy-json",
+                str(policy),
+                "--target-trace-jsonl",
+                str(traces),
+                "--output-json",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(output.read_text(encoding="utf-8"))
+    assert selected["topology_cell_id"] == pcie.cell_id
+    assert len(selected["recommendations"]) == 1


### PR DESCRIPTION
## Draft update — 2026-09-05

Replays the topology cell on the hardened #7750 dependency. Exact topology matching remains mandatory; no extrapolation or hardware speedup claim.

Fresh duplicate checks found the existing #7750–#7755 stack and unrelated checkpoint changes; this updates the existing proposal instead of creating a duplicate. The human submitter confirmed line-by-line review and execution of relevant tests on 2026-09-05. AI assistance: OpenAI Codex. Remains Draft for outstanding production/hardware gates.

The original description and historical validation follow. Old dependency commit IDs below refer to the initial submission, not the updated head.

---

## Dependency

Depends on #7750. This is a stacked draft; until #7750 lands, the GitHub diff also contains its parent commit. Review the topology commit separately: `29fc8c7d`.

## Summary

- derive a canonical, content-addressed topology fingerprint from complete semantic trace shards
- distinguish single-node PCIe, single-node NVLink, and multi-node cells while also preserving world size, rank-to-node placement, and accelerator model by rank
- require an opaque topology inventory signature for multi-node evidence, where node count alone is insufficient
- partition autotuner evidence by exact topology cell before choosing a communication policy
- add a selector CLI that rejects every non-exact topology match rather than extrapolating a measured policy
- keep NIC traffic classes, rail assignment, routing, and transport control outside this PR

## Why this is not duplicate work

I searched open PRs for `topology aware communication policy`, `topology fingerprint collective`, and `communication topology policy`, plus open issues for `topology aware communication` and `topology fingerprint collective`. No existing implementation provides trace-derived topology cells or fail-closed compatibility for communication phase recommendations. #7750 is the only related PR and is the explicit dependency: it selects policies inside a cell, while this PR defines and enforces the cell boundary.

## Validation

- Python 3.12: `python -m pytest -q tests/special_sanity/test_communication_phase_autotuner.py tests/special_sanity/test_communication_topology_policy.py` — 23 passed
- Python 3.10: `uv run --isolated --no-project --python 3.10 --with pytest python -m pytest -q tests/special_sanity/test_communication_phase_autotuner.py tests/special_sanity/test_communication_topology_policy.py` — 23 passed
- direct CLI import smoke tests passed for both scripts
- targeted `pre-commit run --files ...` — all hooks passed, including ruff, formatting, mypy, docs, license, structure, and compileall
- fixtures use only logical 2-rank and 4-rank CPU data; this PR makes no hardware performance claim

## AI assistance disclosure

This draft was developed with OpenAI Codex assistance. The human submitter must review and understand every changed line and be prepared to defend the compatibility model and test coverage before marking it ready for review.
