### PR TITLE
[ci, doc] feat: check that docs reference existing files, fix 5 stale paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,12 @@ repos:
         language: python
         pass_filenames: false
 
+      - id: check-docs-file-refs
+        name: Check docs reference existing files
+        entry: python3 tests/special_sanity/check_docs_file_refs.py
+        language: python
+        pass_filenames: false
+
       - id: check-docstrings
         name: Check doc string coverage
         entry: python3 tests/special_sanity/check_docstrings.py

--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -290,7 +290,7 @@ Convert FSDP and Megatron Checkpoints to HuggingFace Format Model
 -----------------------------------------------------------------
 
 We provide a tool to convert the FSDP and Megatron checkpoints to HuggingFace format model.
-The tool is located in ``verl/model_merger``. For older versions of verl that don't include fsdp_config.json in checkpoints, you can use the legacy model merger located at ``verl/scripts/legacy_model_merger.py``.
+The tool is located in ``verl/model_merger``. For older versions of verl that don't include fsdp_config.json in checkpoints, you can use the legacy model merger located at ``scripts/legacy_model_merger.py``.
 
 The script supports two main sub-commands: `merge` (to convert and save checkpoints) and `test` (to validate merged checkpoints against a reference model).
 The arguments for the `merge` sub-command are as follows:

--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -3,7 +3,7 @@
 Using Checkpoints to Support Fault Tolerance Training
 =====================================================
 
-Last updated: 08/24/2026.
+Last updated: 09/05/2026.
 
 There could be training errors or machine failure during the whole RLHF training process, 
 so it is recommended to enable checkpoints to minimize your loss.
@@ -82,7 +82,7 @@ Hook semantics:
 Checkpoint Saving Directory Structure
 -------------------------------------
 
-Commonly, we use the ``default_local_dir`` declared in ``ppo_trainer.yaml`` or ``ppo_megatron_trainer.yml``
+Commonly, we use the ``default_local_dir`` declared in ``ppo_trainer.yaml``
 to work as preffix when saving checkpoints, which is ``checkpoints/${trainer.project_name}/${trainer.experiment_name}``.
 
 So the inner checkpoint structure of **FSDP** is like:

--- a/docs/ascend_tutorial/zh/contribution_guide/ascend_ci_guide.rst
+++ b/docs/ascend_tutorial/zh/contribution_guide/ascend_ci_guide.rst
@@ -1,14 +1,14 @@
 NPU-CI 添加指导
 ===========
 
-Last updated: 02/02/2026.
+Last updated: 09/05/2026.
 
 我们在 verl 上提供基于华为昇腾设备的CI用例添加指导。
 
 verl 仓库使用 GitHub Actions 作为 CI 平台，通过分层测试架构保障代码质量与系统稳定性。
 NPU 相关的工作流主要包括：
 
-* ``npu_unit_test.yml``：运行单元测试。
+* ``npu_unit_tests.yml``：运行单元测试。
 * 以 ``_ascend.yml`` 结尾的文件：运行针对 Ascend NPU 的端到端测试或专项测试。
 
 添加新用例指南
@@ -163,13 +163,13 @@ NPU 相关的工作流主要包括：
 步骤：
 
 (1) 在 ``tests/`` 目录下创建或修改单元测试文件（例如 ``test_xxx.py``）。
-(2) 若测试文件路径未被 ``npu_unit_test.yml`` 中的 ``--ignore-glob`` 规则排除，则会在以下命令中自动执行：
+(2) 若测试文件路径未被 ``npu_unit_tests.yml`` 中的 ``--ignore-glob`` 规则排除，则会在以下命令中自动执行：
 
    .. code-block:: yaml
    
       pytest -s -x --ignore-glob="xxx" --ignore-glob="xxx" tests/
    
-(3) 若测试路径在 ``--ignore-glob`` 排除范围内，需在 ``npu_unit_test.yml`` 中新增一个 step 来显式运行该测试。
+(3) 若测试路径在 ``--ignore-glob`` 排除范围内，需在 ``npu_unit_tests.yml`` 中新增一个 step 来显式运行该测试。
 (4) 如新增一批相关用例，建议单独创建专门的工作流文件以保持清晰。
 
 4. 添加端到端测试脚本

