### PR TITLE
[trainer, ckpt] fix: skip V1 async warmup after inflight reissue

### DIFF
--- a/tests/trainer/ppo/v1/test_reissue_inflight_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_reissue_inflight_on_cpu.py
@@ -166,6 +166,7 @@ def _clear_partition(partition_id: str) -> None:
 
 
 def test_count_tq_prompt_groups_includes_every_prompt_status(tq_init, partition_id):
+    """Prompt groups occupy the prefetch window whatever their status; trajectories are not prompts."""
     uids = {status: _uid() for status in ("pending", "running", "finished", "failure")}
     for status, uid in uids.items():
         _submit_prompt(partition_id, uid, status, global_steps=2)
@@ -426,6 +427,30 @@ def test_save_load_then_reissue_only_inflight(tq_init, partition_id, tmp_path):
         submitted_uids = {uid for batch in stub.agent_loop_manager.batches for uid in batch["uid"]}
         assert submitted_uids == {pending}
         assert int(stub.agent_loop_manager.batches[0]["global_steps"]) == 5
+    finally:
+        _clear_partition(partition_id)
+
+
+@requires_tq_checkpoint
+def test_save_load_terminal_only_counts_prompts_without_reissue(tq_init, partition_id, tmp_path):
+    """A terminal-only checkpoint re-issues nothing, yet its groups still fill the prefetch window,
+    so warmup must be gated on the prompt count rather than on the re-issue count."""
+    finished = _uid()
+    failure = _uid()
+    _submit_prompt(partition_id, finished, "finished", global_steps=6)
+    _submit_prompt(partition_id, failure, "failure", global_steps=6)
+    _add_trajectory(partition_id, finished, session_id=0, global_steps=6)
+
+    ckpt_dir = str(tmp_path / "transfer_queue")
+    tq.save_checkpoint(ckpt_dir, metadata={"global_steps": 6})
+    _clear_partition(partition_id)
+    tq.load_checkpoint(ckpt_dir)
+
+    stub = _make_trainer_stub(global_steps=7)
+    try:
+        assert trainer_base._count_tq_prompt_groups(partition_id) == 2
+        assert stub._reissue_inflight_prompts(partition_id) == 0
+        assert stub.agent_loop_manager.batches == []
     finally:
         _clear_partition(partition_id)
 

--- a/tests/trainer/ppo/v1/test_reissue_inflight_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_reissue_inflight_on_cpu.py
@@ -165,6 +165,18 @@ def _clear_partition(partition_id: str) -> None:
         tq.kv_clear(keys=keys, partition_id=partition_id)
 
 
+def test_count_tq_prompt_groups_includes_every_prompt_status(tq_init, partition_id):
+    uids = {status: _uid() for status in ("pending", "running", "finished", "failure")}
+    for status, uid in uids.items():
+        _submit_prompt(partition_id, uid, status, global_steps=2)
+    _add_trajectory(partition_id, uids["finished"], session_id=0, global_steps=2)
+
+    try:
+        assert trainer_base._count_tq_prompt_groups(partition_id) == 4
+    finally:
+        _clear_partition(partition_id)
+
+
 def test_async_submission_persists_reissuable_prompt_fields(monkeypatch):
     stub = type("Stub", (), {})()
     stub.trainer_mode = "separate_async"

