### PR TITLE
[training_utils] feat: Add automatic CUDA/NPU OOM snapshots and multi-step memory history

### DIFF
--- a/docs/perf/verl_profiler_system.md
+++ b/docs/perf/verl_profiler_system.md
@@ -24,15 +24,23 @@ For tool config in role-level, there are some detailed behavior needed to contro
 
 Every role has a profiler config, and by default, rollout/ref/reward models follow the Actor's behavior.
 
-## CUDA memory snapshots
+## CUDA/NPU memory snapshots
 
 Selecting `global_profiler.tool=torch_memory` automatically enables best-effort OOM
-snapshot dumping on the selected profiler ranks when the CUDA allocator observer
-is available. No separate OOM switch is needed. The callback logs the Python stack
-and allocator memory summary, then writes a snapshot under
-`<save_path>/oom_<timestamp>/` without synchronizing CUDA. It remains active outside
+snapshot dumping on the selected profiler ranks when the CUDA/NPU allocator observer
+is available. The callback logs the Python stack and allocator memory summary, then writes a snapshot under
+`<save_path>/oom_<timestamp>/` without synchronizing the device. It remains active outside
 the scheduled profiling steps once registered; it cannot run after `SIGKILL`.
 Unsupported devices or PyTorch builds emit a warning and continue without the OOM callback.
+
+NPU support requires `torch_npu._C._npu_attach_out_of_memory_observer` and the memory
+history/snapshot APIs (present in `torch-npu==2.10.0.post4`). Both regular and OOM NPU
+snapshots directly serialize `memory._snapshot()` to a pickle file, skipping the
+extra device memory CSV/profiler operations in `memory._dump_snapshot()`. Regular
+step-boundary dumps still synchronize the device; OOM dumps do not. CUDA snapshots
+continue to use the native dump helper. The callback logs NPU's third argument as
+`total_or_limit`, since it represents the process memory limit when configured,
+otherwise the device total.
 
 Normal step-boundary snapshots remain controlled by `global_profiler.steps` and
 `global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps`

--- a/docs/perf/verl_profiler_system.md
+++ b/docs/perf/verl_profiler_system.md
@@ -1,6 +1,6 @@
 # verl Profiler System
 
-Last updated: 08/18/2025.
+Last updated: 09/07/2026.
 
 ## Architecture
 
@@ -23,6 +23,22 @@ When some tool need to profile behavior of each role, configurations in role-lev
 For tool config in role-level, there are some detailed behavior needed to control, like the `discrete` mode in nsys profiler.
 
 Every role has a profiler config, and by default, rollout/ref/reward models follow the Actor's behavior.
+
+## CUDA memory snapshots
+
+Selecting `global_profiler.tool=torch_memory` automatically enables best-effort OOM
+snapshot dumping on the selected profiler ranks when the CUDA allocator observer
+is available. No separate OOM switch is needed. The callback logs the Python stack
+and allocator memory summary, then writes a snapshot under
+`<save_path>/oom_<timestamp>/` without synchronizing CUDA. It remains active outside
+the scheduled profiling steps once registered; it cannot run after `SIGKILL`.
+Unsupported devices or PyTorch builds emit a warning and continue without the OOM callback.
+
+Normal step-boundary snapshots remain controlled by `global_profiler.steps` and
+`global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps`
+(default: `1`). Set `global_profiler.profile_continuous_steps=False` when using this
+step count so each profiled step contributes one start/stop cycle to the window.
+Training that does not select the `torch_memory` tool is unaffected.
 
 ## To Add a new profiling tool
 

