### PR TITLE
[trainer] fix: honor trainer.balance_batch on the V1 trainer

### DIFF
--- a/tests/trainer/ppo/v1/test_v1_balance_batch_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_v1_balance_batch_on_cpu.py
@@ -1,0 +1,97 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for V1 ``trainer.balance_batch`` gating.
+
+Upsample (mini-batch / DP LCM) must always run. The seqlen reorder is the
+documented optional load-balance and must honor ``trainer.balance_batch``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from omegaconf import OmegaConf
+
+from verl.trainer.ppo.v1 import trainer_base
+from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+
+
+class _FakeBatch:
+    def __init__(self):
+        self.tags = [{"seq_len": 4}, {"seq_len": 8}]
+        self.reordered = None
+
+    def reorder(self, idx):
+        self.reordered = list(idx)
+
+
+class _FakeWorkerGroup:
+    def __init__(self):
+        self._dispatch_info = {"actor": [0, 1]}
+
+
+def _stub(*, balance_batch: bool):
+    stub = SimpleNamespace(
+        config=OmegaConf.create(
+            {
+                "trainer": {
+                    "balance_batch": balance_batch,
+                    "critic_warmup": 0,
+                },
+                "critic": {"ppo_mini_batch_size": 1},
+                "actor_rollout_ref": {
+                    "actor": {"ppo_mini_batch_size": 1},
+                    "rollout": {"n": 1},
+                },
+            }
+        ),
+        actor_rollout_wg=_FakeWorkerGroup(),
+        tokenizer=SimpleNamespace(eos_token_id=0),
+        use_critic=False,
+        global_steps=1,
+    )
+    stub._get_required_batch_multiple = PPOTrainer._get_required_batch_multiple.__get__(stub)
+    stub._balance_batch = PPOTrainer._balance_batch.__get__(stub)
+    return stub
+
+
+def test_balance_batch_false_upsamples_but_does_not_reorder(monkeypatch):
+    stub = _stub(balance_batch=False)
+    batch = _FakeBatch()
+    upsample = MagicMock(side_effect=lambda b, *_args, **_kwargs: b)
+    reorder_partitions = MagicMock()
+    monkeypatch.setattr(trainer_base, "upsample_batch_to_divisible_size", upsample)
+    monkeypatch.setattr(trainer_base, "get_seqlen_balanced_partitions", reorder_partitions)
+
+    out = stub._balance_batch(batch, metrics={})
+
+    upsample.assert_called_once()
+    reorder_partitions.assert_not_called()
+    assert out is batch
+    assert batch.reordered is None
+
+
+def test_balance_batch_true_reorders(monkeypatch):
+    stub = _stub(balance_batch=True)
+    batch = _FakeBatch()
+    upsample = MagicMock(side_effect=lambda b, *_args, **_kwargs: b)
+    monkeypatch.setattr(trainer_base, "upsample_batch_to_divisible_size", upsample)
+    monkeypatch.setattr(trainer_base, "calculate_workload", lambda _seq: [1, 2])
+    monkeypatch.setattr(trainer_base, "get_seqlen_balanced_partitions", lambda *_args, **_kwargs: [[0], [1]])
+    monkeypatch.setattr(trainer_base, "log_seqlen_unbalance", lambda **_kwargs: {"global_seqlen/minmax_diff": 0})
+
+    out = stub._balance_batch(batch, metrics={})
+
+    upsample.assert_called_once()
+    assert out is batch
+    assert batch.reordered == [0, 1]

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1527,9 +1527,14 @@ class PPOTrainer(ABC):
             dp_rank_mapping = worker_group._dispatch_info[role]
         dp_size = max(dp_rank_mapping) + 1
 
-        # Upsampling the batch with padding sequences
+        # Upsampling the batch with padding sequences. This stays on even when
+        # trainer.balance_batch is false: V1 mini-batch / DP LCM still requires
+        # a divisible batch size. The optional seqlen reorder below is the
+        # documented load-balance switch.
         batch_multiple = self._get_required_batch_multiple(dp_size)
         batch = upsample_batch_to_divisible_size(batch, batch_multiple, self.tokenizer.eos_token_id)
+        if not self.config.trainer.get("balance_batch", True):
+            return batch
         global_seqlen_lst = torch.tensor([tag["seq_len"] for tag in batch.tags], dtype=torch.int64)
         workload_lst = calculate_workload(global_seqlen_lst)
 


### PR DESCRIPTION
### What does this PR do?

Fixes #7758.

V0, Ray SFT, and the experimental trainers honor `trainer.balance_batch`. The default V1 trainer always called `_balance_batch()`, which always reordered by seqlen. Official NPU / long-context scripts set `trainer.balance_batch=false` without `use_v1=false`, so the override was a no-op.

This PR keeps V1 upsample (`upsample_batch_to_divisible_size`, required for the actor/critic mini-batch LCM) and only runs the seqlen reorder when `trainer.balance_batch=true`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+balance_batch+V1
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

Not a PrefixGrouper feature and not a duplicate of #4152 (that was a crash inside `balance_batch`). No open PR gates the V1 reorder.

### Test

```bash
pytest tests/trainer/ppo/v1/test_v1_balance_batch_on_cpu.py -q
```

Local login Python does not have `ray` / `torch`. Ruff passed on the touched files. Please run the CPU test in CI.

### API and Usage Example

```bash
# now preserved on trainer.use_v1=true
trainer.balance_batch=false
```

Default remains `true`. No new keys.

### Design & Code Changes

`_balance_batch()` always upsamples, then returns early when `trainer.balance_batch` is false. The reorder / `log_seqlen_unbalance` path is unchanged when the flag is true.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/blob/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU unit tests assert upsample still runs and seqlen reorder is skipped when the flag is false.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

AI assistance was used to locate the bug and draft the patch. A human author reviewed every changed line.
