### PR TITLE
[trainer, ckpt] fix: force-save V1 checkpoints before ESI expiry

### DIFF
--- a/tests/trainer/ppo/v1/test_v1_esi_save_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_v1_esi_save_on_cpu.py
@@ -1,0 +1,90 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for V1 ESI / save_freq checkpoint gating.
+
+``PPOTrainer._maybe_save_checkpoint`` is the default-trainer counterpart of the
+V0 / experimental ``should_save_ckpt_esi`` save condition. These tests bind the
+method to a stub so they do not construct a full trainer.
+"""
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from omegaconf import OmegaConf
+
+from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+
+
+def _stub(*, save_freq: int, global_steps: int, max_steps_duration: float, esi_redundant_time: float = 0):
+    stub = SimpleNamespace(
+        config=OmegaConf.create({"trainer": {"save_freq": save_freq, "esi_redundant_time": esi_redundant_time}}),
+        global_steps=global_steps,
+        max_steps_duration=max_steps_duration,
+        timing_raw={},
+    )
+    stub._save_checkpoint = MagicMock()
+    stub._maybe_save_checkpoint = PPOTrainer._maybe_save_checkpoint.__get__(stub)
+    return stub
+
+
+def _clear_esi_env():
+    os.environ.pop("MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP", None)
+    os.environ.pop("SAGEMAKER_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP", None)
+
+
+def test_save_freq_hit_writes_checkpoint():
+    _clear_esi_env()
+    stub = _stub(save_freq=10, global_steps=20, max_steps_duration=30)
+    assert stub._maybe_save_checkpoint(is_last_step=False) is True
+    stub._save_checkpoint.assert_called_once()
+
+
+def test_save_freq_miss_does_not_write():
+    _clear_esi_env()
+    stub = _stub(save_freq=10, global_steps=3, max_steps_duration=30)
+    assert stub._maybe_save_checkpoint(is_last_step=False) is False
+    stub._save_checkpoint.assert_not_called()
+
+
+def test_last_step_writes_even_when_not_on_freq():
+    _clear_esi_env()
+    stub = _stub(save_freq=10, global_steps=3, max_steps_duration=30)
+    assert stub._maybe_save_checkpoint(is_last_step=True) is True
+    stub._save_checkpoint.assert_called_once()
+
+
+def test_save_freq_disabled_skips_esi_force_save():
+    os.environ["MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"] = str(time.time() + 90)
+    stub = _stub(save_freq=-1, global_steps=3, max_steps_duration=30, esi_redundant_time=30)
+    assert stub._maybe_save_checkpoint(is_last_step=False) is False
+    stub._save_checkpoint.assert_not_called()
+    _clear_esi_env()
+
+
+def test_esi_expiry_force_saves_off_freq():
+    os.environ["MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"] = str(time.time() + 90)
+    stub = _stub(save_freq=100, global_steps=3, max_steps_duration=30, esi_redundant_time=30)
+    assert stub._maybe_save_checkpoint(is_last_step=False) is True
+    stub._save_checkpoint.assert_called_once()
+    _clear_esi_env()
+
+
+def test_esi_far_future_does_not_force_save():
+    os.environ["MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"] = str(time.time() + 10_000)
+    stub = _stub(save_freq=100, global_steps=3, max_steps_duration=30, esi_redundant_time=30)
+    assert stub._maybe_save_checkpoint(is_last_step=False) is False
+    stub._save_checkpoint.assert_not_called()
+    _clear_esi_env()

--- a/tests/trainer/ppo/v1/test_v1_esi_save_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_v1_esi_save_on_cpu.py
@@ -14,77 +14,156 @@
 """CPU tests for V1 ESI / save_freq checkpoint gating.
 
 ``PPOTrainer._maybe_save_checkpoint`` is the default-trainer counterpart of the
