### PR TITLE
[doc] fix: point nsight profiling doc at stable Dockerfile

### DIFF
--- a/docs/perf/nsight_profiling.md
+++ b/docs/perf/nsight_profiling.md
@@ -10,7 +10,7 @@ Profiling in verl can be configured through several parameters in the trainer co
 
 ### Prerequisites
 
-Nsight Systems version is important, please reference `docker/Dockerfile.vllm.sglang.megatron` for the version we used.
+Nsight Systems version is important, please reference `docker/Dockerfile.stable.vllm` for the version we used.
 
 ### Global profiling control
 


### PR DESCRIPTION
## Summary
- `docs/perf/nsight_profiling.md` still pointed at `docker/Dockerfile.vllm.sglang.megatron` for the Nsight Systems version.
- That Dockerfile was removed in the docker image refactor; current images pin Nsight in `docker/Dockerfile.stable.vllm` (same release in `docker/Dockerfile.stable.sglang` / `docker/Dockerfile.uv.cu130`).
- Update the doc reference to the live stable Dockerfile.

## Test plan
- [x] Confirm `docker/Dockerfile.vllm.sglang.megatron` is 404 at HEAD
- [x] Confirm `docker/Dockerfile.stable.vllm` exists and sets `NSIGHT_VERSION`
- [x] Confirm no open PR already covers this path