### PR TITLE
[distributed] Add structured async collective handles

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -112,6 +112,7 @@ verl is fast with:
    perf/verl_profiler_system.md
    perf/nsight_profiling.md
    perf/torch_profiling.md
+   perf/async_collective_handles.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/perf/async_collective_handles.md
+++ b/docs/perf/async_collective_handles.md
@@ -1,0 +1,42 @@
+# Async collective handle stream contract
+
+Last updated: 09/05/2026.
+
+`verl.utils.collective.AsyncCollectiveHandle` separates communication waiting
+from result finalization. It owns references needed by the asynchronous work
+and runs the finalizer at most once.
+
+For CUDA collectives, pass the result tensor's device as `consumer_device`.
+The first call to `wait_collective()`, `finalize_result()`, or `wait()` binds
+the handle to the current CUDA stream on that device. All later calls must use
+that same stream. A call from another stream raises an error instead of
+silently returning a result whose dependency was established elsewhere.
+
+`Work.wait()` establishes ordering on the bound CUDA stream. It does not mean
+that the CPU waited for physical kernel completion. `complete_event`, when
+provided, is recorded on the bound stream after `Work.wait()` and before the
+result finalizer. CUDA layout and copy operations started by the finalizer are
+therefore ordered before later consumers on the same stream.
+
+The handle does not support implicit consumption from multiple CUDA streams.
+Code that needs that behavior must establish and own an explicit cross-stream
+event protocol outside this API. Do not use the global `finalized` state as a
+substitute for a per-stream dependency.
+
+A finalizer exception is cached. Later waits re-raise the same exception
+without executing the finalizer again. `owned_resources` must be a tuple and
+keeps input, output, and staging objects alive until the handle itself is
+released.
+
+The opt-in two- or four-rank NCCL validation is:
+
+```bash
+VERL_RUN_ASYNC_COLLECTIVE_NCCL_TEST=1 \
+VERL_ASYNC_COLLECTIVE_WORLD_SIZE=2 \
+python -m pytest -q tests/utils/test_async_collective_cuda.py
+```
+
+The test deliberately rejects any world size other than two or four. It
+checks same-stream asynchronous finalization, exact-once finalization, result
+correctness, completion-event observation, and fail-loud use from a second
+consumer stream. It does not establish multi-node behavior or performance.

--- a/tests/utils/test_async_collective.py
+++ b/tests/utils/test_async_collective.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import importlib.util
 import sys
 import types
+import weakref
 from pathlib import Path
 
 import pytest
@@ -131,6 +133,101 @@ def test_handle_rejects_invalid_completion_event():
     )
     with pytest.raises(TypeError, match=r"record\(\)"):
         handle.wait_collective()
+    assert handle.work.wait_count == 0
+
+
+def test_handle_caches_finalizer_error_without_repeating_side_effects():
+    calls = 0
+    error = RuntimeError("layout failed")
+
+    def fail_finalize():
+        nonlocal calls
+        calls += 1
+        raise error
+
+    work = _FakeWork()
+    handle = collective.AsyncCollectiveHandle(
+        work=work,
+        finalize=fail_finalize,
+        comm_kind="all_gather",
+        process_group_id="sp-group-0",
+        sequence_id=0,
+    )
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="layout failed") as raised:
+            handle.wait()
+        assert raised.value is error
+    assert work.wait_count == 1
+    assert calls == 1
+    assert handle.finalization_attempted
+    assert not handle.finalized
+    assert handle.finalization_error is error
+
+
+def test_handle_rejects_a_second_cuda_consumer_stream(monkeypatch):
+    current_stream = [(0, 11)]
+    monkeypatch.setattr(collective, "_accelerator_stream_key", lambda _device: current_stream[0])
+    finalize_calls = 0
+
+    def finalize():
+        nonlocal finalize_calls
+        finalize_calls += 1
+        return object()
+
+    handle = collective.AsyncCollectiveHandle(
+        work=_FakeWork(),
+        finalize=finalize,
+        comm_kind="all_reduce",
+        process_group_id="dp-group-0",
+        sequence_id=0,
+        consumer_device=torch.device("cuda", 0),
+    )
+
+    handle.wait_collective()
+    current_stream[0] = (0, 12)
+    with pytest.raises(RuntimeError, match="one CUDA consumer stream"):
+        handle.finalize_result()
+    assert finalize_calls == 0
+
+    current_stream[0] = (0, 11)
+    result = handle.finalize_result()
+    assert handle.wait() is result
+    assert finalize_calls == 1
+
+
+def test_handle_keeps_owned_resources_alive():
+    class Resource:
+        pass
+
+    resource = Resource()
+    reference = weakref.ref(resource)
+    handle = collective.AsyncCollectiveHandle(
+        work=_FakeWork(),
+        finalize=lambda: None,
+        comm_kind="all_reduce",
+        process_group_id="dp-group-0",
+        sequence_id=0,
+        owned_resources=(resource,),
+    )
+    del resource
+    gc.collect()
+    assert reference() is not None
+    del handle
+    gc.collect()
+    assert reference() is None
+
+
+def test_handle_requires_immutable_owned_resource_container():
+    with pytest.raises(TypeError, match="immutable tuple"):
+        collective.AsyncCollectiveHandle(
+            work=_FakeWork(),
+            finalize=lambda: None,
+            comm_kind="all_reduce",
+            process_group_id="dp-group-0",
+            sequence_id=0,
+            owned_resources=[],
+        )
 
 
 def test_sequence_ids_are_monotonic_per_process_group():
