### PR TITLE
[distributed] Add opt-in NCCL rail and traffic-class executor

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -112,6 +112,7 @@ verl is fast with:
    perf/verl_profiler_system.md
    perf/nsight_profiling.md
    perf/torch_profiling.md
+   perf/communication_phase_autotuning.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -136,6 +136,78 @@ NIC traffic classes, rail assignment, and route selection are outside this
 policy layer. `topology_signature` is only an opaque compatibility identity; it
 does not configure or infer any NIC behavior.
 
+## NIC and rail policy eligibility
+
+`scripts/communication_network_policy.py` adds a second, stricter gate for a
+policy measured with explicit NIC rail or traffic-class bindings. It remains an
+offline tool: it never writes host QoS settings, selects routes, changes a NIC,
+or applies a recommendation to a training process.
+
+The operator-authored NIC capability JSON must contain:
+
+- the complete topology fingerprint and its matching `topology_cell_id`;
+- an explicit `infiniband` or `roce` fabric;
+- an opaque inventory signature covering the NIC, firmware, wiring, and
+  operator-defined logical rail namespace;
+- every rank from the topology cell, every logical rail visible to that rank,
+  and the explicit traffic classes supported by each rail.
+
+NIC eligibility is restricted to multi-node topology cells. Missing ranks,
+empty capability sets, unsupported fabrics, and sentinel values such as
+`unknown`, `unspecified`, or `auto` are rejected.
+
+Each selected source trace record must also contain:
+
+- `network_telemetry_observed=true`;
+- `network_fabric` and `nic_inventory_signature` matching the capability JSON;
+- an explicit `network_telemetry_source` and
+  `network_telemetry_schema_signature`;
+- the observed `nic_rail_id` and `nic_traffic_class`.
+
+Every selected operation must have a consistent observed binding on every
+rank. Build the eligibility block from only the trace shards that measured one
+candidate:
+
+```bash
+python scripts/communication_network_policy.py build \
+  --capabilities-json measured-nic-capabilities.json \
+  --trace-jsonl measured-policy/rank-*.jsonl \
+  --operation ep_dispatch_tokens \
+  --operation dp_grad_reduce_scatter \
+  --output-json measured-policy-eligibility.json
+```
+
+The telemetry compatibility cell identifies the exact topology, NIC
+capabilities, telemetry source, and telemetry schema. The policy eligibility
+digest separately binds that cell to the complete observed rail/class
+assignment. This separation permits measured assignments to be compared inside
+one compatible environment without treating one assignment as evidence for a
+different environment.
+
+Attach the generated `network_policy_eligibility` object only to the
+recommendation produced from those source traces. Then gate that recommendation
+against telemetry from the target environment:
+
+```bash
+python scripts/communication_network_policy.py select \
+  --policy-json phase-policy-with-network-eligibility.json \
+  --capabilities-json target-nic-capabilities.json \
+  --target-trace-jsonl target-probe/rank-*.jsonl \
+  --operation ep_dispatch_tokens \
+  --operation dp_grad_reduce_scatter \
+  --output-json eligible-policy.json
+```
+
+Selection requires an exact telemetry-cell match and verifies that every
+required rank binding is present in the target capability inventory.
+Unannotated recommendations are not a fallback. A changed inventory,
+telemetry schema, topology, rail, or traffic class requires new measurements.
+
+The CPU fixtures for this interface use logical two- and four-rank evidence.
+They validate the schema and rejection rules only; they do not establish an
+InfiniBand or RoCE performance benefit. Real multi-node NIC telemetry and
+operator review are required before using a selected policy.
+
 An aggregate phase-sweep summary may record isolated/contended latency and
 GPU-realized offsets, but it has no consumer timestamp. Feed semantic trace
 records to this tool; do not infer consumer slack from aggregate collective

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -16,8 +16,8 @@ Pass every rank shard from every candidate run. Each JSONL record must contain:
 
 - `framework`, `run_id`, `rank`, `operation`, `message_bytes`, `transport`, and
   `topology_class`;
-- `world_size` when available, so an accidentally omitted highest-rank shard is
-  detected directly;
+- `world_size`, so an accidentally omitted highest-rank shard is detected
+  directly;
 - `gpu_start_timestamp_ns` and `gpu_end_timestamp_ns` from a common monotonic
   time domain across ranks;
 - `gpu_timestamp_semantics=kernel-observed`, the shared `timestamp_domain`, and
@@ -28,6 +28,8 @@ Pass every rank shard from every candidate run. Each JSONL record must contain:
 - `requested_offset_us` for an offset experiment, and optionally `policy`;
 - semantic context fields that pair operation A and B, such as `iteration`,
   `microbatch`, and `layer`;
+- stable `process_group_id` and non-negative `communicator_sequence_id` values
+  for both operations;
 - `metadata.completion_observed=true` for asynchronous operations;
 - `sequence_consistent=false` when launch-order validation detects divergence.
 

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -20,6 +20,8 @@ Pass every rank shard from every candidate run. Each JSONL record must contain:
   detected directly;
 - `gpu_start_timestamp_ns` and `gpu_end_timestamp_ns` from a common monotonic
   time domain across ranks;
+- `gpu_timestamp_semantics=kernel-observed`, the shared `timestamp_domain`, and
+  a measured non-negative `clock_sync_error_bound_us` for that domain;
 - `consumer_timestamp_ns` for operation B;
 - optionally, `critical_path_duration_us` on both records for the enclosing
   step's slowest-rank critical-path duration;
@@ -33,6 +35,10 @@ The default pairing fields also cover weight-version and bucket traces. Override
 them with `--pair-by` when a framework uses a different semantic boundary.
 Every selected run must contain a complete, contiguous rank set beginning at
 rank zero. The implementation has no topology-specific rank-count branch.
+CUDA-event eligibility/completion brackets may be inspected with the same tool,
+but they are rejected as policy evidence and produce `insufficient_evidence`.
+Likewise, evidence whose measured clock error exceeds
+`--max-clock-sync-error-us` cannot select or refine a policy.
 
 ## Decision rules
 

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -1,0 +1,98 @@
+# Evidence-driven communication phase autotuning
+
+Last updated: 09/04/2026.
+
+`scripts/autotune_communication_phase.py` turns semantic communication traces
+into a conservative policy recommendation. It is an offline analysis tool: it
+does not add sleeps, timers, or scheduling behavior to a training process.
+
+The recommendation is keyed by framework, topology, operation pair, transport,
+message sizes, and observed world size. Results from different workload keys
+are never pooled.
+
+## Required trace evidence
+
+Pass every rank shard from every candidate run. Each JSONL record must contain:
+
+- `framework`, `run_id`, `rank`, `operation`, `message_bytes`, `transport`, and
+  `topology_class`;
+- `world_size` when available, so an accidentally omitted highest-rank shard is
+  detected directly;
+- `gpu_start_timestamp_ns` and `gpu_end_timestamp_ns` from a common monotonic
+  time domain across ranks;
+- `consumer_timestamp_ns` for operation B;
+- optionally, `critical_path_duration_us` on both records for the enclosing
+  step's slowest-rank critical-path duration;
+- `requested_offset_us` for an offset experiment, and optionally `policy`;
+- semantic context fields that pair operation A and B, such as `iteration`,
+  `microbatch`, and `layer`;
+- `metadata.completion_observed=true` for asynchronous operations;
+- `sequence_consistent=false` when launch-order validation detects divergence.
+
+The default pairing fields also cover weight-version and bucket traces. Override
+them with `--pair-by` when a framework uses a different semantic boundary.
+Every selected run must contain a complete, contiguous rank set beginning at
+rank zero. The implementation has no topology-specific rank-count branch.
+
+## Decision rules
+
+For each global A/B trial, the tuner derives:
+
+```text
+realized offset = gpu_start(B) - gpu_start(A)
+consumer slack = consumer(B) - gpu_end(B)
+pair completion = max_rank(end(A), end(B)) - min_rank(start(A), start(B))
+rank skew = max launch/finish skew over A and B
+```
+
+When `critical_path_duration_us` is present on every rank and candidate, it is
+the optimization objective. Otherwise the tuner uses pair completion as the
+explicitly labelled fallback. Candidates using different objective sources are
+not compared.
+
+Negative consumer slack means B was still incomplete when its consumer arrived.
+A candidate is rejected if its lower-tail slack is worse than the baseline
+deadline guard, if added rank skew exceeds the remaining measured slack, if
+logical sequence validation failed, if the requested and realized directions
+disagree, or if it has too few complete trials.
+
+Among the remaining candidates, the objective is lexicographic: minimize p95
+critical path, then consumer wait, then rank skew. A non-baseline policy is
+recommended only when a deterministic bootstrap confidence interval says its
+critical-path improvement is positive. Trials with a unique shared semantic
+context use paired mean improvement; otherwise the reported fallback is an
+independent p95 comparison. This makes the tool fail closed under ambiguous or
+noisy evidence.
+
+## Adaptive refinement without a fixed delay
+
+The tuner may propose another requested offset. Every proposal is the midpoint
+of an already measured request interval. Its interpolated consumer slack must
+remain inside the baseline-derived deadline guard, and the tuner never
+extrapolates beyond the measured envelope. Run the proposed points, append the
+new trace shards, and invoke the tuner again.
+
+No default millisecond offset exists. The scale comes entirely from the
+observed workload, GPU realization, and consumer deadline.
+
+## Usage
+
+```bash
+python scripts/autotune_communication_phase.py \
+  --trace-jsonl traces/candidate-*/rank-*.jsonl \
+  --operation-a ep_dispatch_tokens \
+  --operation-b dp_grad_reduce_scatter \
+  --output-json phase-policy.json
+```
+
+The output includes all candidate summaries and rejection reasons, the baseline
+and recommended settings, the realized offset of the recommendation, and any
+data-derived refinement points with their interpolated realized offset and
+deadline slack. A `keep_baseline` or `insufficient_evidence`
+decision is a valid result and must not be converted into a phase shift by the
+caller.
+
+An aggregate phase-sweep summary may record isolated/contended latency and
+GPU-realized offsets, but it has no consumer timestamp. Feed semantic trace
+records to this tool; do not infer consumer slack from aggregate collective
+latency.

--- a/docs/perf/communication_phase_autotuning.md
+++ b/docs/perf/communication_phase_autotuning.md
@@ -100,6 +100,42 @@ deadline slack. A `keep_baseline` or `insufficient_evidence`
 decision is a valid result and must not be converted into a phase shift by the
 caller.
 
+## Topology policy cells
+
+Every recommendation also contains a content-addressed `topology_cell_id` and
+its canonical `topology_fingerprint`. The fingerprint includes:
+
+- single-node or multi-node scope;
+- local PCIe, NVLink, or unknown fabric;
+- world size and the exact rank-to-node placement, without embedding ephemeral
+  hostnames;
+- accelerator model by rank;
+- an optional opaque topology inventory signature.
+
+Single-node PCIe, single-node NVLink, and multi-node measurements therefore
+land in separate cells. Multi-node evidence must include a consistent
+`topology_signature`; node count alone is not sufficient to identify a cluster
+topology. Runs with missing ranks, partially missing node identities, or a
+declared class that disagrees with observed host placement are rejected.
+
+Use the selector before applying a stored policy to a new run:
+
+```bash
+python scripts/communication_topology_policy.py \
+  --policy-json phase-policy.json \
+  --target-trace-jsonl current-run/rank-*.jsonl \
+  --output-json compatible-policy.json
+```
+
+Selection is exact: every fingerprint field must match. There is no nearest
+topology, model-family fallback, or cross-topology extrapolation. If no cell
+matches, the command exits unsuccessfully and the workload must collect a new
+baseline and candidate traces for its own cell.
+
+NIC traffic classes, rail assignment, and route selection are outside this
+policy layer. `topology_signature` is only an opaque compatibility identity; it
+does not configure or infer any NIC behavior.
+
 An aggregate phase-sweep summary may record isolated/contended latency and
 GPU-realized offsets, but it has no consumer timestamp. Feed semantic trace
 records to this tool; do not infer consumer slack from aggregate collective

