### PR TITLE
[profiling] Add semantic communication NVTX ranges

### DIFF
--- a/docs/perf/nsight_profiling.md
+++ b/docs/perf/nsight_profiling.md
@@ -135,3 +135,17 @@ When profiling is enabled, verl will generate Nsight Systems profiles for the sp
 - NVTX markers for key operations
 
 Nsight Systems supports multi-report view, to open multiple databases together. In this mode, different processes and steps can be aligned in one time line for better analysis.
+
+## Semantic communication ranges
+
+Set `VERL_COMM_TRACE=1` before starting workers to add opt-in ranges for
+Ulysses all-to-all/all-gather operations and NCCL checkpoint weight transfer.
+The labels begin with `verl.comm/` and include available step, microbatch,
+direction, byte count, process-group identity, and logical sequence metadata.
+The FSDP engine propagates `global_steps` and its microbatch index into nested
+Ulysses ranges; checkpoint transfer propagates its supplied global step.
+
+The switch is disabled by default. It does not create a second profiler or
+change collective ordering. NVTX identifies the semantic API call so Nsight
+Systems can correlate it with NCCL kernels; the NVTX range boundary itself is
+not an exact kernel start/end timestamp.

--- a/tests/utils/test_comm_trace.py
+++ b/tests/utils/test_comm_trace.py
@@ -28,6 +28,14 @@ comm_trace = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(comm_trace)
 
 
+def _reload_comm_trace(module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _load_ulysses_module(monkeypatch):
     verl_package = types.ModuleType("verl")
     verl_package.__path__ = []
@@ -45,8 +53,35 @@ def _load_ulysses_module(monkeypatch):
     return module
 
 
+def _install_fake_device_api(monkeypatch, *, vendor, device_module):
+    verl_package = types.ModuleType("verl")
+    verl_package.__path__ = []
+    utils_package = types.ModuleType("verl.utils")
+    utils_package.__path__ = []
+    device_api = types.ModuleType("verl.utils.device")
+    device_api.get_vendor = lambda: vendor
+    device_api.get_torch_device = lambda: device_module
+    monkeypatch.setitem(sys.modules, "verl", verl_package)
+    monkeypatch.setitem(sys.modules, "verl.utils", utils_package)
+    monkeypatch.setitem(sys.modules, "verl.utils.device", device_api)
+
+
 class _FakeGroup:
     group_name = "sp-group-0"
+
+
+class _UnnamedGroup:
+    pass
+
+
+def test_trace_is_disabled_by_default_and_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.delenv("VERL_COMM_TRACE", raising=False)
+    default_module = _reload_comm_trace("comm_trace_default_under_test")
+    assert default_module._COMM_TRACE_ENABLED is False
+
+    monkeypatch.setenv("VERL_COMM_TRACE", "1")
+    enabled_module = _reload_comm_trace("comm_trace_enabled_under_test")
+    assert enabled_module._COMM_TRACE_ENABLED is True
 
 
 def test_format_communication_range_has_stable_field_order_and_escaping():
@@ -71,8 +106,7 @@ def test_communication_trace_context_is_nested_and_restored(monkeypatch):
         yield
 
     monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", True)
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-    monkeypatch.setattr(torch.cuda.nvtx, "range", fake_range)
+    monkeypatch.setattr(comm_trace, "_get_nvtx_range", lambda: fake_range)
 
     tensor = torch.empty(16, dtype=torch.float32)
     with comm_trace.communication_trace_context(step=3, microbatch=2, layer=11, logical_sequence_id="3/2/11"):
@@ -90,15 +124,36 @@ def test_communication_trace_context_is_nested_and_restored(monkeypatch):
 
 def test_disabled_trace_is_a_noop(monkeypatch):
     monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", False)
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: pytest.fail("CUDA probe should not run"))
-    with comm_trace.communication_nvtx_range("ulysses_a2a"):
-        pass
+    monkeypatch.setattr(comm_trace, "_get_nvtx_range", lambda: None)
+    with comm_trace.communication_trace_context(step=9):
+        assert comm_trace._COMM_CONTEXT.get() is None
+        with comm_trace.communication_nvtx_range("ulysses_a2a"):
+            pass
 
 
-def test_rocm_trace_is_a_noop(monkeypatch):
+def test_unnamed_process_group_uses_membership_not_only_size(monkeypatch):
+    group = _UnnamedGroup()
+    monkeypatch.setattr(comm_trace.dist, "_get_process_group_name", None, raising=False)
+    monkeypatch.setattr(comm_trace.dist, "get_process_group_ranks", lambda candidate: [0, 2])
+    assert comm_trace._process_group_id(group) == "ranks-0,2"
+
+
+def test_nvtx_factory_uses_platform_device_abstraction(monkeypatch):
+    @contextmanager
+    def fake_range(_message):
+        yield
+
+    device_module = types.SimpleNamespace(is_available=lambda: True, nvtx=types.SimpleNamespace(range=fake_range))
+    _install_fake_device_api(monkeypatch, vendor="nvidia", device_module=device_module)
     monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", True)