@@ -183,6 +280,8 @@ def test_ulysses_async_all_to_all_returns_structured_handle(monkeypatch):
     assert isinstance(handle, collective.AsyncCollectiveHandle)
     assert handle.comm_kind == "ulysses_all_to_all"
     assert handle.process_group_id == "sp-group-0"
+    assert handle.consumer_device == tensor.device
+    assert len(handle.owned_resources) == 5
     assert torch.equal(handle.wait(), tensor)
     assert works[0].wait_count == 1
     assert order == ["launch_event", "collective_launch", "work_complete", "complete_event"]
@@ -191,6 +290,36 @@ def test_ulysses_async_all_to_all_returns_structured_handle(monkeypatch):
     assert callable(legacy_wait)
     assert torch.equal(legacy_wait(), tensor)
     assert works[1].wait_count == 1
+
+
+def test_ulysses_legacy_async_closure_preserves_wait_errors(monkeypatch):
+    ulysses = _load_ulysses_module(monkeypatch)
+    group = _FakeGroup()
+    error = RuntimeError("collective failed")
+
+    def fail_wait():
+        raise error
+
+    work = _FakeWork(fail_wait)
+    monkeypatch.setattr(ulysses.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        ulysses.dist,
+        "all_to_all",
+        lambda output_list, input_list, *, group, async_op: work,
+    )
+
+    legacy_wait = ulysses.all_to_all_tensor(
+        torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        scatter_dim=0,
+        gather_dim=0,
+        group=group,
+        async_op=True,
+    )
+    assert callable(legacy_wait)
+    with pytest.raises(RuntimeError, match="collective failed") as raised:
+        legacy_wait()
+    assert raised.value is error
+    assert work.wait_count == 1
 
 
 def test_ulysses_async_all_gather_returns_structured_handle(monkeypatch):
@@ -213,4 +342,7 @@ def test_ulysses_async_all_gather_returns_structured_handle(monkeypatch):
 
     assert handle.comm_kind == "ulysses_all_gather"
     assert handle.process_group_id == "sp-group-0"
+    assert handle.consumer_device == tensor.device
+    assert len(handle.owned_resources) == 2
+    assert handle.owned_resources[0] is tensor
     assert torch.equal(handle.wait(), torch.cat((tensor, tensor)))

