### PR TITLE
[misc] fix: extract_system_prompt_and_generation drops the prompt when diff==0 (#6477)

### DIFF
--- a/tests/utils/test_system_prompt_extraction_on_cpu.py
+++ b/tests/utils/test_system_prompt_extraction_on_cpu.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for ``extract_system_prompt_and_generation`` (verl issue #6477).
+
+The helper derives the system-prompt prefix as ``token1[: -(len(token2) - len(token1))]``, where
+``token1``/``token2`` are the token ids for one and two probe turns. When the marginal per-turn
+token count (``diff``) is zero -- e.g. a template whose rendering does not grow with extra
+messages -- Python's ``x[:-0]`` is ``x[:0]`` (the empty list), not "keep everything", so the whole
+system prompt was silently dropped.
+
+``MultiTurnSFTDataset`` uses the returned prefix to strip the system preamble from each turn
+(``verl/utils/dataset/multiturn_sft_dataset.py``), so an empty result makes that strip a no-op and
+every turn after the first keeps its own copy of the preamble.
+
+No GPU, network, or model download is required: a self-contained Jinja2 template stands in for a
+real tokenizer.
+"""
+
+import re
+
+from jinja2 import Template
+
+from verl.utils.tokenizer.chat_template import extract_system_prompt_and_generation
+
+_IM_START, _IM_END, _NL = 1, 2, 3
+_SPECIALS = {"<|im_start|>": _IM_START, "<|im_end|>": _IM_END, "\n": _NL}
+
+# Ordinary ChatML template: the rendering grows with every extra turn, so the marginal per-turn
+# probe (`diff`) is non-zero. This is the common case and must keep working.
+_CHATML_WITH_SYSTEM = (
+    "<|im_start|>system\nYou are helpful<|im_end|>\n"
+    "{% for m in messages %}<|im_start|>{{m['role']}}\n{{m['content']}}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
+
+# Degenerate template that only ever renders the *first* message, ignoring the rest of the list.
+# One probe turn and two probe turns therefore render identically, so
+# `diff == len(token2) - len(token1) == 0` -- exactly the case `x[:-0]` gets wrong.
+_CHATML_FIRST_MESSAGE_ONLY = (
+    "<|im_start|>system\nYou are helpful<|im_end|>\n"
+    "{% set m = messages[0] %}<|im_start|>{{m['role']}}\n{{m['content']}}<|im_end|>\n"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
+
+
+class ChatMLTokenizer:
+    """Deterministic, offline tokenizer mimicking a ChatML ``apply_chat_template``."""
+
+    def __init__(self, template: str):
+        self._template = Template(template)
+        self._vocab: dict[str, int] = {}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        ids: list[int] = []
+        for piece in re.split(r"(<\|im_start\|>|<\|im_end\|>|\n)", text):
+            if piece == "":
+                continue
+            if piece in _SPECIALS:
+                ids.append(_SPECIALS[piece])
+            else:
+                for word in piece.split(" "):
+                    if word:
+                        ids.append(self._vocab.setdefault(word, len(self._vocab) + 100))
+        return ids
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=True, tools=None, **kwargs):
+        text = self._template.render(messages=messages, add_generation_prompt=add_generation_prompt)
+        return self.encode(text) if tokenize else text
+
+
+def test_zero_diff_does_not_drop_system_prompt():
+    """Regression for #6477: a zero marginal turn probe must not silently empty the prompt."""
+    tok = ChatMLTokenizer(_CHATML_FIRST_MESSAGE_ONLY)
+
+    token1 = tok.apply_chat_template([{"role": "user", "content": ""}], add_generation_prompt=False)
+    token2 = tok.apply_chat_template([{"role": "user", "content": ""}] * 2, add_generation_prompt=False)
+    # Confirm the template really does trigger the zero-diff edge case this test targets.
+    assert len(token1) == len(token2) > 0
+
+    system_prompt, generation_prompt = extract_system_prompt_and_generation(tok)
+
+    # The buggy `token1[:-(len(token2) - len(token1))]` == `token1[:-0]` == `[]` here. With a zero
+    # marginal turn probe the entire probe render is the only information available, so it must be
+    # returned as-is rather than emptied.
+    assert system_prompt != []
+    assert system_prompt == token1
+    assert generation_prompt == [_IM_START, tok._vocab["assistant"], _NL]
+
+
+def test_normal_template_unaffected():
+    """Sanity check: the common (``diff > 0``) case still returns the real system prompt."""
+    tok = ChatMLTokenizer(_CHATML_WITH_SYSTEM)
+
+    system_prompt, generation_prompt = extract_system_prompt_and_generation(tok)
+
+    # `[]` is not a valid chat-template input for every tokenizer in production, but this fake one
+    # renders just the fixed system preamble, giving the ground-truth prefix to compare against.
+    expected_system_prompt = tok.apply_chat_template([], add_generation_prompt=False)
+    assert system_prompt == expected_system_prompt
+    assert len(system_prompt) > 0
+    assert generation_prompt == [_IM_START, tok._vocab["assistant"], _NL]

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -125,8 +125,14 @@ def extract_system_prompt_and_generation(tokenizer, **apply_chat_template_kwargs
             **apply_chat_template_kwargs,
         )
     )
-    # get system prompt tokens
-    system_prompt = token1[: -(len(token2) - len(token1))]
+    # get system prompt tokens: token1 is [system-prefix, turn1], token2 is [system-prefix, turn1,
+    # turn2] where turn1 == turn2 (same empty-content probe), so the marginal length `diff` is
+    # exactly one turn's own token count. Slicing via `len(token1) - diff` (rather than the
+    # negative-index form `token1[:-diff]`) also handles `diff == 0` correctly: Python's `x[:-0]`
+    # means `x[:0]` (empty list), not "keep everything", which silently dropped the whole system
+    # prompt whenever a turn probe added zero marginal tokens.
+    diff = len(token2) - len(token1)
+    system_prompt = token1[: len(token1) - diff]
     # get generate prompt tokens
     token3 = normalize_token_ids(
         tokenizer.apply_chat_template(


### PR DESCRIPTION
## Motivation

`extract_system_prompt_and_generation` derives the system-prompt prefix as:

```python
system_prompt = token1[: -(len(token2) - len(token1))]
```

where `token1` and `token2` are the renders of one and two empty-content probe
turns, so the marginal length is one turn's own token count.

When a chat template's rendering does not grow with the extra probe turn, that
marginal count is zero — and `x[:-0]` is `x[:0]`, the empty list, not "keep
everything". The whole system prompt is silently dropped.

`MultiTurnSFTDataset` uses that prefix to strip the system preamble from each
turn:

```python
# verl/utils/dataset/multiturn_sft_dataset.py:231-232
input_ids = input_ids[len(self.system_prompt):]
attention_mask = attention_mask[len(self.system_prompt):]
```

With an empty prefix the strip becomes `[0:]` and removes nothing, so every turn
after the first keeps its own copy of the system preamble and the assembled
sequence diverges from `apply_chat_template` of the equivalent full conversation.
It fails silently — no exception, just wrong training data.

## Change

Compute the marginal count explicitly and slice from the front, which behaves
correctly at zero:

```python
diff = len(token2) - len(token1)
system_prompt = token1[: len(token1) - diff]
```

## Relationship to #7592

#7592 patched this same expression in both `extract_system_prompt_and_generation`
and `initialize_system_prompt`. @wuxibin89 closed it because
`initialize_system_prompt` is no longer used — which is correct: on current `main`
it has no callers outside `tests/utils/test_turn_separator_on_cpu.py`.

This PR is narrowed to only the live function. `extract_system_prompt_and_generation`
is still imported and called by `MultiTurnSFTDataset`, and the ContinuousToken
migration (#6779, #6804) did not replace it, so the defect is still reachable on
`main` today. `initialize_system_prompt` is left untouched here; happy to delete it
and its sibling `initialize_turn_separator` in a separate cleanup if that is wanted.

## Test

`tests/utils/test_system_prompt_extraction_on_cpu.py`, CPU-only — a self-contained
Jinja2 template stands in for a real tokenizer, so no GPU, network, or model
download is needed.

- `test_zero_diff_does_not_drop_system_prompt` — a template that renders only the
  first message, so one and two probe turns render identically. Asserts the prefix
  comes back intact rather than empty.
- `test_normal_template_unaffected` — the ordinary `diff > 0` path still returns
  the real system prompt.

```
tests/utils/test_system_prompt_extraction_on_cpu.py
tests/utils/test_turn_separator_on_cpu.py
tests/utils/test_continuous_token_on_cpu.py
134 passed
```

Confirmed non-vacuous: restoring `token1[: -(len(token2) - len(token1))]` fails
`test_zero_diff_does_not_drop_system_prompt`. `ruff check` and
`ruff format --check` are clean at the pinned v0.12.2.

Fixes #6477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