--- a/docs/ascend_tutorial/zh/model_support/examples/ascend_sglang_best_practices.rst
+++ b/docs/ascend_tutorial/zh/model_support/examples/ascend_sglang_best_practices.rst
@@ -1,7 +1,7 @@
 昇腾 SGLang 最佳实践
 ===================================
 
-Last updated: 06/02/2026.
+Last updated: 09/05/2026.
 
 .. _Qwen3-30B: https://github.com/verl-project/verl/blob/main/examples/ascend_extras/grpo_trainer/run_qwen3_30b_a3b_megatron.sh
 .. _doclink: https://github.com/verl-project/verl/blob/c98cb8cc/docs/ascend_tutorial/examples/ascend_sglang_best_practices.rst
@@ -94,7 +94,7 @@ SGLang 是当前主流的高性能开源推理引擎, 昇腾已经全面原生�
 
 .. code-block:: bash 
 
-  bash examples/grpo_trainer/run_qwen3moe-30b_sglang_megatron_npu.sh
+  bash examples/ascend_extras/grpo_trainer/run_qwen3_30b_a3b_megatron.sh
 如果您想扩展至多节点，我们推荐使用以下脚本进行大规模多节点训练拉起
 
 .. code-block:: bash

--- a/docs/workers/trtllm_worker.rst
+++ b/docs/workers/trtllm_worker.rst
@@ -1,7 +1,7 @@
 TensorRT-LLM Backend
 ====================
 
-Last updated: 5/6/2026.
+Last updated: 09/05/2026.
 
 **Authored By NVIDIA TensorRT-LLM Team**
 
@@ -71,4 +71,4 @@ Using TensorRT-LLM rollout in fully async with GRPO
 .. code-block:: bash
 
     # Fully async policy with Megatron-Core training engine
-    bash verl/experimental/fully_async_policy/shell/grpo_30b_a3b_base_math_megatron_4_4_mis_trtllm.sh
+    bash verl/experimental/fully_async_policy/shell/grpo_30b_a3b_base_math_megatron_8_8_mis_trtllm.sh