--- a/tests/utils/test_async_collective.py
+++ b/tests/utils/test_async_collective.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+_MODULE_PATH = Path(__file__).parents[2] / "verl" / "utils" / "collective.py"
+_SPEC = importlib.util.spec_from_file_location("collective_under_test", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+collective = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = collective
+_SPEC.loader.exec_module(collective)
+
+
+class _FakeWork:
+    def __init__(self, callback=lambda: None):
+        self.callback = callback
+        self.wait_count = 0
+
+    def wait(self):
+        self.wait_count += 1
+        self.callback()
+
+
+class _FakeEvent:
+    def __init__(self, order, name="complete_event"):
+        self.order = order
+        self.name = name
+
+    def record(self):
+        self.order.append(self.name)
+
+
+class _FakeGroup:
+    group_name = "sp-group-0"
+
+
+def _run_gloo_collective(rank, world_size, init_method):
+    dist.init_process_group("gloo", init_method=init_method, rank=rank, world_size=world_size)
+    try:
+        tensor = torch.tensor(float(rank + 1))
+        handle = collective.AsyncCollectiveHandle(
+            work=dist.all_reduce(tensor, async_op=True),
+            finalize=tensor.clone,
+            comm_kind="all_reduce",
+            process_group_id="world",
+            sequence_id=0,
+        )
+        result = handle.wait()
+        assert result.item() == 3.0
+        assert handle.collective_complete
+        assert handle.finalized
+    finally:
+        dist.destroy_process_group()
+
+
+def _load_ulysses_module(monkeypatch):
+    verl_package = types.ModuleType("verl")
+    verl_package.__path__ = []
+    utils_package = types.ModuleType("verl.utils")
+    utils_package.__path__ = []
+    monkeypatch.setitem(sys.modules, "verl", verl_package)
+    monkeypatch.setitem(sys.modules, "verl.utils", utils_package)
+    monkeypatch.setitem(sys.modules, "verl.utils.collective", collective)
+
+    module_path = _MODULE_PATH.with_name("ulysses.py")
+    spec = importlib.util.spec_from_file_location("ulysses_under_test", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_handle_separates_collective_completion_from_finalize():
+    order = []
+    work = _FakeWork(lambda: order.append("work"))
+    result = object()
+
+    def finalize():
+        order.append("finalize")
+        return result
+
+    handle = collective.AsyncCollectiveHandle(
+        work=work,
+        finalize=finalize,
+        comm_kind="all_to_all",
+        process_group_id="sp-group-0",
+        sequence_id=4,
+        complete_event=_FakeEvent(order),
+    )
+
+    handle.wait_collective()
+    handle.wait_collective()
+    assert order == ["work", "complete_event"]
+    assert handle.collective_complete
+    assert not handle.finalized
+
+    assert handle.finalize_result() is result
+    assert handle.wait() is result
+    assert order == ["work", "complete_event", "finalize"]
+    assert work.wait_count == 1
+    assert handle.finalized
+
+
+def test_handle_rejects_invalid_completion_event():
+    handle = collective.AsyncCollectiveHandle(
+        work=_FakeWork(),
+        finalize=lambda: None,
+        comm_kind="all_reduce",
+        process_group_id="dp-group-0",
+        sequence_id=0,
+        complete_event=object(),
+    )
+    with pytest.raises(TypeError, match=r"record\(\)"):
+        handle.wait_collective()
+
+
+def test_sequence_ids_are_monotonic_per_process_group():
+    group_a = _FakeGroup()
+    group_b = _FakeGroup()
+    a0 = collective.next_collective_sequence_id(group_a)
+    a1 = collective.next_collective_sequence_id(group_a)
+    b0 = collective.next_collective_sequence_id(group_b)
+    assert a1 == a0 + 1
+    assert b0 == 0
+    assert collective.resolve_process_group_id(group_a) == "sp-group-0"
+
+
+def test_handle_wraps_real_gloo_work(tmp_path):
+    init_method = f"file://{tmp_path / 'gloo_init'}"
+    mp.spawn(_run_gloo_collective, args=(2, init_method), nprocs=2, join=True)
+
+
+def test_ulysses_async_all_to_all_returns_structured_handle(monkeypatch):
+    ulysses = _load_ulysses_module(monkeypatch)
+    group = _FakeGroup()
+    works = []
+    order = []
+    monkeypatch.setattr(ulysses.dist, "get_world_size", lambda group=None: 2)
+
+    def fake_all_to_all(output_list, input_list, *, group, async_op):
+        assert async_op
+        order.append("collective_launch")
+
+        def complete():
+            order.append("work_complete")
+            for output, input_ in zip(output_list, input_list, strict=True):
+                output.copy_(input_)
+
+        work = _FakeWork(complete)
+        works.append(work)
+        return work
+
+    monkeypatch.setattr(ulysses.dist, "all_to_all", fake_all_to_all)
+    tensor = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+
+    handle = ulysses.launch_all_to_all_tensor(
+        tensor,
+        scatter_dim=0,
+        gather_dim=0,
+        group=group,
+        launch_event=_FakeEvent(order, "launch_event"),
+        complete_event=_FakeEvent(order),
+    )
+    assert isinstance(handle, collective.AsyncCollectiveHandle)
+    assert handle.comm_kind == "ulysses_all_to_all"
+    assert handle.process_group_id == "sp-group-0"
+    assert torch.equal(handle.wait(), tensor)
+    assert works[0].wait_count == 1
+    assert order == ["launch_event", "collective_launch", "work_complete", "complete_event"]
+
+    legacy_wait = ulysses.all_to_all_tensor(tensor, scatter_dim=0, gather_dim=0, group=group, async_op=True)
+    assert callable(legacy_wait)
+    assert torch.equal(legacy_wait(), tensor)
+    assert works[1].wait_count == 1
+
+
+def test_ulysses_async_all_gather_returns_structured_handle(monkeypatch):
+    ulysses = _load_ulysses_module(monkeypatch)
+    group = _FakeGroup()
+    monkeypatch.setattr(ulysses.dist, "get_world_size", lambda group=None: 2)
+
+    def fake_all_gather_into_tensor(output, input_, *, group, async_op):
+        assert async_op
+
+        def complete():
+            output[: input_.shape[0]].copy_(input_)
+            output[input_.shape[0] :].copy_(input_)
+
+        return _FakeWork(complete)
+
+    monkeypatch.setattr(ulysses.dist, "all_gather_into_tensor", fake_all_gather_into_tensor)
+    tensor = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    handle = ulysses.launch_all_gather_tensor(tensor, group)
+
+    assert handle.comm_kind == "ulysses_all_gather"
+    assert handle.process_group_id == "sp-group-0"
+    assert torch.equal(handle.wait(), torch.cat((tensor, tensor)))

--- a/tests/utils/test_async_collective_cuda.py
+++ b/tests/utils/test_async_collective_cuda.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Opt-in NCCL checks for the AsyncCollectiveHandle CUDA stream contract."""
+
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+_MODULE_PATH = Path(__file__).parents[2] / "verl" / "utils" / "collective.py"
+_SPEC = importlib.util.spec_from_file_location("collective_cuda_under_test", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+collective = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = collective
+_SPEC.loader.exec_module(collective)
+
+
+def _nccl_stream_worker(rank: int, world_size: int, init_method: str, artifact_dir: str) -> None:
+    torch.cuda.set_device(rank)
+    verl_package = types.ModuleType("verl")
+    verl_package.__path__ = []
+    utils_package = types.ModuleType("verl.utils")
+    utils_package.__path__ = []
+    device_module = types.ModuleType("verl.utils.device")
+    device_module.get_device_id = torch.cuda.current_device
+    device_module.get_device_name = lambda: "cuda"
+    device_module.get_torch_device = lambda: torch.cuda
+    device_module.is_device_available = torch.cuda.is_available
+    sys.modules["verl"] = verl_package
+    sys.modules["verl.utils"] = utils_package
+    sys.modules["verl.utils.device"] = device_module
+    dist.init_process_group("nccl", init_method=init_method, rank=rank, world_size=world_size)
+    try:
+        device = torch.device("cuda", rank)
+        producer_stream = torch.cuda.Stream(device=device)
+        other_stream = torch.cuda.Stream(device=device)
+        tensor = torch.tensor(float(rank + 1), device=device)
+        producer_stream.wait_stream(torch.cuda.current_stream(device))
+        finalize_calls = 0
+
+        def finalize() -> torch.Tensor:
+            nonlocal finalize_calls
+            finalize_calls += 1
+            return tensor.clone()
+
+        with torch.cuda.stream(producer_stream):
+            complete_event = torch.cuda.Event()
+            handle = collective.AsyncCollectiveHandle(
+                work=dist.all_reduce(tensor, async_op=True),
+                finalize=finalize,
+                comm_kind="all_reduce",
+                process_group_id="world",
+                sequence_id=0,
+                complete_event=complete_event,
+                consumer_device=device,
+                owned_resources=(tensor,),
+            )
+            handle.wait_collective()
+
+        with torch.cuda.stream(other_stream):
+            with pytest.raises(RuntimeError, match="one CUDA consumer stream"):
+                handle.finalize_result()
+
+        with torch.cuda.stream(producer_stream):
+            result = handle.finalize_result()
+            repeated_result = handle.wait()
+            consumed = result * 2
+        producer_stream.synchronize()
+
+        expected = world_size * (world_size + 1) / 2
+        assert result is repeated_result
+        assert result.item() == expected
+        assert consumed.item() == expected * 2
+        assert finalize_calls == 1
+        assert complete_event.query()
+        assert handle.collective_complete
+        assert handle.finalized
+        assert handle.finalization_error is None
+
+        properties = torch.cuda.get_device_properties(device)
+        report = {
+            "backend": dist.get_backend(),
+            "comm_kind": handle.comm_kind,
+            "complete_event_observed": complete_event.query(),
+            "consumer_stream_contract": "single_stream_fail_loud",
+            "cuda_version": torch.version.cuda,
+            "device_name": properties.name,
+            "finalize_calls": finalize_calls,
+            "physical_gpu_uuids": os.environ.get("PHYSICAL_GPU_UUIDS", "unknown"),
+            "process_group_membership": list(range(world_size)),
+            "rank": rank,
+            "result": result.item(),
+            "single_consumer_stream_rejected": True,
+            "torch_version": torch.__version__,
+            "visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", "container-managed"),
+            "world_size": world_size,
+        }
+        output = Path(artifact_dir) / f"async-collective-nccl-rank-{rank}.json"
+        output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    os.environ.get("VERL_RUN_ASYNC_COLLECTIVE_NCCL_TEST") != "1",
+    reason="set VERL_RUN_ASYNC_COLLECTIVE_NCCL_TEST=1 for the opt-in NCCL check",
+)
+def test_async_collective_handle_nccl_stream_contract(tmp_path):
+    world_size = int(os.environ.get("VERL_ASYNC_COLLECTIVE_WORLD_SIZE", "2"))
+    if world_size not in (2, 4):
+        pytest.fail("VERL_ASYNC_COLLECTIVE_WORLD_SIZE must be 2 or 4")
+    if not torch.cuda.is_available() or torch.cuda.device_count() < world_size:
+        pytest.skip(f"the NCCL check requires {world_size} visible CUDA devices")
+    artifact_dir = os.environ.get("VERL_ASYNC_COLLECTIVE_ARTIFACT_DIR", str(tmp_path))
+    Path(artifact_dir).mkdir(parents=True, exist_ok=True)
+    init_method = f"file://{tmp_path / 'nccl_init'}"
+    mp.spawn(
+        _nccl_stream_worker,
+        args=(world_size, init_method, artifact_dir),
+        nprocs=world_size,
+        join=True,
+    )

--- a/verl/utils/collective.py
+++ b/verl/utils/collective.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Generic, Protocol, TypeVar, cast
 
+import torch
 import torch.distributed as dist
 
 T = TypeVar("T")
@@ -32,6 +33,30 @@ class CollectiveWork(Protocol):
     """Minimum interface implemented by ``torch.distributed.Work``."""
 
     def wait(self) -> object: ...
+
+
+def _accelerator_stream_key(device: torch.device) -> tuple[int, int]:
+    """Return the current accelerator stream identity for a concrete device."""
+
+    from verl.utils.device import get_device_id, get_device_name, get_torch_device, is_device_available
+
+    if not is_device_available():
+        raise RuntimeError("an accelerator consumer device requires an available device runtime")
+    if device.type != get_device_name():
+        raise RuntimeError(f"unsupported consumer device type: {device.type}")
+    device_index = device.index
+    if device_index is None:
+        device_index = get_device_id()
+    current_stream = getattr(get_torch_device(), "current_stream", None)
+    if not callable(current_stream):
+        raise RuntimeError("the accelerator runtime does not expose current_stream()")
+    stream = current_stream(device_index)
+    stream_id = getattr(stream, "stream_id", None)
+    if stream_id is None:
+        stream_id = getattr(stream, f"{get_device_name()}_stream", None)
+    if stream_id is None:
+        raise RuntimeError("the accelerator stream does not expose a stable identity")
+    return device_index, int(stream_id)
 
 
 def resolve_process_group_id(group: dist.ProcessGroup | None = None) -> str:
@@ -68,11 +93,19 @@ def next_collective_sequence_id(group: dist.ProcessGroup | None = None, process_
 class AsyncCollectiveHandle(Generic[T]):
     """Own an async collective and its post-communication transformation.
 
-    ``wait_collective`` waits for transport completion and records
-    ``complete_event`` before any concat/reshape finalizer runs. Callers that
-    need separate measurements can invoke ``wait_collective`` and
-    ``finalize_result`` independently; ``wait`` provides the usual combined
-    behavior. All three methods are idempotent.
+    ``wait_collective`` calls ``Work.wait`` and records ``complete_event``
+    before any concat/reshape finalizer runs. For CUDA work, this establishes
+    ordering on one consumer stream; it does not claim CPU-visible physical
+    kernel completion. The first wait binds the handle to the current stream
+    of ``consumer_device``. Later waits from a different CUDA stream fail
+    loudly instead of silently omitting that stream's dependency.
+
+    Callers that need separate measurements can invoke ``wait_collective`` and
+    ``finalize_result`` independently on that same stream; ``wait`` provides
+    the usual combined behavior. The collective wait and finalizer each run at
+    most once. A finalizer exception is cached and re-raised without repeating
+    its side effects. ``owned_resources`` keeps asynchronous input, output,
+    and staging objects alive for at least the handle lifetime.
     """
 
     work: CollectiveWork
@@ -82,9 +115,20 @@ class AsyncCollectiveHandle(Generic[T]):
     sequence_id: int
     launch_event: Any | None = None
     complete_event: Any | None = None
+    consumer_device: torch.device | str | None = None
+    owned_resources: tuple[Any, ...] = ()
     _collective_complete: bool = field(default=False, init=False, repr=False)
     _result: object = field(default=_UNSET, init=False, repr=False)
+    _finalization_attempted: bool = field(default=False, init=False, repr=False)
+    _finalization_error: BaseException | None = field(default=None, init=False, repr=False)
+    _consumer_stream_key: tuple[int, int] | None = field(default=None, init=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.consumer_device is not None:
+            self.consumer_device = torch.device(self.consumer_device)
+        if type(self.owned_resources) is not tuple:
+            raise TypeError("owned_resources must be an immutable tuple")
 
     @property
     def collective_complete(self) -> bool:
@@ -94,17 +138,41 @@ class AsyncCollectiveHandle(Generic[T]):
     def finalized(self) -> bool:
         return self._result is not _UNSET
 
+    @property
+    def finalization_attempted(self) -> bool:
+        return self._finalization_attempted
+
+    @property
+    def finalization_error(self) -> BaseException | None:
+        return self._finalization_error
+
+    def _bind_consumer_stream(self) -> None:
+        device = self.consumer_device
+        if device is None or device.type == "cpu":
+            return
+        stream_key = _accelerator_stream_key(device)
+        if self._consumer_stream_key is None:
+            self._consumer_stream_key = stream_key
+        elif self._consumer_stream_key != stream_key:
+            raise RuntimeError(
+                "AsyncCollectiveHandle supports one CUDA consumer stream; "
+                "wait and finalize on the stream that performed the first wait"
+            )
+
     def wait_collective(self) -> None:
-        """Wait once for the collective and mark its completion event."""
+        """Establish collective completion ordering on the bound stream once."""
 
         with self._lock:
+            self._bind_consumer_stream()
             if self._collective_complete:
                 return
-            self.work.wait()
+            record = None
             if self.complete_event is not None:
                 record = getattr(self.complete_event, "record", None)
                 if not callable(record):
                     raise TypeError("complete_event must provide a callable record() method")
+            self.work.wait()
+            if record is not None:
                 record()
             self._collective_complete = True
 
@@ -113,8 +181,18 @@ class AsyncCollectiveHandle(Generic[T]):
 
         self.wait_collective()
         with self._lock:
+            if self._finalization_attempted:
+                if self._finalization_error is not None:
+                    raise self._finalization_error
+            else:
+                self._finalization_attempted = True
+                try:
+                    self._result = self.finalize()
+                except BaseException as exc:
+                    self._finalization_error = exc
+                    raise
             if self._result is _UNSET:
-                self._result = self.finalize()
+                raise RuntimeError("collective finalizer did not produce a result")
             return cast(T, self._result)
 
     def wait(self) -> T:

--- a/verl/utils/collective.py
+++ b/verl/utils/collective.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Common primitives for asynchronous distributed collectives."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Generic, Protocol, TypeVar, cast
+
+import torch.distributed as dist
+
+T = TypeVar("T")
+_UNSET = object()
+_SEQUENCE_LOCK = threading.Lock()
+_SEQUENCE_IDS: dict[tuple[int, str], int] = {}
+
+
+class CollectiveWork(Protocol):
+    """Minimum interface implemented by ``torch.distributed.Work``."""
+
+    def wait(self) -> object: ...
+
+
+def resolve_process_group_id(group: dist.ProcessGroup | None = None) -> str:
+    """Return a useful process-group identifier without requiring private APIs."""
+
+    if group is None:
+        if not dist.is_initialized():
+            return "world"
+        group = dist.group.WORLD
+    name = getattr(group, "group_name", None)
+    if name is not None:
+        return str(name)
+    return "world" if group is dist.group.WORLD else f"group-size-{dist.get_world_size(group)}"
+
+
+def next_collective_sequence_id(group: dist.ProcessGroup | None = None, process_group_id: str | None = None) -> int:
+    """Allocate a rank-local sequence number for one communicator.
+
+    Ranks that launch collectives in the same order obtain matching IDs. A
+    trace or benchmark can use the IDs to detect divergent launch order.
+    """
+
+    if group is None and dist.is_initialized():
+        group = dist.group.WORLD
+    resolved_group_id = process_group_id if process_group_id is not None else resolve_process_group_id(group)
+    key = (id(group), resolved_group_id)
+    with _SEQUENCE_LOCK:
+        sequence_id = _SEQUENCE_IDS.get(key, 0)
+        _SEQUENCE_IDS[key] = sequence_id + 1
+    return sequence_id
+
+
+@dataclass(slots=True)
+class AsyncCollectiveHandle(Generic[T]):
+    """Own an async collective and its post-communication transformation.
+
+    ``wait_collective`` waits for transport completion and records
+    ``complete_event`` before any concat/reshape finalizer runs. Callers that
+    need separate measurements can invoke ``wait_collective`` and
+    ``finalize_result`` independently; ``wait`` provides the usual combined
+    behavior. All three methods are idempotent.
+    """
+
+    work: CollectiveWork
+    finalize: Callable[[], T]
+    comm_kind: str
+    process_group_id: str
+    sequence_id: int
+    launch_event: Any | None = None
+    complete_event: Any | None = None
+    _collective_complete: bool = field(default=False, init=False, repr=False)
+    _result: object = field(default=_UNSET, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    @property
+    def collective_complete(self) -> bool:
+        return self._collective_complete
+
+    @property
+    def finalized(self) -> bool:
+        return self._result is not _UNSET
+
+    def wait_collective(self) -> None:
+        """Wait once for the collective and mark its completion event."""
+
+        with self._lock:
+            if self._collective_complete:
+                return
+            self.work.wait()
+            if self.complete_event is not None:
+                record = getattr(self.complete_event, "record", None)
+                if not callable(record):
+                    raise TypeError("complete_event must provide a callable record() method")
+                record()
+            self._collective_complete = True
+
+    def finalize_result(self) -> T:
+        """Wait for communication if needed, then run the finalizer once."""
+
+        self.wait_collective()
+        with self._lock:
+            if self._result is _UNSET:
+                self._result = self.finalize()
+            return cast(T, self._result)
+
+    def wait(self) -> T:
+        """Wait for communication and return the finalized result."""
+
+        return self.finalize_result()

--- a/verl/utils/ulysses.py
+++ b/verl/utils/ulysses.py
@@ -187,6 +187,8 @@ def launch_all_to_all_tensor(
         sequence_id=next_collective_sequence_id(group, process_group_id),
         launch_event=launch_event,
         complete_event=complete_event,
+        consumer_device=local_input.device,
+        owned_resources=(local_input, *input_list, *output_list),
     )
 
 
@@ -226,6 +228,8 @@ def launch_all_gather_tensor(
         sequence_id=next_collective_sequence_id(group, process_group_id),
         launch_event=launch_event,
         complete_event=complete_event,
+        consumer_device=local_tensor.device,
+        owned_resources=(local_tensor, output),
     )
 
 

--- a/verl/utils/ulysses.py
+++ b/verl/utils/ulysses.py
@@ -25,10 +25,19 @@ from torch import Tensor
 from torch.distributed import ProcessGroup
 from torch.distributed.device_mesh import DeviceMesh
 
+from verl.utils.collective import AsyncCollectiveHandle, next_collective_sequence_id, resolve_process_group_id
+
 if TYPE_CHECKING:
     from verl import DataProto
 
 _ULYSSES_SEQUENCE_PARALLEL_GROUP = None
+
+
+def _record_collective_event(event: Any, name: str) -> None:
+    record = getattr(event, "record", None)
+    if not callable(record):
+        raise TypeError(f"{name} must provide a callable record() method")
+    record()
 
 
 def set_ulysses_sequence_parallel_group(group: dist.ProcessGroup):
@@ -142,18 +151,43 @@ def all_to_all_tensor(
     async_op: bool = False,
 ):
     group = get_ulysses_sequence_parallel_group() if group is None else group
+    if async_op:
+        return launch_all_to_all_tensor(local_input, scatter_dim, gather_dim, group).wait
     seq_world_size = dist.get_world_size(group)
     input_list = [t.contiguous() for t in torch.tensor_split(local_input, seq_world_size, scatter_dim)]
     output_list = [torch.empty_like(input_list[0]) for _ in range(seq_world_size)]
-    comm = dist.all_to_all(output_list, input_list, group=group, async_op=async_op)
-    if async_op:
-
-        def wait():
-            comm.wait()
-            return torch.cat(output_list, dim=gather_dim).contiguous()
-
-        return wait
+    dist.all_to_all(output_list, input_list, group=group, async_op=False)
     return torch.cat(output_list, dim=gather_dim).contiguous()
+
+
+def launch_all_to_all_tensor(
+    local_input: Tensor,
+    scatter_dim: int,
+    gather_dim: int,
+    group: Optional[dist.ProcessGroup] = None,
+    *,
+    launch_event: Any | None = None,
+    complete_event: Any | None = None,
+) -> AsyncCollectiveHandle[Tensor]:
+    """Launch Ulysses all-to-all and return a structured async handle."""
+
+    group = get_ulysses_sequence_parallel_group() if group is None else group
+    seq_world_size = dist.get_world_size(group)
+    input_list = [t.contiguous() for t in torch.tensor_split(local_input, seq_world_size, scatter_dim)]
+    output_list = [torch.empty_like(input_list[0]) for _ in range(seq_world_size)]
+    if launch_event is not None:
+        _record_collective_event(launch_event, "launch_event")
+    work = dist.all_to_all(output_list, input_list, group=group, async_op=True)
+    process_group_id = resolve_process_group_id(group)
+    return AsyncCollectiveHandle(
+        work=work,
+        finalize=lambda: torch.cat(output_list, dim=gather_dim).contiguous(),
+        comm_kind="ulysses_all_to_all",
+        process_group_id=process_group_id,
+        sequence_id=next_collective_sequence_id(group, process_group_id),
+        launch_event=launch_event,
+        complete_event=complete_event,
+    )
 
 
 def all_gather_tensor(local_tensor: Tensor, group: Optional[dist.ProcessGroup] = None, async_op: bool = False):
@@ -164,6 +198,35 @@ def all_gather_tensor(local_tensor: Tensor, group: Optional[dist.ProcessGroup] =
     output = torch.empty(output_shape, dtype=local_tensor.dtype, device=local_tensor.device)
     dist.all_gather_into_tensor(output, local_tensor, group=group, async_op=async_op)
     return output
+
+
+def launch_all_gather_tensor(
+    local_tensor: Tensor,
+    group: Optional[dist.ProcessGroup] = None,
+    *,
+    launch_event: Any | None = None,
+    complete_event: Any | None = None,
+) -> AsyncCollectiveHandle[Tensor]:
+    """Launch Ulysses all-gather and return a structured async handle."""
+
+    group = get_ulysses_sequence_parallel_group() if group is None else group
+    sp_world_size = dist.get_world_size(group=group)
+    output_shape = list(local_tensor.shape)
+    output_shape[0] = output_shape[0] * sp_world_size
+    output = torch.empty(output_shape, dtype=local_tensor.dtype, device=local_tensor.device)
+    if launch_event is not None:
+        _record_collective_event(launch_event, "launch_event")
+    work = dist.all_gather_into_tensor(output, local_tensor, group=group, async_op=True)
+    process_group_id = resolve_process_group_id(group)
+    return AsyncCollectiveHandle(
+        work=work,
+        finalize=lambda: output,
+        comm_kind="ulysses_all_gather",
+        process_group_id=process_group_id,
+        sequence_id=next_collective_sequence_id(group, process_group_id),
+        launch_event=launch_event,
+        complete_event=complete_event,
+    )
 
 
 class SeqAllToAll(torch.autograd.Function):


### PR DESCRIPTION
## Draft update — 2026-09-05

Adds an explicit single-CUDA-consumer-stream contract, owned-resource retention and cached finalizer exceptions. Work.wait establishes ordering on that stream; it is not a host-visible physical-kernel-completion claim. The stream-contract commit and tests are included without pulling in an unrelated dirty worktree.

Fresh duplicate checks found the existing #7750–#7755 stack and unrelated checkpoint changes; this updates the existing proposal instead of creating a duplicate. The human submitter confirmed line-by-line review and execution of relevant tests on 2026-09-05. AI assistance: OpenAI Codex. Remains Draft for outstanding production/hardware gates.

The original description and historical validation follow. Old dependency commit IDs below refer to the initial submission, not the updated head.

---

## Summary

- add an `AsyncCollectiveHandle` that separates transport completion from result finalization
- provide idempotent completion/finalization waits, per-process-group sequence metadata, and optional CUDA launch/completion events
- add structured Ulysses async all-to-all and all-gather launch helpers while preserving the existing callable closure interface

## Why this is not duplicate work

I searched open PRs and issues for `AsyncCollectiveHandle`, structured async collectives, and Ulysses async handles. I found no existing implementation with separate transport/finalization boundaries and communicator-local sequence metadata. This draft supplies a reusable primitive only; it does not add scheduling policy or an outstanding-byte window.

## Validation

- targeted CPU/Gloo test: `python -m pytest -q tests/utils/test_async_collective.py` — 6 passed
- coverage includes idempotent waits, invalid event rejection, communicator-local sequence IDs, a real 2-rank Gloo `Work`, structured Ulysses all-to-all/all-gather, and legacy closure compatibility
- this PR makes no hardware performance claim

## AI assistance disclosure

This draft was developed with OpenAI Codex assistance. The human submitter must review and understand every changed line and be prepared to defend the design and test coverage before marking it ready for review.