--- a/tests/special_sanity/check_device_api_usage.py
+++ b/tests/special_sanity/check_device_api_usage.py
@@ -32,6 +32,7 @@ CUDA_KEYWORD_CHECK_WHITELIST = [
     "verl/plugin/platform/platform_manager.py",  # platform auto-detection probes torch.cuda
     "verl/utils/profiler/nvtx_profile.py",  # appear in NsightSystemsProfiler
     "verl/utils/profiler/torch_profile.py",  # appear in TorchProfiler
+    "verl/utils/profiler/torch_memory_profile.py",  # explicitly limit OOM observers to CUDA/NPU
     "verl/utils/profiler/config.py",  # appear in TorchProfilerToolConfig
     "verl/utils/kernel/linear_cross_entropy.py",  # appear in nvidia nvtx
     "verl/utils/rendezvous/ray_backend.py",  # appear in cupy importance

--- a/tests/utils/test_torch_memory_profile.py
+++ b/tests/utils/test_torch_memory_profile.py
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
+import sys
+import tempfile
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import torch
 
 from verl.utils.profiler.config import ProfilerConfig, TorchMemoryToolConfig
 from verl.utils.profiler.profile import DistProfiler
@@ -21,16 +28,21 @@ from verl.utils.profiler.torch_memory_profile import TorchMemoryProfiler
 
 
 class TestTorchMemoryProfiler(unittest.TestCase):
+    device_name = "cuda"
+
     def setUp(self):
         self.attach_observer = MagicMock()
+        self.device = MagicMock()
+        self.device.is_available.return_value = True
+        self.npu = SimpleNamespace(_C=SimpleNamespace())
+        self.backend = self.npu._C if self.device_name == "npu" else torch._C
+        self.observer_api = f"_{self.device_name}_attach_out_of_memory_observer"
         for patcher in (
             patch("verl.utils.profiler.torch_memory_profile.enable_memory_visualize"),
-            patch("verl.utils.profiler.torch_memory_profile.is_cuda_available", True),
-            patch(
-                "verl.utils.profiler.torch_memory_profile.torch._C._cuda_attach_out_of_memory_observer",
-                self.attach_observer,
-                create=True,
-            ),
+            patch("verl.utils.profiler.torch_memory_profile.get_device_name", return_value=self.device_name),
+            patch("verl.utils.profiler.torch_memory_profile.get_torch_device", return_value=self.device),
+            patch.dict(sys.modules, {"torch_npu": self.npu}),
+            patch.object(self.backend, self.observer_api, self.attach_observer, create=True),
             patch.object(TorchMemoryProfiler, "_memory_history_enabled", False),
             patch.object(TorchMemoryProfiler, "_oom_observer_attached", False),
         ):
@@ -57,7 +69,9 @@ class TestTorchMemoryProfiler(unittest.TestCase):
 
         dump_snapshot.assert_called_once()
         memory_info.assert_called_once()
-        self.assertTrue(any("requested=4096 total=1234 free=5678" in entry for entry in logs.output))
+        total_label = "total_or_limit" if self.device_name == "npu" else "total"
+        self.assertTrue(any(f"{self.device_name.upper()} OOM on device 0" in entry for entry in logs.output))
+        self.assertTrue(any(f"requested=4096 {total_label}=1234 free=5678" in entry for entry in logs.output))
         self.assertTrue(any("Python stack at OOM:\nstack" in entry for entry in logs.output))
         self.assertTrue(any("allocator memory at OOM" in entry for entry in logs.output))
         kwargs = dump_snapshot.call_args.kwargs
@@ -79,25 +93,33 @@ class TestTorchMemoryProfiler(unittest.TestCase):
         TorchMemoryProfiler(rank=0, config=self._config())
         self.attach_observer.assert_called_once()
 
-    def test_non_cuda_device_skips_oom_observer(self):
-        with (
-            patch("verl.utils.profiler.torch_memory_profile.is_cuda_available", False),
-            self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING"),
-        ):
+    def test_unavailable_device_skips_oom_observer(self):
+        self.device.is_available.return_value = False
+        with self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING"):
             TorchMemoryProfiler(rank=0, config=self._config())
         self.attach_observer.assert_not_called()
         self.assertFalse(TorchMemoryProfiler._oom_observer_attached)
 
     def test_missing_oom_observer_api_is_nonfatal(self):
         with (
-            patch(
-                "verl.utils.profiler.torch_memory_profile.torch._C._cuda_attach_out_of_memory_observer",
-                None,
-                create=True,
-            ),
+            patch.object(self.backend, self.observer_api, None),
             self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING"),
         ):
             TorchMemoryProfiler(rank=0, config=self._config())
+        self.attach_observer.assert_not_called()
+        self.assertFalse(TorchMemoryProfiler._oom_observer_attached)
+
+    def test_unsupported_device_skips_oom_observer(self):
+        with (
+            patch("verl.utils.profiler.torch_memory_profile.get_device_name", return_value="cpu"),
+            patch("verl.utils.profiler.torch_memory_profile.get_torch_device", return_value=self.device) as get_device,
+            patch.object(torch._C, "_cpu_attach_out_of_memory_observer", create=True) as unsupported_attach,
+            self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING") as logs,
+        ):
+            TorchMemoryProfiler(rank=0, config=self._config())
+        get_device.assert_not_called()
+        unsupported_attach.assert_not_called()
+        self.assertTrue(any("only available on CUDA/NPU devices" in entry for entry in logs.output))
         self.attach_observer.assert_not_called()
         self.assertFalse(TorchMemoryProfiler._oom_observer_attached)
 
@@ -128,3 +150,55 @@ class TestTorchMemoryProfiler(unittest.TestCase):
 
             dump_snapshot.assert_called_once_with(out_dir="/tmp/profiles", tag="torch_memory", sub_dir="steps4-5")
             clear_memory_history.assert_called_once_with(trace_alloc_max_entries=100_000, stack_depth=32)
+
+    def test_oom_diagnostics_and_dump_failures_are_nonfatal(self):
+        profiler = TorchMemoryProfiler(rank=0, config=self._config())
+        observer = self.attach_observer.call_args.args[0]
+        with (
+            patch("verl.utils.profiler.torch_memory_profile.get_memory_info", side_effect=RuntimeError("stats failed")),
+            patch.object(profiler.sampler, "dump_memory_snapshot", side_effect=OSError("disk full")) as dump_snapshot,
+            self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING") as logs,
+        ):
+            observer(0, 4096, 1234, 5678)
+        dump_snapshot.assert_called_once()
+        self.assertTrue(any("stats failed" in entry for entry in logs.output))
+        self.assertTrue(any("disk full" in entry for entry in logs.output))
+
+
+class TestNpuTorchMemoryProfiler(TestTorchMemoryProfiler):
+    device_name = "npu"
+
+    def test_missing_torch_npu_is_nonfatal(self):
+        with (
+            patch.dict(sys.modules, {"torch_npu": None}),
+            self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING"),
+        ):
+            TorchMemoryProfiler(rank=0, config=self._config())
+        self.attach_observer.assert_not_called()
+        self.assertFalse(TorchMemoryProfiler._oom_observer_attached)
+
+    def test_npu_callback_writes_pickle_without_sync_or_native_dump(self):
+        snapshot = {"segments": [], "device_traces": [[{"action": "oom", "size": 4096}]]}
+        self.device.memory._snapshot.return_value = snapshot
+        with (
+            tempfile.TemporaryDirectory() as out_dir,
+            patch("verl.utils.memory_utils.get_device_name", return_value="npu"),
+            patch("verl.utils.memory_utils.get_torch_device", return_value=self.device),
+            patch("verl.utils.profiler.torch_memory_profile.get_memory_info", return_value={}),
+            patch(
+                "verl.utils.profiler.torch_memory_profile.torch._C._cuda_attach_out_of_memory_observer", create=True
+            ) as cuda_attach,
+        ):
+            TorchMemoryProfiler(rank=0, config=ProfilerConfig(save_path=out_dir))
+            observer = self.attach_observer.call_args.args[0]
+            with self.assertLogs("verl.utils.profiler.torch_memory_profile", level="ERROR"):
+                observer(0, 4096, 1234, 5678)
+
+            paths = list(Path(out_dir).glob("oom_*/torch_memory_oom_rank*_pid*.pickle"))
+            self.assertEqual(len(paths), 1)
+            with paths[0].open("rb") as f:
+                self.assertEqual(pickle.load(f), snapshot)
+            cuda_attach.assert_not_called()
+        self.device.memory._snapshot.assert_called_once_with()
+        self.device.memory._dump_snapshot.assert_not_called()
+        self.device.synchronize.assert_not_called()

--- a/tests/utils/test_torch_memory_profile.py
+++ b/tests/utils/test_torch_memory_profile.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from verl.utils.profiler.config import ProfilerConfig, TorchMemoryToolConfig
+from verl.utils.profiler.profile import DistProfiler
+from verl.utils.profiler.torch_memory_profile import TorchMemoryProfiler
+
+
+class TestTorchMemoryProfiler(unittest.TestCase):
+    def setUp(self):
+        self.attach_observer = MagicMock()
+        for patcher in (
+            patch("verl.utils.profiler.torch_memory_profile.enable_memory_visualize"),
+            patch("verl.utils.profiler.torch_memory_profile.is_cuda_available", True),
+            patch(
+                "verl.utils.profiler.torch_memory_profile.torch._C._cuda_attach_out_of_memory_observer",
+                self.attach_observer,
+                create=True,
+            ),
+            patch.object(TorchMemoryProfiler, "_memory_history_enabled", False),
+            patch.object(TorchMemoryProfiler, "_oom_observer_attached", False),
+        ):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _config(self) -> ProfilerConfig:
+        return ProfilerConfig(enable=True, ranks=[0], save_path="/tmp/profiles")
+
+    def test_oom_observer_is_automatic_and_dumps_without_sync(self):
+        profiler = TorchMemoryProfiler(rank=0, config=self._config(), tool_config=TorchMemoryToolConfig())
+
+        self.attach_observer.assert_called_once()
+        observer = self.attach_observer.call_args.args[0]
+        with (
+            patch("verl.utils.profiler.torch_memory_profile.traceback.format_stack", return_value=["stack"]),
+            patch(
+                "verl.utils.profiler.torch_memory_profile.get_memory_info", return_value={"allocated": 1234}
+            ) as memory_info,
+            patch.object(profiler.sampler, "dump_memory_snapshot") as dump_snapshot,
+        ):
+            with self.assertLogs("verl.utils.profiler.torch_memory_profile", level="ERROR") as logs:
+                observer(0, 4096, 1234, 5678)
+
+        dump_snapshot.assert_called_once()
+        memory_info.assert_called_once()
+        self.assertTrue(any("requested=4096 total=1234 free=5678" in entry for entry in logs.output))
+        self.assertTrue(any("Python stack at OOM:\nstack" in entry for entry in logs.output))
+        self.assertTrue(any("allocator memory at OOM" in entry for entry in logs.output))
+        kwargs = dump_snapshot.call_args.kwargs
+        self.assertEqual(kwargs["out_dir"], "/tmp/profiles")
+        self.assertEqual(kwargs["tag"], "torch_memory_oom")
+        self.assertTrue(kwargs["sub_dir"].startswith("oom_"))
+        self.assertFalse(kwargs["synchronize"])
+
+    def test_oom_observer_is_automatic_without_tool_config(self):
+        TorchMemoryProfiler(rank=0, config=None)
+        self.attach_observer.assert_called_once()
+
+    def test_oom_observer_skips_unselected_ranks(self):
+        TorchMemoryProfiler(rank=1, config=self._config())
+        self.attach_observer.assert_not_called()
+
+    def test_oom_observer_is_registered_once_per_process(self):
+        TorchMemoryProfiler(rank=0, config=self._config())
+        TorchMemoryProfiler(rank=0, config=self._config())
+        self.attach_observer.assert_called_once()
+
+    def test_non_cuda_device_skips_oom_observer(self):
+        with (
+            patch("verl.utils.profiler.torch_memory_profile.is_cuda_available", False),
+            self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING"),
+        ):
+            TorchMemoryProfiler(rank=0, config=self._config())
+        self.attach_observer.assert_not_called()
+        self.assertFalse(TorchMemoryProfiler._oom_observer_attached)
+
+    def test_missing_oom_observer_api_is_nonfatal(self):
+        with (
+            patch(
+                "verl.utils.profiler.torch_memory_profile.torch._C._cuda_attach_out_of_memory_observer",
+                None,
+                create=True,
+            ),
+            self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING"),
+        ):
+            TorchMemoryProfiler(rank=0, config=self._config())
+        self.attach_observer.assert_not_called()
+        self.assertFalse(TorchMemoryProfiler._oom_observer_attached)
+
+    def test_oom_observer_registration_failure_is_nonfatal(self):
+        self.attach_observer.side_effect = RuntimeError("allocator does not support OOM observers")
+        with self.assertLogs("verl.utils.profiler.torch_memory_profile", level="WARNING"):
+            TorchMemoryProfiler(rank=0, config=self._config())
+        self.attach_observer.assert_called_once()
+        self.assertFalse(TorchMemoryProfiler._oom_observer_attached)
+
+    def test_unselected_memory_tool_does_not_register_oom_observer(self):
+        DistProfiler(rank=0, config=ProfilerConfig(tool=None))
+        self.attach_observer.assert_not_called()
+        self.assertFalse(TorchMemoryProfiler._memory_history_enabled)
+
+    def test_snapshot_window_keeps_history_until_the_configured_step_count(self):
+        tool_config = TorchMemoryToolConfig(memory_snapshot_num_steps=2)
+        with patch("verl.utils.profiler.torch_memory_profile.clear_memory_history") as clear_memory_history:
+            profiler = TorchMemoryProfiler(rank=0, config=self._config(), tool_config=tool_config)
+            with patch.object(profiler.sampler, "dump_memory_snapshot") as dump_snapshot:
+                profiler.start(profile_step=4)
+                profiler.stop()
+                dump_snapshot.assert_not_called()
+                clear_memory_history.assert_not_called()
+
+                profiler.start(profile_step=5)
+                profiler.stop()
+
+            dump_snapshot.assert_called_once_with(out_dir="/tmp/profiles", tag="torch_memory", sub_dir="steps4-5")
+            clear_memory_history.assert_called_once_with(trace_alloc_max_entries=100_000, stack_depth=32)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -182,6 +182,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -244,6 +245,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -700,6 +702,7 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
       precision_debugger:
         _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
         config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -1065,6 +1068,7 @@ global_profiler:
     torch_memory:
       trace_alloc_max_entries: 100000
       stack_depth: 32
+      memory_snapshot_num_steps: 1
       context: all
       stacks: all
       kw_args: {}

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -133,6 +133,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -238,6 +239,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -593,6 +595,7 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
       precision_debugger:
         _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
         config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -957,6 +960,7 @@ global_profiler:
     torch_memory:
       trace_alloc_max_entries: 100000
       stack_depth: 32
+      memory_snapshot_num_steps: 1
       context: all
       stacks: all
       kw_args: {}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -156,6 +156,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -223,6 +224,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -655,6 +657,7 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
       precision_debugger:
         _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
         config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -1023,6 +1026,7 @@ global_profiler:
     torch_memory:
       trace_alloc_max_entries: 100000
       stack_depth: 32
+      memory_snapshot_num_steps: 1
       context: all
       stacks: all
       kw_args: {}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -148,6 +148,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -210,6 +211,7 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+          memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -624,6 +626,7 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
       precision_debugger:
         _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
         config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
@@ -988,6 +991,7 @@ global_profiler:
     torch_memory:
       trace_alloc_max_entries: 100000
       stack_depth: 32
+      memory_snapshot_num_steps: 1
       context: all
       stacks: all
       kw_args: {}

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -296,6 +296,9 @@ profiler:
       # Stack trace depth for memory allocations
       stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
 
+      # Number of profiled RL steps to retain before dumping a memory snapshot.
+      memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
+
     # msprobe precision debugger config
     precision_debugger:
 

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -205,6 +205,9 @@ profiler:
       # Stack trace depth for memory allocations
       stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
 
+      # Number of profiled RL steps to retain before dumping a memory snapshot.
+      memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
+
     # msprobe precision debugger config
     precision_debugger:
 

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -400,7 +400,7 @@ global_profiler:
         # Send signal to the target application's process group. We let the program to exit by itself.
         kill: none
 
-    # Enable memory visualization and automatic CUDA OOM snapshots for debugging memory usage.
+    # Enable memory visualization and automatic CUDA/NPU OOM snapshots for debugging memory usage.
     torch_memory:
 
       #  Maximum number of allocation entries to record

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -400,7 +400,7 @@ global_profiler:
         # Send signal to the target application's process group. We let the program to exit by itself.
         kill: none
 
-    # enable memory visualization for debugging memory usage
+    # Enable memory visualization and automatic CUDA OOM snapshots for debugging memory usage.
     torch_memory:
 
       #  Maximum number of allocation entries to record
@@ -408,6 +408,9 @@ global_profiler:
 
       # The depth of the call stack to capture for each allocation
       stack_depth: 32
+
+      # Number of profiled RL steps to retain before dumping a memory snapshot.
+      memory_snapshot_num_steps: 1
 
       # 'alloc': records only allocation events || 'state': records memory state changes || 'all': records both.
       context: "all"

--- a/verl/trainer/config/profiler/profiler.yaml
+++ b/verl/trainer/config/profiler/profiler.yaml
@@ -140,6 +140,9 @@ tool_config:
     # Stack trace depth for memory allocations
     stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
 
+    # Number of profiled RL steps to retain before dumping a memory snapshot.
+    memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
+
     name: torch_memory
 
   precision_debugger:

--- a/verl/trainer/config/ref/ref.yaml
+++ b/verl/trainer/config/ref/ref.yaml
@@ -144,6 +144,9 @@ profiler:
       # Stack trace depth for memory allocations
       stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
 
+      # Number of profiled RL steps to retain before dumping a memory snapshot.
+      memory_snapshot_num_steps: ${oc.select:global_profiler.global_tool_config.torch_memory.memory_snapshot_num_steps,1}
+
     # msprobe precision debugger config
     precision_debugger:
 

--- a/verl/utils/memory_utils.py
+++ b/verl/utils/memory_utils.py
@@ -266,7 +266,9 @@ class MemorySnapshotSampler:
         self.out_dir = out_dir
         self.tag = tag
 
-    def dump_memory_snapshot(self, out_dir: str = "./mem_snapshots", tag: str = "snapshot", sub_dir: str = None):
+    def dump_memory_snapshot(
+        self, out_dir: str = "./mem_snapshots", tag: str = "snapshot", sub_dir: str = None, synchronize: bool = True
+    ) -> Path | None:
         """
         Generates a memory snapshot and saves it as a pickle file in a specified directory.
         The files are organized by timestamp in subdirectories, with all ranks' files
@@ -277,6 +279,8 @@ class MemorySnapshotSampler:
                 The directory is created if it does not exist.
             tag (str): A string tag to prepend to the filename for easier identification.
             sub_dir (str): A subdirectory to place the snapshot file in.
+            synchronize (bool): Whether to synchronize the device before dumping. Disable this
+                for an OOM observer because the CUDA stream may already be in an error state.
         """
         if sub_dir is None:
             timestamp = datetime.now().strftime("%Y%m%d-%H%M")
@@ -295,11 +299,14 @@ class MemorySnapshotSampler:
         device = get_torch_device()
         if not device.is_available():
             logger.warning("[memory_visualize] is only available on CUDA devices.")
-            return
+            return None
         try:
-            device.synchronize()
+            if synchronize:
+                device.synchronize()
             # Memory snapshot is CUDA-specific functionality
             device.memory._dump_snapshot(str(path))
             logger.info(f"[memory_visualize] dumped: {path}")
+            return path
         except Exception as e:
             logger.info(f"[memory_visualize][warn] dump failed: {e}")
+            return None

--- a/verl/utils/memory_utils.py
+++ b/verl/utils/memory_utils.py
@@ -17,12 +17,13 @@ import gc
 import inspect
 import logging
 import os
+import pickle
 from datetime import datetime
 from pathlib import Path
 
 import torch
 
-from verl.utils.device import get_torch_device
+from verl.utils.device import get_device_name, get_torch_device
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -181,18 +182,22 @@ def enable_memory_visualize(
         return
 
     f = device.memory._record_memory_history
-    params = set(inspect.signature(f).parameters.keys())
+    params = inspect.signature(f).parameters
+    # torch-npu exposes the modern API through an (enabled, *args, **kwargs) wrapper.
+    accepts_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
 
     def _one_call(dev_kw=None):
         kwargs = {}
-        if "context" in params:
+        if "context" in params or (accepts_kwargs and "record_context" not in params):
             kwargs["context"] = context
-        if "stacks" in params:
+        if "stacks" in params or (accepts_kwargs and "record_context" not in params):
             kwargs["stacks"] = stacks
         if "max_entries" in params:
             kwargs["max_entries"] = trace_alloc_max_entries
         elif "trace_alloc_max_entries" in params:
             kwargs["trace_alloc_max_entries"] = trace_alloc_max_entries
+        elif accepts_kwargs:
+            kwargs["max_entries"] = trace_alloc_max_entries
         if "stack_depth" in params:
             kwargs["stack_depth"] = stack_depth
         if dev_kw is not None:
@@ -200,6 +205,8 @@ def enable_memory_visualize(
                 kwargs["device"] = dev_kw
             elif "devices" in params:
                 kwargs["devices"] = dev_kw if isinstance(dev_kw, list) else [dev_kw]
+            elif accepts_kwargs:
+                kwargs["device"] = dev_kw
         if "record_context" in params:
             kwargs["record_context"] = record_context
 
@@ -252,7 +259,7 @@ def clear_memory_history(trace_alloc_max_entries: int = 200_000, stack_depth: in
 
 class MemorySnapshotSampler:
     """
-    A utility class that dumps GPU memory snapshots.
+    A utility class that dumps CUDA/NPU memory snapshots.
     This is useful for monitoring memory usage over a long-running process.
 
     The dumped files can be visualized with https://docs.pytorch.org/memory_viz
@@ -280,7 +287,7 @@ class MemorySnapshotSampler:
             tag (str): A string tag to prepend to the filename for easier identification.
             sub_dir (str): A subdirectory to place the snapshot file in.
             synchronize (bool): Whether to synchronize the device before dumping. Disable this
-                for an OOM observer because the CUDA stream may already be in an error state.
+                for an OOM observer because the device stream may already be in an error state.
         """
         if sub_dir is None:
             timestamp = datetime.now().strftime("%Y%m%d-%H%M")
@@ -289,7 +296,7 @@ class MemorySnapshotSampler:
             out_path = Path(out_dir) / sub_dir
         out_path.mkdir(parents=True, exist_ok=True)
 
-        # get the GPU rank on the current process
+        # get the accelerator rank on the current process
         rank = os.environ.get("RANK", "0")
         pid = os.getpid()
         # todo(chenyang): check wether we need to sync all ranks before dump
@@ -298,15 +305,21 @@ class MemorySnapshotSampler:
 
         device = get_torch_device()
         if not device.is_available():
-            logger.warning("[memory_visualize] is only available on CUDA devices.")
+            logger.warning("[memory_visualize] is only available on accelerator devices.")
             return None
         try:
             if synchronize:
                 device.synchronize()
-            # Memory snapshot is CUDA-specific functionality
-            device.memory._dump_snapshot(str(path))
+            if get_device_name() == "npu":
+                # NPU's _dump_snapshot may start/stop a profiler to collect extra device data.
+                # Only serialize allocator state for both regular and OOM snapshots.
+                snapshot = device.memory._snapshot()
+                with path.open("wb") as f:
+                    pickle.dump(snapshot, f)
+            else:
+                device.memory._dump_snapshot(str(path))
             logger.info(f"[memory_visualize] dumped: {path}")
             return path
         except Exception as e:
-            logger.info(f"[memory_visualize][warn] dump failed: {e}")
+            logger.warning(f"[memory_visualize] dump failed: {e}")
             return None

--- a/verl/utils/profiler/config.py
+++ b/verl/utils/profiler/config.py
@@ -144,15 +144,18 @@ class TorchProfilerToolConfig(BaseConfig):
 
 @dataclass
 class TorchMemoryToolConfig(BaseConfig):
-    """Torch memory profiler tool config.
+    """Torch memory profiler tool config. CUDA OOM snapshots are enabled automatically.
 
     Args:
         trace_alloc_max_entries (int): Maximum number of memory allocation entries to track.
         stack_depth (int): Stack trace depth for memory allocations.
+        memory_snapshot_num_steps (int): Number of profiled RL steps to retain before
+            dumping a memory snapshot.
     """
 
     trace_alloc_max_entries: int = 100_000
     stack_depth: int = 32
+    memory_snapshot_num_steps: int = 1
     name: str = "torch_memory"
 
     def __post_init__(self) -> None:
@@ -165,6 +168,12 @@ class TorchMemoryToolConfig(BaseConfig):
             f"trace_alloc_max_entries must be positive, got {self.trace_alloc_max_entries}"
         )
         assert self.stack_depth > 0, f"stack_depth must be positive, got {self.stack_depth}"
+        assert isinstance(self.memory_snapshot_num_steps, int), (
+            f"memory_snapshot_num_steps must be int, got {type(self.memory_snapshot_num_steps)}"
+        )
+        assert self.memory_snapshot_num_steps > 0, (
+            f"memory_snapshot_num_steps must be positive, got {self.memory_snapshot_num_steps}"
+        )
 
 
 @dataclass

--- a/verl/utils/profiler/config.py
+++ b/verl/utils/profiler/config.py
@@ -144,7 +144,7 @@ class TorchProfilerToolConfig(BaseConfig):
 
 @dataclass
 class TorchMemoryToolConfig(BaseConfig):
-    """Torch memory profiler tool config. CUDA OOM snapshots are enabled automatically.
+    """Torch memory profiler tool config. CUDA/NPU OOM snapshots are enabled automatically.
 
     Args:
         trace_alloc_max_entries (int): Maximum number of memory allocation entries to track.

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -92,7 +92,7 @@ class DistProfiler:
     - nsys: NsightSystemsProfiler
     - npu: NPUProfiler (Ascend)
     - torch: PyTorch torch.profiler wrapper
-    - torch_memory: Torch CUDA memory snapshot dump
+    - torch_memory: Torch CUDA/NPU memory snapshot dump
     - precision_debugger: msprobe precision debugger
     """
 

--- a/verl/utils/profiler/torch_memory_profile.py
+++ b/verl/utils/profiler/torch_memory_profile.py
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import traceback
+from datetime import datetime
 from typing import Optional
 
-from ..memory_utils import MemorySnapshotSampler, clear_memory_history, enable_memory_visualize
+import torch
+
+from ..device import is_cuda_available
+from ..memory_utils import MemorySnapshotSampler, clear_memory_history, enable_memory_visualize, get_memory_info
 from .config import ProfilerConfig, TorchMemoryToolConfig
+
+logger = logging.getLogger(__name__)
 
 
 class TorchMemoryProfiler:
@@ -23,11 +31,13 @@ class TorchMemoryProfiler:
 
     Behavior:
     - On first construction (per process), enable memory history recording if CUDA is available
-    - On start(step=X), remember sub_dir for this step
-    - On stop(), dump a memory snapshot into config.save_path under the remembered sub_dir
+    - Automatically register an OOM snapshot callback on selected ranks when supported
+    - On start(step=X), begin or extend a configured memory-history window
+    - On stop(), dump a memory snapshot once the window reaches its configured number of steps
     """
 
     _memory_history_enabled: bool = False
+    _oom_observer_attached: bool = False
 
     def __init__(
         self, rank: int, config: Optional[ProfilerConfig], tool_config: Optional[TorchMemoryToolConfig] = None
@@ -40,16 +50,20 @@ class TorchMemoryProfiler:
         self.config = config
         self.rank = rank
         self.this_step = False
-        self.sub_dir = None
+        self._window_start_step = None
+        self._window_end_step = None
+        self._steps_in_window = 0
         self.sampler = MemorySnapshotSampler()
 
         # Get parameters from tool_config, with fallback to defaults
         if tool_config:
             self.trace_alloc_max_entries = tool_config.trace_alloc_max_entries
             self.stack_depth = tool_config.stack_depth
+            self.memory_snapshot_num_steps = tool_config.memory_snapshot_num_steps
         else:
             self.trace_alloc_max_entries = 100_000
             self.stack_depth = 32
+            self.memory_snapshot_num_steps = 1
 
         # Best-effort enable memory history once
         if not TorchMemoryProfiler._memory_history_enabled:
@@ -62,14 +76,63 @@ class TorchMemoryProfiler:
                 pass
             TorchMemoryProfiler._memory_history_enabled = True
 
+        if self._should_profile_this_rank():
+            self._attach_oom_observer()
+
+    def _attach_oom_observer(self) -> None:
+        """Register one process-local callback that writes a snapshot at CUDA OOM time."""
+        if TorchMemoryProfiler._oom_observer_attached:
+            return
+
+        if not is_cuda_available:
+            logger.warning("[torch_memory] automatic OOM snapshots are only available on CUDA devices")
+            return
+
+        attach_observer = getattr(torch._C, "_cuda_attach_out_of_memory_observer", None)
+        if attach_observer is None:
+            logger.warning("[torch_memory] this PyTorch build does not support CUDA OOM observers")
+            return
+
+        try:
+            attach_observer(self._on_out_of_memory)
+            TorchMemoryProfiler._oom_observer_attached = True
+            logger.info("[torch_memory] CUDA OOM snapshot observer attached")
+        except Exception as exc:
+            logger.warning(f"[torch_memory] failed to attach CUDA OOM snapshot observer: {exc}")
+
+    def _on_out_of_memory(self, device: int, alloc: int, device_total: int, device_free: int) -> None:
+        """Best-effort snapshot callback invoked by PyTorch's CUDA allocator."""
+        out_dir = self.config.save_path or "outputs/profile"
+        sub_dir = f"oom_{datetime.now().strftime('%Y%m%d-%H%M%S-%f')}"
+        logger.error(
+            "[torch_memory] CUDA OOM on device %s: requested=%s total=%s free=%s; dumping allocator snapshot",
+            device,
+            alloc,
+            device_total,
+            device_free,
+        )
+        logger.error("[torch_memory] Python stack at OOM:\n%s", "".join(traceback.format_stack()))
+        try:
+            logger.error("[torch_memory] allocator memory at OOM: %s", get_memory_info())
+        except Exception as exc:
+            logger.warning(f"[torch_memory] failed to collect allocator memory at OOM: {exc}")
+        try:
+            # Do not synchronize here: an OOM may have left the CUDA stream in an error state.
+            self.sampler.dump_memory_snapshot(
+                out_dir=out_dir, tag="torch_memory_oom", sub_dir=sub_dir, synchronize=False
+            )
+        except Exception as exc:
+            logger.warning(f"[torch_memory] failed to dump CUDA OOM snapshot: {exc}")
+
     def start(self, **kwargs):
         if not self.enable:
             return
         if not self._should_profile_this_rank():
             return
-        profile_step = kwargs.get("profile_step", None)
-        # Keep ranks aligned under same folder name
-        self.sub_dir = f"step{profile_step}" if profile_step is not None else None
+        profile_step = kwargs.get("profile_step", kwargs.get("global_step"))
+        if self._steps_in_window == 0:
+            self._window_start_step = profile_step
+        self._window_end_step = profile_step
         self.this_step = True
 
     def stop(self):
@@ -78,16 +141,30 @@ class TorchMemoryProfiler:
         self.this_step = False
         if not self._should_profile_this_rank():
             return
+        self._steps_in_window += 1
+        if self._steps_in_window < self.memory_snapshot_num_steps:
+            return
+
         out_dir = self.config.save_path or "outputs/profile"
         tag = "torch_memory"
-        # Dump snapshot; all ranks write into same sub_dir
+        # Dump snapshot; all ranks write into the same window directory.
         try:
-            self.sampler.dump_memory_snapshot(out_dir=out_dir, tag=tag, sub_dir=self.sub_dir)
+            self.sampler.dump_memory_snapshot(out_dir=out_dir, tag=tag, sub_dir=self._window_sub_dir())
         except Exception:
             pass
         # Clear memory history
         if TorchMemoryProfiler._memory_history_enabled:
             clear_memory_history(trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth)
+        self._steps_in_window = 0
+        self._window_start_step = None
+        self._window_end_step = None
+
+    def _window_sub_dir(self) -> str | None:
+        if self._window_start_step is None:
+            return None
+        if self._window_start_step == self._window_end_step:
+            return f"step{self._window_start_step}"
+        return f"steps{self._window_start_step}-{self._window_end_step}"
 
     def _should_profile_this_rank(self) -> bool:
         if self.config.all_ranks:

--- a/verl/utils/profiler/torch_memory_profile.py
+++ b/verl/utils/profiler/torch_memory_profile.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 import torch
 
-from ..device import is_cuda_available
+from ..device import get_device_name, get_torch_device
 from ..memory_utils import MemorySnapshotSampler, clear_memory_history, enable_memory_visualize, get_memory_info
 from .config import ProfilerConfig, TorchMemoryToolConfig
 
@@ -27,10 +27,10 @@ logger = logging.getLogger(__name__)
 
 
 class TorchMemoryProfiler:
-    """Profiler that dumps CUDA memory snapshots at step boundaries.
+    """Profiler that dumps CUDA/NPU memory snapshots at step boundaries.
 
     Behavior:
-    - On first construction (per process), enable memory history recording if CUDA is available
+    - On first construction (per process), enable memory history recording if an accelerator is available
     - Automatically register an OOM snapshot callback on selected ranks when supported
     - On start(step=X), begin or extend a configured memory-history window
     - On stop(), dump a memory snapshot once the window reaches its configured number of steps
@@ -49,6 +49,7 @@ class TorchMemoryProfiler:
             config = ProfilerConfig(ranks=[])
         self.config = config
         self.rank = rank
+        self._device_name = get_device_name()
         self.this_step = False
         self._window_start_step = None
         self._window_end_step = None
@@ -80,34 +81,50 @@ class TorchMemoryProfiler:
             self._attach_oom_observer()
 
     def _attach_oom_observer(self) -> None:
-        """Register one process-local callback that writes a snapshot at CUDA OOM time."""
+        """Register one process-local callback that writes a snapshot at allocator OOM time."""
         if TorchMemoryProfiler._oom_observer_attached:
             return
 
-        if not is_cuda_available:
-            logger.warning("[torch_memory] automatic OOM snapshots are only available on CUDA devices")
-            return
-
-        attach_observer = getattr(torch._C, "_cuda_attach_out_of_memory_observer", None)
-        if attach_observer is None:
-            logger.warning("[torch_memory] this PyTorch build does not support CUDA OOM observers")
+        if self._device_name not in ("cuda", "npu"):
+            logger.warning("[torch_memory] automatic OOM snapshots are only available on CUDA/NPU devices")
             return
 
         try:
+            if not get_torch_device().is_available():
+                logger.warning("[torch_memory] automatic OOM snapshots require an available accelerator")
+                return
+
+            if self._device_name == "npu":
+                import torch_npu
+
+                backend = torch_npu._C
+            else:
+                backend = torch._C
+            attach_observer = getattr(backend, f"_{self._device_name}_attach_out_of_memory_observer", None)
+            if attach_observer is None:
+                logger.warning("[torch_memory] this build does not support %s OOM observers", self._device_name.upper())
+                return
+
             attach_observer(self._on_out_of_memory)
             TorchMemoryProfiler._oom_observer_attached = True
-            logger.info("[torch_memory] CUDA OOM snapshot observer attached")
+            logger.info("[torch_memory] %s OOM snapshot observer attached", self._device_name.upper())
         except Exception as exc:
-            logger.warning(f"[torch_memory] failed to attach CUDA OOM snapshot observer: {exc}")
+            logger.warning(
+                "[torch_memory] failed to attach %s OOM snapshot observer: %s", self._device_name.upper(), exc
+            )
 
     def _on_out_of_memory(self, device: int, alloc: int, device_total: int, device_free: int) -> None:
-        """Best-effort snapshot callback invoked by PyTorch's CUDA allocator."""
+        """Best-effort snapshot callback invoked by the CUDA/NPU allocator."""
         out_dir = self.config.save_path or "outputs/profile"
         sub_dir = f"oom_{datetime.now().strftime('%Y%m%d-%H%M%S-%f')}"
+        # NPU reports the configured process memory limit, or device total if no limit is set.
+        total_label = "total_or_limit" if self._device_name == "npu" else "total"
         logger.error(
-            "[torch_memory] CUDA OOM on device %s: requested=%s total=%s free=%s; dumping allocator snapshot",
+            "[torch_memory] %s OOM on device %s: requested=%s %s=%s free=%s; dumping allocator snapshot",
+            self._device_name.upper(),
             device,
             alloc,
+            total_label,
             device_total,
             device_free,
         )
@@ -117,12 +134,12 @@ class TorchMemoryProfiler:
         except Exception as exc:
             logger.warning(f"[torch_memory] failed to collect allocator memory at OOM: {exc}")
         try:
-            # Do not synchronize here: an OOM may have left the CUDA stream in an error state.
+            # Do not synchronize here: an OOM may have left the device stream in an error state.
             self.sampler.dump_memory_snapshot(
                 out_dir=out_dir, tag="torch_memory_oom", sub_dir=sub_dir, synchronize=False
             )
         except Exception as exc:
-            logger.warning(f"[torch_memory] failed to dump CUDA OOM snapshot: {exc}")
+            logger.warning("[torch_memory] failed to dump %s OOM snapshot: %s", self._device_name.upper(), exc)
 
     def start(self, **kwargs):
         if not self.enable:


### PR DESCRIPTION
### What does this PR do?

Add automatic CUDA OOM snapshots and configurable multi-step memory-history windows to the torch_memory profiler.
This helps diagnose OOMs that occur before the next scheduled snapshot, as well as memory growth across training steps.


#### Changes
- Automatically register a process-local CUDA OOM observer on selected profiler ranks when using torch_memory.
- On OOM:
  - Log the requested allocation size, total device memory, and free device memory.
  - Print the Python call stack and allocator memory summary.
  - Write a snapshot under `<save_path>/oom_<timestamp>/` without synchronizing CUDA.
- Add memory_snapshot_num_steps to retain memory history across multiple profiled steps before dumping and resetting it. The default value of 1 preserves the existing dump frequency.
- Gracefully skip OOM observer registration when the device, PyTorch build, or allocator does not support it.
- Update configuration files, generated configurations, documentation, and tests. Training that does not select torch_memory is unaffected.

#### Limitations
OOM dumping is best-effort and requires a supported CUDA allocator observer. It does not handle SIGKILL or host OOM-killer termination.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

An end-to-end test case was built and run on NVIDIA H20 GPUs to validate the functionality introduced by this PR. The test environment, scripts, and results are available in this [gist](https://gist.github.com/ji-huazhong/f93c399b42fda7227d073b8903d9a783#file-launcher-log).

### API and Usage Example

For a two-step memory-history window:
```yaml
global_profiler:
  tool: torch_memory
  steps: [1, 2, 3, 4]
  profile_continuous_steps: false
  global_tool_config:
    torch_memory:
      memory_snapshot_num_steps: 2
```
Existing role and rank selection still applies. Once registered, the OOM observer remains active outside scheduled profiling steps.

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