-V0 / experimental ``should_save_ckpt_esi`` save condition. These tests bind the
-method to a stub so they do not construct a full trainer.
+V0 / experimental ``should_save_ckpt_esi`` save condition, and
+``PPOTrainer._record_step_duration`` is the ``max_steps_duration`` bookkeeping that feeds
+it. These tests bind both methods to a stub so they do not construct a full trainer.
+
+``should_save_ckpt_esi`` only force-saves once ``max_steps_duration > 0``, so the
+bookkeeping is load-bearing: #7757 was a silent no-op precisely because V1 never
+recorded it. ``test_esi_force_save_needs_a_recorded_step_duration`` covers that
+coupling, and ``test_fit_records_the_step_duration`` guards the ``fit()`` call site.
 """
 
-import os
 import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from omegaconf import OmegaConf
 
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer
 
+MLP_EXPIRATION_ENV = "MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"
+AWS_EXPIRATION_ENV = "SAGEMAKER_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"
 
-def _stub(*, save_freq: int, global_steps: int, max_steps_duration: float, esi_redundant_time: float = 0):
+
+@pytest.fixture(autouse=True)
+def _isolate_esi_env(monkeypatch):
+    """Hide any ambient expiration timestamp, and undo whatever a test sets."""
+    monkeypatch.delenv(MLP_EXPIRATION_ENV, raising=False)
+    monkeypatch.delenv(AWS_EXPIRATION_ENV, raising=False)
+
+
+def _stub(
+    *,
+    save_freq: int,
+    global_steps: int,
+    max_steps_duration: float,
+    esi_redundant_time: float = 0,
+    with_esi_redundant_time: bool = True,
+):
+    trainer_config = {"save_freq": save_freq}
+    if with_esi_redundant_time:
+        trainer_config["esi_redundant_time"] = esi_redundant_time
     stub = SimpleNamespace(
-        config=OmegaConf.create({"trainer": {"save_freq": save_freq, "esi_redundant_time": esi_redundant_time}}),
+        config=OmegaConf.create({"trainer": trainer_config}),
         global_steps=global_steps,
         max_steps_duration=max_steps_duration,
         timing_raw={},
     )
     stub._save_checkpoint = MagicMock()
     stub._maybe_save_checkpoint = PPOTrainer._maybe_save_checkpoint.__get__(stub)
+    stub._record_step_duration = PPOTrainer._record_step_duration.__get__(stub)
     return stub
 
 
-def _clear_esi_env():
-    os.environ.pop("MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP", None)
-    os.environ.pop("SAGEMAKER_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP", None)
-
-
 def test_save_freq_hit_writes_checkpoint():
-    _clear_esi_env()
     stub = _stub(save_freq=10, global_steps=20, max_steps_duration=30)
     assert stub._maybe_save_checkpoint(is_last_step=False) is True
     stub._save_checkpoint.assert_called_once()
 
 
 def test_save_freq_miss_does_not_write():
-    _clear_esi_env()
     stub = _stub(save_freq=10, global_steps=3, max_steps_duration=30)
     assert stub._maybe_save_checkpoint(is_last_step=False) is False
     stub._save_checkpoint.assert_not_called()
 
 
 def test_last_step_writes_even_when_not_on_freq():
-    _clear_esi_env()
     stub = _stub(save_freq=10, global_steps=3, max_steps_duration=30)
     assert stub._maybe_save_checkpoint(is_last_step=True) is True
     stub._save_checkpoint.assert_called_once()
 
 
-def test_save_freq_disabled_skips_esi_force_save():
-    os.environ["MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"] = str(time.time() + 90)
+def test_save_freq_disabled_skips_esi_force_save(monkeypatch):
+    monkeypatch.setenv(MLP_EXPIRATION_ENV, str(time.time() + 90))
     stub = _stub(save_freq=-1, global_steps=3, max_steps_duration=30, esi_redundant_time=30)
     assert stub._maybe_save_checkpoint(is_last_step=False) is False
     stub._save_checkpoint.assert_not_called()
-    _clear_esi_env()
 
 
-def test_esi_expiry_force_saves_off_freq():
-    os.environ["MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"] = str(time.time() + 90)
+def test_save_freq_disabled_skips_last_step_save():
+    """``save_freq <= 0`` disables checkpointing outright, last step included (V0 parity)."""
+    stub = _stub(save_freq=-1, global_steps=3, max_steps_duration=30)
+    assert stub._maybe_save_checkpoint(is_last_step=True) is False
+    stub._save_checkpoint.assert_not_called()
+
+
+def test_esi_expiry_force_saves_off_freq(monkeypatch):
+    monkeypatch.setenv(MLP_EXPIRATION_ENV, str(time.time() + 90))
     stub = _stub(save_freq=100, global_steps=3, max_steps_duration=30, esi_redundant_time=30)
     assert stub._maybe_save_checkpoint(is_last_step=False) is True
     stub._save_checkpoint.assert_called_once()
-    _clear_esi_env()
 
 
-def test_esi_far_future_does_not_force_save():
-    os.environ["MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP"] = str(time.time() + 10_000)
+def test_esi_far_future_does_not_force_save(monkeypatch):
+    monkeypatch.setenv(MLP_EXPIRATION_ENV, str(time.time() + 10_000))
     stub = _stub(save_freq=100, global_steps=3, max_steps_duration=30, esi_redundant_time=30)
     assert stub._maybe_save_checkpoint(is_last_step=False) is False
     stub._save_checkpoint.assert_not_called()
-    _clear_esi_env()
+
+
+def test_zero_max_steps_duration_does_not_force_save(monkeypatch):
+    """The first training step is unprotected: nothing has been timed yet (V0 parity)."""
+    monkeypatch.setenv(MLP_EXPIRATION_ENV, str(time.time() + 90))
+    stub = _stub(save_freq=100, global_steps=3, max_steps_duration=0, esi_redundant_time=30)
+    assert stub._maybe_save_checkpoint(is_last_step=False) is False
+    stub._save_checkpoint.assert_not_called()
+
+
+def test_missing_esi_redundant_time_defaults_to_zero(monkeypatch):
+    """``trainer.esi_redundant_time`` is read with a default, so an older config still works."""
+    monkeypatch.setenv(MLP_EXPIRATION_ENV, str(time.time() + 80))
+    stub = _stub(save_freq=100, global_steps=3, max_steps_duration=30, with_esi_redundant_time=False)
+    assert "esi_redundant_time" not in stub.config.trainer
+    assert stub._maybe_save_checkpoint(is_last_step=False) is True
+    stub._save_checkpoint.assert_called_once()
+
+
+def test_record_step_duration_tracks_the_slowest_step():
+    stub = _stub(save_freq=100, global_steps=3, max_steps_duration=0)
+    stub.timing_raw = {"step": 12}
+    stub._record_step_duration()
+    assert stub.max_steps_duration == 12
+    stub.timing_raw = {"step": 40}
+    stub._record_step_duration()
+    assert stub.max_steps_duration == 40
+    stub.timing_raw = {"step": 5}
+    stub._record_step_duration()
+    assert stub.max_steps_duration == 40
+
+
+def test_record_step_duration_tolerates_missing_step_timing():
+    stub = _stub(save_freq=100, global_steps=3, max_steps_duration=0)
+    stub.timing_raw = {}
+    stub._record_step_duration()
+    assert stub.max_steps_duration == 0
+
+
+def test_esi_force_save_needs_a_recorded_step_duration(monkeypatch):
+    """Replay two steps: ESI force-save only arms once a step duration has been recorded."""
+    monkeypatch.setenv(MLP_EXPIRATION_ENV, str(time.time() + 90))
+    stub = _stub(save_freq=100, global_steps=3, max_steps_duration=0, esi_redundant_time=30)
+
+    # Step 1: no duration recorded yet, so the expiry window is not yet estimable.
+    assert stub._maybe_save_checkpoint(is_last_step=False) is False
+    stub._save_checkpoint.assert_not_called()
+
+    # End-of-step bookkeeping, exactly as ``fit()`` performs it.
+    stub.timing_raw = {"step": 30}
+    stub._record_step_duration()
+    assert stub.max_steps_duration == 30
+
+    # Step 2: the recorded duration now puts the expiry inside the save window.
+    assert stub._maybe_save_checkpoint(is_last_step=False) is True
+    stub._save_checkpoint.assert_called_once()

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -149,6 +149,8 @@ class PPOTrainer(ABC):
         # track mini-batch index within a parameter_sync_step cycle for Decoupled PPO
         self.local_trigger_step = 0
         self._restored_tq_prompt_count = 0
+        # slowest training step seen so far, used to size the ESI force-save window
+        self.max_steps_duration = 0
 
     def _build_replay_buffer(self) -> ReplayBuffer:
         """Instantiate the replay buffer (or a user-provided custom sampler).