--- a/tests/trainer/ppo/v1/test_v1_async_warmup_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_v1_async_warmup_on_cpu.py
@@ -1,0 +1,75 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for V1 async warmup-after-resume gating."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from omegaconf import OmegaConf
+
+from verl.trainer.ppo.v1.trainer_base import PPOTrainer
+from verl.trainer.ppo.v1.trainer_colocate_async import PPOTrainerColocateAsync
+from verl.trainer.ppo.v1.trainer_separate_async import PPOTrainerSeparateAsync
+
+
+def _stub(*, skip_rollout_tq: bool = False, resumed_inflight_prompts: int = 0, num_warmup_batches: int = 2):
+    stub = SimpleNamespace(
+        config=OmegaConf.create(
+            {
+                "skip": {"rollout_tq": {"enable": skip_rollout_tq}},
+                "trainer": {
+                    "v1": {
+                        "colocate_async": {"num_warmup_batches": num_warmup_batches},
+                        "separate_async": {"num_warmup_batches": num_warmup_batches},
+                    }
+                },
+            }
+        ),
+        _resumed_inflight_prompts=resumed_inflight_prompts,
+    )
+    stub._add_batch_to_generate = MagicMock()
+    stub._add_async_warmup_batches = PPOTrainer._add_async_warmup_batches.__get__(stub)
+    return stub
+
+
+def test_fresh_start_submits_warmup_batches():
+    stub = _stub(resumed_inflight_prompts=0, num_warmup_batches=3)
+    stub._add_async_warmup_batches(3)
+    assert stub._add_batch_to_generate.call_count == 3
+
+
+def test_reissued_inflight_skips_warmup():
+    stub = _stub(resumed_inflight_prompts=4, num_warmup_batches=3)
+    stub._add_async_warmup_batches(3)
+    stub._add_batch_to_generate.assert_not_called()
+
+
+def test_skip_rollout_tq_skips_warmup_even_without_reissue():
+    stub = _stub(skip_rollout_tq=True, resumed_inflight_prompts=0, num_warmup_batches=3)
+    stub._add_async_warmup_batches(3)
+    stub._add_batch_to_generate.assert_not_called()
+
+
+def test_colocate_async_on_train_begin_uses_shared_helper():
+    stub = _stub(resumed_inflight_prompts=2, num_warmup_batches=3)
+    stub.on_train_begin = PPOTrainerColocateAsync.on_train_begin.__get__(stub)
+    stub.on_train_begin()
+    stub._add_batch_to_generate.assert_not_called()
+
+
+def test_separate_async_on_train_begin_uses_shared_helper():
+    stub = _stub(resumed_inflight_prompts=0, num_warmup_batches=2)
+    stub.on_train_begin = PPOTrainerSeparateAsync.on_train_begin.__get__(stub)
+    stub.on_train_begin()
+    assert stub._add_batch_to_generate.call_count == 2