-    monkeypatch.setattr(torch.version, "hip", "6.3")
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: pytest.fail("CUDA probe should not run on ROCm"))
+    assert comm_trace._get_nvtx_range() is fake_range
+
+
+def test_non_nvidia_trace_is_a_noop(monkeypatch):
+    device_module = types.SimpleNamespace(is_available=lambda: pytest.fail("device probe should not run"))
+    _install_fake_device_api(monkeypatch, vendor="amd", device_module=device_module)
+    monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", True)
+    assert comm_trace._get_nvtx_range() is None
     with comm_trace.communication_nvtx_range("ulysses_a2a"):
         pass
 
@@ -118,8 +173,7 @@ def test_explicit_process_group_id_supports_non_torch_collectives(monkeypatch):
         yield
 
     monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", True)
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-    monkeypatch.setattr(torch.cuda.nvtx, "range", fake_range)
+    monkeypatch.setattr(comm_trace, "_get_nvtx_range", lambda: fake_range)
     with comm_trace.communication_nvtx_range(
         "weight_sync",
         step=19,

--- a/tests/utils/test_comm_trace.py
+++ b/tests/utils/test_comm_trace.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+import torch
+
+_MODULE_PATH = Path(__file__).parents[2] / "verl" / "utils" / "comm_trace.py"
+_SPEC = importlib.util.spec_from_file_location("comm_trace_under_test", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+comm_trace = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(comm_trace)
+
+
+def _load_ulysses_module(monkeypatch):
+    verl_package = types.ModuleType("verl")
+    verl_package.__path__ = []
+    utils_package = types.ModuleType("verl.utils")
+    utils_package.__path__ = []
+    monkeypatch.setitem(sys.modules, "verl", verl_package)
+    monkeypatch.setitem(sys.modules, "verl.utils", utils_package)
+    monkeypatch.setitem(sys.modules, "verl.utils.comm_trace", comm_trace)
+
+    module_path = _MODULE_PATH.with_name("ulysses.py")
+    spec = importlib.util.spec_from_file_location("ulysses_under_test", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeGroup:
+    group_name = "sp-group-0"
+
+
+def test_format_communication_range_has_stable_field_order_and_escaping():
+    label = comm_trace.format_communication_range(
+        "ulysses_a2a",
+        requested_offset_us=500,
+        direction="scatter=2|gather=1",
+        step=7,
+        message_bytes=4096,
+    )
+    assert label == (
+        "verl.comm/ulysses_a2a|step=7|direction=scatter%3D2%7Cgather%3D1|message_bytes=4096|requested_offset_us=500"
+    )
+
+
+def test_communication_trace_context_is_nested_and_restored(monkeypatch):
+    labels = []
+
+    @contextmanager
+    def fake_range(message):
+        labels.append(message)
+        yield
+
+    monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda.nvtx, "range", fake_range)
+
+    tensor = torch.empty(16, dtype=torch.float32)
+    with comm_trace.communication_trace_context(step=3, microbatch=2, layer=11, logical_sequence_id="3/2/11"):
+        with comm_trace.communication_nvtx_range(
+            "ulysses_a2a", tensor=tensor, group=_FakeGroup(), direction="scatter_dim=2,gather_dim=1"
+        ):
+            pass
+
+    assert labels == [
+        "verl.comm/ulysses_a2a|step=3|microbatch=2|layer=11|direction=scatter_dim%3D2,gather_dim%3D1|"
+        "message_bytes=64|process_group_id=sp-group-0|logical_sequence_id=3/2/11"
+    ]
+    assert comm_trace._COMM_CONTEXT.get() is None
+
+
+def test_disabled_trace_is_a_noop(monkeypatch):
+    monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: pytest.fail("CUDA probe should not run"))
+    with comm_trace.communication_nvtx_range("ulysses_a2a"):
+        pass
+
+
+def test_rocm_trace_is_a_noop(monkeypatch):
+    monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", True)
+    monkeypatch.setattr(torch.version, "hip", "6.3")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: pytest.fail("CUDA probe should not run on ROCm"))
+    with comm_trace.communication_nvtx_range("ulysses_a2a"):
+        pass
+
+
+def test_unknown_field_is_rejected():
+    with pytest.raises(ValueError, match="unsupported communication trace fields"):
+        with comm_trace.communication_trace_context(typo_field=1):
+            pass
+
+
+def test_explicit_process_group_id_supports_non_torch_collectives(monkeypatch):
+    labels = []
+
+    @contextmanager
+    def fake_range(message):
+        labels.append(message)
+        yield
+
+    monkeypatch.setattr(comm_trace, "_COMM_TRACE_ENABLED", True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda.nvtx, "range", fake_range)
+    with comm_trace.communication_nvtx_range(
+        "weight_sync",
+        step=19,
+        direction="send",
+        message_bytes=1024,
+        process_group_id="rollout-update",
+        logical_sequence_id="bucket-2",
+    ):
+        pass
+
+    assert labels[0].startswith(
+        "verl.comm/weight_sync|step=19|direction=send|message_bytes=1024|process_group_id=rollout-update|"
+        "logical_sequence_id=bucket-2"
+    )
+
+
+def test_ulysses_collectives_have_semantic_ranges(monkeypatch):
+    ulysses = _load_ulysses_module(monkeypatch)
+    ranges = []
+
+    @contextmanager
+    def fake_range(operation, **metadata):
+        ranges.append((operation, metadata))
+        yield
+
+    group = object()
+    monkeypatch.setattr(ulysses, "communication_nvtx_range", fake_range)
+    monkeypatch.setattr(ulysses.dist, "get_world_size", lambda group=None: 2)
+
+    def fake_all_to_all(output_list, input_list, **kwargs):
+        for output, input_ in zip(output_list, input_list, strict=True):
+            output.copy_(input_)
+
+    def fake_all_gather_into_tensor(output, input_, **kwargs):
+        output[: input_.shape[0]].copy_(input_)
+        output[input_.shape[0] :].copy_(input_)
+
+    monkeypatch.setattr(ulysses.dist, "all_to_all", fake_all_to_all)
+    monkeypatch.setattr(ulysses.dist, "all_gather_into_tensor", fake_all_gather_into_tensor)
+
+    tensor = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    assert torch.equal(ulysses.all_to_all_tensor(tensor, 0, 0, group), tensor)
+    assert torch.equal(ulysses.all_gather_tensor(tensor, group), torch.cat((tensor, tensor)))
+
+    assert [operation for operation, _ in ranges] == ["ulysses_a2a", "ulysses_all_gather"]
+    assert ranges[0][1]["tensor"] is tensor
+    assert ranges[0][1]["group"] is group
+    assert ranges[0][1]["direction"] == "scatter_dim=0,gather_dim=0"
+    assert set(ranges[1][1]) == {"tensor", "group"}
+    assert ranges[1][1]["tensor"] is tensor
+    assert ranges[1][1]["group"] is group

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -34,6 +34,7 @@ from verl.checkpoint_engine.base import (
     merge_weight_chunks,
     split_weight_chunks,
 )