--- a/docs/perf/network_collective_executor.md
+++ b/docs/perf/network_collective_executor.md
@@ -1,0 +1,63 @@
+# Opt-in network collective executor
+
+Last updated: 09/05/2026.
+
+`verl.utils.communication_network.NetworkCollectiveExecutor` consumes a
+validated `NetworkPolicyEligibility`, exact target telemetry, an immutable
+operation sequence, and a separately approved execution digest. It creates
+operation-specific NCCL communicators and issues actual asynchronous
+broadcast, all-reduce and equal-split all-to-all operations through them.
+
+This is an explicit SPMD transfer API, **not an automatic integration into
+Ray's NCCL checkpoint engine**. Ray collective group names and PyTorch process
+groups are different runtimes. Existing trainer/checkpoint paths are unchanged.
+Use it only at a quiescent, post-autograd transfer boundary from one host thread,
+with all world ranks participating in the same control sequence.
+
+## Required operator evidence
+
+- An exact measured multi-node topology and rank-complete rail/class policy.
+- A full-world Gloo control group, a supported PyTorch/NCCL build and a current
+  CUDA device selected by the caller on every rank.
+- Operator-installed rail-specific NCCL network plugins. Stock `IB`/`Socket`
+  cannot be used to claim per-communicator rail pinning. Different logical
+  rails cannot alias the same plugin.
+- A numeric service level (0–15, InfiniBand) or traffic class (0–255, RoCE)
+  for each logical lane. This library does not configure switches, QoS or NICs.
+- A telemetry observer returning the actual `NetworkLane` of each initialized
+  communicator. Echoing requested settings is not measured evidence.
+- A reviewed `network_plan_digest(...)` binding every operation, rank, lane,
+  message size, dtype, policy fingerprint and source evidence SHA-256.
+
+Conflicting NCCL environment/configuration-file overrides are rejected. All
+local preflight errors are exchanged before launching the next data collective.
+The runtime rejects plan disagreement, different host grouping, wrong order,
+message-size/dtype drift, partial steps and reuse after failure. Close drains
+owned work and destroys only owned communicators; it never touches world or
+external groups. Transport failure poisons the instance and requires job-level
+recovery; it is not retried as a new collective.
+
+## Calling sequence
+
+```python
+# All ranks construct with externally reviewed kwargs and a real observer.
+executor = NetworkCollectiveExecutor(**reviewed_runtime_kwargs)
+try:
+    executor.begin_step(weight_version)
+    for operation, detached_contiguous_tensor in ordered_transfer_buckets:
+        handle = executor.launch(operation, detached_contiguous_tensor)
+        received = handle.wait()  # stream-safe result, not a host completion claim
+    executor.finish_step()        # physical completion before publishing the version
+finally:
+    executor.close()
+```
+
+The API fences the previous operation before switching communicators, following
+the NCCL cross-process-group wait contract. It therefore makes **no cross-lane
+overlap or speedup claim**. Finish drains CUDA events before releasing retained
+buffers. Missing physical rails/plugins or telemetry is a real deployment
+blocker; logical two/four-rank mock tests are not a substitute.
+
+API references: [NCCL communicator configuration](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/types.html),
+[NCCL communicator QoS](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html),
+[PyTorch distributed process groups](https://docs.pytorch.org/docs/stable/distributed.html).

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -34,6 +34,21 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+if __package__:
+    from scripts.communication_topology_policy import (
+        TopologyEvidenceError,
+        TopologyFingerprint,
+        fingerprint_trace_runs,
+        topology_run_key,
+    )
+else:
+    from communication_topology_policy import (
+        TopologyEvidenceError,
+        TopologyFingerprint,
+        fingerprint_trace_runs,
+        topology_run_key,
+    )
+
 SCHEMA_VERSION = 2
 DEFAULT_PAIR_FIELDS = (
     "step",
@@ -66,6 +81,8 @@ class RankPair:
     timestamp_domain: str
     gpu_timestamp_semantics: str
     clock_sync_error_bound_us: float
+    topology_cell_id: str
+    topology_fingerprint_json: str
     operation_a: str
     operation_b: str
     message_bytes_a: int
@@ -95,6 +112,8 @@ class RankPair:
             self.topology_class,
             self.timestamp_domain,
             self.gpu_timestamp_semantics,
+            self.topology_cell_id,
+            self.topology_fingerprint_json,
             self.operation_a,
             self.operation_b,
             self.message_bytes_a,
@@ -299,6 +318,7 @@ def _pair_records(
     ordinal: int,
     operation_a: str,
     operation_b: str,
+    topology: TopologyFingerprint,
 ) -> RankPair:
     a_start, a_end = _validate_timestamps(record_a)
     b_start, b_end = _validate_timestamps(record_b)
@@ -397,10 +417,12 @@ def _pair_records(
         rank=rank,
         declared_world_size=declared_world_size,
         framework=framework,
-        topology_class=topology_class,
+        topology_class=topology.topology_class,
         timestamp_domain=timestamp_domain,
         gpu_timestamp_semantics=gpu_timestamp_semantics,
         clock_sync_error_bound_us=float(clock_sync_error_bound_us),
+        topology_cell_id=topology.cell_id,
+        topology_fingerprint_json=topology.canonical_json,
         operation_a=operation_a,
         operation_b=operation_b,
         message_bytes_a=message_bytes_a,
@@ -431,6 +453,11 @@ def pair_trace_records(
 ) -> list[RankPair]:
     """Pair A/B trace records by run, rank, semantic context, and launch order."""
 
+    records = list(records)
+    try:
+        topology_by_run = fingerprint_trace_runs(records, (operation_a, operation_b))
+    except TopologyEvidenceError as exc:
+        raise TraceFormatError(str(exc)) from exc
     grouped: defaultdict[tuple[Any, ...], dict[str, list[Mapping[str, Any]]]] = defaultdict(
         lambda: {operation_a: [], operation_b: []}
     )
@@ -475,6 +502,7 @@ def pair_trace_records(
                     ordinal=ordinal,
                     operation_a=operation_a,
                     operation_b=operation_b,
+                    topology=topology_by_run[topology_run_key(record_a)],
                 )
             )
     return pairs
@@ -676,6 +704,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
         topology_class,
         timestamp_domain,
         gpu_timestamp_semantics,
+        topology_cell_id,
+        topology_fingerprint_json,
         operation_a,
         operation_b,
         message_bytes_a,
@@ -689,6 +719,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
         "topology_class": topology_class,
         "timestamp_domain": timestamp_domain,
         "gpu_timestamp_semantics": gpu_timestamp_semantics,
+        "topology_cell_id": topology_cell_id,
+        "topology_fingerprint": json.loads(topology_fingerprint_json),
         "operation_a": operation_a,
         "operation_b": operation_b,
         "message_bytes_a": message_bytes_a,

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -234,15 +234,6 @@ def _integer(record: Mapping[str, Any], name: str) -> int:
     return int(value)
 
 
-def _optional_integer(record: Mapping[str, Any], name: str) -> int | None:
-    value = _number(record, name, required=False)
-    if value is None:
-        return None
-    if not value.is_integer():
-        raise TraceFormatError(f"{name} must be an integer or null")
-    return int(value)
-
-
 def _string(record: Mapping[str, Any], name: str, *, default: str | None = None) -> str:
     value = _record_value(record, name)
     if value is None and default is not None:
@@ -282,14 +273,21 @@ def _required_common_value(records: Sequence[Mapping[str, Any]], name: str) -> A
     return _common_value(records, name)
 
 
+def _optional_common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
+    values = [_record_value(record, name) for record in records]
+    if any(value is None for value in values) and not all(value is None for value in values):
+        raise TraceFormatError(f"{name} must be present on both paired records or neither")
+    return _common_value(records, name)
+
+
 def _validate_timestamps(record: Mapping[str, Any]) -> tuple[int, int]:
     start = _integer(record, "gpu_start_timestamp_ns")
     end = _integer(record, "gpu_end_timestamp_ns")
     if end < start:
         raise TraceFormatError("gpu_end_timestamp_ns precedes gpu_start_timestamp_ns")
     completion_observed = _record_value(record, "completion_observed")
-    if completion_observed is False:
-        raise TraceFormatError("trace contains an operation without observed completion")
+    if completion_observed is not True:
+        raise TraceFormatError("completion_observed=true is required for every operation")
     return start, end
 
 
@@ -313,25 +311,24 @@ def _pair_records(
         raise TraceFormatError("paired records disagree on rank")
     if rank < 0:
         raise TraceFormatError("rank must be non-negative")
-    declared_world_size = _common_value((record_a, record_b), "world_size")
-    if declared_world_size is not None:
-        if (
-            isinstance(declared_world_size, bool)
-            or not isinstance(declared_world_size, int | float)
-            or not float(declared_world_size).is_integer()
-            or declared_world_size < 2
-        ):
-            raise TraceFormatError("world_size must be an integer of at least two")
-        declared_world_size = int(declared_world_size)
-        if rank >= declared_world_size:
-            raise TraceFormatError("rank must be smaller than world_size")
+    declared_world_size = _required_common_value((record_a, record_b), "world_size")
+    if (
+        isinstance(declared_world_size, bool)
+        or not isinstance(declared_world_size, int | float)
+        or not float(declared_world_size).is_integer()
+        or declared_world_size < 2
+    ):
+        raise TraceFormatError("world_size must be an integer of at least two")
+    declared_world_size = int(declared_world_size)
+    if rank >= declared_world_size:
+        raise TraceFormatError("rank must be smaller than world_size")
 
-    framework = _common_value((record_a, record_b), "framework")
+    framework = _required_common_value((record_a, record_b), "framework")
     if not isinstance(framework, str) or not framework:
         raise TraceFormatError("framework must be a non-empty string")
-    topology_class = _common_value((record_a, record_b), "topology_class") or "unknown"
-    if not isinstance(topology_class, str):
-        raise TraceFormatError("topology_class must be a string")
+    topology_class = _required_common_value((record_a, record_b), "topology_class")
+    if not isinstance(topology_class, str) or not topology_class:
+        raise TraceFormatError("topology_class must be a non-empty string")
     timestamp_domain = _required_common_value((record_a, record_b), "timestamp_domain")
     if not isinstance(timestamp_domain, str) or not timestamp_domain:
         raise TraceFormatError("timestamp_domain must be a non-empty string")
@@ -351,14 +348,14 @@ def _pair_records(
     if message_bytes_a <= 0 or message_bytes_b <= 0:
         raise TraceFormatError("message_bytes must be positive")
 
-    requested_offset = _common_value((record_a, record_b), "requested_offset_us")
+    requested_offset = _optional_common_value((record_a, record_b), "requested_offset_us")
     if requested_offset is not None:
         if isinstance(requested_offset, bool) or not isinstance(requested_offset, int | float):
             raise TraceFormatError("requested_offset_us must be numeric or null")
         requested_offset = float(requested_offset)
         if not math.isfinite(requested_offset):
             raise TraceFormatError("requested_offset_us must be finite")
-    policy = _common_value((record_a, record_b), "policy")
+    policy = _optional_common_value((record_a, record_b), "policy")
     if policy is None:
         if requested_offset == 0:
             policy = "eager"
@@ -369,7 +366,7 @@ def _pair_records(
     if not isinstance(policy, str) or not policy:
         raise TraceFormatError("policy must be a non-empty string")
 
-    critical_path_duration_us = _common_value((record_a, record_b), "critical_path_duration_us")
+    critical_path_duration_us = _optional_common_value((record_a, record_b), "critical_path_duration_us")
     if critical_path_duration_us is not None:
         if (
             isinstance(critical_path_duration_us, bool)
@@ -386,6 +383,13 @@ def _pair_records(
         if explicit is False:
             sequence_consistent = False
 
+    process_group_id_a = _string(record_a, "process_group_id")
+    process_group_id_b = _string(record_b, "process_group_id")
+    sequence_id_a = _integer(record_a, "communicator_sequence_id")
+    sequence_id_b = _integer(record_b, "communicator_sequence_id")
+    if sequence_id_a < 0 or sequence_id_b < 0:
+        raise TraceFormatError("communicator_sequence_id must be non-negative")
+
     return RankPair(
         run_id=run_id,
         context=context,
@@ -401,12 +405,12 @@ def _pair_records(
         operation_b=operation_b,
         message_bytes_a=message_bytes_a,
         message_bytes_b=message_bytes_b,
-        transport_a=_string(record_a, "transport", default="unknown"),
-        transport_b=_string(record_b, "transport", default="unknown"),
-        process_group_id_a=_string(record_a, "process_group_id", default="unknown-a"),
-        process_group_id_b=_string(record_b, "process_group_id", default="unknown-b"),
-        sequence_id_a=_optional_integer(record_a, "communicator_sequence_id"),
-        sequence_id_b=_optional_integer(record_b, "communicator_sequence_id"),
+        transport_a=_string(record_a, "transport"),
+        transport_b=_string(record_b, "transport"),
+        process_group_id_a=process_group_id_a,
+        process_group_id_b=process_group_id_b,
+        sequence_id_a=sequence_id_a,
+        sequence_id_b=sequence_id_b,
         policy=policy,
         requested_offset_us=requested_offset,
         a_start_ns=a_start,
@@ -440,7 +444,16 @@ def pair_trace_records(
         rank = _integer(record, "rank")
         context = _context(record, pair_fields)
         declared_world_size = _record_value(record, "world_size")
-        grouped[(run_id, rank, declared_world_size, context)][operation].append(record)
+        if declared_world_size is None:
+            raise TraceFormatError("world_size must be present on every selected record")
+        if (
+            isinstance(declared_world_size, bool)
+            or not isinstance(declared_world_size, int | float)
+            or not float(declared_world_size).is_integer()
+            or declared_world_size < 2
+        ):
+            raise TraceFormatError("world_size must be an integer of at least two")
+        grouped[(run_id, rank, int(declared_world_size), context)][operation].append(record)
     if not selected:
         raise TraceFormatError(f"no records matched operations {operation_a!r} and {operation_b!r}")
 

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -34,7 +34,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DEFAULT_PAIR_FIELDS = (
     "step",
     "iteration",
@@ -63,6 +63,9 @@ class RankPair:
     declared_world_size: int | None
     framework: str
     topology_class: str
+    timestamp_domain: str
+    gpu_timestamp_semantics: str
+    clock_sync_error_bound_us: float
     operation_a: str
     operation_b: str
     message_bytes_a: int
@@ -90,6 +93,8 @@ class RankPair:
         return (
             self.framework,
             self.topology_class,
+            self.timestamp_domain,
+            self.gpu_timestamp_semantics,
             self.operation_a,
             self.operation_b,
             self.message_bytes_a,
@@ -270,6 +275,13 @@ def _common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
     return next(iter(values)) if values else None
 
 
+def _required_common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
+    values = [_record_value(record, name) for record in records]
+    if any(value is None for value in values):
+        raise TraceFormatError(f"{name} must be present on both paired records")
+    return _common_value(records, name)
+
+
 def _validate_timestamps(record: Mapping[str, Any]) -> tuple[int, int]:
     start = _integer(record, "gpu_start_timestamp_ns")
     end = _integer(record, "gpu_end_timestamp_ns")
@@ -320,6 +332,20 @@ def _pair_records(
     topology_class = _common_value((record_a, record_b), "topology_class") or "unknown"
     if not isinstance(topology_class, str):
         raise TraceFormatError("topology_class must be a string")
+    timestamp_domain = _required_common_value((record_a, record_b), "timestamp_domain")
+    if not isinstance(timestamp_domain, str) or not timestamp_domain:
+        raise TraceFormatError("timestamp_domain must be a non-empty string")
+    gpu_timestamp_semantics = _required_common_value((record_a, record_b), "gpu_timestamp_semantics")
+    if gpu_timestamp_semantics not in {"kernel-observed", "event-bracket"}:
+        raise TraceFormatError("gpu_timestamp_semantics must be 'kernel-observed' or 'event-bracket'")
+    clock_sync_error_bound_us = _required_common_value((record_a, record_b), "clock_sync_error_bound_us")
+    if (
+        isinstance(clock_sync_error_bound_us, bool)
+        or not isinstance(clock_sync_error_bound_us, int | float)
+        or not math.isfinite(clock_sync_error_bound_us)
+        or clock_sync_error_bound_us < 0
+    ):
+        raise TraceFormatError("clock_sync_error_bound_us must be finite and non-negative")
     message_bytes_a = _integer(record_a, "message_bytes")
     message_bytes_b = _integer(record_b, "message_bytes")
     if message_bytes_a <= 0 or message_bytes_b <= 0:
@@ -368,6 +394,9 @@ def _pair_records(
         declared_world_size=declared_world_size,
         framework=framework,
         topology_class=topology_class,
+        timestamp_domain=timestamp_domain,
+        gpu_timestamp_semantics=gpu_timestamp_semantics,
+        clock_sync_error_bound_us=float(clock_sync_error_bound_us),
         operation_a=operation_a,
         operation_b=operation_b,
         message_bytes_a=message_bytes_a,
@@ -534,6 +563,7 @@ def summarize_candidate(candidate: Candidate) -> dict[str, Any]:
         "consumer_slack_us_p50": _rounded(percentile(consumer_slacks, 50)),
         "consumer_wait_us_p95": _rounded(percentile(consumer_waits, 95)),
         "rank_skew_us_p95": _rounded(percentile(rank_skews, 95)),
+        "clock_sync_error_bound_us": _rounded(max(pair.clock_sync_error_bound_us for pair in rank_pairs)),
         "sequence_consistent": all(trial.sequence_consistent for trial in candidate.trials),
     }
 
@@ -631,6 +661,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
     (
         framework,
         topology_class,
+        timestamp_domain,
+        gpu_timestamp_semantics,
         operation_a,
         operation_b,
         message_bytes_a,
@@ -642,6 +674,8 @@ def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
     return {
         "framework": framework,
         "topology_class": topology_class,
+        "timestamp_domain": timestamp_domain,
+        "gpu_timestamp_semantics": gpu_timestamp_semantics,
         "operation_a": operation_a,
         "operation_b": operation_b,
         "message_bytes_a": message_bytes_a,
@@ -697,6 +731,7 @@ def tune_workload(
     confidence: float = 0.95,
     bootstrap_resamples: int = 2000,
     min_trials: int = 2,
+    max_clock_sync_error_us: float = 50.0,
 ) -> dict[str, Any]:
     """Choose a safe policy and data-derived refinement offsets for one workload."""
 
@@ -712,6 +747,10 @@ def tune_workload(
     eligible = []
     for index, (candidate, summary) in enumerate(zip(candidates, summaries, strict=True)):
         reasons = []
+        if candidate.rank_pairs[0].gpu_timestamp_semantics != "kernel-observed":
+            reasons.append("kernel_observed_gpu_timestamps_required")
+        if float(summary["clock_sync_error_bound_us"]) > max_clock_sync_error_us:
+            reasons.append("clock_sync_error_bound_exceeded")
         if summary["trial_count"] < min_trials:
             reasons.append("insufficient_trials")
         if not summary["sequence_consistent"]:
@@ -769,9 +808,11 @@ def tune_workload(
     else:
         decision = "switch_policy"
 
-    focus_pool = eligible or [baseline_index]
-    focus_index = min(focus_pool, key=lambda index: _candidate_sort_key(summaries[index]))
-    next_candidates = _refinement_points(summaries, focus_index, minimum_slack_us)
+    if evidence_ready:
+        focus_index = min(eligible, key=lambda index: _candidate_sort_key(summaries[index]))
+        next_candidates = _refinement_points(summaries, focus_index, minimum_slack_us)
+    else:
+        next_candidates = []
     return {
         "workload_key": _workload_dict(workload),
         "decision": decision,
@@ -810,6 +851,7 @@ def tune_traces(
     confidence: float = 0.95,
     bootstrap_resamples: int = 2000,
     min_trials: int = 2,
+    max_clock_sync_error_us: float = 50.0,
 ) -> dict[str, Any]:
     """Build recommendations from framework-neutral semantic trace records."""
 
@@ -819,6 +861,8 @@ def tune_traces(
         raise ValueError("bootstrap_resamples must be non-negative")
     if min_trials <= 0:
         raise ValueError("min_trials must be positive")
+    if not math.isfinite(max_clock_sync_error_us) or max_clock_sync_error_us < 0:
+        raise ValueError("max_clock_sync_error_us must be finite and non-negative")
     if not pair_fields:
         raise ValueError("at least one pair field is required")
     pairs = pair_trace_records(records, operation_a, operation_b, pair_fields)
@@ -830,6 +874,7 @@ def tune_traces(
             confidence=confidence,
             bootstrap_resamples=bootstrap_resamples,
             min_trials=min_trials,
+            max_clock_sync_error_us=max_clock_sync_error_us,
         )
         for workload, candidates in sorted(by_workload.items(), key=lambda item: repr(item[0]))
     ]
@@ -838,6 +883,7 @@ def tune_traces(
         "operation_a": operation_a,
         "operation_b": operation_b,
         "pair_fields": list(pair_fields),
+        "max_clock_sync_error_us": max_clock_sync_error_us,
         "recommendations": recommendations,
     }
 
@@ -875,6 +921,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--confidence", type=float, default=0.95)
     parser.add_argument("--bootstrap-resamples", type=int, default=2000)
     parser.add_argument("--min-trials", type=int, default=2)
+    parser.add_argument(
+        "--max-clock-sync-error-us",
+        type=float,
+        default=50.0,
+        help="largest measured cross-rank clock error allowed for a policy recommendation",
+    )
     parser.add_argument("--output-json", type=Path, required=True)
     return parser
 
@@ -890,6 +942,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             confidence=args.confidence,
             bootstrap_resamples=args.bootstrap_resamples,
             min_trials=args.min_trials,
+            max_clock_sync_error_us=args.max_clock_sync_error_us,
         )
     except (OSError, TraceFormatError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/autotune_communication_phase.py
+++ b/scripts/autotune_communication_phase.py
@@ -1,0 +1,905 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Select and refine communication phase policies from semantic traces.
+
+The tuner is deliberately offline: it never sleeps in a training process and
+never invents a hardware-specific delay.  It compares observed policies using
+GPU-realized offset, consumer slack, rank skew, and the global pair critical
+path.  Refinement points are midpoints of the measured request intervals and
+are rejected when interpolated slack would cross the baseline deadline guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+import random
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+DEFAULT_PAIR_FIELDS = (
+    "step",
+    "iteration",
+    "microbatch",
+    "virtual_pipeline_stage",
+    "layer",
+    "bucket_id",
+    "weight_version",
+    "rollout_id",
+)
+BASELINE_POLICIES = {"baseline", "concurrent", "eager"}
+
+
+class TraceFormatError(ValueError):
+    """Raised when trace evidence cannot be compared safely."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RankPair:
+    """Two communication operations observed on one rank."""
+
+    run_id: str
+    context: tuple[tuple[str, Any], ...]
+    ordinal: int
+    rank: int
+    declared_world_size: int | None
+    framework: str
+    topology_class: str
+    operation_a: str
+    operation_b: str
+    message_bytes_a: int
+    message_bytes_b: int
+    transport_a: str
+    transport_b: str
+    process_group_id_a: str
+    process_group_id_b: str
+    sequence_id_a: int | None
+    sequence_id_b: int | None
+    policy: str
+    requested_offset_us: float | None
+    a_start_ns: int
+    a_end_ns: int
+    b_start_ns: int
+    b_end_ns: int
+    b_consumer_ns: int
+    critical_path_duration_us: float | None
+    sequence_consistent: bool
+
+    @property
+    def workload_base(self) -> tuple[Any, ...]:
+        """Return fields that must not be mixed in one recommendation."""
+
+        return (
+            self.framework,
+            self.topology_class,
+            self.operation_a,
+            self.operation_b,
+            self.message_bytes_a,
+            self.message_bytes_b,
+            self.transport_a,
+            self.transport_b,
+        )
+
+    @property
+    def realized_offset_us(self) -> float:
+        """Return operation B's GPU start relative to operation A."""
+
+        return (self.b_start_ns - self.a_start_ns) / 1000
+
+    @property
+    def consumer_slack_us(self) -> float:
+        """Return positive slack, or negative time spent waiting for B."""
+
+        return (self.b_consumer_ns - self.b_end_ns) / 1000
+
+
+@dataclasses.dataclass(frozen=True)
+class Trial:
+    """One globally complete operation pair across all participating ranks."""
+
+    run_id: str
+    context: tuple[tuple[str, Any], ...]
+    ordinal: int
+    ranks: tuple[RankPair, ...]
+
+    @property
+    def pair_completion_us(self) -> float:
+        """Return the global communication-pair completion window."""
+
+        start_ns = min(min(pair.a_start_ns, pair.b_start_ns) for pair in self.ranks)
+        end_ns = max(max(pair.a_end_ns, pair.b_end_ns) for pair in self.ranks)
+        return (end_ns - start_ns) / 1000
+
+    @property
+    def critical_path_us(self) -> float:
+        """Return the slowest-rank step critical path, or pair completion fallback."""
+
+        values = [pair.critical_path_duration_us for pair in self.ranks]
+        present = [value for value in values if value is not None]
+        if present and len(present) != len(values):
+            raise TraceFormatError("critical_path_duration_us is missing on only some ranks")
+        return max(present) if present else self.pair_completion_us
+
+    @property
+    def critical_path_source(self) -> str:
+        """Return which trace signal supplies the optimization objective."""
+
+        return "trace_critical_path" if self.ranks[0].critical_path_duration_us is not None else "pair_completion"
+
+    @property
+    def rank_skew_us(self) -> float:
+        """Return the largest launch or finish skew of the two operations."""
+
+        timestamp_sets = (
+            [pair.a_start_ns for pair in self.ranks],
+            [pair.a_end_ns for pair in self.ranks],
+            [pair.b_start_ns for pair in self.ranks],
+            [pair.b_end_ns for pair in self.ranks],
+        )
+        return max((max(values) - min(values)) / 1000 for values in timestamp_sets)
+
+    @property
+    def sequence_consistent(self) -> bool:
+        """Return whether every communicator has one logical sequence ID."""
+
+        if not all(pair.sequence_consistent for pair in self.ranks):
+            return False
+        for group_field, sequence_field in (
+            ("process_group_id_a", "sequence_id_a"),
+            ("process_group_id_b", "sequence_id_b"),
+        ):
+            by_group: defaultdict[str, set[int]] = defaultdict(set)
+            for pair in self.ranks:
+                sequence_id = getattr(pair, sequence_field)
+                if sequence_id is not None:
+                    by_group[getattr(pair, group_field)].add(sequence_id)
+            if any(len(sequence_ids) > 1 for sequence_ids in by_group.values()):
+                return False
+        return True
+
+
+@dataclasses.dataclass(frozen=True)
+class Candidate:
+    """Aggregate trace evidence for one observed policy setting."""
+
+    policy: str
+    requested_offset_us: float | None
+    trials: tuple[Trial, ...]
+
+    @property
+    def rank_pairs(self) -> tuple[RankPair, ...]:
+        """Flatten per-trial rank observations."""
+
+        return tuple(pair for trial in self.trials for pair in trial.ranks)
+
+
+def percentile(values: Sequence[float], percent: float) -> float:
+    """Return a linearly interpolated percentile."""
+
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * percent / 100
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] * (upper - position) + ordered[upper] * (position - lower)
+
+
+def _record_value(record: Mapping[str, Any], name: str) -> Any:
+    value = record.get(name)
+    if value is not None:
+        return value
+    metadata = record.get("metadata")
+    return metadata.get(name) if isinstance(metadata, Mapping) else None
+
+
+def _number(record: Mapping[str, Any], name: str, *, required: bool = True) -> float | None:
+    value = _record_value(record, name)
+    if value is None and not required:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float) or not math.isfinite(value):
+        raise TraceFormatError(f"{name} must be a finite number")
+    return float(value)
+
+
+def _integer(record: Mapping[str, Any], name: str) -> int:
+    value = _number(record, name)
+    if value is None or not value.is_integer():
+        raise TraceFormatError(f"{name} must be an integer")
+    return int(value)
+
+
+def _optional_integer(record: Mapping[str, Any], name: str) -> int | None:
+    value = _number(record, name, required=False)
+    if value is None:
+        return None
+    if not value.is_integer():
+        raise TraceFormatError(f"{name} must be an integer or null")
+    return int(value)
+
+
+def _string(record: Mapping[str, Any], name: str, *, default: str | None = None) -> str:
+    value = _record_value(record, name)
+    if value is None and default is not None:
+        return default
+    if not isinstance(value, str) or not value:
+        raise TraceFormatError(f"{name} must be a non-empty string")
+    return value
+
+
+def _context(record: Mapping[str, Any], pair_fields: Sequence[str]) -> tuple[tuple[str, Any], ...]:
+    values = []
+    for field in pair_fields:
+        value = _record_value(record, field)
+        if isinstance(value, dict | list):
+            raise TraceFormatError(f"pair field {field!r} must be scalar")
+        values.append((field, value))
+    return tuple(values)
+
+
+def _sort_key(record: Mapping[str, Any]) -> tuple[float, float]:
+    start = _number(record, "gpu_start_timestamp_ns")
+    sequence = _number(record, "communicator_sequence_id", required=False)
+    return float(start), -1 if sequence is None else sequence
+
+
+def _common_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
+    values = {_record_value(record, name) for record in records if _record_value(record, name) is not None}
+    if len(values) > 1:
+        raise TraceFormatError(f"paired records disagree on {name}: {sorted(values, key=str)!r}")
+    return next(iter(values)) if values else None
+
+
+def _validate_timestamps(record: Mapping[str, Any]) -> tuple[int, int]:
+    start = _integer(record, "gpu_start_timestamp_ns")
+    end = _integer(record, "gpu_end_timestamp_ns")
+    if end < start:
+        raise TraceFormatError("gpu_end_timestamp_ns precedes gpu_start_timestamp_ns")
+    completion_observed = _record_value(record, "completion_observed")
+    if completion_observed is False:
+        raise TraceFormatError("trace contains an operation without observed completion")
+    return start, end
+
+
+def _pair_records(
+    record_a: Mapping[str, Any],
+    record_b: Mapping[str, Any],
+    *,
+    context: tuple[tuple[str, Any], ...],
+    ordinal: int,
+    operation_a: str,
+    operation_b: str,
+) -> RankPair:
+    a_start, a_end = _validate_timestamps(record_a)
+    b_start, b_end = _validate_timestamps(record_b)
+    consumer = _integer(record_b, "consumer_timestamp_ns")
+    run_id = _string(record_a, "run_id")
+    if _string(record_b, "run_id") != run_id:
+        raise TraceFormatError("paired records disagree on run_id")
+    rank = _integer(record_a, "rank")
+    if _integer(record_b, "rank") != rank:
+        raise TraceFormatError("paired records disagree on rank")
+    if rank < 0:
+        raise TraceFormatError("rank must be non-negative")
+    declared_world_size = _common_value((record_a, record_b), "world_size")
+    if declared_world_size is not None:
+        if (
+            isinstance(declared_world_size, bool)
+            or not isinstance(declared_world_size, int | float)
+            or not float(declared_world_size).is_integer()
+            or declared_world_size < 2
+        ):
+            raise TraceFormatError("world_size must be an integer of at least two")
+        declared_world_size = int(declared_world_size)
+        if rank >= declared_world_size:
+            raise TraceFormatError("rank must be smaller than world_size")
+
+    framework = _common_value((record_a, record_b), "framework")
+    if not isinstance(framework, str) or not framework:
+        raise TraceFormatError("framework must be a non-empty string")
+    topology_class = _common_value((record_a, record_b), "topology_class") or "unknown"
+    if not isinstance(topology_class, str):
+        raise TraceFormatError("topology_class must be a string")
+    message_bytes_a = _integer(record_a, "message_bytes")
+    message_bytes_b = _integer(record_b, "message_bytes")
+    if message_bytes_a <= 0 or message_bytes_b <= 0:
+        raise TraceFormatError("message_bytes must be positive")
+
+    requested_offset = _common_value((record_a, record_b), "requested_offset_us")
+    if requested_offset is not None:
+        if isinstance(requested_offset, bool) or not isinstance(requested_offset, int | float):
+            raise TraceFormatError("requested_offset_us must be numeric or null")
+        requested_offset = float(requested_offset)
+        if not math.isfinite(requested_offset):
+            raise TraceFormatError("requested_offset_us must be finite")
+    policy = _common_value((record_a, record_b), "policy")
+    if policy is None:
+        if requested_offset == 0:
+            policy = "eager"
+        elif requested_offset is None:
+            policy = "unspecified"
+        else:
+            policy = "phase_shifted"
+    if not isinstance(policy, str) or not policy:
+        raise TraceFormatError("policy must be a non-empty string")
+
+    critical_path_duration_us = _common_value((record_a, record_b), "critical_path_duration_us")
+    if critical_path_duration_us is not None:
+        if (
+            isinstance(critical_path_duration_us, bool)
+            or not isinstance(critical_path_duration_us, int | float)
+            or not math.isfinite(critical_path_duration_us)
+            or critical_path_duration_us <= 0
+        ):
+            raise TraceFormatError("critical_path_duration_us must be positive and finite")
+        critical_path_duration_us = float(critical_path_duration_us)
+
+    sequence_consistent = True
+    for record in (record_a, record_b):
+        explicit = _record_value(record, "sequence_consistent")
+        if explicit is False:
+            sequence_consistent = False
+
+    return RankPair(
+        run_id=run_id,
+        context=context,
+        ordinal=ordinal,
+        rank=rank,
+        declared_world_size=declared_world_size,
+        framework=framework,
+        topology_class=topology_class,
+        operation_a=operation_a,
+        operation_b=operation_b,
+        message_bytes_a=message_bytes_a,
+        message_bytes_b=message_bytes_b,
+        transport_a=_string(record_a, "transport", default="unknown"),
+        transport_b=_string(record_b, "transport", default="unknown"),
+        process_group_id_a=_string(record_a, "process_group_id", default="unknown-a"),
+        process_group_id_b=_string(record_b, "process_group_id", default="unknown-b"),
+        sequence_id_a=_optional_integer(record_a, "communicator_sequence_id"),
+        sequence_id_b=_optional_integer(record_b, "communicator_sequence_id"),
+        policy=policy,
+        requested_offset_us=requested_offset,
+        a_start_ns=a_start,
+        a_end_ns=a_end,
+        b_start_ns=b_start,
+        b_end_ns=b_end,
+        b_consumer_ns=consumer,
+        critical_path_duration_us=critical_path_duration_us,
+        sequence_consistent=sequence_consistent,
+    )
+
+
+def pair_trace_records(
+    records: Iterable[Mapping[str, Any]],
+    operation_a: str,
+    operation_b: str,
+    pair_fields: Sequence[str] = DEFAULT_PAIR_FIELDS,
+) -> list[RankPair]:
+    """Pair A/B trace records by run, rank, semantic context, and launch order."""
+
+    grouped: defaultdict[tuple[Any, ...], dict[str, list[Mapping[str, Any]]]] = defaultdict(
+        lambda: {operation_a: [], operation_b: []}
+    )
+    selected = 0
+    for record in records:
+        operation = _record_value(record, "operation")
+        if operation not in (operation_a, operation_b):
+            continue
+        selected += 1
+        run_id = _string(record, "run_id")
+        rank = _integer(record, "rank")
+        context = _context(record, pair_fields)
+        declared_world_size = _record_value(record, "world_size")
+        grouped[(run_id, rank, declared_world_size, context)][operation].append(record)
+    if not selected:
+        raise TraceFormatError(f"no records matched operations {operation_a!r} and {operation_b!r}")
+
+    pairs = []
+    for (run_id, rank, _, context), by_operation in grouped.items():
+        records_a = sorted(by_operation[operation_a], key=_sort_key)
+        records_b = sorted(by_operation[operation_b], key=_sort_key)
+        if len(records_a) != len(records_b) or not records_a:
+            raise TraceFormatError(
+                f"run {run_id!r} rank {rank} context {dict(context)!r} has "
+                f"{len(records_a)} {operation_a!r} records and {len(records_b)} {operation_b!r} records"
+            )
+        for ordinal, (record_a, record_b) in enumerate(zip(records_a, records_b, strict=True)):
+            pairs.append(
+                _pair_records(
+                    record_a,
+                    record_b,
+                    context=context,
+                    ordinal=ordinal,
+                    operation_a=operation_a,
+                    operation_b=operation_b,
+                )
+            )
+    return pairs
+
+
+def build_candidates(rank_pairs: Sequence[RankPair]) -> dict[tuple[Any, ...], list[Candidate]]:
+    """Build complete global trials and group them by portable workload key."""
+
+    trials_by_key: defaultdict[tuple[Any, ...], list[RankPair]] = defaultdict(list)
+    ranks_by_run: defaultdict[tuple[Any, ...], set[int]] = defaultdict(set)
+    ranks_by_workload: defaultdict[tuple[Any, ...], set[int]] = defaultdict(set)
+    declared_sizes_by_workload: defaultdict[tuple[Any, ...], set[int]] = defaultdict(set)
+    for pair in rank_pairs:
+        grouping_key = (pair.workload_base, pair.declared_world_size)
+        candidate_key = (pair.policy, pair.requested_offset_us)
+        run_key = (pair.run_id, grouping_key, candidate_key)
+        ranks_by_run[run_key].add(pair.rank)
+        ranks_by_workload[grouping_key].add(pair.rank)
+        if pair.declared_world_size is not None:
+            declared_sizes_by_workload[grouping_key].add(pair.declared_world_size)
+        trials_by_key[(run_key, pair.context, pair.ordinal)].append(pair)
+
+    expected_by_workload: dict[tuple[Any, ...], tuple[int, ...]] = {}
+    for grouping_key, observed_ranks in ranks_by_workload.items():
+        declared_sizes = declared_sizes_by_workload[grouping_key]
+        if len(declared_sizes) > 1:
+            raise TraceFormatError(f"workload has conflicting declared world sizes: {sorted(declared_sizes)}")
+        world_size = next(iter(declared_sizes)) if declared_sizes else max(observed_ranks) + 1
+        expected_by_workload[grouping_key] = tuple(range(world_size))
+
+    for run_key, observed_ranks in ranks_by_run.items():
+        expected = expected_by_workload[run_key[1]]
+        if tuple(sorted(observed_ranks)) != expected:
+            raise TraceFormatError(f"run {run_key[0]!r} has ranks {tuple(sorted(observed_ranks))}, expected {expected}")
+
+    candidate_trials: defaultdict[tuple[Any, ...], list[Trial]] = defaultdict(list)
+    for (run_key, context, ordinal), pairs in trials_by_key.items():
+        run_id, grouping_key, candidate_key = run_key
+        workload_base, _ = grouping_key
+        expected = expected_by_workload[grouping_key]
+        observed = tuple(sorted(pair.rank for pair in pairs))
+        if observed != expected:
+            raise TraceFormatError(
+                f"run {run_id!r} context {dict(context)!r} has ranks {observed}, expected {expected}"
+            )
+        workload_key = (*workload_base, len(expected))
+        candidate_trials[(workload_key, candidate_key)].append(
+            Trial(run_id, context, ordinal, tuple(sorted(pairs, key=lambda pair: pair.rank)))
+        )
+
+    by_workload: defaultdict[tuple[Any, ...], list[Candidate]] = defaultdict(list)
+    for (workload_key, candidate_key), trials in candidate_trials.items():
+        policy, requested_offset_us = candidate_key
+        by_workload[workload_key].append(
+            Candidate(policy, requested_offset_us, tuple(sorted(trials, key=_trial_sort_key)))
+        )
+    return dict(by_workload)
+
+
+def _trial_sort_key(trial: Trial) -> tuple[str, str, int]:
+    return trial.run_id, json.dumps(trial.context, sort_keys=True), trial.ordinal
+
+
+def _rounded(value: float | None) -> float | None:
+    return round(value, 6) if value is not None else None
+
+
+def summarize_candidate(candidate: Candidate) -> dict[str, Any]:
+    """Summarize one candidate without discarding tail or safety signals."""
+
+    rank_pairs = candidate.rank_pairs
+    critical_path_sources = {trial.critical_path_source for trial in candidate.trials}
+    if len(critical_path_sources) != 1:
+        raise TraceFormatError("critical_path_duration_us is missing on only some trials")
+    critical_paths = [trial.critical_path_us for trial in candidate.trials]
+    pair_completions = [trial.pair_completion_us for trial in candidate.trials]
+    realized_offsets = [pair.realized_offset_us for pair in rank_pairs]
+    consumer_slacks = [pair.consumer_slack_us for pair in rank_pairs]
+    consumer_waits = [max(0.0, -slack) for slack in consumer_slacks]
+    rank_skews = [trial.rank_skew_us for trial in candidate.trials]
+    realized_p50 = percentile(realized_offsets, 50)
+    requested = candidate.requested_offset_us
+    return {
+        "policy": candidate.policy,
+        "requested_offset_us": requested,
+        "trial_count": len(candidate.trials),
+        "rank_observation_count": len(rank_pairs),
+        "critical_path_source": next(iter(critical_path_sources)),
+        "critical_path_us_p50": _rounded(percentile(critical_paths, 50)),
+        "critical_path_us_p95": _rounded(percentile(critical_paths, 95)),
+        "critical_path_us_p99": _rounded(percentile(critical_paths, 99)),
+        "pair_completion_us_p50": _rounded(percentile(pair_completions, 50)),
+        "pair_completion_us_p95": _rounded(percentile(pair_completions, 95)),
+        "realized_gpu_offset_us_p50": _rounded(realized_p50),
+        "realized_gpu_offset_us_p05": _rounded(percentile(realized_offsets, 5)),
+        "realized_gpu_offset_us_p95": _rounded(percentile(realized_offsets, 95)),
+        "realized_offset_error_us_p50": (_rounded(abs(realized_p50 - requested)) if requested is not None else None),
+        "consumer_slack_us_p05": _rounded(percentile(consumer_slacks, 5)),
+        "consumer_slack_us_p50": _rounded(percentile(consumer_slacks, 50)),
+        "consumer_wait_us_p95": _rounded(percentile(consumer_waits, 95)),
+        "rank_skew_us_p95": _rounded(percentile(rank_skews, 95)),
+        "sequence_consistent": all(trial.sequence_consistent for trial in candidate.trials),
+    }
+
+
+def _bootstrap_improvement_interval(
+    baseline: Sequence[float],
+    candidate: Sequence[float],
+    *,
+    confidence: float,
+    resamples: int,
+    seed_material: str,
+) -> tuple[float, float] | None:
+    if len(baseline) < 2 or len(candidate) < 2 or resamples <= 0:
+        return None
+    seed = int.from_bytes(hashlib.sha256(seed_material.encode()).digest()[:8], "big")
+    generator = random.Random(seed)
+    differences = []
+    for _ in range(resamples):
+        baseline_sample = [baseline[generator.randrange(len(baseline))] for _ in baseline]
+        candidate_sample = [candidate[generator.randrange(len(candidate))] for _ in candidate]
+        differences.append(percentile(baseline_sample, 95) - percentile(candidate_sample, 95))
+    tail_percent = (1 - confidence) * 50
+    return percentile(differences, tail_percent), percentile(differences, 100 - tail_percent)
+
+
+def _paired_improvement_interval(
+    baseline: Sequence[Trial],
+    candidate: Sequence[Trial],
+    *,
+    confidence: float,
+    resamples: int,
+    seed_material: str,
+) -> tuple[tuple[float, float] | None, str]:
+    baseline_by_context: defaultdict[tuple[Any, ...], list[Trial]] = defaultdict(list)
+    candidate_by_context: defaultdict[tuple[Any, ...], list[Trial]] = defaultdict(list)
+    for trial in baseline:
+        baseline_by_context[(trial.context, trial.ordinal)].append(trial)
+    for trial in candidate:
+        candidate_by_context[(trial.context, trial.ordinal)].append(trial)
+
+    contexts = set(baseline_by_context) & set(candidate_by_context)
+    unambiguous = (
+        contexts
+        and contexts == set(baseline_by_context) == set(candidate_by_context)
+        and all(len(baseline_by_context[context]) == len(candidate_by_context[context]) == 1 for context in contexts)
+    )
+    if unambiguous and len(contexts) >= 2 and resamples > 0:
+        differences = [
+            baseline_by_context[context][0].critical_path_us - candidate_by_context[context][0].critical_path_us
+            for context in sorted(contexts, key=repr)
+        ]
+        seed = int.from_bytes(hashlib.sha256(seed_material.encode()).digest()[:8], "big")
+        generator = random.Random(seed)
+        estimates = []
+        for _ in range(resamples):
+            sample = [differences[generator.randrange(len(differences))] for _ in differences]
+            estimates.append(sum(sample) / len(sample))
+        tail_percent = (1 - confidence) * 50
+        return (
+            percentile(estimates, tail_percent),
+            percentile(estimates, 100 - tail_percent),
+        ), "paired_mean"
+
+    interval = _bootstrap_improvement_interval(
+        [trial.critical_path_us for trial in baseline],
+        [trial.critical_path_us for trial in candidate],
+        confidence=confidence,
+        resamples=resamples,
+        seed_material=seed_material,
+    )
+    return interval, "independent_p95"
+
+
+def _candidate_sort_key(summary: Mapping[str, Any]) -> tuple[float, float, float]:
+    return (
+        float(summary["critical_path_us_p95"]),
+        float(summary["consumer_wait_us_p95"]),
+        float(summary["rank_skew_us_p95"]),
+    )
+
+
+def _baseline_index(summaries: Sequence[Mapping[str, Any]]) -> int:
+    explicit = [index for index, item in enumerate(summaries) if item["policy"] in BASELINE_POLICIES]
+    candidates = explicit or list(range(len(summaries)))
+    return min(
+        candidates,
+        key=lambda index: (
+            abs(float(summaries[index]["realized_gpu_offset_us_p50"])),
+            _candidate_sort_key(summaries[index]),
+        ),
+    )
+
+
+def _workload_dict(workload: tuple[Any, ...]) -> dict[str, Any]:
+    (
+        framework,
+        topology_class,
+        operation_a,
+        operation_b,
+        message_bytes_a,
+        message_bytes_b,
+        transport_a,
+        transport_b,
+        world_size,
+    ) = workload
+    return {
+        "framework": framework,
+        "topology_class": topology_class,
+        "operation_a": operation_a,
+        "operation_b": operation_b,
+        "message_bytes_a": message_bytes_a,
+        "message_bytes_b": message_bytes_b,
+        "transport_a": transport_a,
+        "transport_b": transport_b,
+        "world_size": world_size,
+    }
+
+
+def _refinement_points(
+    summaries: Sequence[Mapping[str, Any]],
+    focus_index: int,
+    minimum_slack_us: float,
+) -> list[dict[str, float]]:
+    observed = sorted(
+        (float(item["requested_offset_us"]), index)
+        for index, item in enumerate(summaries)
+        if item["requested_offset_us"] is not None
+    )
+    position = next((position for position, (_, index) in enumerate(observed) if index == focus_index), None)
+    if position is None:
+        return []
+    proposals = []
+    for neighbor_position in (position - 1, position + 1):
+        if not 0 <= neighbor_position < len(observed):
+            continue
+        request_a, index_a = observed[position]
+        request_b, index_b = observed[neighbor_position]
+        midpoint = (request_a + request_b) / 2
+        if midpoint in {request for request, _ in observed}:
+            continue
+        slack_a = float(summaries[index_a]["consumer_slack_us_p05"])
+        slack_b = float(summaries[index_b]["consumer_slack_us_p05"])
+        predicted_slack = (slack_a + slack_b) / 2
+        if predicted_slack >= minimum_slack_us:
+            realized_a = float(summaries[index_a]["realized_gpu_offset_us_p50"])
+            realized_b = float(summaries[index_b]["realized_gpu_offset_us_p50"])
+            proposals.append(
+                {
+                    "requested_offset_us": midpoint,
+                    "predicted_realized_gpu_offset_us": (realized_a + realized_b) / 2,
+                    "predicted_consumer_slack_us_p05": predicted_slack,
+                }
+            )
+    return sorted(proposals, key=lambda proposal: proposal["requested_offset_us"])
+
+
+def tune_workload(
+    workload: tuple[Any, ...],
+    candidates: Sequence[Candidate],
+    *,
+    confidence: float = 0.95,
+    bootstrap_resamples: int = 2000,
+    min_trials: int = 2,
+) -> dict[str, Any]:
+    """Choose a safe policy and data-derived refinement offsets for one workload."""
+
+    summaries = [summarize_candidate(candidate) for candidate in candidates]
+    critical_path_sources = {summary["critical_path_source"] for summary in summaries}
+    if len(critical_path_sources) != 1:
+        raise TraceFormatError("all candidates for a workload must use the same critical-path source")
+    baseline_index = _baseline_index(summaries)
+    baseline = summaries[baseline_index]
+    minimum_slack_us = min(0.0, float(baseline["consumer_slack_us_p05"]))
+    baseline_rank_skew_us = float(baseline["rank_skew_us_p95"])
+
+    eligible = []
+    for index, (candidate, summary) in enumerate(zip(candidates, summaries, strict=True)):
+        reasons = []
+        if summary["trial_count"] < min_trials:
+            reasons.append("insufficient_trials")
+        if not summary["sequence_consistent"]:
+            reasons.append("communicator_sequence_divergence")
+        if float(summary["consumer_slack_us_p05"]) < minimum_slack_us:
+            reasons.append("consumer_deadline_regression")
+        rank_skew_growth_us = max(0.0, float(summary["rank_skew_us_p95"]) - baseline_rank_skew_us)
+        rank_skew_headroom_us = max(0.0, float(summary["consumer_slack_us_p05"]) - minimum_slack_us)
+        summary["rank_skew_growth_us"] = _rounded(rank_skew_growth_us)
+        summary["rank_skew_slack_headroom_us"] = _rounded(rank_skew_headroom_us)
+        if rank_skew_growth_us > rank_skew_headroom_us:
+            reasons.append("rank_skew_exceeds_slack_headroom")
+        requested = summary["requested_offset_us"]
+        realized = float(summary["realized_gpu_offset_us_p50"])
+        if requested not in (None, 0) and math.copysign(1, float(requested)) != math.copysign(1, realized):
+            reasons.append("realized_offset_direction_mismatch")
+        elif requested is not None and requested > 0 and summary["realized_gpu_offset_us_p05"] <= 0:
+            reasons.append("realized_offset_direction_unstable")
+        elif requested is not None and requested < 0 and summary["realized_gpu_offset_us_p95"] >= 0:
+            reasons.append("realized_offset_direction_unstable")
+
+        interval = (0.0, 0.0)
+        confidence_method = "identity"
+        if index != baseline_index:
+            interval, confidence_method = _paired_improvement_interval(
+                candidates[baseline_index].trials,
+                candidate.trials,
+                confidence=confidence,
+                resamples=bootstrap_resamples,
+                seed_material=f"{workload!r}/{candidate.policy}/{candidate.requested_offset_us}",
+            )
+        summary["critical_path_improvement_ci_us"] = (
+            [_rounded(interval[0]), _rounded(interval[1])] if interval is not None else None
+        )
+        summary["confidence_method"] = confidence_method
+        summary["eligible"] = not reasons
+        summary["rejection_reasons"] = reasons
+        if not reasons:
+            eligible.append(index)
+
+    improving = []
+    for index in eligible:
+        interval = summaries[index]["critical_path_improvement_ci_us"]
+        if index != baseline_index and interval is not None and interval[0] > 0:
+            improving.append(index)
+    selected_index = (
+        min(improving, key=lambda index: _candidate_sort_key(summaries[index])) if improving else baseline_index
+    )
+
+    evidence_ready = baseline["trial_count"] >= min_trials and baseline_index in eligible
+    if not evidence_ready:
+        decision = "insufficient_evidence"
+    elif selected_index == baseline_index:
+        decision = "keep_baseline"
+    else:
+        decision = "switch_policy"
+
+    focus_pool = eligible or [baseline_index]
+    focus_index = min(focus_pool, key=lambda index: _candidate_sort_key(summaries[index]))
+    next_candidates = _refinement_points(summaries, focus_index, minimum_slack_us)
+    return {
+        "workload_key": _workload_dict(workload),
+        "decision": decision,
+        "baseline_candidate": {
+            "policy": baseline["policy"],
+            "requested_offset_us": baseline["requested_offset_us"],
+        },
+        "recommended_candidate": {
+            "policy": summaries[selected_index]["policy"],
+            "requested_offset_us": summaries[selected_index]["requested_offset_us"],
+            "realized_gpu_offset_us_p50": summaries[selected_index]["realized_gpu_offset_us_p50"],
+        },
+        "consumer_deadline_guard_us": _rounded(minimum_slack_us),
+        "refinement": {
+            "next_requested_offsets_us": [candidate["requested_offset_us"] for candidate in next_candidates],
+            "next_candidates": next_candidates,
+            "method": "measured-interval midpoint bounded by consumer slack; no extrapolation",
+        },
+        "candidates": sorted(
+            summaries,
+            key=lambda item: (
+                item["requested_offset_us"] is None,
+                0 if item["requested_offset_us"] is None else item["requested_offset_us"],
+                item["policy"],
+            ),
+        ),
+    }
+
+
+def tune_traces(
+    records: Iterable[Mapping[str, Any]],
+    operation_a: str,
+    operation_b: str,
+    *,
+    pair_fields: Sequence[str] = DEFAULT_PAIR_FIELDS,
+    confidence: float = 0.95,
+    bootstrap_resamples: int = 2000,
+    min_trials: int = 2,
+) -> dict[str, Any]:
+    """Build recommendations from framework-neutral semantic trace records."""
+
+    if not 0 < confidence < 1:
+        raise ValueError("confidence must be between zero and one")
+    if bootstrap_resamples < 0:
+        raise ValueError("bootstrap_resamples must be non-negative")
+    if min_trials <= 0:
+        raise ValueError("min_trials must be positive")
+    if not pair_fields:
+        raise ValueError("at least one pair field is required")
+    pairs = pair_trace_records(records, operation_a, operation_b, pair_fields)
+    by_workload = build_candidates(pairs)
+    recommendations = [
+        tune_workload(
+            workload,
+            candidates,
+            confidence=confidence,
+            bootstrap_resamples=bootstrap_resamples,
+            min_trials=min_trials,
+        )
+        for workload, candidates in sorted(by_workload.items(), key=lambda item: repr(item[0]))
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "operation_a": operation_a,
+        "operation_b": operation_b,
+        "pair_fields": list(pair_fields),
+        "recommendations": recommendations,
+    }
+
+
+def load_jsonl(paths: Sequence[Path]) -> list[dict[str, Any]]:
+    """Load JSON objects from one or more JSONL trace shards."""
+
+    records = []
+    for path in paths:
+        with path.open(encoding="utf-8") as trace_file:
+            for line_number, line in enumerate(trace_file, 1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise TraceFormatError(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
+                if not isinstance(record, dict):
+                    raise TraceFormatError(f"{path}:{line_number}: each line must contain a JSON object")
+                records.append(record)
+    return records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--trace-jsonl", nargs="+", type=Path, required=True, help="all rank shards for all candidates")
+    parser.add_argument("--operation-a", required=True)
+    parser.add_argument("--operation-b", required=True)
+    parser.add_argument(
+        "--pair-by",
+        nargs="+",
+        default=list(DEFAULT_PAIR_FIELDS),
+        help="scalar trace fields identifying one semantic A/B pair",
+    )
+    parser.add_argument("--confidence", type=float, default=0.95)
+    parser.add_argument("--bootstrap-resamples", type=int, default=2000)
+    parser.add_argument("--min-trials", type=int, default=2)
+    parser.add_argument("--output-json", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        payload = tune_traces(
+            load_jsonl(args.trace_jsonl),
+            args.operation_a,
+            args.operation_b,
+            pair_fields=args.pair_by,
+            confidence=args.confidence,
+            bootstrap_resamples=args.bootstrap_resamples,
+            min_trials=args.min_trials,
+        )
+    except (OSError, TraceFormatError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    payload["trace_files"] = [str(path) for path in args.trace_jsonl]
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/communication_network_policy.py
+++ b/scripts/communication_network_policy.py
@@ -1,0 +1,861 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gate measured communication policies on exact NIC and telemetry evidence.
+
+The module is an offline compatibility and eligibility layer. It never changes
+NIC traffic classes, rail routing, host QoS, or transport configuration. A
+caller must provide a complete operator-authored capability inventory and
+telemetry that observed every selected rank. Unknown or incompatible evidence
+fails closed instead of falling back to a nearby rail or traffic class.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__:
+    from scripts.communication_topology_policy import (
+        TopologyEvidenceError,
+        TopologyFingerprint,
+        fingerprint_trace_run,
+        load_jsonl,
+        topology_run_key,
+    )
+else:
+    from communication_topology_policy import (
+        TopologyEvidenceError,
+        TopologyFingerprint,
+        fingerprint_trace_run,
+        load_jsonl,
+        topology_run_key,
+    )
+
+NIC_CAPABILITY_SCHEMA_VERSION = 1
+NETWORK_TELEMETRY_SCHEMA_VERSION = 1
+NETWORK_POLICY_SCHEMA_VERSION = 1
+SUPPORTED_NETWORK_FABRICS = frozenset({"infiniband", "roce"})
+_UNKNOWN_TOKENS = frozenset({"", "auto", "n/a", "none", "unknown", "unspecified"})
+_RAIL_FIELDS = {"rail_id", "traffic_classes"}
+_RANK_CAPABILITY_FIELDS = {"rank", "rails"}
+_NIC_CAPABILITY_FIELDS = {
+    "schema_version",
+    "topology_cell_id",
+    "topology_fingerprint",
+    "network_fabric",
+    "inventory_signature",
+    "rank_capabilities",
+}
+_TELEMETRY_FIELDS = {
+    "schema_version",
+    "topology_cell_id",
+    "nic_capability_id",
+    "nic_capability_fingerprint",
+    "network_fabric",
+    "telemetry_source",
+    "telemetry_schema_signature",
+}
+_ASSIGNMENT_FIELDS = {"operation", "rank", "rail_id", "traffic_class"}
+_ELIGIBILITY_FIELDS = {
+    "schema_version",
+    "eligibility_id",
+    "network_telemetry_cell_id",
+    "network_telemetry_fingerprint",
+    "required_assignments",
+}
+
+
+class NetworkEvidenceError(ValueError):
+    """Raised when NIC capability or telemetry evidence is incomplete."""
+
+
+class IneligibleNetworkPolicyError(ValueError):
+    """Raised when no measured network policy is eligible for a target."""
+
+
+def _require_exact_fields(value: Mapping[str, Any], expected: set[str], label: str) -> None:
+    missing = expected - set(value)
+    unexpected = set(value) - expected
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append(f"missing {sorted(missing)}")
+        if unexpected:
+            details.append(f"unexpected {sorted(unexpected)}")
+        raise NetworkEvidenceError(f"{label} fields are invalid: {', '.join(details)}")
+
+
+def _require_schema_version(value: Mapping[str, Any], expected: int, label: str) -> None:
+    version = value.get("schema_version")
+    if isinstance(version, bool) or not isinstance(version, int) or version != expected:
+        raise NetworkEvidenceError(f"unsupported {label} schema_version")
+
+
+def _known_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or value != value.strip() or value.casefold() in _UNKNOWN_TOKENS:
+        raise NetworkEvidenceError(f"{label} must be an explicit, non-unknown string")
+    return value
+
+
+def _strict_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise NetworkEvidenceError(f"{label} must be an integer")
+    return value
+
+
+@dataclasses.dataclass(frozen=True)
+class RailCapability:
+    """Traffic classes explicitly supported on one logical rail."""
+
+    rail_id: str
+    traffic_classes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+
+        return {
+            "rail_id": self.rail_id,
+            "traffic_classes": list(self.traffic_classes),
+        }
+
+    def validate(self) -> None:
+        """Validate that no rail or traffic-class capability is implicit."""
+
+        _known_string(self.rail_id, "rail_id")
+        if not self.traffic_classes:
+            raise NetworkEvidenceError(f"rail {self.rail_id!r} has no explicit traffic classes")
+        if tuple(sorted(self.traffic_classes)) != self.traffic_classes:
+            raise NetworkEvidenceError("traffic_classes must be in canonical sorted order")
+        if len(set(self.traffic_classes)) != len(self.traffic_classes):
+            raise NetworkEvidenceError(f"rail {self.rail_id!r} contains duplicate traffic classes")
+        for traffic_class in self.traffic_classes:
+            _known_string(traffic_class, "traffic_class")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RailCapability:
+        """Validate and deserialize one rail capability."""
+
+        _require_exact_fields(value, _RAIL_FIELDS, "rail capability")
+        rail_id = _known_string(value["rail_id"], "rail_id")
+        raw_traffic_classes = value["traffic_classes"]
+        if not isinstance(raw_traffic_classes, list):
+            raise NetworkEvidenceError("traffic_classes must be a list")
+        traffic_classes = tuple(sorted(_known_string(item, "traffic_class") for item in raw_traffic_classes))
+        capability = cls(rail_id=rail_id, traffic_classes=traffic_classes)
+        capability.validate()
+        return capability
+
+
+@dataclasses.dataclass(frozen=True)
+class RankNicCapability:
+    """Logical rail inventory visible to one distributed rank."""
+
+    rank: int
+    rails: tuple[RailCapability, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+
+        return {
+            "rank": self.rank,
+            "rails": [rail.to_dict() for rail in self.rails],
+        }
+
+    def validate(self) -> None:
+        """Validate one rank's complete logical rail inventory."""
+
+        if _strict_int(self.rank, "rank") < 0:
+            raise NetworkEvidenceError("rank must be non-negative")
+        if not self.rails:
+            raise NetworkEvidenceError(f"rank {self.rank} has no explicit rails")
+        if tuple(sorted(self.rails, key=lambda rail: rail.rail_id)) != self.rails:
+            raise NetworkEvidenceError("rails must be in canonical sorted order")
+        rail_ids = [rail.rail_id for rail in self.rails]
+        if len(set(rail_ids)) != len(rail_ids):
+            raise NetworkEvidenceError(f"rank {self.rank} contains duplicate rail IDs")
+        for rail in self.rails:
+            rail.validate()
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> RankNicCapability:
+        """Validate and deserialize one rank capability."""
+
+        _require_exact_fields(value, _RANK_CAPABILITY_FIELDS, "rank capability")
+        rank = _strict_int(value["rank"], "rank")
+        raw_rails = value["rails"]
+        if not isinstance(raw_rails, list):
+            raise NetworkEvidenceError("rails must be a list")
+        rails = []
+        for raw_rail in raw_rails:
+            if not isinstance(raw_rail, Mapping):
+                raise NetworkEvidenceError("each rail capability must be an object")
+            rails.append(RailCapability.from_dict(raw_rail))
+        capability = cls(rank=rank, rails=tuple(sorted(rails, key=lambda rail: rail.rail_id)))
+        capability.validate()
+        return capability
+
+
+@dataclasses.dataclass(frozen=True)
+class NicCapabilityFingerprint:
+    """Content-addressed NIC inventory tied to an exact topology cell."""
+
+    topology: TopologyFingerprint
+    network_fabric: str
+    inventory_signature: str
+    rank_capabilities: tuple[RankNicCapability, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+
+        return {
+            "schema_version": NIC_CAPABILITY_SCHEMA_VERSION,
+            "topology_cell_id": self.topology.cell_id,
+            "topology_fingerprint": self.topology.to_dict(),
+            "network_fabric": self.network_fabric,
+            "inventory_signature": self.inventory_signature,
+            "rank_capabilities": [capability.to_dict() for capability in self.rank_capabilities],
+        }
+
+    @property
+    def canonical_json(self) -> str:
+        """Return a stable serialization for hashing and storage."""
+
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+    @property
+    def capability_id(self) -> str:
+        """Return the content-addressed NIC capability identifier."""
+
+        digest = hashlib.sha256(self.canonical_json.encode()).hexdigest()
+        return f"nic-capability-v{NIC_CAPABILITY_SCHEMA_VERSION}:{digest}"
+
+    def validate(self) -> None:
+        """Validate topology binding and complete per-rank capabilities."""
+
+        try:
+            self.topology.validate()
+        except TopologyEvidenceError as exc:
+            raise NetworkEvidenceError(f"invalid topology fingerprint: {exc}") from exc
+        if self.topology.scope != "multi_node":
+            raise NetworkEvidenceError("NIC rail policies require a multi-node topology cell")
+        if self.network_fabric not in SUPPORTED_NETWORK_FABRICS:
+            raise NetworkEvidenceError(f"network_fabric must be one of {sorted(SUPPORTED_NETWORK_FABRICS)}")
+        _known_string(self.inventory_signature, "inventory_signature")
+        if tuple(sorted(self.rank_capabilities, key=lambda item: item.rank)) != self.rank_capabilities:
+            raise NetworkEvidenceError("rank_capabilities must be in canonical sorted order")
+        ranks = tuple(capability.rank for capability in self.rank_capabilities)
+        if ranks != tuple(range(self.topology.world_size)):
+            raise NetworkEvidenceError(
+                f"rank_capabilities contain ranks {ranks}, expected {tuple(range(self.topology.world_size))}"
+            )
+        for capability in self.rank_capabilities:
+            capability.validate()
+
+    def supports(self, rank: int, rail_id: str, traffic_class: str) -> bool:
+        """Return whether a rank explicitly supports a rail/class binding."""
+
+        if rank < 0 or rank >= len(self.rank_capabilities):
+            return False
+        rank_capability = self.rank_capabilities[rank]
+        if rank_capability.rank != rank:
+            return False
+        return any(rail.rail_id == rail_id and traffic_class in rail.traffic_classes for rail in rank_capability.rails)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> NicCapabilityFingerprint:
+        """Validate and deserialize an operator-authored NIC inventory."""
+
+        _require_schema_version(value, NIC_CAPABILITY_SCHEMA_VERSION, "NIC capability")
+        _require_exact_fields(value, _NIC_CAPABILITY_FIELDS, "NIC capability")
+        raw_topology = value["topology_fingerprint"]
+        if not isinstance(raw_topology, Mapping):
+            raise NetworkEvidenceError("topology_fingerprint must be an object")
+        try:
+            topology = TopologyFingerprint.from_dict(raw_topology)
+        except TopologyEvidenceError as exc:
+            raise NetworkEvidenceError(f"invalid topology_fingerprint: {exc}") from exc
+        if value["topology_cell_id"] != topology.cell_id:
+            raise NetworkEvidenceError("topology_cell_id does not match topology_fingerprint")
+        network_fabric = _known_string(value["network_fabric"], "network_fabric")
+        inventory_signature = _known_string(value["inventory_signature"], "inventory_signature")
+        raw_rank_capabilities = value["rank_capabilities"]
+        if not isinstance(raw_rank_capabilities, list):
+            raise NetworkEvidenceError("rank_capabilities must be a list")
+        rank_capabilities = []
+        for raw_capability in raw_rank_capabilities:
+            if not isinstance(raw_capability, Mapping):
+                raise NetworkEvidenceError("each rank capability must be an object")
+            rank_capabilities.append(RankNicCapability.from_dict(raw_capability))
+        fingerprint = cls(
+            topology=topology,
+            network_fabric=network_fabric,
+            inventory_signature=inventory_signature,
+            rank_capabilities=tuple(sorted(rank_capabilities, key=lambda item: item.rank)),
+        )
+        fingerprint.validate()
+        return fingerprint
+
+
+@dataclasses.dataclass(frozen=True)
+class NetworkCompatibility:
+    """Exact compatibility result for two network telemetry cells."""
+
+    compatible: bool
+    reasons: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class NetworkTelemetryFingerprint:
+    """Measurement environment in which network policy evidence was observed."""
+
+    capability: NicCapabilityFingerprint
+    telemetry_source: str
+    telemetry_schema_signature: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+
+        return {
+            "schema_version": NETWORK_TELEMETRY_SCHEMA_VERSION,
+            "topology_cell_id": self.capability.topology.cell_id,
+            "nic_capability_id": self.capability.capability_id,
+            "nic_capability_fingerprint": self.capability.to_dict(),
+            "network_fabric": self.capability.network_fabric,
+            "telemetry_source": self.telemetry_source,
+            "telemetry_schema_signature": self.telemetry_schema_signature,
+        }
+
+    @property
+    def canonical_json(self) -> str:
+        """Return a stable serialization for hashing and storage."""
+
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+    @property
+    def cell_id(self) -> str:
+        """Return the content-addressed telemetry compatibility cell."""
+
+        digest = hashlib.sha256(self.canonical_json.encode()).hexdigest()
+        return f"network-telemetry-v{NETWORK_TELEMETRY_SCHEMA_VERSION}:{digest}"
+
+    def validate(self) -> None:
+        """Validate the embedded capability and telemetry semantics."""
+
+        self.capability.validate()
+        _known_string(self.telemetry_source, "network_telemetry_source")
+        _known_string(self.telemetry_schema_signature, "network_telemetry_schema_signature")
+
+    def compare(self, other: NetworkTelemetryFingerprint) -> NetworkCompatibility:
+        """Compare every portability boundary without fuzzy matching."""
+
+        reasons = []
+        fields = (
+            ("topology_cell_id", self.capability.topology.cell_id, other.capability.topology.cell_id),
+            ("nic_capability_id", self.capability.capability_id, other.capability.capability_id),
+            ("network_fabric", self.capability.network_fabric, other.capability.network_fabric),
+            ("telemetry_source", self.telemetry_source, other.telemetry_source),
+            (
+                "telemetry_schema_signature",
+                self.telemetry_schema_signature,
+                other.telemetry_schema_signature,
+            ),
+        )
+        for name, left, right in fields:
+            if left != right:
+                reasons.append(name)
+        return NetworkCompatibility(not reasons, tuple(reasons))
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> NetworkTelemetryFingerprint:
+        """Validate and deserialize a stored telemetry compatibility cell."""
+
+        _require_schema_version(value, NETWORK_TELEMETRY_SCHEMA_VERSION, "network telemetry")
+        _require_exact_fields(value, _TELEMETRY_FIELDS, "network telemetry")
+        raw_capability = value["nic_capability_fingerprint"]
+        if not isinstance(raw_capability, Mapping):
+            raise NetworkEvidenceError("nic_capability_fingerprint must be an object")
+        capability = NicCapabilityFingerprint.from_dict(raw_capability)
+        if value["topology_cell_id"] != capability.topology.cell_id:
+            raise NetworkEvidenceError("stored telemetry topology_cell_id is inconsistent")
+        if value["nic_capability_id"] != capability.capability_id:
+            raise NetworkEvidenceError("stored nic_capability_id does not match its fingerprint")
+        if value["network_fabric"] != capability.network_fabric:
+            raise NetworkEvidenceError("stored telemetry network_fabric is inconsistent")
+        fingerprint = cls(
+            capability=capability,
+            telemetry_source=_known_string(value["telemetry_source"], "telemetry_source"),
+            telemetry_schema_signature=_known_string(value["telemetry_schema_signature"], "telemetry_schema_signature"),
+        )
+        fingerprint.validate()
+        return fingerprint
+
+
+@dataclasses.dataclass(frozen=True, order=True)
+class NetworkAssignment:
+    """One observed operation/rank rail and traffic-class binding."""
+
+    operation: str
+    rank: int
+    rail_id: str
+    traffic_class: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+
+        return {
+            "operation": self.operation,
+            "rank": self.rank,
+            "rail_id": self.rail_id,
+            "traffic_class": self.traffic_class,
+        }
+
+    def validate(self) -> None:
+        """Validate an explicit assignment without accepting sentinels."""
+
+        _known_string(self.operation, "operation")
+        if _strict_int(self.rank, "rank") < 0:
+            raise NetworkEvidenceError("rank must be non-negative")
+        _known_string(self.rail_id, "rail_id")
+        _known_string(self.traffic_class, "traffic_class")
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> NetworkAssignment:
+        """Validate and deserialize one required assignment."""
+
+        _require_exact_fields(value, _ASSIGNMENT_FIELDS, "network assignment")
+        assignment = cls(
+            operation=_known_string(value["operation"], "operation"),
+            rank=_strict_int(value["rank"], "rank"),
+            rail_id=_known_string(value["rail_id"], "rail_id"),
+            traffic_class=_known_string(value["traffic_class"], "traffic_class"),
+        )
+        assignment.validate()
+        return assignment
+
+
+@dataclasses.dataclass(frozen=True)
+class NetworkPolicyEligibility:
+    """Measured network cell and complete bindings required by one policy."""
+
+    telemetry: NetworkTelemetryFingerprint
+    required_assignments: tuple[NetworkAssignment, ...]
+
+    def _identity_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": NETWORK_POLICY_SCHEMA_VERSION,
+            "network_telemetry_cell_id": self.telemetry.cell_id,
+            "network_telemetry_fingerprint": self.telemetry.to_dict(),
+            "required_assignments": [assignment.to_dict() for assignment in self.required_assignments],
+        }
+
+    @property
+    def eligibility_id(self) -> str:
+        """Return a digest binding the telemetry cell to measured assignments."""
+
+        canonical = json.dumps(self._identity_dict(), separators=(",", ":"), sort_keys=True)
+        digest = hashlib.sha256(canonical.encode()).hexdigest()
+        return f"network-policy-v{NETWORK_POLICY_SCHEMA_VERSION}:{digest}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stored eligibility block including its integrity digest."""
+
+        return {"eligibility_id": self.eligibility_id, **self._identity_dict()}
+
+    def validate(self) -> None:
+        """Validate rank-complete requirements against explicit capabilities."""
+
+        self.telemetry.validate()
+        if not self.required_assignments:
+            raise NetworkEvidenceError("a network policy must have explicit required_assignments")
+        if tuple(sorted(self.required_assignments)) != self.required_assignments:
+            raise NetworkEvidenceError("required_assignments must be in canonical sorted order")
+        keys = [(assignment.operation, assignment.rank) for assignment in self.required_assignments]
+        if len(set(keys)) != len(keys):
+            raise NetworkEvidenceError("required_assignments contain duplicate operation/rank bindings")
+        assignments_by_operation: defaultdict[str, list[NetworkAssignment]] = defaultdict(list)
+        for assignment in self.required_assignments:
+            assignment.validate()
+            assignments_by_operation[assignment.operation].append(assignment)
+            if not self.telemetry.capability.supports(assignment.rank, assignment.rail_id, assignment.traffic_class):
+                raise NetworkEvidenceError(
+                    f"rank {assignment.rank} does not support rail {assignment.rail_id!r} "
+                    f"with traffic class {assignment.traffic_class!r}"
+                )
+        expected_ranks = tuple(range(self.telemetry.capability.topology.world_size))
+        for operation, assignments in assignments_by_operation.items():
+            observed_ranks = tuple(sorted(assignment.rank for assignment in assignments))
+            if observed_ranks != expected_ranks:
+                raise NetworkEvidenceError(
+                    f"operation {operation!r} has assignment ranks {observed_ranks}, expected {expected_ranks}"
+                )
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> NetworkPolicyEligibility:
+        """Validate and deserialize a policy eligibility block."""
+
+        _require_schema_version(value, NETWORK_POLICY_SCHEMA_VERSION, "network policy")
+        _require_exact_fields(value, _ELIGIBILITY_FIELDS, "network policy eligibility")
+        raw_telemetry = value["network_telemetry_fingerprint"]
+        if not isinstance(raw_telemetry, Mapping):
+            raise NetworkEvidenceError("network_telemetry_fingerprint must be an object")
+        telemetry = NetworkTelemetryFingerprint.from_dict(raw_telemetry)
+        if value["network_telemetry_cell_id"] != telemetry.cell_id:
+            raise NetworkEvidenceError("network_telemetry_cell_id does not match its fingerprint")
+        raw_assignments = value["required_assignments"]
+        if not isinstance(raw_assignments, list):
+            raise NetworkEvidenceError("required_assignments must be a list")
+        assignments = []
+        for raw_assignment in raw_assignments:
+            if not isinstance(raw_assignment, Mapping):
+                raise NetworkEvidenceError("each required assignment must be an object")
+            assignments.append(NetworkAssignment.from_dict(raw_assignment))
+        eligibility = cls(telemetry=telemetry, required_assignments=tuple(sorted(assignments)))
+        eligibility.validate()
+        if value["eligibility_id"] != eligibility.eligibility_id:
+            raise NetworkEvidenceError("eligibility_id does not match the eligibility evidence")
+        return eligibility
+
+
+def _record_value(record: Mapping[str, Any], name: str) -> Any:
+    value = record.get(name)
+    if value is not None:
+        return value
+    metadata = record.get("metadata")
+    return metadata.get(name) if isinstance(metadata, Mapping) else None
+
+
+def _required_consistent_value(records: Sequence[Mapping[str, Any]], name: str) -> Any:
+    values = []
+    for record in records:
+        value = _record_value(record, name)
+        if value is None:
+            raise NetworkEvidenceError(f"{name} is required on every selected telemetry record")
+        if isinstance(value, dict | list):
+            raise NetworkEvidenceError(f"{name} must be scalar")
+        values.append(value)
+    unique = set(values)
+    if len(unique) != 1:
+        raise NetworkEvidenceError(f"conflicting {name} values: {sorted(unique, key=str)!r}")
+    return values[0]
+
+
+def _trace_rank(record: Mapping[str, Any]) -> int:
+    rank = _record_value(record, "rank")
+    if isinstance(rank, bool) or not isinstance(rank, int):
+        raise NetworkEvidenceError("rank must be an integer in network telemetry")
+    if rank < 0:
+        raise NetworkEvidenceError("rank must be non-negative")
+    return rank
+
+
+def _select_records(records: Iterable[Mapping[str, Any]], operations: Sequence[str] | None) -> list[Mapping[str, Any]]:
+    selected_operations = None
+    if operations is not None:
+        if not operations:
+            raise NetworkEvidenceError("at least one operation must be selected")
+        selected_operations = {_known_string(operation, "operation") for operation in operations}
+    selected = []
+    for record in records:
+        operation = _record_value(record, "operation")
+        if selected_operations is not None and operation not in selected_operations:
+            continue
+        _known_string(operation, "operation")
+        selected.append(record)
+    if not selected:
+        raise NetworkEvidenceError("no trace records matched the network telemetry request")
+    return selected
+
+
+def _assignments_from_records(
+    records: Sequence[Mapping[str, Any]], capability: NicCapabilityFingerprint
+) -> tuple[NetworkAssignment, ...]:
+    bindings: defaultdict[tuple[str, int], set[tuple[str, str]]] = defaultdict(set)
+    for record in records:
+        operation = _known_string(_record_value(record, "operation"), "operation")
+        rank = _trace_rank(record)
+        rail_id = _known_string(_record_value(record, "nic_rail_id"), "nic_rail_id")
+        traffic_class = _known_string(_record_value(record, "nic_traffic_class"), "nic_traffic_class")
+        if not capability.supports(rank, rail_id, traffic_class):
+            raise NetworkEvidenceError(
+                f"rank {rank} telemetry observed unsupported rail {rail_id!r} and traffic class {traffic_class!r}"
+            )
+        bindings[(operation, rank)].add((rail_id, traffic_class))
+
+    assignments = []
+    for (operation, rank), observed in bindings.items():
+        if len(observed) != 1:
+            raise NetworkEvidenceError(
+                f"operation {operation!r} rank {rank} has inconsistent observed rail/class bindings"
+            )
+        rail_id, traffic_class = next(iter(observed))
+        assignments.append(NetworkAssignment(operation, rank, rail_id, traffic_class))
+
+    expected_ranks = tuple(range(capability.topology.world_size))
+    operations = sorted({assignment.operation for assignment in assignments})
+    for operation in operations:
+        observed_ranks = tuple(
+            sorted(assignment.rank for assignment in assignments if assignment.operation == operation)
+        )
+        if observed_ranks != expected_ranks:
+            raise NetworkEvidenceError(
+                f"operation {operation!r} has telemetry ranks {observed_ranks}, expected {expected_ranks}"
+            )
+    return tuple(sorted(assignments))
+
+
+def _fingerprint_network_telemetry_run(
+    records: Sequence[Mapping[str, Any]],
+    capability: NicCapabilityFingerprint,
+) -> tuple[NetworkTelemetryFingerprint, tuple[NetworkAssignment, ...]]:
+    capability.validate()
+    if not records:
+        raise NetworkEvidenceError("cannot fingerprint an empty network telemetry run")
+    try:
+        topology = fingerprint_trace_run(records)
+    except TopologyEvidenceError as exc:
+        raise NetworkEvidenceError(str(exc)) from exc
+    topology_compatibility = capability.topology.compare(topology)
+    if not topology_compatibility.compatible:
+        raise NetworkEvidenceError(
+            "NIC capability topology does not match trace topology: " + ", ".join(topology_compatibility.reasons)
+        )
+
+    for record in records:
+        if _record_value(record, "network_telemetry_observed") is not True:
+            raise NetworkEvidenceError("network_telemetry_observed=true is required on every selected record")
+    network_fabric = _known_string(_required_consistent_value(records, "network_fabric"), "network_fabric")
+    if network_fabric != capability.network_fabric:
+        raise NetworkEvidenceError("trace network_fabric does not match NIC capabilities")
+    inventory_signature = _known_string(
+        _required_consistent_value(records, "nic_inventory_signature"),
+        "nic_inventory_signature",
+    )
+    if inventory_signature != capability.inventory_signature:
+        raise NetworkEvidenceError("trace nic_inventory_signature does not match NIC capabilities")
+    telemetry_source = _known_string(
+        _required_consistent_value(records, "network_telemetry_source"),
+        "network_telemetry_source",
+    )
+    telemetry_schema_signature = _known_string(
+        _required_consistent_value(records, "network_telemetry_schema_signature"),
+        "network_telemetry_schema_signature",
+    )
+    assignments = _assignments_from_records(records, capability)
+    fingerprint = NetworkTelemetryFingerprint(
+        capability=capability,
+        telemetry_source=telemetry_source,
+        telemetry_schema_signature=telemetry_schema_signature,
+    )
+    fingerprint.validate()
+    return fingerprint, assignments
+
+
+def _network_evidence_by_run(
+    records: Iterable[Mapping[str, Any]],
+    capability: NicCapabilityFingerprint,
+    operations: Sequence[str] | None,
+) -> dict[
+    tuple[str, int | None],
+    tuple[NetworkTelemetryFingerprint, tuple[NetworkAssignment, ...]],
+]:
+    selected = _select_records(records, operations)
+    by_run: defaultdict[tuple[str, int | None], list[Mapping[str, Any]]] = defaultdict(list)
+    for record in selected:
+        try:
+            run_key = topology_run_key(record)
+        except TopologyEvidenceError as exc:
+            raise NetworkEvidenceError(str(exc)) from exc
+        by_run[run_key].append(record)
+    evidence = {}
+    for run_key, run_records in by_run.items():
+        try:
+            evidence[run_key] = _fingerprint_network_telemetry_run(run_records, capability)
+        except NetworkEvidenceError as exc:
+            raise NetworkEvidenceError(f"run {run_key[0]!r}: {exc}") from exc
+    return evidence
+
+
+def fingerprint_network_telemetry_run(
+    records: Sequence[Mapping[str, Any]],
+    capability: NicCapabilityFingerprint,
+) -> NetworkTelemetryFingerprint:
+    """Fingerprint one complete run after validating every observed binding."""
+
+    fingerprint, _ = _fingerprint_network_telemetry_run(records, capability)
+    return fingerprint
+
+
+def fingerprint_network_telemetry_runs(
+    records: Iterable[Mapping[str, Any]],
+    capability: NicCapabilityFingerprint,
+    operations: Sequence[str] | None = None,
+) -> dict[tuple[str, int | None], NetworkTelemetryFingerprint]:
+    """Fingerprint every selected run without mixing telemetry semantics."""
+
+    return {
+        run_key: fingerprint
+        for run_key, (fingerprint, _) in _network_evidence_by_run(records, capability, operations).items()
+    }
+
+
+def build_network_policy_eligibility(
+    records: Iterable[Mapping[str, Any]],
+    capability: NicCapabilityFingerprint,
+    operations: Sequence[str] | None = None,
+) -> NetworkPolicyEligibility:
+    """Bind rank-complete observed assignments to one telemetry cell."""
+
+    evidence = _network_evidence_by_run(records, capability, operations)
+    fingerprints = {fingerprint.cell_id: fingerprint for fingerprint, _ in evidence.values()}
+    if len(fingerprints) != 1:
+        raise NetworkEvidenceError("policy evidence spans more than one network telemetry cell")
+    assignments_by_run = {assignments for _, assignments in evidence.values()}
+    if len(assignments_by_run) != 1:
+        raise NetworkEvidenceError("policy evidence has inconsistent rail/class assignments across runs")
+    eligibility = NetworkPolicyEligibility(
+        telemetry=next(iter(fingerprints.values())),
+        required_assignments=next(iter(assignments_by_run)),
+    )
+    eligibility.validate()
+    return eligibility
+
+
+def select_eligible_network_policies(
+    recommendations: Sequence[Mapping[str, Any]],
+    target: NetworkTelemetryFingerprint,
+) -> list[Mapping[str, Any]]:
+    """Return only exact, capability-supported network policy recommendations."""
+
+    target.validate()
+    matches = []
+    mismatch_counts: Counter[str] = Counter()
+    unannotated = 0
+    for recommendation in recommendations:
+        raw_eligibility = recommendation.get("network_policy_eligibility")
+        if raw_eligibility is None:
+            unannotated += 1
+            continue
+        if not isinstance(raw_eligibility, Mapping):
+            raise NetworkEvidenceError("network_policy_eligibility must be an object")
+        eligibility = NetworkPolicyEligibility.from_dict(raw_eligibility)
+        compatibility = eligibility.telemetry.compare(target)
+        if not compatibility.compatible:
+            mismatch_counts.update(compatibility.reasons)
+            continue
+        for assignment in eligibility.required_assignments:
+            if not target.capability.supports(assignment.rank, assignment.rail_id, assignment.traffic_class):
+                mismatch_counts.update(("required_assignments",))
+                break
+        else:
+            matches.append(recommendation)
+    if matches:
+        return matches
+    details = [f"{field} ({count})" for field, count in sorted(mismatch_counts.items())]
+    if unannotated:
+        details.append(f"unannotated recommendations ({unannotated})")
+    raise IneligibleNetworkPolicyError(
+        f"no eligible network policy for {target.cell_id}; "
+        f"incompatibilities: {', '.join(details) or 'no measured policies'}"
+    )
+
+
+def _load_capability(path: Path) -> NicCapabilityFingerprint:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise NetworkEvidenceError("NIC capability JSON must contain an object")
+    return NicCapabilityFingerprint.from_dict(payload)
+
+
+def _one_target_fingerprint(
+    records: Iterable[Mapping[str, Any]],
+    capability: NicCapabilityFingerprint,
+    operations: Sequence[str],
+) -> NetworkTelemetryFingerprint:
+    fingerprints = fingerprint_network_telemetry_runs(records, capability, operations)
+    unique = {fingerprint.cell_id: fingerprint for fingerprint in fingerprints.values()}
+    if len(unique) != 1:
+        raise NetworkEvidenceError("target traces contain more than one network telemetry cell")
+    return next(iter(unique.values()))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the eligibility and selection CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="build eligibility from measured trace shards")
+    build.add_argument("--capabilities-json", type=Path, required=True)
+    build.add_argument("--trace-jsonl", nargs="+", type=Path, required=True)
+    build.add_argument("--operation", action="append", required=True)
+    build.add_argument("--output-json", type=Path, required=True)
+
+    select = subparsers.add_parser("select", help="select exact eligible policy recommendations")
+    select.add_argument("--policy-json", type=Path, required=True)
+    select.add_argument("--capabilities-json", type=Path, required=True)
+    select.add_argument("--target-trace-jsonl", nargs="+", type=Path, required=True)
+    select.add_argument("--operation", action="append", required=True)
+    select.add_argument("--output-json", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build an eligibility block or select recommendations."""
+
+    args = build_parser().parse_args(argv)
+    try:
+        capability = _load_capability(args.capabilities_json)
+        if args.command == "build":
+            eligibility = build_network_policy_eligibility(load_jsonl(args.trace_jsonl), capability, args.operation)
+            output = {
+                "schema_version": NETWORK_POLICY_SCHEMA_VERSION,
+                "network_policy_eligibility": eligibility.to_dict(),
+            }
+        else:
+            policy_payload = json.loads(args.policy_json.read_text(encoding="utf-8"))
+            if not isinstance(policy_payload, Mapping) or not isinstance(policy_payload.get("recommendations"), list):
+                raise NetworkEvidenceError("policy JSON must contain a recommendations list")
+            target = _one_target_fingerprint(load_jsonl(args.target_trace_jsonl), capability, args.operation)
+            matches = select_eligible_network_policies(policy_payload["recommendations"], target)
+            output = {
+                "schema_version": NETWORK_POLICY_SCHEMA_VERSION,
+                "nic_capability_id": capability.capability_id,
+                "network_telemetry_cell_id": target.cell_id,
+                "network_telemetry_fingerprint": target.to_dict(),
+                "recommendations": matches,
+            }
+    except (
+        OSError,
+        json.JSONDecodeError,
+        TopologyEvidenceError,
+        NetworkEvidenceError,
+        IneligibleNetworkPolicyError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(output, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/communication_topology_policy.py
+++ b/scripts/communication_topology_policy.py
@@ -1,0 +1,474 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fingerprint communication topology and select only exact policy cells.
+
+This module intentionally does not configure NIC traffic classes, rails, or
+routing.  It creates a stable compatibility boundary for measured policies so
+that a recommendation from one topology is never extrapolated to another.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+TOPOLOGY_SCHEMA_VERSION = 1
+_FINGERPRINT_FIELDS = {
+    "schema_version",
+    "scope",
+    "local_fabric",
+    "node_count",
+    "world_size",
+    "rank_groups",
+    "ranks_per_node",
+    "accelerator_models_by_rank",
+    "topology_signature",
+}
+
+
+class TopologyEvidenceError(ValueError):
+    """Raised when trace records cannot form a safe topology fingerprint."""
+
+
+class IncompatibleTopologyError(ValueError):
+    """Raised when no measured policy cell exactly matches a target topology."""
+
+
+@dataclasses.dataclass(frozen=True)
+class TopologyCompatibility:
+    """Exact compatibility result between two topology fingerprints."""
+
+    compatible: bool
+    reasons: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class TopologyFingerprint:
+    """Portable topology identity for one distributed run.
+
+    Hostnames are deliberately excluded from the identity. ``rank_groups``
+    preserves placement while allowing the same layout on different hosts.
+    ``topology_signature`` is an opaque inventory hash, required for multi-node
+    traces because a node count alone cannot identify an inter-node topology.
+    """
+
+    scope: str
+    local_fabric: str
+    node_count: int
+    world_size: int
+    rank_groups: tuple[tuple[int, ...], ...]
+    accelerator_models_by_rank: tuple[str, ...]
+    topology_signature: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+
+        return {
+            "schema_version": TOPOLOGY_SCHEMA_VERSION,
+            "scope": self.scope,
+            "local_fabric": self.local_fabric,
+            "node_count": self.node_count,
+            "world_size": self.world_size,
+            "rank_groups": [list(group) for group in self.rank_groups],
+            "ranks_per_node": [len(group) for group in self.rank_groups],
+            "accelerator_models_by_rank": list(self.accelerator_models_by_rank),
+            "topology_signature": self.topology_signature,
+        }
+
+    @property
+    def canonical_json(self) -> str:
+        """Return a stable serialization suitable for hashing and storage."""
+
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+    @property
+    def topology_class(self) -> str:
+        """Return a coarse human-readable class without weakening identity."""
+
+        if self.scope == "multi_node":
+            return "multi-node"
+        return f"single-node-{self.local_fabric}"
+
+    @property
+    def cell_id(self) -> str:
+        """Return the content-addressed topology cell identifier."""
+
+        return f"topology-v{TOPOLOGY_SCHEMA_VERSION}:{hashlib.sha256(self.canonical_json.encode()).hexdigest()}"
+
+    def compare(self, other: TopologyFingerprint) -> TopologyCompatibility:
+        """Compare every scheduling-relevant field without fuzzy matching."""
+
+        reasons = []
+        for field in (
+            "scope",
+            "local_fabric",
+            "node_count",
+            "world_size",
+            "rank_groups",
+            "accelerator_models_by_rank",
+            "topology_signature",
+        ):
+            if getattr(self, field) != getattr(other, field):
+                reasons.append(field)
+        return TopologyCompatibility(not reasons, tuple(reasons))
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> TopologyFingerprint:
+        """Validate and deserialize a stored fingerprint."""
+
+        if value.get("schema_version") != TOPOLOGY_SCHEMA_VERSION:
+            raise TopologyEvidenceError("unsupported topology fingerprint schema_version")
+        unexpected = set(value) - _FINGERPRINT_FIELDS
+        if unexpected:
+            raise TopologyEvidenceError(f"unexpected topology fingerprint fields: {sorted(unexpected)}")
+        try:
+            scope = value["scope"]
+            local_fabric = value["local_fabric"]
+            node_count = value["node_count"]
+            world_size = value["world_size"]
+            raw_groups = value["rank_groups"]
+            raw_models = value["accelerator_models_by_rank"]
+            if not isinstance(scope, str) or not isinstance(local_fabric, str):
+                raise TypeError
+            if isinstance(node_count, bool) or not isinstance(node_count, int):
+                raise TypeError
+            if isinstance(world_size, bool) or not isinstance(world_size, int):
+                raise TypeError
+            if not isinstance(raw_groups, list) or not all(isinstance(group, list) for group in raw_groups):
+                raise TypeError
+            if not all(not isinstance(rank, bool) and isinstance(rank, int) for group in raw_groups for rank in group):
+                raise TypeError
+            if not isinstance(raw_models, list) or not all(isinstance(model, str) for model in raw_models):
+                raise TypeError
+            rank_groups = tuple(tuple(group) for group in raw_groups)
+            models = tuple(raw_models)
+            signature = value.get("topology_signature")
+            if signature is not None and not isinstance(signature, str):
+                raise TypeError
+            fingerprint = cls(
+                scope=scope,
+                local_fabric=local_fabric,
+                node_count=node_count,
+                world_size=world_size,
+                rank_groups=rank_groups,
+                accelerator_models_by_rank=models,
+                topology_signature=signature,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise TopologyEvidenceError("malformed topology fingerprint") from exc
+        fingerprint.validate()
+        raw_ranks_per_node = value.get("ranks_per_node")
+        if not isinstance(raw_ranks_per_node, list) or not all(
+            not isinstance(count, bool) and isinstance(count, int) for count in raw_ranks_per_node
+        ):
+            raise TopologyEvidenceError("ranks_per_node must contain integer counts")
+        if raw_ranks_per_node != [len(group) for group in fingerprint.rank_groups]:
+            raise TopologyEvidenceError("ranks_per_node disagrees with rank_groups")
+        return fingerprint
+
+    def validate(self) -> None:
+        """Validate internal topology invariants."""
+
+        if isinstance(self.node_count, bool) or not isinstance(self.node_count, int):
+            raise TopologyEvidenceError("node_count must be an integer")
+        if isinstance(self.world_size, bool) or not isinstance(self.world_size, int):
+            raise TopologyEvidenceError("world_size must be an integer")
+        if self.scope not in {"single_node", "multi_node"}:
+            raise TopologyEvidenceError("scope must be single_node or multi_node")
+        if self.local_fabric not in {"pcie", "nvlink", "unknown"}:
+            raise TopologyEvidenceError("local_fabric must be pcie, nvlink, or unknown")
+        if self.node_count <= 0 or self.world_size < 2:
+            raise TopologyEvidenceError("invalid node_count or world_size")
+        if len(self.rank_groups) != self.node_count:
+            raise TopologyEvidenceError("rank_groups does not match node_count")
+        if any(not group for group in self.rank_groups):
+            raise TopologyEvidenceError("rank_groups cannot contain an empty node")
+        if any(isinstance(rank, bool) or not isinstance(rank, int) for group in self.rank_groups for rank in group):
+            raise TopologyEvidenceError("rank_groups must contain integer ranks")
+        flattened = tuple(sorted(rank for group in self.rank_groups for rank in group))
+        if flattened != tuple(range(self.world_size)):
+            raise TopologyEvidenceError("rank_groups must contain every rank exactly once")
+        if len(self.accelerator_models_by_rank) != self.world_size:
+            raise TopologyEvidenceError("accelerator model vector does not match world_size")
+        if any(not isinstance(model, str) or not model for model in self.accelerator_models_by_rank):
+            raise TopologyEvidenceError("accelerator models must be non-empty strings")
+        if self.scope == "single_node" and self.node_count != 1:
+            raise TopologyEvidenceError("single_node scope must contain exactly one node")
+        if self.scope == "multi_node" and self.node_count < 2:
+            raise TopologyEvidenceError("multi_node scope must contain at least two nodes")
+        if self.scope == "multi_node" and not self.topology_signature:
+            raise TopologyEvidenceError("multi-node traces require an opaque topology_signature")
+        if self.topology_signature is not None and (
+            not isinstance(self.topology_signature, str) or not self.topology_signature.strip()
+        ):
+            raise TopologyEvidenceError("topology_signature must be a non-empty string")
+
+
+def _value(record: Mapping[str, Any], name: str) -> Any:
+    value = record.get(name)
+    if value is not None:
+        return value
+    metadata = record.get("metadata")
+    return metadata.get(name) if isinstance(metadata, Mapping) else None
+
+
+def topology_run_key(record: Mapping[str, Any]) -> tuple[str, int | None]:
+    """Return a run key that keeps explicitly different world sizes separate."""
+
+    run_id = _value(record, "run_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise TopologyEvidenceError("run_id must be a non-empty string")
+    declared_world_size = _value(record, "world_size")
+    if declared_world_size is None:
+        return run_id, None
+    if (
+        isinstance(declared_world_size, bool)
+        or not isinstance(declared_world_size, int | float)
+        or not math.isfinite(declared_world_size)
+        or not float(declared_world_size).is_integer()
+    ):
+        raise TopologyEvidenceError("world_size must be an integer")
+    return run_id, int(declared_world_size)
+
+
+def _rank(record: Mapping[str, Any]) -> int:
+    value = _value(record, "rank")
+    if isinstance(value, bool) or not isinstance(value, int | float) or not float(value).is_integer():
+        raise TopologyEvidenceError("rank must be an integer")
+    rank = int(value)
+    if rank < 0:
+        raise TopologyEvidenceError("rank must be non-negative")
+    return rank
+
+
+def _consistent_scalar(records: Sequence[Mapping[str, Any]], names: Sequence[str]) -> Any:
+    values = set()
+    for record in records:
+        for name in names:
+            value = _value(record, name)
+            if value is not None:
+                if isinstance(value, dict | list):
+                    raise TopologyEvidenceError(f"{name} must be scalar")
+                values.add(value)
+                break
+    if len(values) > 1:
+        raise TopologyEvidenceError(f"conflicting {names[0]} values: {sorted(values, key=str)!r}")
+    return next(iter(values)) if values else None
+
+
+def _scope_and_fabric(topology_class: str | None, node_count: int) -> tuple[str, str]:
+    normalized = (topology_class or "unknown").strip().lower().replace("_", "-")
+    declared_scope = None
+    if "multi-node" in normalized or "multinode" in normalized:
+        declared_scope = "multi_node"
+    elif "single-node" in normalized or "singlenode" in normalized:
+        declared_scope = "single_node"
+    inferred_scope = "single_node" if node_count == 1 else "multi_node"
+    if declared_scope is not None and declared_scope != inferred_scope:
+        raise TopologyEvidenceError("declared topology class disagrees with observed node placement")
+    if "nvlink" in normalized:
+        local_fabric = "nvlink"
+    elif "pcie" in normalized or "pci-e" in normalized:
+        local_fabric = "pcie"
+    else:
+        local_fabric = "unknown"
+    return inferred_scope, local_fabric
+
+
+def fingerprint_trace_run(records: Sequence[Mapping[str, Any]]) -> TopologyFingerprint:
+    """Build one fingerprint from all selected rank records of a run."""
+
+    if not records:
+        raise TopologyEvidenceError("cannot fingerprint an empty trace run")
+    _consistent_scalar(records, ("run_id",))
+    ranks = sorted({_rank(record) for record in records})
+    declared_sizes = {key[1] for key in (topology_run_key(record) for record in records) if key[1] is not None}
+    if len(declared_sizes) > 1:
+        raise TopologyEvidenceError("trace run has conflicting world_size values")
+    world_size = next(iter(declared_sizes)) if declared_sizes else max(ranks) + 1
+    if world_size < 2 or ranks != list(range(world_size)):
+        raise TopologyEvidenceError(f"trace ranks {tuple(ranks)} do not cover world_size {world_size}")
+
+    records_by_rank: defaultdict[int, list[Mapping[str, Any]]] = defaultdict(list)
+    for record in records:
+        records_by_rank[_rank(record)].append(record)
+
+    topology_class = _consistent_scalar(records, ("topology_class",))
+    if topology_class is not None and not isinstance(topology_class, str):
+        raise TopologyEvidenceError("topology_class must be a string")
+
+    node_by_rank = []
+    for rank in range(world_size):
+        node = _consistent_scalar(records_by_rank[rank], ("node_id", "node", "hostname"))
+        node_by_rank.append(str(node) if node is not None else "__unspecified_node__")
+    explicit_nodes = {node for node in node_by_rank if node != "__unspecified_node__"}
+    if explicit_nodes and "__unspecified_node__" in node_by_rank:
+        raise TopologyEvidenceError("node identity is missing on only some ranks")
+    if not explicit_nodes:
+        if isinstance(topology_class, str) and ("multi-node" in topology_class or "multinode" in topology_class):
+            raise TopologyEvidenceError("multi-node traces require hostname or node_id on every rank")
+        node_by_rank = ["__single_node__"] * world_size
+
+    ranks_by_node: defaultdict[str, list[int]] = defaultdict(list)
+    for rank, node in enumerate(node_by_rank):
+        ranks_by_node[node].append(rank)
+    rank_groups = tuple(sorted((tuple(group) for group in ranks_by_node.values()), key=lambda group: group[0]))
+    scope, local_fabric = _scope_and_fabric(topology_class, len(rank_groups))
+
+    models = []
+    for rank in range(world_size):
+        model = _consistent_scalar(records_by_rank[rank], ("accelerator_model", "device_name", "device"))
+        models.append(str(model) if model is not None else "unknown")
+    signatures_by_rank = [
+        _consistent_scalar(records_by_rank[rank], ("topology_signature",)) for rank in range(world_size)
+    ]
+    present_signatures = {signature for signature in signatures_by_rank if signature is not None}
+    if present_signatures and any(signature is None for signature in signatures_by_rank):
+        raise TopologyEvidenceError("topology_signature is missing on only some ranks")
+    if len(present_signatures) > 1:
+        raise TopologyEvidenceError("conflicting topology_signature values across ranks")
+    topology_signature = next(iter(present_signatures)) if present_signatures else None
+    if topology_signature is not None and not isinstance(topology_signature, str):
+        raise TopologyEvidenceError("topology_signature must be a string")
+
+    fingerprint = TopologyFingerprint(
+        scope=scope,
+        local_fabric=local_fabric,
+        node_count=len(rank_groups),
+        world_size=world_size,
+        rank_groups=rank_groups,
+        accelerator_models_by_rank=tuple(models),
+        topology_signature=topology_signature,
+    )
+    fingerprint.validate()
+    return fingerprint
+
+
+def fingerprint_trace_runs(
+    records: Iterable[Mapping[str, Any]], operations: Sequence[str] | None = None
+) -> dict[tuple[str, int | None], TopologyFingerprint]:
+    """Fingerprint every run represented in a trace collection."""
+
+    selected_operations = set(operations) if operations is not None else None
+    by_run: defaultdict[tuple[str, int | None], list[Mapping[str, Any]]] = defaultdict(list)
+    for record in records:
+        if selected_operations is not None and _value(record, "operation") not in selected_operations:
+            continue
+        by_run[topology_run_key(record)].append(record)
+    if not by_run:
+        raise TopologyEvidenceError("no trace records matched the topology request")
+    fingerprints = {}
+    for run_key, run_records in by_run.items():
+        try:
+            fingerprints[run_key] = fingerprint_trace_run(run_records)
+        except TopologyEvidenceError as exc:
+            raise TopologyEvidenceError(f"run {run_key[0]!r}: {exc}") from exc
+    return fingerprints
+
+
+def select_compatible_policy_cells(
+    recommendations: Sequence[Mapping[str, Any]], target: TopologyFingerprint
+) -> list[Mapping[str, Any]]:
+    """Return exact topology matches and reject every cross-topology fallback."""
+
+    target.validate()
+    matches = []
+    mismatch_counts: Counter[str] = Counter()
+    for recommendation in recommendations:
+        workload_key = recommendation.get("workload_key")
+        if not isinstance(workload_key, Mapping):
+            raise TopologyEvidenceError("recommendation is missing workload_key")
+        stored = workload_key.get("topology_fingerprint")
+        if not isinstance(stored, Mapping):
+            raise TopologyEvidenceError("recommendation is missing topology_fingerprint")
+        fingerprint = TopologyFingerprint.from_dict(stored)
+        if workload_key.get("topology_cell_id") != fingerprint.cell_id:
+            raise TopologyEvidenceError("stored topology_cell_id does not match its fingerprint")
+        compatibility = fingerprint.compare(target)
+        if compatibility.compatible:
+            matches.append(recommendation)
+        else:
+            mismatch_counts.update(compatibility.reasons)
+    if matches:
+        return matches
+    mismatch_summary = ", ".join(f"{field} ({count})" for field, count in sorted(mismatch_counts.items()))
+    raise IncompatibleTopologyError(
+        f"no exact policy cell for {target.cell_id}; mismatched fields: {mismatch_summary or 'no measured cells'}"
+    )
+
+
+def load_jsonl(paths: Sequence[Path]) -> list[dict[str, Any]]:
+    """Load topology evidence from JSONL trace shards."""
+
+    records = []
+    for path in paths:
+        with path.open(encoding="utf-8") as trace_file:
+            for line_number, line in enumerate(trace_file, 1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise TopologyEvidenceError(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
+                if not isinstance(record, dict):
+                    raise TopologyEvidenceError(f"{path}:{line_number}: each line must be a JSON object")
+                records.append(record)
+    return records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--policy-json", type=Path, required=True)
+    parser.add_argument("--target-trace-jsonl", nargs="+", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        policy_payload = json.loads(args.policy_json.read_text(encoding="utf-8"))
+        if not isinstance(policy_payload, dict) or not isinstance(policy_payload.get("recommendations"), list):
+            raise TopologyEvidenceError("policy JSON must contain a recommendations list")
+        fingerprints = fingerprint_trace_runs(load_jsonl(args.target_trace_jsonl))
+        unique_targets = {fingerprint.cell_id: fingerprint for fingerprint in fingerprints.values()}
+        if len(unique_targets) != 1:
+            raise TopologyEvidenceError("target traces contain more than one topology cell")
+        target = next(iter(unique_targets.values()))
+        matches = select_compatible_policy_cells(policy_payload["recommendations"], target)
+        output = {
+            "schema_version": TOPOLOGY_SCHEMA_VERSION,
+            "topology_cell_id": target.cell_id,
+            "topology_fingerprint": target.to_dict(),
+            "recommendations": matches,
+        }
+    except (OSError, json.JSONDecodeError, TopologyEvidenceError, IncompatibleTopologyError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(output, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/special_sanity/check_device_api_usage.py
+++ b/tests/special_sanity/check_device_api_usage.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 # directory or file path must contain keyword ".cuda" or "cuda"
 CUDA_KEYWORD_CHECK_WHITELIST = [
+    "verl/utils/communication_network.py",  # explicit NCCL-only rail/QoS executor
     "verl/utils/device.py",
     "verl/utils/torch_functional.py",  # import flash_attn only on cuda
     "verl/plugin/platform/platform_base.py",  # docstring mentions torch.cuda

--- a/tests/special_sanity/test_communication_network_executor.py
+++ b/tests/special_sanity/test_communication_network_executor.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logical two/four-rank contracts; these mocks are not NIC/RoCE validation."""
+
+import importlib.util
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from scripts.communication_network_policy import build_network_policy_eligibility
+from tests.special_sanity.test_communication_network_policy import _capability, _telemetry_records
+
+spec = importlib.util.spec_from_file_location(
+    "network_executor_under_test", Path(__file__).parents[2] / "verl/utils/communication_network.py"
+)
+network = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = network
+spec.loader.exec_module(network)
+
+
+@pytest.fixture(params=[2, 4])
+def runtime(monkeypatch, request):
+    world = request.param
+    capability = _capability(world)
+    eligibility = build_network_policy_eligibility(_telemetry_records(capability), capability)
+    lanes = tuple(
+        network.NetworkLane(rank, rail, traffic, f"Measured-{rail}", value)
+        for rank in range(world)
+        for rail, traffic, value in (("rail-a", "tc-low", 0), ("rail-b", "tc-high", 32))
+    )
+    operations = (
+        network.NetworkOperation("comm_a", "broadcast", 16, "torch.float32"),
+        network.NetworkOperation("comm_b", "all_to_all_single", 16, "torch.float32"),
+    )
+    calls = []
+    monkeypatch.setattr(network.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(network.dist, "get_world_size", lambda: world)
+    monkeypatch.setattr(network.dist, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(network.dist, "get_process_group_ranks", lambda group: list(range(world)))
+    monkeypatch.setattr(network.socket, "gethostname", lambda: "logical-host-0")
+
+    def gather(output, value, group):
+        if isinstance(value[0], tuple) and len(value[0]) == 2 and value[0][1] == "logical-host-0":
+            output[:] = [((value[0][0], f"logical-host-{rank // (world // 2)}"), value[1]) for rank in range(world)]
+        else:
+            output[:] = [value] * world
+
+    monkeypatch.setattr(network.dist, "all_gather_object", gather)
+    monkeypatch.setattr(
+        network.dist,
+        "ProcessGroupNCCL",
+        SimpleNamespace(Options=lambda: SimpleNamespace(config=SimpleNamespace(net_name=None, traffic_class=None))),
+        raising=False,
+    )
+
+    def new_group(**kwargs):
+        config = kwargs["pg_options"].config
+        calls.append(("group", config.net_name, config.traffic_class))
+        return config.net_name
+
+    monkeypatch.setattr(network.dist, "new_group", new_group)
+    monkeypatch.setattr(network.dist, "destroy_process_group", lambda group: calls.append(("destroy", group)))
+    work = lambda: SimpleNamespace(wait=lambda: calls.append(("wait",)))
+    monkeypatch.setattr(network.dist, "all_reduce", lambda *args, **kwargs: work())
+    monkeypatch.setattr(network.dist, "broadcast", lambda *args, **kwargs: work())
+
+    def all_to_all(output, tensor, **kwargs):
+        output.copy_(tensor)
+        return work()
+
+    monkeypatch.setattr(network.dist, "all_to_all_single", all_to_all)
+    zeros = torch.zeros
+    monkeypatch.setattr(network.torch, "zeros", lambda *args, **kwargs: zeros(*args, **{**kwargs, "device": "cpu"}))
+    monkeypatch.setattr(torch.Tensor, "is_cuda", property(lambda self: True))
+    monkeypatch.setattr(torch.Tensor, "record_stream", lambda *args: None)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+    monkeypatch.setattr(
+        torch.cuda, "current_stream", lambda *args: SimpleNamespace(wait_event=lambda event: calls.append(("fence",)))
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "Event",
+        lambda: SimpleNamespace(
+            record=lambda *args: calls.append(("event",)), synchronize=lambda: calls.append(("physical",))
+        ),
+    )
+    monkeypatch.setattr(network, "_check_environment", lambda: None)
+    kwargs = dict(
+        eligibility=eligibility,
+        target_telemetry=eligibility.telemetry,
+        lanes=lanes,
+        operations=operations,
+        evidence_sha256="a" * 64,
+        approved_digest=network.network_plan_digest(eligibility, lanes, operations, "a" * 64),
+        control_group="control",
+        observe_binding=lambda group, operation: lanes[0 if operation == "comm_a" else 1],
+    )
+    return kwargs, calls
+
+
+def test_runtime_executes_and_fences_exact_lanes(runtime):
+    kwargs, calls = runtime
+    executor = network.NetworkCollectiveExecutor(**kwargs)
+    assert calls[:2] == [("group", "Measured-rail-a", 0), ("group", "Measured-rail-b", 32)]
+    for step in (0, 2):
+        executor.begin_step(step)
+        tensor = torch.arange(4, dtype=torch.float32)
+        first = executor.launch("comm_a", tensor)
+        second = executor.launch("comm_b", tensor)
+        torch.testing.assert_close(second.wait(), tensor)
+        assert first.owned[0] is tensor
+        executor.finish_step()
+        assert not executor._works
+    executor.close()
+    executor.close()
+    assert sum(call[0] == "destroy" for call in calls) == 2
+    assert sum(call[0] == "physical" for call in calls) == 4
+
+
+@pytest.mark.parametrize(
+    "change,match",
+    [
+        ({"approved_digest": "b" * 64}, "approved digest"),
+        ({"evidence_sha256": "unbound"}, "SHA-256"),
+        ({"observe_binding": lambda *args: None}, "observed communicator"),
+    ],
+)
+def test_invalid_approval_and_observation_fail_closed(runtime, change, match):
+    kwargs, _ = runtime
+    with pytest.raises(ValueError, match=match):
+        network.NetworkCollectiveExecutor(**{**kwargs, **change})
+
+
+def test_stock_plugin_cannot_claim_rail_pinning(runtime):
+    kwargs, calls = runtime
+    kwargs["lanes"] = (replace(kwargs["lanes"][0], net_name="IB"), *kwargs["lanes"][1:])
+    with pytest.raises(ValueError, match="rail-specific"):
+        network.NetworkCollectiveExecutor(**kwargs)
+    assert not calls
+
+
+@pytest.mark.parametrize("failure", ["skip", "double_begin", "not_tensor", "wrong_size", "early_finish"])
+def test_step_sequence_errors_are_sticky(runtime, failure):
+    kwargs, _ = runtime
+    executor = network.NetworkCollectiveExecutor(**kwargs)
+    executor.begin_step(0)
+    with pytest.raises(ValueError, match="preflight"):
+        if failure == "skip":
+            executor.launch("comm_b", torch.ones(4))
+        elif failure == "double_begin":
+            executor.begin_step(1)
+        elif failure == "not_tensor":
+            executor.launch("comm_a", object())
+        elif failure == "wrong_size":
+            executor.launch("comm_a", torch.ones(8))
+        else:
+            executor.finish_step()
+    assert executor._failed
+    with pytest.raises(ValueError, match="preflight"):
+        executor.begin_step(3)
+    executor.close()
+
+
+def test_wait_failure_is_not_retried():
+    calls = []
+
+    def fail():
+        calls.append("wait")
+        raise RuntimeError("transport failed")
+
+    tensor = torch.ones(1)
+    work = network.NetworkCollectiveWork(SimpleNamespace(wait=fail), tensor, (tensor,))
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="transport failed"):
+            work.wait()
+    assert calls == ["wait"]
+
+
+@pytest.mark.parametrize("key", ["NCCL_NET", "NCCL_IB_TC", "NCCL_IB_SL", "NCCL_IB_HCA"])
+def test_environment_overrides_are_rejected(monkeypatch, key):
+    monkeypatch.setenv(key, "unexpected")
+    with pytest.raises(ValueError, match="environment overrides"):
+        network._check_environment()

--- a/tests/special_sanity/test_communication_network_policy.py
+++ b/tests/special_sanity/test_communication_network_policy.py
@@ -1,0 +1,429 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from scripts.communication_network_policy import (
+    IneligibleNetworkPolicyError,
+    NetworkEvidenceError,
+    NetworkPolicyEligibility,
+    NicCapabilityFingerprint,
+    build_network_policy_eligibility,
+    fingerprint_network_telemetry_run,
+    main,
+    select_eligible_network_policies,
+)
+from scripts.communication_topology_policy import fingerprint_trace_run
+
+
+def _hosts(world_size):
+    ranks_per_node = world_size // 2
+    return [f"logical-host-{rank // ranks_per_node}" for rank in range(world_size)]
+
+
+def _topology_records(world_size, *, run_id="topology"):
+    hosts = _hosts(world_size)
+    return [
+        {
+            "run_id": run_id,
+            "rank": rank,
+            "world_size": world_size,
+            "hostname": hosts[rank],
+            "topology_class": "multi-node",
+            "topology_signature": "logical-topology-v1",
+            "accelerator_model": "logical-device",
+        }
+        for rank in range(world_size)
+    ]
+
+
+def _capability(world_size, *, inventory_signature="logical-nics-v1", telemetry_fabric="roce"):
+    topology = fingerprint_trace_run(_topology_records(world_size))
+    payload = {
+        "schema_version": 1,
+        "topology_cell_id": topology.cell_id,
+        "topology_fingerprint": topology.to_dict(),
+        "network_fabric": telemetry_fabric,
+        "inventory_signature": inventory_signature,
+        "rank_capabilities": [
+            {
+                "rank": rank,
+                "rails": [
+                    {"rail_id": "rail-a", "traffic_classes": ["tc-high", "tc-low"]},
+                    {"rail_id": "rail-b", "traffic_classes": ["tc-high", "tc-low"]},
+                ],
+            }
+            for rank in range(world_size)
+        ],
+    }
+    return NicCapabilityFingerprint.from_dict(payload)
+
+
+def _telemetry_records(
+    capability,
+    *,
+    run_id="measured",
+    telemetry_schema_signature="logical-schema-v1",
+    alternate_assignments=False,
+):
+    world_size = capability.topology.world_size
+    hosts = _hosts(world_size)
+    records = []
+    for operation in ("comm_a", "comm_b"):
+        for rank in range(world_size):
+            if alternate_assignments:
+                rail_id = "rail-b" if operation == "comm_a" else "rail-a"
+                traffic_class = "tc-high" if operation == "comm_a" else "tc-low"
+            else:
+                rail_id = "rail-a" if operation == "comm_a" else "rail-b"
+                traffic_class = "tc-low" if operation == "comm_a" else "tc-high"
+            records.append(
+                {
+                    "run_id": run_id,
+                    "rank": rank,
+                    "world_size": world_size,
+                    "hostname": hosts[rank],
+                    "topology_class": "multi-node",
+                    "topology_signature": "logical-topology-v1",
+                    "accelerator_model": "logical-device",
+                    "operation": operation,
+                    "network_fabric": capability.network_fabric,
+                    "nic_inventory_signature": capability.inventory_signature,
+                    "network_telemetry_source": "logical-counter-exporter",
+                    "network_telemetry_schema_signature": telemetry_schema_signature,
+                    "network_telemetry_observed": True,
+                    "nic_rail_id": rail_id,
+                    "nic_traffic_class": traffic_class,
+                }
+            )
+    return records
+
+
+def test_capability_fingerprint_is_canonical_for_four_logical_ranks():
+    capability = _capability(4)
+    reordered = capability.to_dict()
+    reordered["rank_capabilities"].reverse()
+    for rank_capability in reordered["rank_capabilities"]:
+        rank_capability["rails"].reverse()
+        for rail in rank_capability["rails"]:
+            rail["traffic_classes"].reverse()
+
+    loaded = NicCapabilityFingerprint.from_dict(reordered)
+
+    assert loaded.to_dict() == capability.to_dict()
+    assert loaded.capability_id == capability.capability_id
+    assert loaded.topology.world_size == 4
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("rail_id", "unknown", "rail_id must be an explicit"),
+        ("traffic_class", "unspecified", "traffic_class must be an explicit"),
+    ],
+)
+def test_unknown_capability_values_fail_closed(field, value, message):
+    payload = _capability(2).to_dict()
+    if field == "rail_id":
+        payload["rank_capabilities"][0]["rails"][0]["rail_id"] = value
+    else:
+        payload["rank_capabilities"][0]["rails"][0]["traffic_classes"][0] = value
+
+    with pytest.raises(NetworkEvidenceError, match=message):
+        NicCapabilityFingerprint.from_dict(payload)
+
+
+def test_capability_requires_every_logical_rank():
+    payload = _capability(4).to_dict()
+    payload["rank_capabilities"].pop()
+
+    with pytest.raises(NetworkEvidenceError, match="rank_capabilities contain ranks"):
+        NicCapabilityFingerprint.from_dict(payload)
+
+
+def test_single_node_topology_cannot_claim_a_rail_policy():
+    records = [
+        {
+            **record,
+            "hostname": "one-host",
+            "topology_class": "single-node-pcie",
+            "topology_signature": "single-node-layout",
+        }
+        for record in _topology_records(2)
+    ]
+    topology = fingerprint_trace_run(records)
+    payload = _capability(2).to_dict()
+    payload["topology_cell_id"] = topology.cell_id
+    payload["topology_fingerprint"] = topology.to_dict()
+
+    with pytest.raises(NetworkEvidenceError, match="require a multi-node topology"):
+        NicCapabilityFingerprint.from_dict(payload)
+
+
+def test_telemetry_cell_describes_environment_not_policy_assignment():
+    capability = _capability(4)
+    first = fingerprint_network_telemetry_run(_telemetry_records(capability), capability)
+    second = fingerprint_network_telemetry_run(
+        _telemetry_records(capability, run_id="alternate", alternate_assignments=True),
+        capability,
+    )
+
+    assert first.cell_id == second.cell_id
+    assert first.compare(second).compatible
+
+
+def test_telemetry_schema_change_creates_an_incompatible_cell():
+    capability = _capability(2)
+    first = fingerprint_network_telemetry_run(_telemetry_records(capability), capability)
+    second = fingerprint_network_telemetry_run(
+        _telemetry_records(
+            capability,
+            run_id="new-schema",
+            telemetry_schema_signature="logical-schema-v2",
+        ),
+        capability,
+    )
+
+    assert first.cell_id != second.cell_id
+    assert first.compare(second).reasons == ("telemetry_schema_signature",)
+
+
+def test_unobserved_network_telemetry_fails_closed():
+    capability = _capability(2)
+    records = _telemetry_records(capability)
+    records[0]["network_telemetry_observed"] = False
+
+    with pytest.raises(NetworkEvidenceError, match="network_telemetry_observed=true"):
+        fingerprint_network_telemetry_run(records, capability)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("nic_rail_id", "unknown", "nic_rail_id must be an explicit"),
+        ("nic_traffic_class", "unknown", "nic_traffic_class must be an explicit"),
+        ("nic_rail_id", "rail-not-in-inventory", "observed unsupported rail"),
+    ],
+)
+def test_unknown_or_unsupported_observed_bindings_fail_closed(field, value, message):
+    capability = _capability(2)
+    records = _telemetry_records(capability)
+    records[0][field] = value
+
+    with pytest.raises(NetworkEvidenceError, match=message):
+        fingerprint_network_telemetry_run(records, capability)
+
+
+def test_each_operation_requires_telemetry_from_every_rank():
+    capability = _capability(4)
+    records = [
+        record
+        for record in _telemetry_records(capability)
+        if not (record["operation"] == "comm_b" and record["rank"] == 3)
+    ]
+
+    with pytest.raises(NetworkEvidenceError, match=r"comm_b.*telemetry ranks.*expected"):
+        fingerprint_network_telemetry_run(records, capability)
+
+
+def test_eligibility_binds_complete_four_rank_assignments():
+    capability = _capability(4)
+    eligibility = build_network_policy_eligibility(
+        _telemetry_records(capability),
+        capability,
+        ("comm_a", "comm_b"),
+    )
+    restored = NetworkPolicyEligibility.from_dict(eligibility.to_dict())
+
+    assert restored == eligibility
+    assert len(eligibility.required_assignments) == 8
+    assert eligibility.eligibility_id.startswith("network-policy-v1:")
+    assert {assignment.rank for assignment in eligibility.required_assignments} == {0, 1, 2, 3}
+
+
+def test_eligibility_rejects_inconsistent_assignments_across_runs():
+    capability = _capability(2)
+    records = _telemetry_records(capability, run_id="first")
+    records += _telemetry_records(
+        capability,
+        run_id="second",
+        alternate_assignments=True,
+    )
+
+    with pytest.raises(NetworkEvidenceError, match="inconsistent rail/class assignments across runs"):
+        build_network_policy_eligibility(records, capability, ("comm_a", "comm_b"))
+
+
+def test_selector_accepts_exact_cell_and_supported_assignments():
+    capability = _capability(4)
+    eligibility = build_network_policy_eligibility(
+        _telemetry_records(capability),
+        capability,
+        ("comm_a", "comm_b"),
+    )
+    recommendation = {
+        "decision": "switch_policy",
+        "network_policy_eligibility": eligibility.to_dict(),
+    }
+    target = fingerprint_network_telemetry_run(
+        _telemetry_records(
+            capability,
+            run_id="target",
+            alternate_assignments=True,
+        ),
+        capability,
+    )
+
+    assert select_eligible_network_policies([recommendation], target) == [recommendation]
+
+
+def test_selector_rejects_cross_capability_extrapolation():
+    source_capability = _capability(2)
+    eligibility = build_network_policy_eligibility(
+        _telemetry_records(source_capability),
+        source_capability,
+        ("comm_a", "comm_b"),
+    )
+    recommendation = {"network_policy_eligibility": eligibility.to_dict()}
+    target_capability = _capability(2, inventory_signature="different-logical-nics")
+    target = fingerprint_network_telemetry_run(
+        _telemetry_records(target_capability, run_id="target"),
+        target_capability,
+    )
+
+    with pytest.raises(IneligibleNetworkPolicyError, match="nic_capability_id"):
+        select_eligible_network_policies([recommendation], target)
+
+
+def test_selector_rejects_unannotated_policy_instead_of_falling_back():
+    capability = _capability(2)
+    target = fingerprint_network_telemetry_run(_telemetry_records(capability), capability)
+
+    with pytest.raises(IneligibleNetworkPolicyError, match="unannotated recommendations"):
+        select_eligible_network_policies([{"decision": "keep_baseline"}], target)
+
+
+def test_stored_eligibility_digest_is_verified():
+    capability = _capability(2)
+    eligibility = build_network_policy_eligibility(
+        _telemetry_records(capability),
+        capability,
+        ("comm_a", "comm_b"),
+    ).to_dict()
+    eligibility["required_assignments"][0]["traffic_class"] = "tc-high"
+
+    with pytest.raises(NetworkEvidenceError, match="eligibility_id does not match"):
+        NetworkPolicyEligibility.from_dict(eligibility)
+
+
+def test_two_rank_build_and_select_cli_round_trip(tmp_path):
+    capability = _capability(2)
+    capability_path = tmp_path / "capability.json"
+    source_trace_path = tmp_path / "source.jsonl"
+    eligibility_path = tmp_path / "eligibility.json"
+    policy_path = tmp_path / "policy.json"
+    target_trace_path = tmp_path / "target.jsonl"
+    selected_path = tmp_path / "selected.json"
+    capability_path.write_text(json.dumps(capability.to_dict()), encoding="utf-8")
+    source_trace_path.write_text(
+        "".join(json.dumps(record) + "\n" for record in _telemetry_records(capability)),
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "build",
+                "--capabilities-json",
+                str(capability_path),
+                "--trace-jsonl",
+                str(source_trace_path),
+                "--operation",
+                "comm_a",
+                "--operation",
+                "comm_b",
+                "--output-json",
+                str(eligibility_path),
+            ]
+        )
+        == 0
+    )
+    eligibility_payload = json.loads(eligibility_path.read_text(encoding="utf-8"))
+    policy_path.write_text(
+        json.dumps(
+            {
+                "recommendations": [
+                    {
+                        "decision": "switch_policy",
+                        "network_policy_eligibility": eligibility_payload["network_policy_eligibility"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    target_trace_path.write_text(
+        "".join(
+            json.dumps(record) + "\n"
+            for record in _telemetry_records(
+                capability,
+                run_id="target",
+                alternate_assignments=True,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "select",
+                "--policy-json",
+                str(policy_path),
+                "--capabilities-json",
+                str(capability_path),
+                "--target-trace-jsonl",
+                str(target_trace_path),
+                "--operation",
+                "comm_a",
+                "--operation",
+                "comm_b",
+                "--output-json",
+                str(selected_path),
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(selected_path.read_text(encoding="utf-8"))
+    assert selected["nic_capability_id"] == capability.capability_id
+    assert len(selected["recommendations"]) == 1
+
+
+def test_tampered_stored_telemetry_cell_is_rejected():
+    capability = _capability(2)
+    eligibility = build_network_policy_eligibility(
+        _telemetry_records(capability),
+        capability,
+        ("comm_a", "comm_b"),
+    ).to_dict()
+    tampered = deepcopy(eligibility)
+    tampered["network_telemetry_cell_id"] = "network-telemetry-v1:not-the-cell"
+    recommendation = {"network_policy_eligibility": tampered}
+    target = fingerprint_network_telemetry_run(_telemetry_records(capability), capability)
+
+    with pytest.raises(NetworkEvidenceError, match="does not match its fingerprint"):
+        select_eligible_network_policies([recommendation], target)

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from scripts.autotune_communication_phase import TraceFormatError, main, tune_traces
+
+
+def _candidate_records(
+    world_size,
+    *,
+    run_id,
+    policy,
+    requested_offset_us,
+    realized_offset_us,
+    duration_a_us,
+    duration_b_us,
+    consumer_slack_us,
+    critical_path_duration_us=None,
+    trial_count=4,
+):
+    records = []
+    for trial in range(trial_count):
+        trial_origin_ns = 1_000_000_000 + trial * 10_000_000
+        for rank in range(world_size):
+            rank_skew_ns = rank * 1000
+            a_start_ns = trial_origin_ns + rank_skew_ns
+            b_start_ns = a_start_ns + int((realized_offset_us + rank) * 1000)
+            common = {
+                "framework": "fixture",
+                "run_id": run_id,
+                "rank": rank,
+                "world_size": world_size,
+                "iteration": trial,
+                "microbatch": 0,
+                "layer": 3,
+                "requested_offset_us": requested_offset_us,
+                "topology_class": "logical-fixture",
+                "transport": "fixture",
+                "metadata": {
+                    "policy": policy,
+                    "completion_observed": True,
+                    "sequence_consistent": True,
+                },
+            }
+            if critical_path_duration_us is not None:
+                common["critical_path_duration_us"] = critical_path_duration_us + trial + rank
+            records.extend(
+                [
+                    {
+                        **common,
+                        "operation": "comm_a",
+                        "message_bytes": 8192,
+                        "communicator_sequence_id": trial,
+                        "gpu_start_timestamp_ns": a_start_ns,
+                        "gpu_end_timestamp_ns": a_start_ns + int(duration_a_us * 1000),
+                        "consumer_timestamp_ns": a_start_ns + int(duration_a_us * 1000),
+                    },
+                    {
+                        **common,
+                        "operation": "comm_b",
+                        "message_bytes": 4096,
+                        "communicator_sequence_id": trial,
+                        "gpu_start_timestamp_ns": b_start_ns,
+                        "gpu_end_timestamp_ns": b_start_ns + int(duration_b_us * 1000),
+                        "consumer_timestamp_ns": b_start_ns + int((duration_b_us + consumer_slack_us) * 1000),
+                    },
+                ]
+            )
+    return records
+
+
+def _trace_fixture(world_size):
+    baseline = _candidate_records(
+        world_size,
+        run_id="baseline",
+        policy="eager",
+        requested_offset_us=0,
+        realized_offset_us=0,
+        duration_a_us=1200,
+        duration_b_us=1100,
+        consumer_slack_us=300,
+    )
+    safe = _candidate_records(
+        world_size,
+        run_id="safe-shift",
+        policy="phase_shifted",
+        requested_offset_us=200,
+        realized_offset_us=180,
+        duration_a_us=800,
+        duration_b_us=650,
+        consumer_slack_us=120,
+    )
+    deadline_regression = _candidate_records(
+        world_size,
+        run_id="late-shift",
+        policy="phase_shifted",
+        requested_offset_us=400,
+        realized_offset_us=380,
+        duration_a_us=700,
+        duration_b_us=500,
+        consumer_slack_us=-40,
+    )
+    return baseline + safe + deadline_regression
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_tuner_uses_trace_evidence_for_any_logical_rank_count(world_size):
+    payload = tune_traces(
+        _trace_fixture(world_size),
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=400,
+    )
+
+    assert len(payload["recommendations"]) == 1
+    recommendation = payload["recommendations"][0]
+    assert recommendation["workload_key"]["world_size"] == world_size
+    assert recommendation["decision"] == "switch_policy"
+    assert recommendation["recommended_candidate"] == {
+        "policy": "phase_shifted",
+        "requested_offset_us": 200.0,
+        "realized_gpu_offset_us_p50": pytest.approx(180 + (world_size - 1) / 2),
+    }
+    by_offset = {candidate["requested_offset_us"]: candidate for candidate in recommendation["candidates"]}
+    assert by_offset[200.0]["eligible"]
+    assert by_offset[200.0]["confidence_method"] == "paired_mean"
+    assert by_offset[200.0]["critical_path_improvement_ci_us"][0] > 0
+    assert by_offset[400.0]["rejection_reasons"] == ["consumer_deadline_regression"]
+    assert recommendation["refinement"]["next_requested_offsets_us"] == [100.0, 300.0]
+    assert recommendation["refinement"]["next_candidates"][0] == {
+        "requested_offset_us": 100.0,
+        "predicted_realized_gpu_offset_us": pytest.approx(90 + (world_size - 1) / 2),
+        "predicted_consumer_slack_us_p05": pytest.approx(210),
+    }
+
+
+def test_sequence_divergence_fails_closed_on_two_rank_trace():
+    records = _trace_fixture(2)
+    for record in records:
+        if record["run_id"] == "safe-shift" and record["rank"] == 1:
+            record["metadata"]["sequence_consistent"] = False
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "keep_baseline"
+    safe_candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "communicator_sequence_divergence" in safe_candidate["rejection_reasons"]
+
+
+def test_raw_communicator_sequence_ids_are_checked_on_four_ranks():
+    records = _trace_fixture(4)
+    record = next(
+        record
+        for record in records
+        if record["run_id"] == "safe-shift"
+        and record["rank"] == 2
+        and record["iteration"] == 1
+        and record["operation"] == "comm_b"
+    )
+    record["communicator_sequence_id"] += 1
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "communicator_sequence_divergence" in candidate["rejection_reasons"]
+
+
+def test_rank_skew_must_fit_inside_measured_slack_on_four_ranks():
+    records = _trace_fixture(4)
+    for record in records:
+        if record["run_id"] == "safe-shift" and record["rank"] == 3:
+            record["gpu_start_timestamp_ns"] += 250_000
+            record["gpu_end_timestamp_ns"] += 250_000
+            record["consumer_timestamp_ns"] += 250_000
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "rank_skew_exceeds_slack_headroom" in candidate["rejection_reasons"]
+
+
+def test_incomplete_four_rank_trial_is_rejected():
+    records = _trace_fixture(4)
+    records = [
+        record
+        for record in records
+        if not (
+            record["run_id"] == "safe-shift"
+            and record["rank"] == 3
+            and record["iteration"] == 1
+            and record["operation"] == "comm_b"
+        )
+    ]
+
+    with pytest.raises(TraceFormatError, match="has 1 'comm_a' records and 0 'comm_b' records"):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_declared_world_size_detects_an_entire_missing_rank_shard():
+    records = [record for record in _trace_fixture(4) if not (record["run_id"] == "safe-shift" and record["rank"] == 3)]
+
+    with pytest.raises(TraceFormatError, match=r"run 'safe-shift' has ranks \(0, 1, 2\), expected \(0, 1, 2, 3\)"):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_two_and_four_rank_workloads_are_tuned_independently():
+    records = _trace_fixture(2) + _trace_fixture(4)
+
+    payload = tune_traces(records, "comm_a", "comm_b", bootstrap_resamples=200)
+
+    assert [item["workload_key"]["world_size"] for item in payload["recommendations"]] == [2, 4]
+
+
+def test_negative_offset_uses_the_same_measured_policy_path():
+    records = _candidate_records(
+        2,
+        run_id="baseline",
+        policy="eager",
+        requested_offset_us=0,
+        realized_offset_us=0,
+        duration_a_us=1200,
+        duration_b_us=1100,
+        consumer_slack_us=100,
+    ) + _candidate_records(
+        2,
+        run_id="negative-shift",
+        policy="phase_shifted",
+        requested_offset_us=-200,
+        realized_offset_us=-180,
+        duration_a_us=700,
+        duration_b_us=800,
+        consumer_slack_us=80,
+    )
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "switch_policy"
+    assert recommendation["recommended_candidate"]["requested_offset_us"] == -200.0
+    assert recommendation["refinement"]["next_requested_offsets_us"] == [-100.0]
+
+
+def test_full_step_critical_path_overrides_pair_completion_fallback():
+    records = _candidate_records(
+        2,
+        run_id="baseline",
+        policy="eager",
+        requested_offset_us=0,
+        realized_offset_us=0,
+        duration_a_us=1200,
+        duration_b_us=1100,
+        consumer_slack_us=200,
+        critical_path_duration_us=2000,
+    ) + _candidate_records(
+        2,
+        run_id="shorter-pair-slower-step",
+        policy="phase_shifted",
+        requested_offset_us=200,
+        realized_offset_us=180,
+        duration_a_us=700,
+        duration_b_us=600,
+        consumer_slack_us=100,
+        critical_path_duration_us=2500,
+    )
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "keep_baseline"
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert candidate["critical_path_source"] == "trace_critical_path"
+    assert candidate["pair_completion_us_p95"] < recommendation["candidates"][0]["pair_completion_us_p95"]
+    assert candidate["critical_path_improvement_ci_us"][1] < 0
+
+
+def test_cli_writes_machine_readable_recommendation(tmp_path):
+    trace = tmp_path / "trace.jsonl"
+    output = tmp_path / "recommendation.json"
+    records = _trace_fixture(2)
+    trace.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "--trace-jsonl",
+                str(trace),
+                "--operation-a",
+                "comm_a",
+                "--operation-b",
+                "comm_b",
+                "--bootstrap-resamples",
+                "200",
+                "--output-json",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["recommendations"][0]["workload_key"]["world_size"] == 2
+
+
+def test_realized_offset_direction_mismatch_is_not_recommended():
+    records = deepcopy(_trace_fixture(2))
+    for record in records:
+        if record["run_id"] == "safe-shift" and record["operation"] == "comm_b":
+            a_record = next(
+                candidate
+                for candidate in records
+                if candidate["run_id"] == record["run_id"]
+                and candidate["rank"] == record["rank"]
+                and candidate["iteration"] == record["iteration"]
+                and candidate["operation"] == "comm_a"
+            )
+            duration_ns = record["gpu_end_timestamp_ns"] - record["gpu_start_timestamp_ns"]
+            slack_ns = record["consumer_timestamp_ns"] - record["gpu_end_timestamp_ns"]
+            record["gpu_start_timestamp_ns"] = a_record["gpu_start_timestamp_ns"] - 20_000
+            record["gpu_end_timestamp_ns"] = record["gpu_start_timestamp_ns"] + duration_ns
+            record["consumer_timestamp_ns"] = record["gpu_end_timestamp_ns"] + slack_ns
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"][0]
+    candidate = next(
+        candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
+    )
+    assert "realized_offset_direction_mismatch" in candidate["rejection_reasons"]

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -238,7 +238,10 @@ def test_incomplete_four_rank_trial_is_rejected():
 def test_declared_world_size_detects_an_entire_missing_rank_shard():
     records = [record for record in _trace_fixture(4) if not (record["run_id"] == "safe-shift" and record["rank"] == 3)]
 
-    with pytest.raises(TraceFormatError, match=r"run 'safe-shift' has ranks \(0, 1, 2\), expected \(0, 1, 2, 3\)"):
+    with pytest.raises(
+        TraceFormatError,
+        match=r"run 'safe-shift': trace ranks \(0, 1, 2\) do not cover world_size 4",
+    ):
         tune_traces(records, "comm_a", "comm_b")
 
 

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -51,6 +51,9 @@ def _candidate_records(
                 "requested_offset_us": requested_offset_us,
                 "topology_class": "logical-fixture",
                 "transport": "fixture",
+                "timestamp_domain": "fixture-global-monotonic",
+                "gpu_timestamp_semantics": "kernel-observed",
+                "clock_sync_error_bound_us": 1.0,
                 "metadata": {
                     "policy": policy,
                     "completion_observed": True,
@@ -341,7 +344,8 @@ def test_cli_writes_machine_readable_recommendation(tmp_path):
         == 0
     )
     payload = json.loads(output.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
+    assert payload["max_clock_sync_error_us"] == 50.0
     assert payload["recommendations"][0]["workload_key"]["world_size"] == 2
 
 
@@ -373,3 +377,65 @@ def test_realized_offset_direction_mismatch_is_not_recommended():
         candidate for candidate in recommendation["candidates"] if candidate["requested_offset_us"] == 200.0
     )
     assert "realized_offset_direction_mismatch" in candidate["rejection_reasons"]
+
+
+def test_event_brackets_are_diagnostic_only_and_do_not_refine():
+    records = deepcopy(_trace_fixture(2))
+    for record in records:
+        record["gpu_timestamp_semantics"] = "event-bracket"
+
+    recommendation = tune_traces(records, "comm_a", "comm_b", bootstrap_resamples=200)["recommendations"][0]
+
+    assert recommendation["decision"] == "insufficient_evidence"
+    assert recommendation["refinement"]["next_candidates"] == []
+    assert all(
+        "kernel_observed_gpu_timestamps_required" in candidate["rejection_reasons"]
+        for candidate in recommendation["candidates"]
+    )
+
+
+def test_clock_sync_error_bound_fails_closed():
+    records = deepcopy(_trace_fixture(4))
+    for record in records:
+        record["clock_sync_error_bound_us"] = 75.0
+
+    recommendation = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+        max_clock_sync_error_us=50.0,
+    )["recommendations"][0]
+
+    assert recommendation["decision"] == "insufficient_evidence"
+    assert recommendation["refinement"]["next_candidates"] == []
+    assert all(
+        "clock_sync_error_bound_exceeded" in candidate["rejection_reasons"]
+        for candidate in recommendation["candidates"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("gpu_timestamp_semantics", "assumed-kernel", "gpu_timestamp_semantics"),
+        ("timestamp_domain", "", "timestamp_domain"),
+        ("clock_sync_error_bound_us", -1.0, "clock_sync_error_bound_us"),
+    ],
+)
+def test_timing_provenance_contract_rejects_invalid_values(field, value, message):
+    records = deepcopy(_trace_fixture(2))
+    for record in records:
+        record[field] = value
+
+    with pytest.raises(TraceFormatError, match=message):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_timing_provenance_is_required_on_both_pair_members():
+    records = deepcopy(_trace_fixture(2))
+    record = next(item for item in records if item["operation"] == "comm_b")
+    del record["gpu_timestamp_semantics"]
+
+    with pytest.raises(TraceFormatError, match="must be present on both paired records"):
+        tune_traces(records, "comm_a", "comm_b")

--- a/tests/special_sanity/test_communication_phase_autotuner.py
+++ b/tests/special_sanity/test_communication_phase_autotuner.py
@@ -67,6 +67,7 @@ def _candidate_records(
                     {
                         **common,
                         "operation": "comm_a",
+                        "process_group_id": "group-a",
                         "message_bytes": 8192,
                         "communicator_sequence_id": trial,
                         "gpu_start_timestamp_ns": a_start_ns,
@@ -76,6 +77,7 @@ def _candidate_records(
                     {
                         **common,
                         "operation": "comm_b",
+                        "process_group_id": "group-b",
                         "message_bytes": 4096,
                         "communicator_sequence_id": trial,
                         "gpu_start_timestamp_ns": b_start_ns,
@@ -438,4 +440,34 @@ def test_timing_provenance_is_required_on_both_pair_members():
     del record["gpu_timestamp_semantics"]
 
     with pytest.raises(TraceFormatError, match="must be present on both paired records"):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("world_size", "world_size"),
+        ("process_group_id", "process_group_id must be a non-empty string"),
+        ("communicator_sequence_id", "communicator_sequence_id must be a finite number"),
+        ("completion_observed", "completion_observed=true is required"),
+    ],
+)
+def test_required_safety_evidence_cannot_be_omitted(field, message):
+    records = deepcopy(_trace_fixture(2))
+    record = next(item for item in records if item["operation"] == "comm_b")
+    if field == "completion_observed":
+        del record["metadata"][field]
+    else:
+        del record[field]
+
+    with pytest.raises(TraceFormatError, match=message):
+        tune_traces(records, "comm_a", "comm_b")
+
+
+def test_optional_pair_evidence_cannot_be_present_on_only_one_member():
+    records = deepcopy(_trace_fixture(2))
+    record = next(item for item in records if item["operation"] == "comm_b")
+    del record["requested_offset_us"]
+
+    with pytest.raises(TraceFormatError, match="present on both paired records or neither"):
         tune_traces(records, "comm_a", "comm_b")

--- a/tests/special_sanity/test_communication_topology_policy.py
+++ b/tests/special_sanity/test_communication_topology_policy.py
@@ -1,0 +1,306 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from scripts.autotune_communication_phase import tune_traces
+from scripts.communication_topology_policy import (
+    IncompatibleTopologyError,
+    TopologyEvidenceError,
+    TopologyFingerprint,
+    fingerprint_trace_run,
+    main,
+    select_compatible_policy_cells,
+)
+
+
+def _topology_records(world_size, topology_class, hosts, *, run_id="run", signature=None):
+    records = []
+    for rank in range(world_size):
+        record = {
+            "run_id": run_id,
+            "rank": rank,
+            "world_size": world_size,
+            "hostname": hosts[rank],
+            "topology_class": topology_class,
+            "accelerator_model": "logical-device",
+        }
+        if signature is not None:
+            record["topology_signature"] = signature
+        records.append(record)
+    return records
+
+
+def _tuning_records(
+    world_size,
+    topology_class,
+    *,
+    run_id,
+    policy,
+    requested_offset_us,
+    duration_us,
+):
+    records = []
+    for trial in range(3):
+        for rank in range(world_size):
+            a_start_ns = 1_000_000_000 + trial * 10_000_000 + rank * 1000
+            b_start_ns = a_start_ns + int((requested_offset_us * 0.8 + rank) * 1000)
+            common = {
+                "framework": "fixture",
+                "run_id": run_id,
+                "rank": rank,
+                "world_size": world_size,
+                "hostname": "host-a",
+                "accelerator_model": "logical-device",
+                "topology_class": topology_class,
+                "topology_signature": f"{topology_class}-layout",
+                "iteration": trial,
+                "microbatch": 0,
+                "layer": 1,
+                "requested_offset_us": requested_offset_us,
+                "transport": "fixture",
+                "timestamp_domain": "fixture-global-monotonic",
+                "gpu_timestamp_semantics": "kernel-observed",
+                "clock_sync_error_bound_us": 1.0,
+                "process_group_id": "group",
+                "communicator_sequence_id": trial,
+                "metadata": {"policy": policy, "completion_observed": True},
+            }
+            records.extend(
+                [
+                    {
+                        **common,
+                        "operation": "comm_a",
+                        "message_bytes": 8192,
+                        "gpu_start_timestamp_ns": a_start_ns,
+                        "gpu_end_timestamp_ns": a_start_ns + duration_us * 1000,
+                        "consumer_timestamp_ns": a_start_ns + duration_us * 1000,
+                    },
+                    {
+                        **common,
+                        "operation": "comm_b",
+                        "message_bytes": 4096,
+                        "gpu_start_timestamp_ns": b_start_ns,
+                        "gpu_end_timestamp_ns": b_start_ns + duration_us * 1000,
+                        "consumer_timestamp_ns": b_start_ns + (duration_us + 200) * 1000,
+                    },
+                ]
+            )
+    return records
+
+
+def test_single_node_pcie_and_nvlink_have_distinct_stable_cells():
+    pcie_records = _topology_records(4, "single-node-pcie", ["host-a"] * 4)
+    nvlink_records = _topology_records(4, "single-node-nvlink", ["host-b"] * 4)
+
+    pcie = fingerprint_trace_run(pcie_records)
+    reordered = fingerprint_trace_run(list(reversed(pcie_records)))
+    nvlink = fingerprint_trace_run(nvlink_records)
+
+    assert pcie.scope == "single_node"
+    assert pcie.local_fabric == "pcie"
+    assert pcie.rank_groups == ((0, 1, 2, 3),)
+    assert pcie.cell_id == reordered.cell_id
+    assert pcie.cell_id != nvlink.cell_id
+    assert pcie.compare(nvlink).reasons == ("local_fabric",)
+
+
+def test_multi_node_fingerprint_preserves_rank_placement():
+    records = _topology_records(
+        4,
+        "multi-node",
+        ["host-a", "host-a", "host-b", "host-b"],
+        signature="opaque-cluster-layout",
+    )
+
+    fingerprint = fingerprint_trace_run(records)
+
+    assert fingerprint.scope == "multi_node"
+    assert fingerprint.node_count == 2
+    assert fingerprint.rank_groups == ((0, 1), (2, 3))
+    assert fingerprint.to_dict()["ranks_per_node"] == [2, 2]
+
+
+def test_multi_node_rank_placements_are_different_cells():
+    contiguous = fingerprint_trace_run(
+        _topology_records(
+            4,
+            "multi-node",
+            ["host-a", "host-a", "host-b", "host-b"],
+            signature="same-cluster",
+        )
+    )
+    interleaved = fingerprint_trace_run(
+        _topology_records(
+            4,
+            "multi-node",
+            ["host-a", "host-b", "host-a", "host-b"],
+            signature="same-cluster",
+        )
+    )
+
+    assert contiguous.compare(interleaved).reasons == ("rank_groups",)
+    assert contiguous.cell_id != interleaved.cell_id
+
+
+def test_multi_node_without_topology_signature_fails_closed():
+    records = _topology_records(2, "multi-node", ["host-a", "host-b"])
+
+    with pytest.raises(TopologyEvidenceError, match="require an opaque topology_signature"):
+        fingerprint_trace_run(records)
+
+
+def test_partial_topology_signature_fails_closed():
+    records = _topology_records(
+        2,
+        "multi-node",
+        ["host-a", "host-b"],
+        signature="opaque-cluster-layout",
+    )
+    del records[1]["topology_signature"]
+
+    with pytest.raises(TopologyEvidenceError, match="missing on only some ranks"):
+        fingerprint_trace_run(records)
+
+
+def test_declared_single_node_class_cannot_hide_multiple_hosts():
+    records = _topology_records(2, "single-node-pcie", ["host-a", "host-b"])
+
+    with pytest.raises(TopologyEvidenceError, match="disagrees with observed node placement"):
+        fingerprint_trace_run(records)
+
+
+def test_stored_fingerprint_rejects_non_integer_rank():
+    fingerprint = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2)).to_dict()
+    fingerprint["rank_groups"] = [[0, 1.5]]
+
+    with pytest.raises(TopologyEvidenceError, match="malformed topology fingerprint"):
+        TopologyFingerprint.from_dict(fingerprint)
+
+
+def test_policy_cell_selection_rejects_cross_topology_fallback():
+    pcie = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2))
+    nvlink = fingerprint_trace_run(_topology_records(2, "single-node-nvlink", ["host-b"] * 2))
+    pcie_cell = {
+        "workload_key": {
+            "topology_cell_id": pcie.cell_id,
+            "topology_fingerprint": pcie.to_dict(),
+        },
+        "decision": "keep_baseline",
+    }
+
+    assert select_compatible_policy_cells([pcie_cell], pcie) == [pcie_cell]
+    with pytest.raises(IncompatibleTopologyError, match="local_fabric"):
+        select_compatible_policy_cells([pcie_cell], nvlink)
+
+
+def test_policy_cell_rejects_a_mismatched_stored_digest():
+    pcie = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2))
+    cell = {
+        "workload_key": {
+            "topology_cell_id": "topology-v1:not-the-fingerprint",
+            "topology_fingerprint": pcie.to_dict(),
+        }
+    }
+
+    with pytest.raises(TopologyEvidenceError, match="does not match its fingerprint"):
+        select_compatible_policy_cells([cell], pcie)
+
+
+def test_autotuner_selects_independently_inside_four_rank_topology_cells():
+    records = []
+    for topology_class, shifted_duration in (("single-node-pcie", 600), ("single-node-nvlink", 1200)):
+        records.extend(
+            _tuning_records(
+                4,
+                topology_class,
+                run_id=f"{topology_class}-baseline",
+                policy="eager",
+                requested_offset_us=0,
+                duration_us=1000,
+            )
+        )
+        records.extend(
+            _tuning_records(
+                4,
+                topology_class,
+                run_id=f"{topology_class}-shifted",
+                policy="phase_shifted",
+                requested_offset_us=100,
+                duration_us=shifted_duration,
+            )
+        )
+
+    recommendations = tune_traces(
+        records,
+        "comm_a",
+        "comm_b",
+        bootstrap_resamples=200,
+    )["recommendations"]
+
+    assert len(recommendations) == 2
+    by_topology = {item["workload_key"]["topology_class"]: item for item in recommendations}
+    assert by_topology["single-node-pcie"]["decision"] == "switch_policy"
+    assert by_topology["single-node-pcie"]["recommended_candidate"]["requested_offset_us"] == 100.0
+    assert by_topology["single-node-nvlink"]["decision"] == "keep_baseline"
+    assert (
+        by_topology["single-node-pcie"]["workload_key"]["topology_cell_id"]
+        != by_topology["single-node-nvlink"]["workload_key"]["topology_cell_id"]
+    )
+
+
+def test_selector_cli_uses_two_rank_target_trace(tmp_path):
+    pcie = fingerprint_trace_run(_topology_records(2, "single-node-pcie", ["host-a"] * 2))
+    policy = tmp_path / "policy.json"
+    traces = tmp_path / "target.jsonl"
+    output = tmp_path / "selected.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "recommendations": [
+                    {
+                        "workload_key": {
+                            "topology_cell_id": pcie.cell_id,
+                            "topology_fingerprint": pcie.to_dict(),
+                        },
+                        "decision": "keep_baseline",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    traces.write_text(
+        "".join(json.dumps(record) + "\n" for record in _topology_records(2, "single-node-pcie", ["new"] * 2)),
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "--policy-json",
+                str(policy),
+                "--target-trace-jsonl",
+                str(traces),
+                "--output-json",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    selected = json.loads(output.read_text(encoding="utf-8"))
+    assert selected["topology_cell_id"] == pcie.cell_id
+    assert len(selected["recommendations"]) == 1

--- a/verl/utils/communication_network.py
+++ b/verl/utils/communication_network.py
@@ -1,0 +1,352 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Opt-in execution of an approved collective plan on configured NIC lanes.
+
+The caller supplies validated NetworkPolicyEligibility and current telemetry
+objects from the offline policy tooling. Runtime code does not import scripts.
+Rail isolation is provided by operator-installed, explicitly named NCCL network
+plugins. Stock IB has no per-communicator HCA filter; changing NCCL_IB_HCA around
+new_group is deliberately unsupported. Network configuration is never edited.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import socket
+import threading
+from dataclasses import asdict, dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+import torch.distributed as dist
+
+
+@dataclass(frozen=True)
+class NetworkLane:
+    """Operator mapping of a measured logical rail/class to a NCCL plugin."""
+
+    rank: int
+    rail_id: str
+    traffic_class: str
+    net_name: str
+    traffic_class_value: int
+
+
+@dataclass(frozen=True)
+class NetworkOperation:
+    """One collective slot in the repeated, immutable per-step launch sequence."""
+
+    operation: str
+    kind: str
+    message_bytes: int
+    dtype: str
+    source_rank: int = 0
+
+
+def network_plan_digest(
+    eligibility: Any, lanes: tuple[NetworkLane, ...], operations: tuple[NetworkOperation, ...], evidence_sha256: str
+) -> str:
+    """Address every runtime decision and the reviewed source artifact by content."""
+    payload = {
+        "executor_abi": 1,
+        "eligibility": eligibility.to_dict(),
+        "lanes": [
+            asdict(lane) for lane in sorted(lanes, key=lambda lane: (lane.rank, lane.rail_id, lane.traffic_class))
+        ],
+        "operations": [asdict(operation) for operation in operations],
+        "evidence_sha256": evidence_sha256,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _check_environment() -> None:
+    overrides = {"NCCL_NET", "NCCL_IB_TC", "NCCL_IB_SL", "NCCL_IB_HCA"}
+    if overrides.intersection(os.environ):
+        raise ValueError("NCCL environment overrides conflict with communicator lane settings")
+    paths = {Path("/etc/nccl.conf"), Path.home() / ".nccl.conf"}
+    if "NCCL_CONF_FILE" in os.environ:
+        paths.add(Path(os.environ["NCCL_CONF_FILE"]))
+    for path in paths:
+        if path.is_file():
+            for line in path.read_text().splitlines():
+                if line.strip().split("=", 1)[0].strip() in overrides:
+                    raise ValueError(f"NCCL configuration file overrides communicator lanes: {path}")
+
+
+class NetworkCollectiveWork:
+    """Own transfer buffers and establish completion on each consuming CUDA stream."""
+
+    def __init__(self, work: Any, result: torch.Tensor, owned: tuple[torch.Tensor, ...]):
+        self.work, self.result, self.owned = work, result, owned
+        self._event = None
+        self._complete = False
+        self._error: BaseException | None = None
+        self._lock = threading.Lock()
+
+    def wait(self) -> torch.Tensor:
+        """Wait once, then fence any subsequent CUDA consumer using an event."""
+        with self._lock:
+            return self._wait()
+
+    def _wait(self) -> torch.Tensor:
+        if self._error is not None:
+            raise self._error
+        if not self._complete:
+            try:
+                self.work.wait()
+                if self.result.is_cuda:
+                    self._event = torch.cuda.Event()
+                    self._event.record(torch.cuda.current_stream(self.result.device))
+                self._complete = True
+            except BaseException as exc:
+                self._error = exc
+                raise
+        elif self._event is not None:
+            torch.cuda.current_stream(self.result.device).wait_event(self._event)
+        if self.result.is_cuda:
+            for tensor in self.owned:
+                tensor.record_stream(torch.cuda.current_stream(tensor.device))
+        return self.result
+
+    def synchronize(self) -> None:
+        """Observe physical completion before releasing buffers or publishing state."""
+        with self._lock:
+            self._wait()
+            if self._event is not None:
+                self._event.synchronize()
+
+
+class NetworkCollectiveExecutor:
+    """Create per-operation NCCL lanes and run audited broadcast/AR/A2A slots.
+
+    All global ranks call construction, begin_step, launch and finish_step in
+    the same order. The separate Gloo control group must contain the world.
+    Every validation error is exchanged before a data collective is launched.
+    Use at a quiescent, post-autograd transfer boundary, from one host thread.
+    A telemetry observer must inspect each initialized communicator's actual
+    lane (including plugin and numeric class); returning requested settings is
+    not network evidence. This executor does not promise cross-lane overlap.
+    """
+
+    def __init__(
+        self,
+        *,
+        eligibility: Any,
+        target_telemetry: Any,
+        lanes: tuple[NetworkLane, ...],
+        operations: tuple[NetworkOperation, ...],
+        evidence_sha256: str,
+        approved_digest: str,
+        control_group: Any,
+        observe_binding: Callable[[Any, str], NetworkLane],
+        timeout: timedelta = timedelta(seconds=120),
+    ) -> None:
+        self.control_group = control_group
+        self.rank = dist.get_rank()
+        self.world_size = dist.get_world_size()
+        self.groups: dict[str, Any] = {}
+        self.operations = tuple(operations)
+        self._step = None
+        self._active = False
+        self._index = 0
+        self._works: list[NetworkCollectiveWork] = []
+        self._failed = False
+        self._closed = False
+        error = None
+        digest = ""
+        self._assignments = {}
+        self._lanes = {}
+        try:
+            eligibility.validate()
+            target_telemetry.validate()
+            if not eligibility.telemetry.compare(target_telemetry).compatible:
+                raise ValueError("network telemetry does not match the reviewed policy cell")
+            if eligibility.telemetry.capability.topology.world_size != self.world_size:
+                raise ValueError("network policy world size differs from runtime")
+            if dist.get_backend(control_group) != "gloo" or dist.get_process_group_ranks(control_group) != list(
+                range(self.world_size)
+            ):
+                raise ValueError("network executor requires a full-world Gloo control group")
+            if len(evidence_sha256) != 64 or any(c not in "0123456789abcdef" for c in evidence_sha256):
+                raise ValueError("source evidence must have a SHA-256 content digest")
+            if not operations or len({op.operation for op in operations}) != len(operations):
+                raise ValueError("operation slots must be nonempty and uniquely named")
+            for op in operations:
+                if op.kind not in {"broadcast", "all_reduce", "all_to_all_single"}:
+                    raise ValueError("unsupported network collective kind")
+                if type(op.message_bytes) is not int or op.message_bytes <= 0:
+                    raise ValueError("network collective requires positive message bytes")
+                if type(op.source_rank) is not int or not 0 <= op.source_rank < self.world_size:
+                    raise ValueError("invalid collective source rank")
+                if not op.operation or not op.dtype:
+                    raise ValueError("operation and dtype must be explicit")
+            for lane in lanes:
+                key = (lane.rank, lane.rail_id, lane.traffic_class)
+                if key in self._lanes:
+                    raise ValueError("duplicate network lane")
+                if not eligibility.telemetry.capability.supports(*key):
+                    raise ValueError("lane is absent from the measured capability inventory")
+                max_class = 15 if eligibility.telemetry.capability.network_fabric == "infiniband" else 255
+                if type(lane.traffic_class_value) is not int or not 0 <= lane.traffic_class_value <= max_class:
+                    raise ValueError(f"traffic class must be an explicit value in [0,{max_class}]")
+                if not lane.net_name or lane.net_name.lower() in {"ib", "socket", "auto"}:
+                    raise ValueError("rail pinning requires an explicitly named rail-specific network plugin")
+                self._lanes[key] = lane
+            plugin_rails = {}
+            for lane in lanes:
+                key = (lane.rank, lane.net_name.lower())
+                if plugin_rails.setdefault(key, lane.rail_id) != lane.rail_id:
+                    raise ValueError("distinct rails cannot alias the same network plugin")
+            for assignment in eligibility.required_assignments:
+                key = (assignment.rank, assignment.rail_id, assignment.traffic_class)
+                if key not in self._lanes:
+                    raise ValueError("a measured assignment has no runtime lane binding")
+                self._assignments[(assignment.operation, assignment.rank)] = key
+            if {op.operation for op in operations} != {key[0] for key in self._assignments}:
+                raise ValueError("runtime operations differ from reviewed assignment coverage")
+            digest = network_plan_digest(eligibility, lanes, operations, evidence_sha256)
+            if digest != approved_digest:
+                raise ValueError("runtime plan does not match the operator-approved digest")
+            _check_environment()
+            options = dist.ProcessGroupNCCL.Options()
+            if not all(hasattr(options.config, field) for field in ("net_name", "traffic_class")):
+                raise ValueError("this PyTorch/NCCL build cannot configure communicator traffic classes")
+        except (ValueError, TypeError, AttributeError, OSError) as exc:
+            error = str(exc)
+        startup = self._agreement((digest, socket.gethostname()), error, require_same=False)
+        if len({item[0] for item in startup}) != 1:
+            raise ValueError("ranks supplied different network execution plans")
+        observed_nodes: dict[str, list[int]] = {}
+        for rank, (_, hostname) in enumerate(startup):
+            observed_nodes.setdefault(hostname, []).append(rank)
+        topology = target_telemetry.capability.topology
+        if tuple(sorted(map(tuple, observed_nodes.values()))) != topology.rank_groups:
+            raise ValueError("runtime rank placement differs from measured multi-node topology")
+        self.digest = digest
+        # All ranks build the same operation communicators in the same order.
+        try:
+            for op in operations:
+                lane = self._lanes[self._assignments[(op.operation, self.rank)]]
+                options = dist.ProcessGroupNCCL.Options()
+                options.config.net_name = lane.net_name
+                options.config.traffic_class = lane.traffic_class_value
+                group = dist.new_group(
+                    ranks=list(range(self.world_size)), backend="nccl", pg_options=options, timeout=timeout
+                )
+                self.groups[op.operation] = group
+                probe = torch.zeros(1, dtype=torch.uint8, device="cuda")
+                dist.all_reduce(probe, group=group)
+                torch.cuda.synchronize()
+                error = None
+                try:
+                    if observe_binding(group, op.operation) != lane:
+                        raise ValueError("observed communicator rail/class differs from approved assignment")
+                except Exception as exc:
+                    error = str(exc)
+                self._agreement((self.digest, op.operation), error)
+        except BaseException:
+            self._failed = True
+            self.close()
+            raise
+
+    def _agreement(self, value: Any, error: str | None, *, require_same: bool = True) -> list[Any]:
+        gathered = [None] * self.world_size
+        dist.all_gather_object(gathered, (value, error), group=self.control_group)
+        errors = [(rank, message) for rank, (_, message) in enumerate(gathered) if message is not None]
+        if errors or (require_same and any(item[0] != gathered[0][0] for item in gathered)):
+            self._failed = True
+            raise ValueError(f"network execution preflight failed: {errors or 'rank sequence/digest mismatch'}")
+        return [item[0] for item in gathered]
+
+    def begin_step(self, step: int) -> None:
+        """Open the next strictly increasing step after the preceding step drains."""
+        error = None
+        if self._failed or self._closed or self._active:
+            error = "executor is failed, closed, or has an incomplete preceding step"
+        if type(step) is not int or step < 0 or (self._step is not None and step <= self._step):
+            error = "step must increase monotonically"
+        self._agreement((self.digest, "begin", step), error)
+        self._step, self._index = step, 0
+        self._active = True
+
+    def launch(self, operation: str, tensor: torch.Tensor) -> NetworkCollectiveWork:
+        """Launch the next collective on its configured lane after all-rank preflight."""
+        error = None
+        spec = self.operations[min(self._index, len(self.operations) - 1)]
+        if self._failed or self._closed or not self._active or self._index >= len(self.operations):
+            error = "executor is not ready for another collective"
+        elif operation != spec.operation:
+            error = "collective does not match the canonical operation sequence"
+        elif not isinstance(tensor, torch.Tensor):
+            error = "runtime transfer requires a tensor"
+        elif not tensor.is_cuda or not tensor.is_contiguous() or tensor.requires_grad:
+            error = "runtime transfer requires a contiguous detached CUDA tensor"
+        elif tensor.numel() * tensor.element_size() != spec.message_bytes or str(tensor.dtype) != spec.dtype:
+            error = "tensor differs from reviewed message-size/dtype cell"
+        elif spec.kind == "all_to_all_single" and (tensor.ndim == 0 or tensor.shape[0] % self.world_size):
+            error = "equal-split all-to-all requires a divisible first dimension"
+        shape = tuple(tensor.shape) if isinstance(tensor, torch.Tensor) else None
+        self._agreement((self.digest, self._step, self._index, operation, shape), error)
+        # Follow ProcessGroupNCCL's explicit cross-communicator wait contract.
+        # The dependency is placed on this launch stream, with no host timer.
+        group = self.groups[operation]
+        result = tensor
+        try:
+            if self._works:
+                self._works[-1].wait()
+            if spec.kind == "broadcast":
+                work = dist.broadcast(tensor, src=spec.source_rank, group=group, async_op=True)
+            elif spec.kind == "all_reduce":
+                work = dist.all_reduce(tensor, group=group, async_op=True)
+            else:
+                result = torch.empty_like(tensor)
+                work = dist.all_to_all_single(result, tensor, group=group, async_op=True)
+        except BaseException:
+            self._failed = True
+            raise
+        handle = NetworkCollectiveWork(work, result, (tensor, result))
+        self._works.append(handle)
+        self._index += 1
+        return handle
+
+    def finish_step(self) -> None:
+        """Fence every transfer before the caller publishes the new state."""
+        error = None
+        if self._failed or self._closed or not self._active or self._index != len(self.operations):
+            error = "executor is not active or step omitted planned collectives"
+        self._agreement((self.digest, "finish", self._step, self._index), error)
+        try:
+            for work in self._works:
+                work.synchronize()
+        except BaseException:
+            self._failed = True
+            raise
+        self._works.clear()
+        self._active = False
+
+    def close(self) -> None:
+        """Drain owned work and destroy only this executor's process groups."""
+        if self._closed:
+            return
+        for work in self._works:
+            work.synchronize()
+        for group in reversed(list(self.groups.values())):
+            dist.destroy_process_group(group)
+        self._works.clear()
+        self.groups.clear()
+        self._closed = True


### PR DESCRIPTION
## Summary

Add an opt-in SPMD NCCL collective executor on top of #7755, which depends on #7751 and #7750. Unlike those offline eligibility tools, this increment can execute broadcast, all-reduce and equal-split all-to-all through explicitly configured communicators.

- Bind approved operations, rank layout, messages, dtype, bytes and telemetry identities to an immutable plan digest.
- Preflight rank agreement through Gloo before creating the per-rail/per-traffic-class NCCL communicators.
- Require explicitly installed rail-specific plugins and observer-confirmed bindings; reject process-environment overrides and unverified bindings.
- Retain transport buffers and fence actual completion before consumer/version publication.

Review the increment 5683fa27..0b289956; the main-based GitHub diff includes the prerequisite stack because fork branches cannot be upstream bases.

## Validation

Previously executed dependency/runtime suite: 79 passed with logical 2/4-rank mocks, including 45 runtime/NIC checks. Command: uv run python -m pytest -q tests/special_sanity/test_communication_phase_autotuner.py tests/special_sanity/test_communication_topology_policy.py tests/special_sanity/test_communication_network_policy.py tests/special_sanity/test_communication_network_executor.py. Formatting, Ruff, mypy, device-API and documentation checks passed.

No real multi-node NIC/plugin/QoS environment was available. This API is not yet wired into the Ray NCCL checkpoint engine. It does not modify host/NIC/switch QoS and does not claim cross-lane overlap or performance improvement.

## Duplicate check and human review

Fresh open-PR searches for communication phase, NCCL rail and async collectives found the existing offline dependencies and unrelated checkpoint/runtime changes, not this approved-plan executor. It is not a replacement for #7755's eligibility contract.

AI assistance: OpenAI Codex. The human submitter confirmed on 2026-09-05 that they reviewed the changes line-by-line and ran the relevant tests. Keep Draft for the unfinished production integration and hardware checks.