--- a/tests/trainer/ppo/v1/test_v1_async_warmup_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_v1_async_warmup_on_cpu.py
@@ -11,13 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""CPU tests for V1 async warmup-after-resume gating."""
+"""CPU tests for V1 async warmup-after-resume gating.
+
+The prefetch window is measured in prompts: ``num_warmup_batches * train_batch_size``. Prompt groups
+restored from a TransferQueue checkpoint already occupy that window, whatever their status, so warmup
+only submits the remaining shortfall.
+"""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from omegaconf import OmegaConf
 
+from verl.trainer.ppo.v1 import trainer_base
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer
 from verl.trainer.ppo.v1.trainer_colocate_async import PPOTrainerColocateAsync
 from verl.trainer.ppo.v1.trainer_separate_async import PPOTrainerSeparateAsync
@@ -45,58 +51,86 @@ def _stub(
         ),
         _restored_tq_prompt_count=restored_tq_prompt_count,
     )
-    stub._add_batch_to_generate = MagicMock()
     stub._add_prompts_to_generate = MagicMock()
     stub._add_async_warmup_batches = PPOTrainer._add_async_warmup_batches.__get__(stub)
     return stub
 
 
-def test_fresh_start_submits_warmup_batches():
-    stub = _stub(restored_tq_prompt_count=0, num_warmup_batches=3)
+def test_fresh_start_submits_the_whole_prefetch_window():
+    stub = _stub(restored_tq_prompt_count=0)
     stub._add_async_warmup_batches(3)
-    stub._add_batch_to_generate.assert_not_called()
     stub._add_prompts_to_generate.assert_called_once_with(12)
 
 
 def test_full_restored_prompt_pool_skips_warmup():
-    stub = _stub(restored_tq_prompt_count=12, num_warmup_batches=3)
+    stub = _stub(restored_tq_prompt_count=12)
     stub._add_async_warmup_batches(3)
-    stub._add_batch_to_generate.assert_not_called()
     stub._add_prompts_to_generate.assert_not_called()
 
 
 def test_partial_restored_prompt_pool_is_topped_up():
-    stub = _stub(restored_tq_prompt_count=6, num_warmup_batches=3)
+    stub = _stub(restored_tq_prompt_count=6)
     stub._add_async_warmup_batches(3)
-    stub._add_batch_to_generate.assert_not_called()
     stub._add_prompts_to_generate.assert_called_once_with(6)
 
 
 def test_overfilled_restored_prompt_pool_does_not_add_warmup():
-    stub = _stub(restored_tq_prompt_count=13, num_warmup_batches=3)
+    stub = _stub(restored_tq_prompt_count=13)
     stub._add_async_warmup_batches(3)
-    stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_not_called()
+
+
+def test_zero_warmup_batches_submits_nothing():
+    stub = _stub(restored_tq_prompt_count=0)
+    stub._add_async_warmup_batches(0)
     stub._add_prompts_to_generate.assert_not_called()
 
 
 def test_skip_rollout_tq_skips_warmup_even_without_restored_prompts():
-    stub = _stub(skip_rollout_tq=True, restored_tq_prompt_count=0, num_warmup_batches=3)
+    stub = _stub(skip_rollout_tq=True, restored_tq_prompt_count=0)
     stub._add_async_warmup_batches(3)
-    stub._add_batch_to_generate.assert_not_called()
     stub._add_prompts_to_generate.assert_not_called()
 
 
-def test_colocate_async_on_train_begin_uses_shared_helper():
-    stub = _stub(restored_tq_prompt_count=12, num_warmup_batches=3)
+def test_colocate_async_on_train_begin_tops_up_configured_window():
+    stub = _stub(restored_tq_prompt_count=4, num_warmup_batches=3)
     stub.on_train_begin = PPOTrainerColocateAsync.on_train_begin.__get__(stub)
     stub.on_train_begin()
-    stub._add_batch_to_generate.assert_not_called()
-    stub._add_prompts_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_called_once_with(8)
 
 
-def test_separate_async_on_train_begin_uses_shared_helper():
+def test_separate_async_on_train_begin_tops_up_configured_window():
     stub = _stub(restored_tq_prompt_count=0, num_warmup_batches=2)
     stub.on_train_begin = PPOTrainerSeparateAsync.on_train_begin.__get__(stub)
     stub.on_train_begin()
-    stub._add_batch_to_generate.assert_not_called()
     stub._add_prompts_to_generate.assert_called_once_with(8)
+
+
+def test_loaded_prompt_count_drives_on_train_begin_top_up(monkeypatch, tmp_path):
+    checkpoint_dir = tmp_path / "global_step_6"
+    tq_checkpoint_dir = checkpoint_dir / "transfer_queue"
+    tq_checkpoint_dir.mkdir(parents=True)
+
+    stub = _stub(restored_tq_prompt_count=0, num_warmup_batches=3)
+    stub.config.trainer.resume_mode = "resume_path"
+    stub.config.trainer.resume_from_path = str(checkpoint_dir)
+    stub.config.trainer.del_local_ckpt_after_load = False
+    stub.trainer_mode = "colocate_async"
+    stub.use_critic = False
+    stub.actor_rollout_wg = MagicMock()
+    stub.train_dataloader = MagicMock()
+    stub._load_checkpoint = PPOTrainer._load_checkpoint.__get__(stub)
+    stub.on_train_begin = PPOTrainerColocateAsync.on_train_begin.__get__(stub)
+
+    load_tq_checkpoint = MagicMock()
+    monkeypatch.setattr(trainer_base, "_tq_supports_checkpoint", lambda: True)
+    monkeypatch.setattr(trainer_base, "_count_tq_prompt_groups", lambda: 6)
+    monkeypatch.setattr(trainer_base.tq, "load_checkpoint", load_tq_checkpoint, raising=False)
+
+    stub._load_checkpoint()
+    stub.on_train_begin()
+
+    assert stub.global_steps == 6
+    assert stub._restored_tq_prompt_count == 6
+    load_tq_checkpoint.assert_called_once_with(str(tq_checkpoint_dir))
+    stub._add_prompts_to_generate.assert_called_once_with(6)

--- a/tests/trainer/ppo/v1/test_v1_async_warmup_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_v1_async_warmup_on_cpu.py
@@ -23,11 +23,18 @@ from verl.trainer.ppo.v1.trainer_colocate_async import PPOTrainerColocateAsync
 from verl.trainer.ppo.v1.trainer_separate_async import PPOTrainerSeparateAsync
 
 
-def _stub(*, skip_rollout_tq: bool = False, resumed_inflight_prompts: int = 0, num_warmup_batches: int = 2):
+def _stub(
+    *,
+    skip_rollout_tq: bool = False,
+    restored_tq_prompt_count: int = 0,
+    num_warmup_batches: int = 2,
+    train_batch_size: int = 4,
+):
     stub = SimpleNamespace(
         config=OmegaConf.create(
             {
                 "skip": {"rollout_tq": {"enable": skip_rollout_tq}},
+                "data": {"train_batch_size": train_batch_size},
                 "trainer": {
                     "v1": {
                         "colocate_async": {"num_warmup_batches": num_warmup_batches},
@@ -36,40 +43,60 @@ def _stub(*, skip_rollout_tq: bool = False, resumed_inflight_prompts: int = 0, n
                 },
             }
         ),
-        _resumed_inflight_prompts=resumed_inflight_prompts,
+        _restored_tq_prompt_count=restored_tq_prompt_count,
     )
     stub._add_batch_to_generate = MagicMock()
+    stub._add_prompts_to_generate = MagicMock()
     stub._add_async_warmup_batches = PPOTrainer._add_async_warmup_batches.__get__(stub)
     return stub
 
 
 def test_fresh_start_submits_warmup_batches():
-    stub = _stub(resumed_inflight_prompts=0, num_warmup_batches=3)
-    stub._add_async_warmup_batches(3)
-    assert stub._add_batch_to_generate.call_count == 3
-
-
-def test_reissued_inflight_skips_warmup():
-    stub = _stub(resumed_inflight_prompts=4, num_warmup_batches=3)
+    stub = _stub(restored_tq_prompt_count=0, num_warmup_batches=3)
     stub._add_async_warmup_batches(3)
     stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_called_once_with(12)
 
 
-def test_skip_rollout_tq_skips_warmup_even_without_reissue():
-    stub = _stub(skip_rollout_tq=True, resumed_inflight_prompts=0, num_warmup_batches=3)
+def test_full_restored_prompt_pool_skips_warmup():
+    stub = _stub(restored_tq_prompt_count=12, num_warmup_batches=3)
     stub._add_async_warmup_batches(3)
     stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_not_called()
+
+
+def test_partial_restored_prompt_pool_is_topped_up():
+    stub = _stub(restored_tq_prompt_count=6, num_warmup_batches=3)
+    stub._add_async_warmup_batches(3)
+    stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_called_once_with(6)
+
+
+def test_overfilled_restored_prompt_pool_does_not_add_warmup():
+    stub = _stub(restored_tq_prompt_count=13, num_warmup_batches=3)
+    stub._add_async_warmup_batches(3)
+    stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_not_called()
+
+
+def test_skip_rollout_tq_skips_warmup_even_without_restored_prompts():
+    stub = _stub(skip_rollout_tq=True, restored_tq_prompt_count=0, num_warmup_batches=3)
+    stub._add_async_warmup_batches(3)
+    stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_not_called()
 
 
 def test_colocate_async_on_train_begin_uses_shared_helper():
-    stub = _stub(resumed_inflight_prompts=2, num_warmup_batches=3)
+    stub = _stub(restored_tq_prompt_count=12, num_warmup_batches=3)
     stub.on_train_begin = PPOTrainerColocateAsync.on_train_begin.__get__(stub)
     stub.on_train_begin()
     stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_not_called()
 
 
 def test_separate_async_on_train_begin_uses_shared_helper():
-    stub = _stub(resumed_inflight_prompts=0, num_warmup_batches=2)
+    stub = _stub(restored_tq_prompt_count=0, num_warmup_batches=2)
     stub.on_train_begin = PPOTrainerSeparateAsync.on_train_begin.__get__(stub)
     stub.on_train_begin()
-    assert stub._add_batch_to_generate.call_count == 2
+    stub._add_batch_to_generate.assert_not_called()
+    stub._add_prompts_to_generate.assert_called_once_with(8)

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -431,7 +431,7 @@ class PPOTrainer(ABC):
         self.global_steps += 1
         # SkipManager skips warmup batches in async trainers, so it doesn't conflict with reissue.
         SkipManager.set_step(self.global_steps)
-        self._reissue_inflight_prompts()
+        self._resumed_inflight_prompts = self._reissue_inflight_prompts()
         self.prev_step_profile = False
         self.curr_step_profile = (
             self.global_steps in self.config.global_profiler.steps
@@ -598,6 +598,28 @@ class PPOTrainer(ABC):
     def on_train_begin(self):
         """Called before the training loop starts."""
         return
+
+    def _add_async_warmup_batches(self, num_warmup_batches: int) -> None:
+        """Submit warmup batches for async trainers, unless resume already refilled the pipeline.
+
+        After checkpoint resume, ``_reissue_inflight_prompts`` re-submits pending/running
+        prompts from the restored TransferQueue. Extra warmup would consume new dataloader
+        rows and overfill the in-flight window relative to the checkpoint. Fresh starts
+        (reissue count 0) and runs without TQ checkpoint support still warm up as before.
+        ``skip.rollout_tq.enable`` continues to skip warmup entirely.
+        """
+        if self.config.skip.rollout_tq.enable:
+            return
+        resumed = getattr(self, "_resumed_inflight_prompts", 0)
+        if resumed > 0:
+            logger.info(
+                "Skipping async warmup: re-issued %s in-flight prompts from checkpoint",
+                resumed,
+            )
+            return
+        for _ in range(num_warmup_batches):
+            self._add_batch_to_generate()
+        logger.info("Added %s warmup batches to the agent loop manager", num_warmup_batches)
 
     def on_train_end(self):
         """Called after the training loop ends."""

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -116,6 +116,13 @@ def _tq_supports_checkpoint() -> bool:
     )
 
 
+def _count_tq_prompt_groups(partition_id: str = "train") -> int:
+    data = tq.kv_list(partition_id)
+    if not data:
+        return 0
+    return sum(tag.get("is_prompt", False) for tag in data.get(partition_id, {}).values())
+
+
 class PPOTrainer(ABC):
     """Base class for PPO trainer.
 