+from verl.utils.comm_trace import communication_nvtx_range
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,7 @@ class BroadcastOperation:
         metadata: dict[str, TensorMeta],
         socket: zmq.Socket,
         topic: str,
+        step: int | None = None,
     ) -> None:
         self.rank = rank
         self.group_name = group_name
@@ -88,6 +90,7 @@ class BroadcastOperation:
         self.metadata = metadata
         self.socket = socket
         self.topic = topic
+        self.step = step
 
         loop = asyncio.get_running_loop()
         self._task = loop.run_in_executor(None, self._run)
@@ -103,7 +106,15 @@ class BroadcastOperation:
             self.bucket = self.bucket[: self.metadata["length"]]
 
         # broadcast tensor via NCCL
-        collective.broadcast(self.bucket, src_rank=0, group_name=self.group_name)
+        direction = "send" if self.rank == 0 else "receive"
+        with communication_nvtx_range(
+            "weight_sync",
+            step=self.step,
+            direction=direction,
+            message_bytes=int(self.bucket.nbytes),
+            process_group_id=self.group_name,
+        ):
+            collective.broadcast(self.bucket, src_rank=0, group_name=self.group_name)
 
     async def wait_for_complete(self) -> dict[str, TensorMeta]:
         """Wait for the broadcast operation to complete.
@@ -332,7 +343,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
             return
 
         if self.rank > 0:
-            await self._relay_weights(weights)
+            await self._relay_weights(weights, global_steps=global_steps)
             return
 
         send_buf, recv_buf = self.send_buf, self.recv_buf
@@ -363,6 +374,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
                     metadata={"bucket_meta": bucket_meta, "is_last": False, "length": offset},
                     socket=self.socket,
                     topic=self.topic,
+                    step=global_steps,
                 )
 
                 # swap send_buf and recv_buf
@@ -394,6 +406,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
             metadata={"bucket_meta": bucket_meta, "is_last": True, "length": offset},
             socket=self.socket,
             topic=self.topic,
+            step=global_steps,
         )
         await broadcast_op.wait_for_complete()
 
@@ -404,7 +417,9 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
         logger.info(f"Rank {self.rank} send weights done, time cost: {time.time() - start_time:.2f}s")
 
-    async def _relay_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    async def _relay_weights(
+        self, weights: Generator[tuple[str, torch.Tensor], None, None], global_steps: int | None = None
+    ):
         """Join every broadcast as an NVLink-local relay for rank 0, dropping the payload.
 
         A relay holds nothing the rollout needs, so it only has to match the root bucket for