--- a/tests/special_sanity/check_docs_file_refs.py
+++ b/tests/special_sanity/check_docs_file_refs.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify that repo file paths mentioned in the docs actually exist.
+
+Docs drift silently: a workflow gets renamed, a config is deprecated, or an
+example script moves, and the prose keeps pointing at the old path. Nothing
+fails, so readers hit the dead path instead. This hook fails fast instead.
+
+Two reference styles are checked:
+
+1. **Inline literals** — a repo-relative path inside double backticks, e.g.
+   ``` ``verl/trainer/config/ppo_trainer.yaml`` ```. Only literals that look
+   repo-relative (they start with a known top-level directory) are checked,
+   so bare filenames and prose stay out of scope.
+
+2. **Runnable commands** — a path passed to ``bash``/``python``/``sh`` inside
+   a code block, e.g. ``bash examples/grpo_trainer/run_qwen3_8b_fsdp.sh``.
+   These are what a reader copy-pastes, so a stale one is the most
+   user-visible kind of rot.
+
+Deliberately **not** flagged, since each is a legitimate miss rather than rot:
+
+* Placeholders the reader is meant to substitute (``path/to/model``,
+  ``your_script.py``, ``test_xxx.py``).
+* Paths inside a submodule (``recipe/``). The working tree is empty until
+  ``git submodule update --init``, so checking them would fail spuriously
+  depending on checkout state.
+* Paths that resolve relative to the *parent* of the repo. The install guides
+  say ``git clone ... && bash verl/scripts/install_*.sh``, which is correct
+  from the directory above the clone.
+* Files a reader is told to create (``config.yaml``, ``ray_start.sh``).
+
+Usage::
+
+    python3 tests/special_sanity/check_docs_file_refs.py
+    python3 tests/special_sanity/check_docs_file_refs.py --docs-dir docs
+
+Exits 1 and prints ``file:line -> path`` for each unresolvable reference.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Top-level directories that make a literal look repo-relative. A literal not
+# starting with one of these is prose or a bare filename, not a path claim.
+REPO_ROOTS = (
+    "verl/",
+    "examples/",
+    "tests/",
+    "docs/",
+    "scripts/",
+    ".github/",
+)
+
+# Submodules: tracked as a commit, so the working tree is empty until
+# `git submodule update --init --recursive`. Checking these would depend on
+# checkout state rather than on whether the docs are correct.
+SUBMODULE_PREFIXES = ("recipe/",)
+
+# Substrings marking a path the reader is meant to replace, not open.
+PLACEHOLDER_MARKERS = (
+    "path/to",
+    "your_",
+    "xxx",
+    "<",  # e.g. run_<model>_<backend>.sh
+    "{",  # e.g. {model}.yaml
+)
+
+# Specific references that are correct but unresolvable from the repo root,
+# or that are known-missing and tracked separately.
+# Keep this list short and say why for each entry.
+ALLOW_LIST = {
+    # The install guides run these from the *parent* of the clone:
+    #   git clone ... verl && bash verl/scripts/install_vllm_mcore_npu.sh
+    # The real files are scripts/install_*.sh, one level down.
+    "verl/scripts/install_vllm_mcore_npu.sh",
+    "verl/scripts/install_sglang_mcore_npu.sh",
+    # --- Known-missing, left for the owning teams rather than guessed at. ---
+    # The Ascend vLLM guide points at a Qwen3-30B vLLM script, but
+    # examples/ascend_extras/ only ships an SGLang variant for that model
+    # (run_qwen3_30b_a3b_megatron.sh). Substituting it would silently change
+    # the documented rollout backend, so this needs an Ascend-team decision:
+    # either add the vLLM script or repoint the guide.
+    "examples/grpo_trainer/run_qwen3moe-30b_grpo_megatron_vllm_npu.sh",
+    # The search-tool and agentic-RL guides reference examples/sglang_multiturn/,
+    # which no longer exists anywhere in the repo (nor in the verl-recipe
+    # submodule). These walkthroughs need a rewrite against the current
+    # agent-loop examples rather than a path substitution.
+    "examples/sglang_multiturn/search_r1_like/local_dense_retriever/download.py",
+    "examples/sglang_multiturn/search_r1_like/local_dense_retriever/retrieval_server.py",
+    "examples/sglang_multiturn/search_r1_like/run_qwen2_5_3b_search_multiturn_fsdp.sh",
+    "examples/sglang_multiturn/config/tool_config/search_tool_config.yaml",
+    "examples/sglang_multiturn/run_qwen2_5_3b_gsm8k_tool_agent_mlflow_fsdp.sh",
+}
+
+# ``some/path.ext`` — inline literal.
+INLINE_RE = re.compile(r"``([A-Za-z0-9_.][A-Za-z0-9_./-]*\.(?:py|sh|yaml|yml|rst|md|txt|json))``")
+
+# bash/python/sh <path> — runnable command inside a code block.
+_ROOTS_ALT = "|".join(re.escape(root) for root in REPO_ROOTS)
+COMMAND_RE = re.compile(r"(?:^|[\s|&;(])(?:bash|sh|python3?)\s+((?:" + _ROOTS_ALT + r")[A-Za-z0-9_./-]*\.(?:sh|py))")
+
+
+def _is_exempt(ref: str) -> bool:
+    """Return whether ``ref`` is a legitimate non-path reference."""
+    if ref in ALLOW_LIST:
+        return True
+    if any(marker in ref for marker in PLACEHOLDER_MARKERS):
+        return True
+    return any(ref.startswith(prefix) for prefix in SUBMODULE_PREFIXES)
+
+
+def _looks_repo_relative(ref: str) -> bool:
+    return ref.startswith(REPO_ROOTS)
+
+
+def check_file(doc: Path, repo_root: Path) -> list[str]:
+    """Return ``file:line -> ref`` strings for unresolvable references in ``doc``."""
+    problems: list[str] = []
+    try:
+        lines = doc.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError as exc:  # pragma: no cover - unreadable file
+        return [f"{doc}: could not read ({exc})"]
+
+    try:
+        shown_doc = doc.relative_to(repo_root).as_posix()
+    except ValueError:
+        shown_doc = str(doc)
+
+    for lineno, line in enumerate(lines, 1):
+        refs: list[str] = []
+        refs.extend(m.group(1) for m in INLINE_RE.finditer(line) if _looks_repo_relative(m.group(1)))
+        refs.extend(m.group(1) for m in COMMAND_RE.finditer(line))
+
+        for ref in refs:
+            if _is_exempt(ref):
+                continue
+            if (repo_root / ref).exists():
+                continue
+            problems.append(f"{shown_doc}:{lineno} -> {ref}")
+
+    return problems
+
+
+def collect_docs(docs_dir: Path) -> list[Path]:
+    """Return sorted ``.rst``/``.md`` files under ``docs_dir``, skipping build output."""
+    return sorted(
+        p for p in docs_dir.rglob("*") if p.is_file() and p.suffix in {".rst", ".md"} and "_build" not in p.parts
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--docs-dir", type=Path, default=Path("docs"), help="Directory to scan (default: docs)")
+    parser.add_argument("--repo-root", type=Path, default=Path("."), help="Repository root (default: .)")
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    docs_dir = (repo_root / args.docs_dir) if not args.docs_dir.is_absolute() else args.docs_dir
+    if not docs_dir.is_dir():
+        print(f"❌  --docs-dir '{args.docs_dir}' does not exist or is not a directory.", file=sys.stderr)
+        return 2
+
+    docs = collect_docs(docs_dir)
+    problems: list[str] = []
+    for doc in docs:
+        problems.extend(check_file(doc, repo_root))
+
+    if problems:
+        print("❌  Docs reference files that do not exist:\n", file=sys.stderr)
+        for problem in problems:
+            print("  - " + problem, file=sys.stderr)
+        print(
+            "\nEach line above is a path mentioned in the docs that is missing from the repo.\n"
+            "Fix the path, or - if the reference is intentional (a placeholder, a\n"
+            "submodule path, or a file the reader creates) - extend ALLOW_LIST or\n"
+            "PLACEHOLDER_MARKERS in tests/special_sanity/check_docs_file_refs.py\n"
+            "with a comment explaining why.\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✅  All repo file references in {len(docs)} docs under '{args.docs_dir}' resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/special_sanity/test_check_docs_file_refs.py
+++ b/tests/special_sanity/test_check_docs_file_refs.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit-style tests for ``check_docs_file_refs``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.special_sanity.check_docs_file_refs import check_file, collect_docs, main
+
+
+def _write(tmp_path: Path, rel: str, body: str) -> Path:
+    doc = tmp_path / rel
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    doc.write_text(body, encoding="utf-8")
+    return doc
+
+
+def _repo(tmp_path: Path, *existing: str) -> Path:
+    """Build a fake repo root containing ``existing`` files."""
+    for rel in existing:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("", encoding="utf-8")
+    return tmp_path
+
+
+# --- inline literals --------------------------------------------------------
+
+
+def test_existing_inline_ref_passes(tmp_path):
+    repo = _repo(tmp_path, "verl/trainer/config/ppo_trainer.yaml")
+    doc = _write(tmp_path, "docs/a.rst", "See ``verl/trainer/config/ppo_trainer.yaml`` for defaults.\n")
+    assert check_file(doc, repo) == []
+
+
+def test_missing_inline_ref_is_flagged(tmp_path):
+    repo = _repo(tmp_path)
+    doc = _write(tmp_path, "docs/a.rst", "See ``verl/trainer/config/ppo_trainer.yaml``.\n")
+    problems = check_file(doc, repo)
+    assert len(problems) == 1
+    assert "verl/trainer/config/ppo_trainer.yaml" in problems[0]
+    assert "docs/a.rst:1" in problems[0]
+
+
+def test_wrong_extension_is_flagged(tmp_path):
+    """The .yml/.yaml mix-up that motivated this hook."""
+    repo = _repo(tmp_path, "verl/trainer/config/ppo_megatron_trainer.yaml")
+    doc = _write(tmp_path, "docs/a.rst", "``verl/trainer/config/ppo_megatron_trainer.yml``\n")
+    assert len(check_file(doc, repo)) == 1
+
+
+def test_bare_filename_is_not_checked(tmp_path):
+    """A filename with no directory is prose, not a path claim."""
+    repo = _repo(tmp_path)
+    doc = _write(tmp_path, "docs/a.rst", "Edit ``config.yaml`` and ``npu_unit_tests.yml`` as needed.\n")
+    assert check_file(doc, repo) == []
+
+
+# --- runnable commands ------------------------------------------------------
+
+
+def test_existing_command_path_passes(tmp_path):
+    repo = _repo(tmp_path, "examples/grpo_trainer/run_qwen3_8b_fsdp.sh")
+    doc = _write(tmp_path, "docs/a.rst", "  bash examples/grpo_trainer/run_qwen3_8b_fsdp.sh\n")
+    assert check_file(doc, repo) == []
+
+
+def test_missing_command_path_is_flagged(tmp_path):
+    repo = _repo(tmp_path)
+    doc = _write(tmp_path, "docs/a.rst", "  bash examples/grpo_trainer/run_gone.sh\n")
+    problems = check_file(doc, repo)
+    assert len(problems) == 1
+    assert "run_gone.sh" in problems[0]
+
+
+def test_python_and_sh_invocations_are_checked(tmp_path):
+    repo = _repo(tmp_path)
+    doc = _write(
+        tmp_path,
+        "docs/a.rst",
+        "  python3 examples/data_preprocess/gone.py\n  sh scripts/gone.sh\n",
+    )
+    assert len(check_file(doc, repo)) == 2
+
+
+def test_line_numbers_are_reported(tmp_path):
+    repo = _repo(tmp_path)
+    doc = _write(tmp_path, "docs/a.rst", "intro\n\n  bash examples/x/gone.sh\n")
+    assert check_file(doc, repo)[0].startswith("docs/a.rst:3")
+
+
+# --- exemptions -------------------------------------------------------------
+
+
+def test_placeholders_are_exempt(tmp_path):
+    repo = _repo(tmp_path)
+    doc = _write(
+        tmp_path,
+        "docs/a.rst",
+        "``examples/path/to/model.yaml``\n"
+        "  bash tests/special_npu/your_test_script.sh\n"
+        "  python3 examples/data_preprocess/test_xxx.py\n",
+    )
+    assert check_file(doc, repo) == []
+
+
+def test_submodule_paths_are_exempt(tmp_path):
+    """recipe/ is a submodule: empty until `git submodule update --init`."""
+    repo = _repo(tmp_path)
+    doc = _write(tmp_path, "docs/a.rst", "  bash recipe/dapo/run_dapo_qwen2.5_32b.sh\n")
+    assert check_file(doc, repo) == []
+
+
+def test_allow_listed_parent_relative_path_is_exempt(tmp_path):
+    """Install guides run `bash verl/scripts/...` from the clone's parent."""
+    repo = _repo(tmp_path)
+    doc = _write(tmp_path, "docs/a.rst", "  bash verl/scripts/install_vllm_mcore_npu.sh\n")
+    assert check_file(doc, repo) == []
+
+
+def test_angle_bracket_template_is_exempt(tmp_path):
+    repo = _repo(tmp_path)
+    doc = _write(tmp_path, "docs/a.rst", "``examples/grpo_trainer/run_<model>_<backend>.sh``\n")
+    assert check_file(doc, repo) == []
+
+
+# --- collection and CLI -----------------------------------------------------
+
+
+def test_collect_docs_skips_build_output(tmp_path):
+    _write(tmp_path, "docs/real.rst", "x\n")
+    _write(tmp_path, "docs/_build/generated.rst", "x\n")
+    _write(tmp_path, "docs/notes.md", "x\n")
+    _write(tmp_path, "docs/ignore.txt", "x\n")
+    found = {p.name for p in collect_docs(tmp_path / "docs")}
+    assert found == {"real.rst", "notes.md"}
+
+
+def test_main_returns_zero_when_clean(tmp_path):
+    _repo(tmp_path, "examples/ok.sh")
+    _write(tmp_path, "docs/a.rst", "  bash examples/ok.sh\n")
+    assert main(["--repo-root", str(tmp_path)]) == 0
+
+
+def test_main_returns_one_on_violation(tmp_path):
+    _repo(tmp_path)
+    _write(tmp_path, "docs/a.rst", "  bash examples/gone.sh\n")
+    assert main(["--repo-root", str(tmp_path)]) == 1
+
+
+def test_main_returns_two_for_missing_docs_dir(tmp_path):
+    assert main(["--repo-root", str(tmp_path), "--docs-dir", "nope"]) == 2
+
+
+def test_repo_docs_are_clean():
+    """The real docs/ tree must stay green so the hook can gate CI."""
+    assert main([]) == 0


### PR DESCRIPTION
### What does this PR do?

Fixes stale file paths in the docs, then adds a sanity hook so they can't silently rot again.

I started from the two filename bugs below, but writing a scanner to confirm I hadn't missed any turned up three more — so the hook is now part of the PR rather than a follow-up.

**Doc fixes (5 paths)**

| file | was | now |
|---|---|---|
| `ascend_ci_guide.rst` (×3) | `npu_unit_test.yml` | `npu_unit_tests.yml` |
| `checkpoint.rst` | `ppo_trainer.yaml` **or `ppo_megatron_trainer.yml`** | drop the stale alternative |
| `checkpoint.rst` | `verl/scripts/legacy_model_merger.py` | `scripts/legacy_model_merger.py` |
| `trtllm_worker.rst` | `..._megatron_4_4_mis_trtllm.sh` | `..._megatron_8_8_mis_trtllm.sh` |
| `ascend_sglang_best_practices.rst` | `examples/grpo_trainer/run_qwen3moe-30b_sglang_megatron_npu.sh` | `examples/ascend_extras/grpo_trainer/run_qwen3_30b_a3b_megatron.sh` |

Notes on the less obvious ones:

- `npu_unit_test.yml` → the workflow is [`npu_unit_tests.yml`](https://github.com/verl-project/verl/blob/main/.github/workflows/npu_unit_tests.yml) (plural). This is the file the guide tells NPU contributors to open and add a step to, so the wrong name is directly blocking.
- `ppo_megatron_trainer.yml` → wrong extension *and* `verl/trainer/config/ppo_megatron_trainer.yaml` is now marked `# Deprecated, use ppo_trainer.yaml instead.`. Renaming to `.yaml` would point readers at a deprecated file, so I dropped the alternative — `ppo_trainer.yaml` is already named in the same sentence.
- `_4_4_mis_trtllm.sh` → only `_8_8_mis_trtllm.sh` and `grpo_8b_base_math_megatron_4_4_trtllm.sh` exist in that directory; the 30b `4_4_mis` variant does not.
- The Ascend NPU examples moved to `examples/ascend_extras/`. I matched the SGLang guide to `run_qwen3_30b_a3b_megatron.sh` on model (`Qwen/Qwen3-30B-A3B`) and on `exp_name='DAPO-Qwen3-30B-A3B-BASE-Megatron-SGLang'`, not on filename similarity.

**New hook: `tests/special_sanity/check_docs_file_refs.py`**

Checks the two ways docs name a repo file:

1. repo-relative inline literals — ``` ``verl/trainer/config/ppo_trainer.yaml`` ```
2. paths passed to `bash`/`python`/`sh` in code blocks — what a reader copy-pastes, so the most user-visible kind of rot

Exempt, each documented inline: placeholders (`path/to/…`, `your_script.py`, `<model>`), submodule paths (`recipe/` is empty until `git submodule update --init`), and paths that resolve from the clone's *parent* (the install guides' `git clone … && bash verl/scripts/install_*.sh` is correct as written). Bare filenames with no directory are treated as prose, not path claims.

**Two known-missing groups are allow-listed, not guessed at.** Substituting a plausible-looking path would change documented behaviour, so these need owner decisions:

- Ascend **vLLM** guide references a Qwen3-30B vLLM script, but `examples/ascend_extras/` only ships an SGLang variant for that model. Repointing it would silently switch the documented rollout backend.
- `examples/sglang_multiturn/` (4 paths in `search_tool_example.rst` / `agentic_rl.rst`) no longer exists in this repo *or* in the `verl-recipe` submodule. Those walkthroughs need a rewrite against the current agent-loop examples, not a path swap.

### Checklist Before Starting

- [x] Search for similar PRs: [`is:pr npu_unit_test`](https://github.com/verl-project/verl/pulls?q=is%3Apr+npu_unit_test) (0 results), [`is:pr ppo_megatron_trainer.yml`](https://github.com/verl-project/verl/pulls?q=is%3Apr+ppo_megatron_trainer.yml) (nothing related), [`is:pr sanity check docs file references`](https://github.com/verl-project/verl/pulls?q=is%3Apr+sanity+check+docs+file+references) (nothing related). Also confirmed the existing `validate_imported_docs.py` checks *docstrings*, not file references — no overlap.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```
$ python3 tests/special_sanity/check_docs_file_refs.py
✅  All repo file references in 124 docs under 'docs' resolve.

$ pytest tests/special_sanity/test_check_docs_file_refs.py -q
17 passed

$ python3 tests/special_sanity/check_docs_time_info.py
✅ All checked files contain 'Last updated'.

$ ruff check … && ruff format --check …
All checks passed!  /  2 files already formatted

$ python3 tests/special_sanity/validate_structure.py
✅  Tests folder structure looks good.
```

The 17 tests cover both directions, not just the happy path: missing refs are flagged with correct `file:line`, the `.yml`/`.yaml` mix-up is caught, exit codes are asserted (0 clean / 1 violation / 2 bad `--docs-dir`), and each exemption class has a test so a future refactor can't silently widen them into blind spots.

Ran the hook against `main` before fixing anything: it reported exactly the 9 real stale paths and **zero** false positives from `recipe/`, placeholders, or the parent-relative install paths. Verified each of the 9 against the default branch via the GitHub API, not just the local checkout.

Also verified the wiring actually gates docs-only PRs: `sanity.yml` filters on `**/*.py` and so would *not* run for an `.rst`-only change, but `pre-commit.yml` runs on every PR with no path filter, which is where this hook lives. Its companion tests are additionally picked up by `sanity.yml`'s existing `pytest -s -x tests/special_sanity`.

### API and Usage Example

No API change. The hook runs automatically via pre-commit; standalone usage:

```bash
python3 tests/special_sanity/check_docs_file_refs.py
python3 tests/special_sanity/check_docs_file_refs.py --docs-dir docs --repo-root .
```

On failure it prints one `file:line -> path` per bad reference plus a note on how to fix or exempt it.

### Design & Code Changes

- **new** `tests/special_sanity/check_docs_file_refs.py` — the checker; argparse CLI and `main(argv) -> int` following `check_example_naming.py`'s conventions.
- **new** `tests/special_sanity/test_check_docs_file_refs.py` — 17 tests.
- `.pre-commit-config.yaml` — register `check-docs-file-refs` next to `check-docs-time-info`.
- 4 docs — the 5 path fixes above; `Last updated` bumped on each touched file per repo convention.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks — `ruff` / `ruff-format` clean on both new files; ran `check-docs-time-info`, `check-license`, and `validate_structure` directly (all pass). I could not run the full `pre-commit run --all-files` locally since some hooks need a complete GPU-side install.
- [x] Add / Update the documentation.
- [x] Add unit or end-to-end test(s) to the CI workflow — 17 tests under `tests/special_sanity/`, collected by the existing `sanity.yml` job; the hook itself runs in `pre-commit.yml`.
- [ ] Send a message in the `ci-request` channel — I don't have access to the verl Slack workspace, so I can't trigger CI myself. Would a maintainer mind kicking it off?
- [ ] Not related to the `recipe` submodule.