### PR TITLE
[training_utils] fix: handle serialized and mispacked 3D position ids

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1284,3 +1284,18 @@ def test_index_select_tensor_dict_with_3d_jagged_position_ids():
 
     torch.testing.assert_close(selected_samples[0], samples[1])
     torch.testing.assert_close(selected_samples[1], samples[0])
+
+
+def test_maybe_fix_3d_position_ids_preserves_valid_layout():
+    samples = [
+        torch.arange(4 * 17).reshape(4, 17),
+        torch.arange(4 * 11).reshape(4, 11),
+    ]
+    position_ids = tu.nested_tensor_from_tensor_list(samples, ragged_idx=2)
+    batch = TensorDict({"position_ids": position_ids}, batch_size=[2])
+
+    tu.maybe_fix_3d_position_ids(batch)
+
+    fixed_samples = batch["position_ids"].unbind(dim=0)
+    torch.testing.assert_close(fixed_samples[0], samples[0])
+    torch.testing.assert_close(fixed_samples[1], samples[1])

--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1256,3 +1256,23 @@ def test_serialize_dataproto_with_empty_tensordict():
     deserialized_data = pickle.loads(serialized_data)
     assert len(deserialized_data.batch.keys()) == 0
     assert deserialized_data.batch.batch_size == torch.Size([10])
+
+
+def test_index_select_tensor_dict_with_3d_jagged_position_ids():
+    samples = [torch.zeros(4, 17), torch.ones(4, 17)]
+    position_ids = torch.nested.as_nested_tensor(samples, layout=torch.jagged)
+    batch = TensorDict({"position_ids": position_ids}, batch_size=[2])
+
+    tu.maybe_fix_3d_position_ids(batch)
+    selected = tu.index_select_tensor_dict(batch, [1, 0])
+
+    actual = selected["position_ids"]
+    assert actual._ragged_idx == 2
+    expected_values = torch.cat([samples[1], samples[0]], dim=1)
+    torch.testing.assert_close(actual.values(), expected_values)
+    expected_offsets = torch.tensor(
+        [0, 17, 34],
+        dtype=actual.offsets().dtype,
+        device=actual.offsets().device,
+    )
+    torch.testing.assert_close(actual.offsets(), expected_offsets)

--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1259,20 +1259,28 @@ def test_serialize_dataproto_with_empty_tensordict():
 
 
 def test_index_select_tensor_dict_with_3d_jagged_position_ids():
-    samples = [torch.zeros(4, 17), torch.ones(4, 17)]
+    samples = [
+        torch.arange(4 * 17).reshape(4, 17),
+        torch.arange(4 * 17, 8 * 17).reshape(4, 17),
+    ]
     position_ids = torch.nested.as_nested_tensor(samples, layout=torch.jagged)
     batch = TensorDict({"position_ids": position_ids}, batch_size=[2])
 
     tu.maybe_fix_3d_position_ids(batch)
-    selected = tu.index_select_tensor_dict(batch, [1, 0])
 
-    actual = selected["position_ids"]
-    assert actual._ragged_idx == 2
-    expected_values = torch.cat([samples[1], samples[0]], dim=1)
-    torch.testing.assert_close(actual.values(), expected_values)
-    expected_offsets = torch.tensor(
-        [0, 17, 34],
-        dtype=actual.offsets().dtype,
-        device=actual.offsets().device,
-    )
-    torch.testing.assert_close(actual.offsets(), expected_offsets)
+    fixed_position_ids = batch["position_ids"]
+    assert fixed_position_ids._ragged_idx == 2
+    assert fixed_position_ids.values().shape == (4, 34)
+    assert fixed_position_ids.offsets().tolist() == [0, 17, 34]
+
+    # The rebuilt tensor itself must support unbind.
+    rebuilt_samples = fixed_position_ids.unbind(dim=0)
+    torch.testing.assert_close(rebuilt_samples[0], samples[0])
+    torch.testing.assert_close(rebuilt_samples[1], samples[1])
+
+    # Batch reordering must also work.
+    selected = tu.index_select_tensor_dict(batch, [1, 0])
+    selected_samples = selected["position_ids"].unbind(dim=0)
+
+    torch.testing.assert_close(selected_samples[0], samples[1])
+    torch.testing.assert_close(selected_samples[1], samples[0])

--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1299,3 +1299,76 @@ def test_maybe_fix_3d_position_ids_preserves_valid_layout():
     fixed_samples = batch["position_ids"].unbind(dim=0)
     torch.testing.assert_close(fixed_samples[0], samples[0])
     torch.testing.assert_close(fixed_samples[1], samples[1])