@@ -420,13 +435,27 @@ class NCCLCheckpointEngine(CheckpointEngine):
         # a single buffer suffices: nothing reads the bucket, so successive broadcasts can share it
         async for tensor_meta, _ in split_weight_chunks(weights, self.bucket_size, meta_only=True):
             if offset + tensor_meta.chunk_size > self.bucket_size:
-                collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)
+                with communication_nvtx_range(
+                    "weight_sync",
+                    step=global_steps,
+                    direction="relay",
+                    message_bytes=int(self.recv_buf[:offset].nbytes),
+                    process_group_id=self.group_name,
+                ):
+                    collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)
                 offset = 0
 
             offset += tensor_meta.chunk_size
 
         # relay last bucket
-        collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)
+        with communication_nvtx_range(
+            "weight_sync",
+            step=global_steps,
+            direction="relay",
+            message_bytes=int(self.recv_buf[:offset].nbytes),
+            process_group_id=self.group_name,
+        ):
+            collective.broadcast(self.recv_buf[:offset], src_rank=0, group_name=self.group_name)
 
         # wait for the enqueued NCCL kernels, so finalize() cannot free the buffer under them
         torch.cuda.synchronize()
@@ -443,10 +472,14 @@ class NCCLCheckpointEngine(CheckpointEngine):
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
         """
-        async for name, weight in merge_weight_chunks(self._receive_weight_chunks(), self.bucket_size):
+        async for name, weight in merge_weight_chunks(
+            self._receive_weight_chunks(global_steps=global_steps), self.bucket_size
+        ):
             yield name, weight
 
-    async def _receive_weight_chunks(self) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    async def _receive_weight_chunks(
+        self, global_steps: int | None = None
+    ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
         """Receive the weight chunks of the model.
 
         Yields:
