### PR TITLE
[tool] fix: keep JSON Schema keywords the tool carriers do not name

### DIFF
--- a/tests/tools/test_schemas_on_cpu.py
+++ b/tests/tools/test_schemas_on_cpu.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the OpenAI tool-schema carrier models."""
+
+from __future__ import annotations
+
+import pytest
+
+from verl.tools import function_tool as function_tool_mod
+from verl.tools.function_tool import FUNCTION_TOOL_REGISTRY, function_tool
+from verl.tools.schemas import OpenAIFunctionToolSchema
+
+# The dump kwargs the rollout path uses, e.g. ToolAgentLoop and rl_dataset when they
+# hand tool schemas to a chat template.
+ROLLOUT_DUMP_KWARGS = {"exclude_unset": True, "exclude_none": True}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    FUNCTION_TOOL_REGISTRY.clear()
+    function_tool_mod._LOADED_FUNCTION_TOOL_PATHS.clear()
+    yield
+    FUNCTION_TOOL_REGISTRY.clear()
+    function_tool_mod._LOADED_FUNCTION_TOOL_PATHS.clear()
+
+
+def _constrained_tool_schema() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read part of a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path"},
+                    "offset": {"type": "integer", "description": "Start line", "minimum": 0},
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum lines",
+                        "minimum": 1,
+                        "maximum": 128,
+                    },
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def test_numeric_constraints_and_additional_properties_survive_a_round_trip():
+    """Keywords the carriers do not name are still part of the caller's contract.
+
+    Pydantic drops unknown keys by default, so ``minimum`` / ``maximum`` /
+    ``additionalProperties`` used to be gone by the time ``model_dump`` reached the
+    chat template -- the model saw a weaker contract than the caller wrote.
+    """
+    raw = _constrained_tool_schema()
+
+    dumped = OpenAIFunctionToolSchema.model_validate(raw).model_dump(exclude_none=True)
+
+    params = dumped["function"]["parameters"]
+    assert params["additionalProperties"] is False
+    assert params["properties"]["offset"]["minimum"] == 0
+    assert params["properties"]["limit"]["minimum"] == 1
+    assert params["properties"]["limit"]["maximum"] == 128
+
+
+def test_rollout_dump_reproduces_the_supplied_schema_exactly():
+    """The dump the rollout path actually performs must not lose or invent keys."""
+    raw = _constrained_tool_schema()
+
+    dumped = OpenAIFunctionToolSchema.model_validate(raw).model_dump(**ROLLOUT_DUMP_KWARGS)
+
+    assert dumped == raw
+
+
+def test_nested_array_and_object_keywords_survive():
+    """A property's own sub-schema is untyped here, so it has to pass through whole."""
+    raw = {
+        "type": "function",
+        "function": {
+            "name": "batch_update",
+            "description": "Apply edits",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "edits": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "properties": {"line": {"type": "integer", "minimum": 1}},
+                            "required": ["line"],
+                        },
+                    },
+                    "mode": {"type": "string", "pattern": "^(insert|replace)$"},
+                },
+                "required": ["edits"],
+            },
+        },
+    }
+
+    dumped = OpenAIFunctionToolSchema.model_validate(raw).model_dump(**ROLLOUT_DUMP_KWARGS)
+
+    assert dumped == raw
+
+
+def test_function_tool_keeps_an_explicit_schema_as_is():
+    """``function_tool(schema=...)`` documents the supplied schema as used as-is."""
+    raw = _constrained_tool_schema()
+
+    @function_tool(schema=raw)
+    def read_file(path: str, offset: int = 0, limit: int = 128) -> str:
+        return ""
+
+    entry = FUNCTION_TOOL_REGISTRY["read_file"]
+
+    assert entry.tool_schema.model_dump(**ROLLOUT_DUMP_KWARGS) == raw
+
+
+def test_declared_fields_are_still_validated():
+    """Accepting extra keywords must not turn into accepting anything."""
+    with pytest.raises(ValueError):
+        OpenAIFunctionToolSchema.model_validate(
+            {
+                "type": "function",
+                "function": {
+                    "name": "broken",
+                    "description": "missing the required property type",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"description": "no type given"}},
+                    },
+                },
+            }
+        )

--- a/verl/tools/schemas.py
+++ b/verl/tools/schemas.py
@@ -15,11 +15,19 @@
 import json
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class OpenAIFunctionPropertySchema(BaseModel):
     """The schema of a parameter in OpenAI format."""
+
+    # JSON Schema keywords this model does not name -- ``minimum``, ``maximum``,
+    # ``items``, ``pattern``, a nested object's own ``properties`` -- are part of the
+    # contract the caller wrote and the model is meant to see. Pydantic drops unknown
+    # keys by default, so without this they were silently gone by the time
+    # ``model_dump`` fed the chat template. Extras count as set, so they also survive
+    # the ``exclude_unset=True`` dumps on the rollout path.
+    model_config = ConfigDict(extra="allow")
 
     # Union's type is list[str], e.g. ["integer", "number"] for int | float unions.
     type: str | list[str]
@@ -31,6 +39,10 @@ class OpenAIFunctionPropertySchema(BaseModel):
 
 class OpenAIFunctionParametersSchema(BaseModel):
     """The schema of parameters in OpenAI format."""