+
+
+def test_fix_3d_position_ids_after_dataproto_serialization():
+    import pickle
+
+    samples = [torch.arange(4 * 17).reshape(4, 17)]
+    position_ids = tu.nested_tensor_from_tensor_list(samples, ragged_idx=2)
+
+    data = DataProto(
+        batch=TensorDict(
+            {"position_ids": position_ids},
+            batch_size=[1],
+        )
+    )
+
+    serialized = pickle.dumps(data)
+    restored = pickle.loads(serialized)
+
+    tu.maybe_fix_3d_position_ids(restored.batch)
+
+    fixed_position_ids = restored.batch["position_ids"]
+
+    assert fixed_position_ids._ragged_idx == 2
+    assert fixed_position_ids.values().shape == (4, 17)
+    assert fixed_position_ids.offsets().tolist() == [0, 17]
+
+    restored_samples = fixed_position_ids.unbind(dim=0)
+    assert len(restored_samples) == 1
+    torch.testing.assert_close(restored_samples[0], samples[0])
+
+    selected = tu.index_select_tensor_dict(restored.batch, [0])
+    selected_samples = selected["position_ids"].unbind(dim=0)
+
+    assert len(selected_samples) == 1
+    torch.testing.assert_close(selected_samples[0], samples[0])
+
+
+def test_3d_position_ids_after_dataproto_serialization(monkeypatch):
+    import pickle
+
+    import torch
+    from tensordict import TensorDict
+
+    from verl.protocol import DataProto
+    from verl.utils import tensordict_utils as tu
+
+    # Use the default serialization path, including consolidation.
+    monkeypatch.delenv("VERL_DATAPROTO_SERIALIZATION_METHOD", raising=False)
+
+    samples = [
+        torch.arange(4 * 17).reshape(4, 17),
+        torch.arange(4 * 17, 8 * 17).reshape(4, 17),
+    ]
+    position_ids = tu.nested_tensor_from_tensor_list(samples, ragged_idx=2)
+    data = DataProto(batch=TensorDict({"position_ids": position_ids}, batch_size=[2]))
+
+    restored = pickle.loads(pickle.dumps(data))
+    tu.maybe_fix_3d_position_ids(restored.batch)
+
+    fixed = restored.batch["position_ids"]
+    assert fixed._ragged_idx == 2
+    assert fixed.values().shape == (4, 34)
+    assert fixed.offsets().tolist() == [0, 17, 34]
+
+    actual_samples = fixed.unbind(dim=0)
+    assert len(actual_samples) == len(samples)
+    for actual, expected in zip(actual_samples, samples, strict=True):
+        torch.testing.assert_close(actual, expected)
+
+    selected = tu.index_select_tensor_dict(restored.batch, [1, 0])
+    selected_samples = selected["position_ids"].unbind(dim=0)
+    torch.testing.assert_close(selected_samples[0], samples[1])
+    torch.testing.assert_close(selected_samples[1], samples[0])

--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1301,41 +1301,6 @@ def test_maybe_fix_3d_position_ids_preserves_valid_layout():
     torch.testing.assert_close(fixed_samples[1], samples[1])
 
 