@@ -465,6 +498,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
             metadata=None,
             socket=self.socket,
             topic=self.topic,
+            step=global_steps,
         )
         metadata = await broadcast_op.wait_for_complete()
         total_bytes += metadata["length"]
@@ -486,6 +520,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
                 metadata=None,
                 socket=self.socket,
                 topic=self.topic,
+                step=global_steps,
             )
 
             # 2. yield tensor from send_buf

--- a/verl/utils/comm_trace.py
+++ b/verl/utils/comm_trace.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Low-overhead semantic NVTX ranges for distributed communication.
 
-Set ``VERL_COMM_TRACE=0`` before importing this module to disable the ranges.
-The default is enabled so an Nsight Systems run contains semantic collective
-names without requiring a second, differently configured training run.
+Set ``VERL_COMM_TRACE=1`` before importing this module to enable the ranges.
+The default is disabled so normal training does not pay NVTX or metadata
+construction overhead unless semantic communication tracing is requested.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ _TRACE_FIELDS = (
     "logical_sequence_id",
     "requested_offset_us",
 )
-_COMM_TRACE_ENABLED = os.environ.get("VERL_COMM_TRACE", "1").lower() not in {"0", "false", "off", "no"}
+_COMM_TRACE_ENABLED = os.environ.get("VERL_COMM_TRACE", "0").lower() not in {"0", "false", "off", "no"}
 _COMM_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar("verl_comm_trace_context", default=None)
 _SEQUENCE_LOCK = threading.Lock()
 _SEQUENCE_IDS: dict[tuple[int, str | None], int] = {}
@@ -55,9 +55,18 @@ def _process_group_id(group: dist.ProcessGroup | None) -> str:
             return "world"
         group = dist.group.WORLD
     name = getattr(group, "group_name", None)
+    if name is None:
+        get_group_name = getattr(dist, "_get_process_group_name", None)
+        if callable(get_group_name):
+            name = get_group_name(group)
     if name is not None:
         return str(name)
-    return "world" if group is dist.group.WORLD else f"group-size-{dist.get_world_size(group)}"
+    if group is dist.group.WORLD:
+        return "world"
+    get_group_ranks = getattr(dist, "get_process_group_ranks", None)
+    if callable(get_group_ranks):
+        return "ranks-" + ",".join(str(rank) for rank in get_group_ranks(group))
+    return f"unnamed-group-size-{dist.get_world_size(group)}"
 
 
 def _next_sequence_id(group: dist.ProcessGroup | None, process_group_id: str | None = None) -> int:
