### PR TITLE
[ckpt] fix: drain Mooncake completion slots across weight versions

### DIFF
--- a/verl/checkpoint_engine/mooncake_checkpoint_engine.py
+++ b/verl/checkpoint_engine/mooncake_checkpoint_engine.py
@@ -225,6 +225,8 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         }
         self.store.send_obj(info, 1)
         await self.wait_for_complete(magic_slots[idx])
+        if should_wait:
+            await self.wait_for_complete(magic_slots[idx ^ 1])
 
         time_cost = time.time() - start_time
         bandwidth = total_bytes / time_cost / (1024 * 1024 * 1024)
@@ -313,6 +315,10 @@ class MooncakeCheckpointEngine(CheckpointEngine):
 
             if info["is_last"]:
                 break
+
+        if self.rank < self.world_size - 1:
+            for slot in range(min(idx, 2)):
+                await self.wait_for_complete(magic_slots[slot])
 
         time_cost = time.time() - start_time
         bandwidth = total_bytes / time_cost / (1024 * 1024 * 1024)


### PR DESCRIPTION
### What does this PR do?

Consume outstanding Mooncake completion slots before a weight update returns. When the engine buffers are reused across updates, an old completion marker can otherwise release a buffer before the next receiver has finished reading its new contents.

Both paths need this: `send_weights()` previously consumed only the last bucket's slot, while an intermediate forwarding rank left its final downstream completion slots unconsumed. A barrier between updates does not clear those markers.

This complements #6813: that PR moved completion markers into dedicated storage to avoid corrupting weights. This PR fixes when those markers are consumed before reuse.

### Checklist Before Starting

- [x] Searched for overlap: [Mooncake completion](https://github.com/verl-project/verl/issues?q=mooncake+completion), [magic slots](https://github.com/verl-project/verl/pulls?q=magic+slot). #6813 addresses storage location; other drain-related results address different engines or rollout admission.
- [x] Title follows `[ckpt] fix: ...`.

### Test

Manual validation used the actual `MooncakeCheckpointEngine` at `23af6a7a2e8d6efeeb2adbe5d1689c7a24f503a3`, compiled Mooncake Transfer Engine, CPU staging and torch BF16 parameter consumption on H20. These were synthetic framework-component tests, not a complete SGLang installation or RL run. The component environment used torch 2.5.1+cu121 and SGLang 0.4.9.post6; it is not a validated full-training dependency stack for this verl revision.

The sender change was first checked with two hosts, eight 16 MiB buckets and two successive versions: the original source failed version 2 with both HP TCP and legacy TCP; consuming the sender's remaining slot fixed those runs.

The full change was then checked with three local processes sharing one GPU, legacy TCP explicitly selected, 4 MiB tensors and 16 MiB buckets. Each row is one independent process group with two successive updates:

| Code / case | Result |
| --- | --- |
| Sender-only fix, 3 buckets, final reader delayed 500 ms in update 2 | Rank 2 tensor 0 should contain 2.0, but contains 2.125 from tensor 8; READ/WRITE calls returned success |
| Full fix, same 3-bucket delay case | Both receiving ranks consumed both versions correctly; all three ranks' completion slots were zero after each update barrier |
| Full fix, 1 bucket | Passed; does not wait for unused slot 1 |
| Full fix, 2 buckets | Passed; both used slots consumed |

The delay is a controlled scheduling diagnostic. This does not claim a performance improvement, arbitrary chain/failure coverage, or validation of GPU-resident RDMA completion slots. Raw logs and the executed component harness are retained in the author's audit workspace.

Per-file checks passed with this revision's Ruff configuration:

```bash
pre-commit run ruff --files verl/checkpoint_engine/mooncake_checkpoint_engine.py
pre-commit run ruff-format --files verl/checkpoint_engine/mooncake_checkpoint_engine.py
```

Python syntax checks also passed. Repository-wide sanity checks and CI have not been run.

### API and Usage Example

Existing callers and configuration remain valid. Consumers must continue to consume the weight iterator completely and finish using each yielded buffer view before advancing it.

### Design & Code Changes

Five executable lines in the existing engine:

- After the sender waits for its last bucket, consume the other slot only when a preceding bucket was published.
- At the end of a non-terminal receiver, consume the final `min(bucket_count, 2)` downstream slots.
- The terminal receiver has no downstream notification to wait for.

The existing completion messages and reset operation are reused. No additional messages, checksums, version protocol or scheduler are introduced.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [x] Applicable per-file Ruff lint/format checks passed as listed above.
- [ ] Repository-wide checks and CI — not run.
- [ ] Documentation — no public API/configuration change.
- [ ] CI regression test — manual actual-component regression performed; the required Mooncake/GPU environment was not added to CI in this minimal fix.
- [ ] `ci-request` message — not sent while this is a draft.
- [ ] Recipe submodule — not applicable.

### AI assistance disclosure

Codex assisted with implementation, source review and manual validation. This draft awaits the human submitter's line-by-line review and sign-off; agent review is not represented as human review.