@@ -470,8 +472,7 @@ class PPOTrainer(ABC):
                 self.on_step_end()
                 metrics.update(self._consume_sync_metrics())
 
-            steps_duration = self.timing_raw.get("step", 0)
-            self.max_steps_duration = max(self.max_steps_duration, steps_duration)
+            self._record_step_duration()
 
             # 4. validate
             if self.config.trainer.test_freq > 0 and (
@@ -917,6 +918,16 @@ class PPOTrainer(ABC):
         )
         return len(inflight_uids)
 
+    def _record_step_duration(self) -> None:
+        """Track the slowest training step, which sizes the ESI force-save window.
+
+        ``should_save_ckpt_esi`` only force-saves once ``max_steps_duration > 0``, so
+        losing this bookkeeping silently disables ESI force-save (see #7757). Called once
+        per step from :meth:`fit`, after the ``step`` timer has closed.
+        """
+        steps_duration = self.timing_raw.get("step", 0)
+        self.max_steps_duration = max(self.max_steps_duration, steps_duration)
+
     def _maybe_save_checkpoint(self, is_last_step: bool) -> bool:
         """Save on last step, save_freq, or when an ESI capacity block is about to expire.
 
@@ -928,7 +939,7 @@ class PPOTrainer(ABC):
             True if a checkpoint was written.
         """
         esi_close_to_expiration = should_save_ckpt_esi(
-            max_steps_duration=getattr(self, "max_steps_duration", 0),
+            max_steps_duration=self.max_steps_duration,
             redundant_time=self.config.trainer.get("esi_redundant_time", 0),
         )
         if self.config.trainer.save_freq > 0 and (

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -75,7 +75,7 @@ from verl.trainer.ppo.utils import (
 from verl.trainer.ppo.v1.replay_buffer import DAPO_FILTERED_REWARD_COUNTS_KEY, ReplayBuffer, ReplayBufferAsync
 from verl.trainer.ppo.v1.utils import MetricsAggregator, compute_advantage_for_multi_trajectories
 from verl.utils import tensordict_utils as tu
-from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
+from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import collate_fn
 from verl.utils.debug import marked_timer
@@ -438,6 +438,7 @@ class PPOTrainer(ABC):
 
         # we start from step 1
         self.global_steps += 1
+        self.max_steps_duration = 0
         SkipManager.set_step(self.global_steps)
         self._reissue_inflight_prompts()
         self.prev_step_profile = False
@@ -463,15 +464,14 @@ class PPOTrainer(ABC):
                 batch = self.step(metrics, self.timing_raw)
                 self._stop_profiling()
 
-                # 2. save checkpoint
-                if self.config.trainer.save_freq > 0 and (
-                    is_last_step or self.global_steps % self.config.trainer.save_freq == 0
-                ):
-                    with marked_timer("save_checkpoint", self.timing_raw, color="green"):
-                        self._save_checkpoint()
+                # 2. save checkpoint (save_freq, last step, or ESI close to expiration)
+                self._maybe_save_checkpoint(is_last_step)
 
                 self.on_step_end()
                 metrics.update(self._consume_sync_metrics())
+
+            steps_duration = self.timing_raw.get("step", 0)
+            self.max_steps_duration = max(self.max_steps_duration, steps_duration)
 
             # 4. validate
             if self.config.trainer.test_freq > 0 and (
@@ -916,6 +916,30 @@ class PPOTrainer(ABC):
             f"cleared {len(old_trajectory_keys)} old trajectories from partition {partition_id}"
         )
         return len(inflight_uids)
+
+    def _maybe_save_checkpoint(self, is_last_step: bool) -> bool:
+        """Save on last step, save_freq, or when an ESI capacity block is about to expire.
+
+        Matches V0 / experimental trainers. ``trainer.esi_redundant_time`` is the extra
+        buffer passed to :func:`should_save_ckpt_esi`. ``save_freq <= 0`` disables all
+        checkpointing, including ESI force-save.
+
+        Returns:
+            True if a checkpoint was written.
+        """
+        esi_close_to_expiration = should_save_ckpt_esi(
+            max_steps_duration=getattr(self, "max_steps_duration", 0),
+            redundant_time=self.config.trainer.get("esi_redundant_time", 0),
+        )
+        if self.config.trainer.save_freq > 0 and (
+            is_last_step or self.global_steps % self.config.trainer.save_freq == 0 or esi_close_to_expiration
+        ):
+            if esi_close_to_expiration:
+                logger.info("Force saving checkpoint: ESI instance expiration approaching.")
+            with marked_timer("save_checkpoint", self.timing_raw, color="green"):
+                self._save_checkpoint()
+            return True
+        return False
 
     def _save_checkpoint(self):
         """Save actor, critic, and dataloader checkpoints to local (and optionally remote) storage."""


### PR DESCRIPTION
### What does this PR do?

Fixes #7757.

The default trainer (`trainer.use_v1=true`) only saved on last-step / `save_freq`. It never tracked `max_steps_duration` and never called `should_save_ckpt_esi`, so the documented `trainer.esi_redundant_time` knob was a silent no-op. V0, experimental/separation, and fully-async already force-save when a Volcengine / SageMaker ESI capacity block is about to expire.

This PR ports that condition onto V1:

- Track `max_steps_duration` from the per-step timer, same as V0.
- Save when ESI is close to expiration, even if the step is not a `save_freq` multiple.
- Keep `save_freq <= 0` as a hard disable, including ESI.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+esi_redundant_time+should_save_ckpt_esi
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

No open PR already wires ESI into `verl/trainer/ppo/v1/trainer_base.py`. #7402 / #7396 are SFT resume / retention, not ESI.

### Test

```bash
pytest tests/trainer/ppo/v1/test_v1_esi_save_on_cpu.py -q
```

`12 passed` in a throwaway CPU venv (`TransferQueue==0.1.8` plus pyzmq/msgspec/cachetools installed there only — nothing into the repo); `pytest tests/trainer/ppo/v1/ -q` is green too. Each guard was mutation-checked: deleting the `fit()` call, no-op'ing the helper body, and removing the `__init__` initialization each fail a specific test. Please run the CPU test in CI.

Local login Python does not have `ray` / `torch`. Ruff passed on the touched files. Please run the CPU test in CI.

### API and Usage Example

```bash
# now honored on trainer.use_v1=true
trainer.save_freq=100
trainer.esi_redundant_time=30
```

No new config keys. Existing Volcengine (`MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP`) and SageMaker (`SAGEMAKER_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP`) env vars work the same as V0.

### Design & Code Changes

- `_maybe_save_checkpoint()` next to `_save_checkpoint()` holds the save condition, so it is unit-testable. Logic matches V0: historical max step duration + `esi_redundant_time` + the shared `should_save_ckpt_esi` helper.
- `_record_step_duration()` holds the two bookkeeping lines and is called from `fit()` at the same point in the loop V0 uses (after the `step` timer closes, before validation), so timing semantics are unchanged.
- `self.max_steps_duration = 0` is set in `__init__` as well as per-`fit()`, matching `experimental/separation/ray_trainer.py:90` and `fully_async_policy/fully_async_trainer.py:114`, and `_maybe_save_checkpoint` reads the attribute directly rather than through `getattr(..., 0)`.

That last point is deliberate. The defect in #7757 was not a wrong predicate — V1 never *tracked* `max_steps_duration` — and `should_save_ckpt_esi`'s Volcengine branch only force-saves once `max_steps_duration > 0`. With a `getattr` fallback, losing the bookkeeping would silently return ESI to a no-op; reading the attribute directly makes that failure loud. The tests cover the coupling end to end: step 1 declines to save because nothing has been timed yet, `_record_step_duration()` runs as `fit()` runs it, and step 2 force-saves.

Three behaviors here are inherited V0 parity rather than choices, and I would rather name them than have them read as oversights: the first step is unprotected (the `max_steps_duration > 0` gate has nothing to compare yet — V0 is byte-for-byte the same shape); `max_steps_duration` includes the checkpoint save time and excludes validation time; and `save_ckpt_duration` stays at its default 60 because V0 never passes it either. Happy to file a follow-up against the shared helper if you want any of them changed — they affect V0 and both experimental trainers equally.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/blob/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU unit tests added for save_freq / last-step / ESI force-save / save_freq-disabled; they will run in the existing CPU unit-test workflow once `ray`/`torch` are available.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

AI assistance was used to locate the bug and draft the patch. A human author reviewed every changed line.