+
+    # Same reason as above: keeps root-level keywords such as
+    # ``additionalProperties`` and ``$defs``.
+    model_config = ConfigDict(extra="allow")
 
     type: str
     properties: dict[str, OpenAIFunctionPropertySchema]


### PR DESCRIPTION
### What does this PR do?

Fixes #7505: `OpenAIFunctionToolSchema` validated a tool schema and then silently dropped every JSON Schema keyword its Pydantic carriers do not declare.

`OpenAIFunctionPropertySchema` names only `type` / `description` / `enum`, and `OpenAIFunctionParametersSchema` only `type` / `properties` / `required`. Pydantic ignores unknown keys by default, so `minimum`, `maximum`, `pattern`, `items`, a nested object's own `properties` and root-level `additionalProperties` were gone before the schema was serialized.

This is the model-visible contract rather than an internal detail. `ToolAgentLoop` (`tool_agent_loop.py:116`, `:160`) and `rl_dataset` (`rl_dataset.py:137`) render tools with `tool_schema.model_dump(exclude_unset=True, exclude_none=True)`, so the model was shown a weaker schema than the caller wrote. Nothing raises — tool calls still parse and execute — which is why it stays quiet. It also made `function_tool(schema=...)` untrue to its own docstring, which promises the supplied schema is used "as-is" (`function_tool.py:98`, `:110`).

### Fix

`model_config = ConfigDict(extra="allow")` on the two carriers. Pydantic then keeps unknown keys and counts them as set, so they survive the `exclude_unset=True` dumps on the rollout path, and a property's untyped sub-schema passes through whole. Declared fields are still validated — a property with no `type` is still rejected.

Scoped to the parameter and property carriers, which is where the reproduction loses data. `OpenAIFunctionSchema` and `OpenAIFunctionToolSchema` already name the OpenAI-level keys and are untouched.

One thing worth flagging: the issue's `assert dumped == raw` still does not hold for a plain `model_dump(exclude_none=True)`, because `OpenAIFunctionSchema.strict` defaults to `False` and a non-`None` default is included. That is pre-existing default behaviour, not part of this bug. On the dump the rollout path actually performs — `exclude_unset=True, exclude_none=True` — the round trip is now exact, which is what the test asserts.

### Not a duplicate

Checked before starting, per AGENTS.md:

```
gh issue view 7505 --repo verl-project/verl --comments        # no comments, unassigned
gh pr list --repo verl-project/verl --state open --search "7505 in:body"   # 0
gh pr list --repo verl-project/verl --state open --search "tool schema json schema"
```

No open PR touches `verl/tools/schemas.py`.

### Test

New CPU test file `tests/tools/test_schemas_on_cpu.py`, five cases:

- `test_numeric_constraints_and_additional_properties_survive_a_round_trip` — the issue's exact reproduction
- `test_rollout_dump_reproduces_the_supplied_schema_exactly` — the `exclude_unset=True, exclude_none=True` dump the rollout path performs
- `test_nested_array_and_object_keywords_survive` — `items`, `minItems`, `pattern`, and a nested object's own `properties`
- `test_function_tool_keeps_an_explicit_schema_as_is` — the `function_tool(schema=...)` promise
- `test_declared_fields_are_still_validated` — guards against `extra="allow"` turning into "accept anything"

Reverting `verl/tools/schemas.py` to its pre-fix state, the first four fail and the fifth passes, so they pin the behaviour rather than restating it:

```
$ pytest tests/tools/test_schemas_on_cpu.py          # schemas.py reverted
FAILED test_numeric_constraints_and_additional_properties_survive_a_round_trip
FAILED test_rollout_dump_reproduces_the_supplied_schema_exactly
FAILED test_nested_array_and_object_keywords_survive
FAILED test_function_tool_keeps_an_explicit_schema_as_is
4 failed, 1 passed
```

With the change:

```
$ pytest tests/tools/
47 passed

$ pytest tests/experimental/agent_loop/
44 passed, 2 skipped, 7 errors

$ pytest tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py \
         tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py \
         tests/experimental/agent_loop/test_tool_call_id_on_cpu.py
15 passed
```

The 7 `agent_loop` errors are `KeyError: 'ROLLOUT_NAME'`, and a clean checkout of `main` produces the same 7 — they are an environment requirement, not something this change introduces.

I then went and set the environment up rather than leaving that as an assumption. On a node with 4x L40S, `ROLLOUT_NAME=vllm pytest -svvv tests/experimental/agent_loop` runs the whole suite: every CPU test passes (35 of them — `test_agent_loop_extra_fields_schema`, `test_audio_server_contract`, `test_call_tool`, `TestLoadBalancerRouting`, `TestLoadBalancerHybrid`, ...), and the three rollout tests fail on

```
ValueError: Total available GPUs 4.0 is less than total desired GPUs 8
```

which matches `.github/workflows/vllm.yml` running this suite on an `L20x8` runner. I could not get 8 GPUs on one node to finish that last step, so `test_single_turn` / `test_tool_agent` / `test_function_tool_agent` are unverified here. They exercise rollout mechanics rather than schema serialization; the three CPU files listed above are the ones that actually consume these carriers.

`ruff 0.12.2` check and format clean on both files. `check_license.py` and `check_docstrings.py` pass.

### Note on tooling

AI-assisted. I reviewed every changed line and ran the commands above myself.