@@ -429,9 +436,8 @@ class PPOTrainer(ABC):
 
         # we start from step 1
         self.global_steps += 1
-        # SkipManager skips warmup batches in async trainers, so it doesn't conflict with reissue.
         SkipManager.set_step(self.global_steps)
-        self._resumed_inflight_prompts = self._reissue_inflight_prompts()
+        self._reissue_inflight_prompts()
         self.prev_step_profile = False
         self.curr_step_profile = (
             self.global_steps in self.config.global_profiler.steps
@@ -600,26 +606,29 @@ class PPOTrainer(ABC):
         return
 
     def _add_async_warmup_batches(self, num_warmup_batches: int) -> None:
-        """Submit warmup batches for async trainers, unless resume already refilled the pipeline.
-
-        After checkpoint resume, ``_reissue_inflight_prompts`` re-submits pending/running
-        prompts from the restored TransferQueue. Extra warmup would consume new dataloader
-        rows and overfill the in-flight window relative to the checkpoint. Fresh starts
-        (reissue count 0) and runs without TQ checkpoint support still warm up as before.
-        ``skip.rollout_tq.enable`` continues to skip warmup entirely.
-        """
+        """Fill the async prefetch window without duplicating checkpointed prompt groups."""
         if self.config.skip.rollout_tq.enable:
             return
-        resumed = getattr(self, "_resumed_inflight_prompts", 0)
-        if resumed > 0:
+
+        train_batch_size = self.config.data.train_batch_size
+        target_prompts = num_warmup_batches * train_batch_size
+        restored_prompts = getattr(self, "_restored_tq_prompt_count", 0)
+        missing_prompts = max(0, target_prompts - restored_prompts)
+        if missing_prompts == 0:
             logger.info(
-                "Skipping async warmup: re-issued %s in-flight prompts from checkpoint",
-                resumed,
+                "Skipping async warmup: restored %s prompt groups for a %s-prompt prefetch window",
+                restored_prompts,
+                target_prompts,
             )
             return
-        for _ in range(num_warmup_batches):
-            self._add_batch_to_generate()
-        logger.info("Added %s warmup batches to the agent loop manager", num_warmup_batches)
+
+        self._add_prompts_to_generate(missing_prompts)
+        logger.info(
+            "Added %s warmup prompts after restoring %s of %s target prompt groups",
+            missing_prompts,
+            restored_prompts,
+            target_prompts,
+        )
 
     def on_train_end(self):
         """Called after the training loop ends."""
@@ -814,6 +823,7 @@ class PPOTrainer(ABC):
 
     def _load_checkpoint(self):
         self.global_steps = 0
+        self._restored_tq_prompt_count = 0
 
         # 1. find latest checkpoint folder
         if self.config.trainer.resume_mode == "disable":
@@ -869,6 +879,8 @@ class PPOTrainer(ABC):
             if os.path.exists(tq_ckpt_path):
                 logger.info(f"Loading TransferQueue state from {tq_ckpt_path}")
                 tq.load_checkpoint(tq_ckpt_path)
+                self._restored_tq_prompt_count = _count_tq_prompt_groups()
+                logger.info("Restored %s training prompt groups from TransferQueue", self._restored_tq_prompt_count)
 
     def _reissue_inflight_prompts(self, partition_id: str = "train") -> int:
         """Restart checkpointed pending/running prompt groups from their persisted prompt data."""

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -117,10 +117,11 @@ def _tq_supports_checkpoint() -> bool:
 
 
 def _count_tq_prompt_groups(partition_id: str = "train") -> int:
+    """Number of prompt groups currently registered in a TransferQueue partition."""
     data = tq.kv_list(partition_id)
     if not data:
         return 0
-    return sum(tag.get("is_prompt", False) for tag in data.get(partition_id, {}).values())
+    return sum(1 for tag in data.get(partition_id, {}).values() if tag.get("is_prompt", False))
 
 
 class PPOTrainer(ABC):
@@ -147,6 +148,7 @@ class PPOTrainer(ABC):
         )
         # track mini-batch index within a parameter_sync_step cycle for Decoupled PPO
         self.local_trigger_step = 0