@@ -70,15 +79,22 @@ def _next_sequence_id(group: dist.ProcessGroup | None, process_group_id: str | N
     return sequence_id
 
 
-def _nvtx_available() -> bool:
-    """Return whether this process can emit NVIDIA NVTX ranges."""
+def _get_nvtx_range():
+    """Return the platform NVTX range factory when NVIDIA tracing is available."""
 
-    return (
-        _COMM_TRACE_ENABLED
-        and getattr(torch.version, "hip", None) is None
-        and torch.cuda.is_available()
-        and callable(getattr(getattr(torch.cuda, "nvtx", None), "range", None))
-    )
+    if not _COMM_TRACE_ENABLED:
+        return None
+    # Keep this import lazy. ``comm_trace`` is also used by lightweight tools
+    # that deliberately do not import verl's worker/runtime dependencies.
+    from verl.utils.device import get_torch_device, get_vendor
+
+    if get_vendor() != "nvidia":
+        return None
+    device_module = get_torch_device()
+    if not device_module.is_available():
+        return None
+    nvtx_range = getattr(getattr(device_module, "nvtx", None), "range", None)
+    return nvtx_range if callable(nvtx_range) else None
 
 
 def format_communication_range(operation: str, **metadata: Any) -> str:
@@ -100,6 +116,9 @@ def communication_trace_context(**metadata: Any) -> Iterator[None]:
     unknown = metadata.keys() - _TRACE_FIELDS
     if unknown:
         raise ValueError(f"unsupported communication trace fields: {sorted(unknown)}")
+    if not _COMM_TRACE_ENABLED:
+        yield
+        return
     merged = {**(_COMM_CONTEXT.get() or {}), **{key: value for key, value in metadata.items() if value is not None}}
     token = _COMM_CONTEXT.set(merged)
     try:
@@ -130,7 +149,8 @@ def communication_nvtx_range(
     with its Ulysses/FSDP/Megatron meaning.
     """
 
-    if not _nvtx_available():
+    nvtx_range = _get_nvtx_range()
+    if nvtx_range is None:
         yield
         return
     metadata = dict(_COMM_CONTEXT.get() or {})
@@ -162,5 +182,5 @@ def communication_nvtx_range(
         }
     )
     message = format_communication_range(operation, **metadata)
-    with torch.cuda.nvtx.range(message):
+    with nvtx_range(message):
         yield

--- a/verl/utils/comm_trace.py
+++ b/verl/utils/comm_trace.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Low-overhead semantic NVTX ranges for distributed communication.
+
+Set ``VERL_COMM_TRACE=0`` before importing this module to disable the ranges.
+The default is enabled so an Nsight Systems run contains semantic collective
+names without requiring a second, differently configured training run.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator
+
+import torch
+import torch.distributed as dist
+
+_TRACE_FIELDS = (
+    "step",
+    "microbatch",
+    "layer",
+    "direction",
+    "message_bytes",
+    "process_group_id",
+    "logical_sequence_id",
+    "requested_offset_us",
+)
+_COMM_TRACE_ENABLED = os.environ.get("VERL_COMM_TRACE", "1").lower() not in {"0", "false", "off", "no"}
+_COMM_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar("verl_comm_trace_context", default=None)
+_SEQUENCE_LOCK = threading.Lock()
+_SEQUENCE_IDS: dict[tuple[int, str | None], int] = {}
+
+
+def _escape(value: Any) -> str:
+    return str(value).replace("%", "%25").replace("|", "%7C").replace("=", "%3D")
+
+
+def _process_group_id(group: dist.ProcessGroup | None) -> str:
+    if group is None:
+        if not dist.is_initialized():
+            return "world"
+        group = dist.group.WORLD
+    name = getattr(group, "group_name", None)
+    if name is not None:
+        return str(name)
+    return "world" if group is dist.group.WORLD else f"group-size-{dist.get_world_size(group)}"
+
+
+def _next_sequence_id(group: dist.ProcessGroup | None, process_group_id: str | None = None) -> int:
+    if group is None and dist.is_initialized():
+        group = dist.group.WORLD
+    key = (id(group), process_group_id)
+    with _SEQUENCE_LOCK:
+        sequence_id = _SEQUENCE_IDS.get(key, 0)
+        _SEQUENCE_IDS[key] = sequence_id + 1
+    return sequence_id
+
+
+def _nvtx_available() -> bool:
+    """Return whether this process can emit NVIDIA NVTX ranges."""
+
+    return (
+        _COMM_TRACE_ENABLED
+        and getattr(torch.version, "hip", None) is None
+        and torch.cuda.is_available()
+        and callable(getattr(getattr(torch.cuda, "nvtx", None), "range", None))
+    )
+
+
+def format_communication_range(operation: str, **metadata: Any) -> str:
+    """Build a deterministic, parseable ``verl.comm/*`` range label."""
+
+    if not operation or "|" in operation or "=" in operation:
+        raise ValueError("operation must be non-empty and cannot contain '|' or '='")
+    unknown = metadata.keys() - _TRACE_FIELDS
+    if unknown:
+        raise ValueError(f"unsupported communication trace fields: {sorted(unknown)}")
+    fields = [f"{name}={_escape(metadata[name])}" for name in _TRACE_FIELDS if metadata.get(name) is not None]
+    return "|".join((f"verl.comm/{operation}", *fields))
+
+
+@contextmanager
+def communication_trace_context(**metadata: Any) -> Iterator[None]:
+    """Attach step/microbatch/layer metadata to nested communication ranges."""
+
+    unknown = metadata.keys() - _TRACE_FIELDS
+    if unknown:
+        raise ValueError(f"unsupported communication trace fields: {sorted(unknown)}")
+    merged = {**(_COMM_CONTEXT.get() or {}), **{key: value for key, value in metadata.items() if value is not None}}
+    token = _COMM_CONTEXT.set(merged)
+    try:
+        yield
+    finally:
+        _COMM_CONTEXT.reset(token)
+
+
+@contextmanager
+def communication_nvtx_range(
+    operation: str,
+    *,
+    tensor: torch.Tensor | None = None,
+    group: dist.ProcessGroup | None = None,
+    step: int | None = None,
+    microbatch: int | None = None,
+    layer: int | str | None = None,
+    direction: str | None = None,
+    message_bytes: int | None = None,
+    process_group_id: str | None = None,
+    logical_sequence_id: int | str | None = None,
+    requested_offset_us: int | float | None = None,
+) -> Iterator[None]:
+    """Open a semantic NVTX range around a collective launch.
+
+    The range describes the framework operation rather than the transport
+    kernel. Nsight Systems can therefore associate the enclosed NCCL API call
+    with its Ulysses/FSDP/Megatron meaning.
+    """
+
+    if not _nvtx_available():
+        yield
+        return
+    metadata = dict(_COMM_CONTEXT.get() or {})
+    resolved_group_id = process_group_id if process_group_id is not None else _process_group_id(group)
+    metadata.update(
+        {
+            "step": step if step is not None else metadata.get("step"),
+            "microbatch": microbatch if microbatch is not None else metadata.get("microbatch"),
+            "layer": layer if layer is not None else metadata.get("layer"),
+            "direction": direction if direction is not None else metadata.get("direction"),
+            "message_bytes": (
+                message_bytes
+                if message_bytes is not None
+                else tensor.numel() * tensor.element_size()
+                if tensor is not None
+                else metadata.get("message_bytes")
+            ),
+            "process_group_id": resolved_group_id,
+            "logical_sequence_id": (
+                logical_sequence_id
+                if logical_sequence_id is not None
+                else metadata["logical_sequence_id"]
+                if metadata.get("logical_sequence_id") is not None
+                else _next_sequence_id(group, resolved_group_id)
+            ),
+            "requested_offset_us": (
+                requested_offset_us if requested_offset_us is not None else metadata.get("requested_offset_us")
+            ),
+        }
+    )
+    message = format_communication_range(operation, **metadata)
+    with torch.cuda.nvtx.range(message):
+        yield

--- a/verl/utils/ulysses.py
+++ b/verl/utils/ulysses.py
@@ -25,6 +25,8 @@ from torch import Tensor
 from torch.distributed import ProcessGroup
 from torch.distributed.device_mesh import DeviceMesh
 
+from verl.utils.comm_trace import communication_nvtx_range
+
 if TYPE_CHECKING:
     from verl import DataProto
 
@@ -145,7 +147,9 @@ def all_to_all_tensor(
     seq_world_size = dist.get_world_size(group)
     input_list = [t.contiguous() for t in torch.tensor_split(local_input, seq_world_size, scatter_dim)]
     output_list = [torch.empty_like(input_list[0]) for _ in range(seq_world_size)]
-    comm = dist.all_to_all(output_list, input_list, group=group, async_op=async_op)
+    direction = f"scatter_dim={scatter_dim},gather_dim={gather_dim}"
+    with communication_nvtx_range("ulysses_a2a", tensor=local_input, group=group, direction=direction):
+        comm = dist.all_to_all(output_list, input_list, group=group, async_op=async_op)
     if async_op:
 
         def wait():
@@ -162,7 +166,8 @@ def all_gather_tensor(local_tensor: Tensor, group: Optional[dist.ProcessGroup] =
     output_shape = list(local_tensor.shape)
     output_shape[0] = output_shape[0] * sp_world_size
     output = torch.empty(output_shape, dtype=local_tensor.dtype, device=local_tensor.device)
-    dist.all_gather_into_tensor(output, local_tensor, group=group, async_op=async_op)
+    with communication_nvtx_range("ulysses_all_gather", tensor=local_tensor, group=group):
+        dist.all_gather_into_tensor(output, local_tensor, group=group, async_op=async_op)
     return output
 
 

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -721,6 +721,7 @@ class FSDPEngine(BaseEngine):
         # note that the global_batch_size should include data on all the dp
         tu.assign_non_tensor(data, sp_size=self.ulysses_sequence_parallel_size)
         return_model_output = tu.get_non_tensor_data(data=data, key="return_model_output", default=False)
+        global_step = tu.get(data, key="global_steps", default=None)
 
         # compute num_tokens in global batch for loss normalization
         batch_num_tokens = data["loss_mask"].sum().to(get_device_id())
@@ -754,7 +755,7 @@ class FSDPEngine(BaseEngine):
             # distinguishable "micro_batch<i>" row -- nested under the update loop's "mini_batch<i>"
             # when training, or directly under the stage for log-prob.
             with (
-                communication_trace_context(microbatch=micro_batch_idx),
+                communication_trace_context(step=global_step, microbatch=micro_batch_idx),
                 ctx,
                 sync_ctx,
                 torch.profiler.record_function(f"micro_batch{micro_batch_idx}"),

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -37,6 +37,7 @@ from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.activation_offload import enable_activation_offloading
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
+from verl.utils.comm_trace import communication_trace_context
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.debug import log_gpu_memory_usage
 from verl.utils.device import get_device_id, get_device_name
@@ -752,7 +753,12 @@ class FSDPEngine(BaseEngine):
             # inside; here every micro-batch forward (and, when training, its backward) becomes a
             # distinguishable "micro_batch<i>" row -- nested under the update loop's "mini_batch<i>"
             # when training, or directly under the stage for log-prob.
-            with ctx, sync_ctx, torch.profiler.record_function(f"micro_batch{micro_batch_idx}"):
+            with (
+                communication_trace_context(microbatch=micro_batch_idx),
+                ctx,
+                sync_ctx,
+                torch.profiler.record_function(f"micro_batch{micro_batch_idx}"),
+            ):
                 loss, meta_info = self.forward_step(micro_batch, loss_function=loss_function, forward_only=forward_only)
 
                 if not forward_only:


### PR DESCRIPTION
## Draft update — 2026-09-05

Includes semantic-range hot-path and validation hardening on the updated upstream base. Observability only; does not change communication scheduling.

Fresh duplicate checks found the existing #7750–#7755 stack and unrelated checkpoint changes; this updates the existing proposal instead of creating a duplicate. The human submitter confirmed line-by-line review and execution of relevant tests on 2026-09-05. AI assistance: OpenAI Codex. Remains Draft for outstanding production/hardware gates.

The original description and historical validation follow. Old dependency commit IDs below refer to the initial submission, not the updated head.

---

## Summary

- add opt-in semantic NVTX ranges with stable, escaped metadata for communication operations
- annotate Ulysses all-to-all/all-gather and NCCL checkpoint weight synchronization with step, microbatch, layer, direction, bytes, process-group identity, logical sequence, and requested offset when available
- keep disabled and ROCm paths as no-ops so the default runtime behavior is unchanged

## Why this is not duplicate work

I searched open PRs and issues for semantic communication NVTX ranges, Ulysses NVTX tracing, and weight-sync NVTX metadata. I found no existing implementation that supplies stable cross-path semantic labels for these communication boundaries. This draft is instrumentation only; it does not schedule collectives or change communication ordering.

## Validation

- targeted CPU test: `python -m pytest -q tests/utils/test_comm_trace.py` — 7 passed
- tests cover stable field ordering and escaping, nested context restoration, disabled and ROCm no-op behavior, field validation, explicit process-group identity, and Ulysses range propagation
- this PR makes no hardware performance claim

## AI assistance disclosure

This draft was developed with OpenAI Codex assistance. The human submitter must review and understand every changed line and be prepared to defend the design and test coverage before marking it ready for review.