-def test_fix_3d_position_ids_after_dataproto_serialization():
-    import pickle
-
-    samples = [torch.arange(4 * 17).reshape(4, 17)]
-    position_ids = tu.nested_tensor_from_tensor_list(samples, ragged_idx=2)
-
-    data = DataProto(
-        batch=TensorDict(
-            {"position_ids": position_ids},
-            batch_size=[1],
-        )
-    )
-
-    serialized = pickle.dumps(data)
-    restored = pickle.loads(serialized)
-
-    tu.maybe_fix_3d_position_ids(restored.batch)
-
-    fixed_position_ids = restored.batch["position_ids"]
-
-    assert fixed_position_ids._ragged_idx == 2
-    assert fixed_position_ids.values().shape == (4, 17)
-    assert fixed_position_ids.offsets().tolist() == [0, 17]
-
-    restored_samples = fixed_position_ids.unbind(dim=0)
-    assert len(restored_samples) == 1
-    torch.testing.assert_close(restored_samples[0], samples[0])
-
-    selected = tu.index_select_tensor_dict(restored.batch, [0])
-    selected_samples = selected["position_ids"].unbind(dim=0)
-
-    assert len(selected_samples) == 1
-    torch.testing.assert_close(selected_samples[0], samples[0])
-
-
 def test_3d_position_ids_after_dataproto_serialization(monkeypatch):
     import pickle
 

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -492,13 +492,7 @@ def index_select_tensor_dict(batch: TensorDict, indices: torch.Tensor | list[int
             if isinstance(tensor, torch.Tensor) and not tensor.is_nested:
                 data_dict[key] = tensor[indices]
             elif isinstance(tensor, torch.Tensor) and tensor.is_nested:
-                try:
-                    tensor_lst = tensor.unbind()  # fast path
-                except RuntimeError:
-                    if tensor.dim() != 3 or getattr(tensor, "_ragged_idx", None) != 2:
-                        raise
-                    lengths = tensor.offsets().diff().tolist()
-                    tensor_lst = torch.split(tensor.values(), lengths, dim=0)
+                tensor_lst = tensor.unbind()  # for performance
                 selected_tensors = [tensor_lst[idx] for idx in indices]
                 data_dict[key] = nested_tensor_from_tensor_list(
                     selected_tensors, ragged_idx=getattr(tensor, "_ragged_idx", tensor.dim() - 1)
@@ -914,11 +908,21 @@ def contiguous(data: TensorDict) -> TensorDict:
 
 
 def maybe_fix_3d_position_ids(data: TensorDict):
-    # note for tensordict with pickle/unpickle. nested tensor in tensordict after consolidate and pickle/unpickle
-    # will incur indexing error for ragged tensor. This only happens when using 3D position ids in VLMs.
-    # This is likely a bug in tensordict. As a workaround, we manually set _ragged_index.
-    if "position_ids" in data.keys() and data["position_ids"].dim() == 3 and data["position_ids"].is_nested:
-        data["position_ids"]._ragged_idx = 2
+    """Rebuild 3D nested position_ids with the sequence dimension as ragged."""
+
+    if "position_ids" in data and data["position_ids"].dim() == 3 and data["position_ids"].is_nested:
+        position_ids = data["position_ids"]
+
+        # Equal-length mRoPE position_ids may be constructed with the
+        # head dimension as ragged. Rebuild the NestedTensor instead of
+        # only modifying _ragged_idx, which would leave its values and
+        # offsets inconsistent.
+        if getattr(position_ids, "_ragged_idx", None) != 2:
+            samples = list(position_ids.unbind(dim=0))
+            data["position_ids"] = nested_tensor_from_tensor_list(
+                samples,
+                ragged_idx=2,
+            )
 
 
 def list_of_dict_to_tensordict(list_of_dicts: list[dict[str, Any]]) -> TensorDict:

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -908,15 +908,14 @@ def contiguous(data: TensorDict) -> TensorDict:
 
 
 def maybe_fix_3d_position_ids(data: TensorDict):
-    """Rebuild 3D nested position_ids with the sequence dimension as ragged."""
+    """Repair 3D nested position_ids after TensorDict serialization."""
 
+    # TensorDict consolidation and pickle/unpickle may leave 3D VLM
+    # position_ids with an incorrect ragged dimension. Rebuild the
+    # NestedTensor so its values, offsets, and _ragged_idx remain consistent.
     if "position_ids" in data and data["position_ids"].dim() == 3 and data["position_ids"].is_nested:
         position_ids = data["position_ids"]
 
-        # Equal-length mRoPE position_ids may be constructed with the
-        # head dimension as ragged. Rebuild the NestedTensor instead of
-        # only modifying _ragged_idx, which would leave its values and
-        # offsets inconsistent.
         if getattr(position_ids, "_ragged_idx", None) != 2:
             samples = list(position_ids.unbind(dim=0))
             data["position_ids"] = nested_tensor_from_tensor_list(

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -492,7 +492,13 @@ def index_select_tensor_dict(batch: TensorDict, indices: torch.Tensor | list[int
             if isinstance(tensor, torch.Tensor) and not tensor.is_nested:
                 data_dict[key] = tensor[indices]
             elif isinstance(tensor, torch.Tensor) and tensor.is_nested:
-                tensor_lst = tensor.unbind()  # for performance
+                try:
+                    tensor_lst = tensor.unbind()  # fast path
+                except RuntimeError:
+                    if tensor.dim() != 3 or getattr(tensor, "_ragged_idx", None) != 2:
+                        raise
+                    lengths = tensor.offsets().diff().tolist()
+                    tensor_lst = torch.split(tensor.values(), lengths, dim=0)
                 selected_tensors = [tensor_lst[idx] for idx in indices]
                 data_dict[key] = nested_tensor_from_tensor_list(
                     selected_tensors, ragged_idx=getattr(tensor, "_ragged_idx", tensor.dim() - 1)

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -908,20 +908,39 @@ def contiguous(data: TensorDict) -> TensorDict:
 
 
 def maybe_fix_3d_position_ids(data: TensorDict):
-    """Repair 3D nested position_ids after TensorDict serialization."""
+    """Repair the layout of 3D nested position_ids."""
+    if "position_ids" not in data:
+        return
 
-    # TensorDict consolidation and pickle/unpickle may leave 3D VLM
-    # position_ids with an incorrect ragged dimension. Rebuild the
-    # NestedTensor so its values, offsets, and _ragged_idx remain consistent.
-    if "position_ids" in data and data["position_ids"].dim() == 3 and data["position_ids"].is_nested:
-        position_ids = data["position_ids"]
+    position_ids = data["position_ids"]
+    if position_ids.dim() != 3 or not position_ids.is_nested:
+        return
 
-        if getattr(position_ids, "_ragged_idx", None) != 2:
-            samples = list(position_ids.unbind(dim=0))
-            data["position_ids"] = nested_tensor_from_tensor_list(
-                samples,
-                ragged_idx=2,
-            )
+    if getattr(position_ids, "_ragged_idx", None) == 2:
+        return
+
+    values = position_ids.values()
+    offsets = position_ids.offsets()
+    total_length = offsets[-1].item()
+
+    # The sequence storage survived serialization, but its ragged
+    # dimension metadata was reset. Reconstruct before calling unbind.
+    if total_length == values.shape[1] and total_length > values.shape[0]:
+        data["position_ids"] = torch.nested.nested_tensor_from_jagged(
+            values=values,
+            offsets=offsets,
+            lengths=position_ids.lengths(),
+            jagged_dim=2,
+        )
+        return
+
+    # The current layout is internally consistent but uses the
+    # coordinate dimension as ragged. Repack the original samples.
+    samples = list(position_ids.unbind(dim=0))
+    data["position_ids"] = nested_tensor_from_tensor_list(
+        samples,
+        ragged_idx=2,
+    )
 
 
 def list_of_dict_to_tensordict(list_of_dicts: list[dict[str, Any]]) -> TensorDict:

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -925,7 +925,7 @@ def maybe_fix_3d_position_ids(data: TensorDict):
 
     # The sequence storage survived serialization, but its ragged
     # dimension metadata was reset. Reconstruct before calling unbind.
-    if total_length == values.shape[1] and total_length > values.shape[0]:
+    if total_length == values.shape[1] and values.shape[0] in (3, 4):
         data["position_ids"] = torch.nested.nested_tensor_from_jagged(
             values=values,
             offsets=offsets,


### PR DESCRIPTION
## What does this PR do?

Fixes two inconsistent layouts of 3D jagged `position_ids` handled by `maybe_fix_3d_position_ids()`.

For multimodal position IDs with per-sample shape `[coordinates, sequence_length]`, TensorDict operations can produce two distinct states:

- **Coordinate-packed layout:** equal-length samples created with `torch.nested.as_nested_tensor()` may store values as `[batch_size * coordinates, sequence_length]`, with the coordinate dimension marked as ragged.
- **Serialized sequence-packed layout:** after TensorDict consolidation and `DataProto` serialization, values and offsets may still describe the sequence-ragged layout, while `_ragged_idx` is reset from `2` to `1`. Calling `unbind()` with that inconsistent metadata raises `split_with_sizes`.

The previous workaround unconditionally assigned `_ragged_idx = 2`. Changing only this private metadata can leave the values and offsets inconsistent with the declared ragged dimension.

This PR rebuilds the NestedTensor so its values, offsets, and ragged-dimension metadata agree.

Addresses #6851.

Related: #5689 fixed 3D position ID construction in the SFT collator. This PR repairs layouts at the shared TensorDict indexing boundary, including after a `DataProto` serialization round trip.

## Implementation

`maybe_fix_3d_position_ids()` now:

- Returns immediately for missing, non-nested, non-3D, or already-correct ragged-dimension-2 position IDs.
- Detects serialized mRoPE storage when:
  - the coordinate axis contains 3 or 4 rows; and
  - the final offset equals the sequence-storage dimension.
- Reconstructs detected serialized storage directly with the existing values, offsets, and lengths using `jagged_dim=2`, before any unsafe `unbind()`.
- Rebuilds other internally consistent coordinate-packed layouts from their original samples with the sequence dimension marked as ragged.

No public API, configuration, or caller changes are required. Existing callers continue to invoke `maybe_fix_3d_position_ids()` before indexing.

## Tests

The added CPU tests cover:

- Rebuilding equal-length coordinate-packed position IDs.
- Preserving already-valid variable-length sequence-ragged position IDs.
- Preserving exact sample values through the default `DataProto` serialization path.
- Reordering repaired position IDs through `index_select_tensor_dict()`.

Validated locally with PyTorch `2.11.0+cu130` and TensorDict `0.10.0`:

```bash
pytest -q --tb=short \
  tests/test_protocol_on_cpu.py::test_index_select_tensor_dict_with_3d_jagged_position_ids \
  tests/test_protocol_on_cpu.py::test_maybe_fix_3d_position_ids_preserves_valid_layout \
  tests/test_protocol_on_cpu.py::test_3d_position_ids_after_dataproto_serialization
```

## Checklist

- [x] Read the contribution guide.
- [x] Added CPU regression coverage.
- [x] Completed local pre-commit checks.
- [x] No documentation changes are required for this internal repair.
- [ ] Requested repository CI in the verl Slack `ci-request` channel.
- [x] Not applicable to the `recipe` submodule.