+        self._restored_tq_prompt_count = 0
 
     def _build_replay_buffer(self) -> ReplayBuffer:
         """Instantiate the replay buffer (or a user-provided custom sampler).
@@ -607,27 +609,23 @@ class PPOTrainer(ABC):
 
     def _add_async_warmup_batches(self, num_warmup_batches: int) -> None:
         """Fill the async prefetch window without duplicating checkpointed prompt groups."""
-        if self.config.skip.rollout_tq.enable:
+        if self.config.skip.rollout_tq.enable or num_warmup_batches <= 0:
             return
 
-        train_batch_size = self.config.data.train_batch_size
-        target_prompts = num_warmup_batches * train_batch_size
-        restored_prompts = getattr(self, "_restored_tq_prompt_count", 0)
+        restored_prompts = self._restored_tq_prompt_count
+        target_prompts = num_warmup_batches * self.config.data.train_batch_size
         missing_prompts = max(0, target_prompts - restored_prompts)
         if missing_prompts == 0:
             logger.info(
-                "Skipping async warmup: restored %s prompt groups for a %s-prompt prefetch window",
-                restored_prompts,
-                target_prompts,
+                f"Skipping async warmup: {restored_prompts} restored prompt groups already fill the "
+                f"{target_prompts}-prompt prefetch window"
             )
             return
 
         self._add_prompts_to_generate(missing_prompts)
         logger.info(
-            "Added %s warmup prompts after restoring %s of %s target prompt groups",
-            missing_prompts,
-            restored_prompts,
-            target_prompts,
+            f"Added {missing_prompts} warmup prompts after restoring {restored_prompts} of "
+            f"{target_prompts} target prompt groups"
         )
 
     def on_train_end(self):
@@ -823,7 +821,6 @@ class PPOTrainer(ABC):
 
     def _load_checkpoint(self):
         self.global_steps = 0
-        self._restored_tq_prompt_count = 0
 
         # 1. find latest checkpoint folder
         if self.config.trainer.resume_mode == "disable":
@@ -880,7 +877,7 @@ class PPOTrainer(ABC):
                 logger.info(f"Loading TransferQueue state from {tq_ckpt_path}")
                 tq.load_checkpoint(tq_ckpt_path)
                 self._restored_tq_prompt_count = _count_tq_prompt_groups()
-                logger.info("Restored %s training prompt groups from TransferQueue", self._restored_tq_prompt_count)
+                logger.info(f"Restored {self._restored_tq_prompt_count} training prompt groups from TransferQueue")
 
     def _reissue_inflight_prompts(self, partition_id: str = "train") -> int:
         """Restart checkpointed pending/running prompt groups from their persisted prompt data."""

--- a/verl/trainer/ppo/v1/trainer_colocate_async.py
+++ b/verl/trainer/ppo/v1/trainer_colocate_async.py
@@ -11,15 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
-import os
-
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
 from verl.utils.debug import marked_timer
 from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient
-
-logger = logging.getLogger(__name__)
-logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
 
 @register_trainer("colocate_async")
@@ -38,12 +32,7 @@ class PPOTrainerColocateAsync(PPOTrainer):
         self.checkpoint_manager.update_weights(self.global_steps)
 
     def on_train_begin(self):
-        if self.config.skip.rollout_tq.enable:
-            return
-        num_warmup_batches = self.config.trainer.v1.colocate_async.num_warmup_batches
-        for _ in range(num_warmup_batches):
-            self._add_batch_to_generate()
-        logger.info(f"Added {num_warmup_batches} warmup batches to the agent loop manager")
+        self._add_async_warmup_batches(self.config.trainer.v1.colocate_async.num_warmup_batches)
 
     def on_step_end(self):
         with marked_timer("update_weights", self.timing_raw, color="red"):

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -194,12 +194,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         self.checkpoint_manager.update_weights(self.global_steps)
 
     def on_train_begin(self):
-        if self.config.skip.rollout_tq.enable:
-            return
-        num_warmup_batches = self.config.trainer.v1.separate_async.num_warmup_batches
-        for _ in range(num_warmup_batches):
-            self._add_batch_to_generate()
-        logger.info(f"Added {num_warmup_batches} warmup batches to the agent loop manager")
+        self._add_async_warmup_batches(self.config.trainer.v1.separate_async.num_warmup_batches)
 
     def on_validate_begin(self):
         if self.current_mode == HybridEngineMode.TRAINER:


### PR DESCRIPTION
### What does this PR do?

Fixes #7759.

On V1 `colocate_async` / `separate_async` resume, `fit()` already restores TransferQueue state and re-submits pending/running prompts via `_reissue_inflight_prompts()`. Both async trainers then unconditionally submitted `num_warmup_batches` more batches from the already-restored dataloader. That skipped prompts relative to a non-preempted run and overfilled the in-flight window.

This PR records all the restored prompt count and only submit enough new prompts to reach the configured warmup target. Pending/running prompts are re-issued, while finished/failure prompts are not re-issued but still count toward the target. If the restored pool exceeds the target, it is preserved and a warning is logged. Fresh starts and runs without TQ checkpoint support still warm up. skip.rollout_tq.enable still short-circuits warmup.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+num_warmup_batches+reissue+_reissue_inflight_prompts
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

Not a duplicate of #7401 (SFT epoch-boundary dataloader) or #7579 (RFC for a crash-durable replay buffer). No open PR gates async warmup on resume.

### Test

```bash
pytest tests/trainer/ppo/v1/test_v1_async_warmup_on_cpu.py \
       tests/trainer/ppo/v1/test_reissue_inflight_on_cpu.py -q
```

2 steps e2e save-and-load tested.


### API and Usage Example

No new config keys. After `resume_mode=auto` on `colocate_async` / `separate_async`, the restored TransferQueue prompt pool is reused. Pending/running prompts are re-issued, finished/failure prompts remain available to the replay buffer, and only the missing warmup capacity is filled from the dataloader.

### Design & Code Changes

- `_load_checkpoint()` records the total number of restored prompt groups, including pending, running, finished, and failure states.
- `_reissue_inflight_prompts()` re-submits only pending/running prompts.
- Shared `_add_async_warmup_batches()` fills only the difference between the restored prompt count and the configured warmup target.
- `PPOTrainerColocateAsync` and `PPOTrainerSeparateAsync` both use the shared helper.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/blob/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU unit tests cover fresh-start warmup, skip-after-reissue, skip.rollout_tq, and both async `on_train_begin` entry points.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

AI assistance was used to locate the bug and draft the patch. A human author reviewed every changed line.
