### PR TITLE
[vllm, hardware] fix: patch vllm-ascend for GLM-5.2 RL training on Ascend NPUs

### DIFF
--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -15,9 +15,145 @@
 # limitations under the License.
 
 
+import inspect
+import logging
+import os
+from contextvars import ContextVar
 from functools import wraps
 
 from verl.utils.device import is_torch_npu_available
+
+logger = logging.getLogger(__name__)
+
+_GLM52_PATCH_ENV = "VERL_VLLM_ASCEND_GLM52_PATCH"
+_GLM52_PATCH_TRUTHY_VALUES = {"1", "true", "yes"}
+_GLM52_PATCH_MARKER = "_verl_vllm_ascend_glm52_patched"
+
+
+def _glm52_patch_enabled() -> bool:
+    return os.getenv(_GLM52_PATCH_ENV, "").strip().lower() in _GLM52_PATCH_TRUTHY_VALUES
+
+
+def _normalized_source(fn) -> str:
+    try:
+        return "".join(inspect.getsource(fn).split())
+    except (OSError, TypeError) as exc:
+        raise RuntimeError(f"{_GLM52_PATCH_ENV} requires inspectable vllm-ascend 0.23.x Python sources.") from exc
+
+
+def _patch_glm52_ascend_rms_norm(layernorm_module) -> bool:
+    ascend_rms_norm = layernorm_module.AscendRMSNorm
+    original_forward = ascend_rms_norm.forward_oot
+    if getattr(original_forward, _GLM52_PATCH_MARKER, False):
+        return False
+
+    source = _normalized_source(original_forward)
+    if "residual=x+residual" in source and "npu_rms_norm(residual,self.weight" in source:
+        return False
+    if "npu_add_rms_norm" not in source:
+        raise RuntimeError(f"{_GLM52_PATCH_ENV} found an unsupported AscendRMSNorm.forward_oot implementation.")
+
+    @wraps(original_forward)
+    def patched_forward(self, x, residual=None):
+        if residual is None:
+            return original_forward(self, x, residual)
+
+        import torch_npu
+
+        residual = layernorm_module.torch.ops.vllm.maybe_chunk_residual(x, residual)
+        residual = x + residual
+        x = torch_npu.npu_rms_norm(residual, self.weight, epsilon=self.variance_epsilon)[0]
+        return x, residual
+
+    setattr(patched_forward, _GLM52_PATCH_MARKER, True)
+    ascend_rms_norm.forward_oot = patched_forward
+    return True
+
+
+def _patch_glm52_sfa_kv_b_proj_disposal(sfa_module) -> bool:
+    ascend_sfa_impl = sfa_module.AscendSFAImpl
+    original_process_weights = ascend_sfa_impl.process_weights_after_loading
+    if getattr(original_process_weights, _GLM52_PATCH_MARKER, False):
+        return False
+
+    source = _normalized_source(original_process_weights)
+    if "dispose_layer(self.kv_b_proj)" not in source:
+        return False
+
+    original_dispose_layer = sfa_module.dispose_layer
+    no_preserved_layer = object()
+    preserved_layer: ContextVar[object] = ContextVar(
+        "verl_vllm_ascend_glm52_preserved_layer", default=no_preserved_layer
+    )
+
+    @wraps(original_dispose_layer)
+    def selective_dispose_layer(layer):
+        if layer is preserved_layer.get():
+            return None
+        return original_dispose_layer(layer)
+
+    @wraps(original_process_weights)
+    def patched_process_weights(self, act_dtype):
+        token = preserved_layer.set(self.kv_b_proj)
+        try:
+            return original_process_weights(self, act_dtype)
+        finally:
+            preserved_layer.reset(token)
+
+    setattr(patched_process_weights, _GLM52_PATCH_MARKER, True)
+    sfa_module.dispose_layer = selective_dispose_layer
+    ascend_sfa_impl.process_weights_after_loading = patched_process_weights
+    return True
+
+
+def _patch_glm52_sfa_indexer_scale(sfa_module) -> bool:
+    indexer_post_process = sfa_module.AscendSFAImpl.indexer_select_post_process
+    source = _normalized_source(indexer_post_process)
+    scale_expression = "weights=weights*(self.n_head**-0.5)*(self.head_dim**-0.5)"
+    if scale_expression in source:
+        return False
+    if "weights=kw[:,self.head_dim:]" not in source or "DeviceOperator.indexer_select_post_process" not in source:
+        raise RuntimeError(
+            f"{_GLM52_PATCH_ENV} found an unsupported AscendSFAImpl.indexer_select_post_process implementation."
+        )
+
+    device_operator = sfa_module.DeviceOperator
+    original_operator = device_operator.indexer_select_post_process
+    if getattr(original_operator, _GLM52_PATCH_MARKER, False):
+        return False
+
+    parameter_names = tuple(inspect.signature(original_operator).parameters)
+    expected_prefix = ("sfa_impl", "q_li", "q_li_scale", "q_li_shape_ori", "weights")
+    if parameter_names[: len(expected_prefix)] != expected_prefix:
+        raise RuntimeError(
+            f"{_GLM52_PATCH_ENV} found an unsupported DeviceOperator.indexer_select_post_process signature."
+        )
+
+    @wraps(original_operator)
+    def patched_operator(sfa_impl, q_li, q_li_scale, q_li_shape_ori, weights, *args, **kwargs):
+        weights = weights * (sfa_impl.n_head**-0.5) * (sfa_impl.head_dim**-0.5)
+        return original_operator(sfa_impl, q_li, q_li_scale, q_li_shape_ori, weights, *args, **kwargs)
+
+    setattr(patched_operator, _GLM52_PATCH_MARKER, True)
+    device_operator.indexer_select_post_process = staticmethod(patched_operator)
+    return True
+
+
+def patch_vllm_ascend_glm52() -> None:
+    """Apply the vllm-ascend GLM-5.2 fixes from commit ca0420391."""
+    try:
+        from vllm_ascend.attention import sfa_v1
+        from vllm_ascend.ops import layernorm
+    except (AttributeError, ImportError) as exc:
+        raise RuntimeError(f"{_GLM52_PATCH_ENV} could not load the required vllm-ascend 0.23.x patch targets.") from exc
+
+    patched = [
+        _patch_glm52_ascend_rms_norm(layernorm),
+        _patch_glm52_sfa_kv_b_proj_disposal(sfa_v1),
+        _patch_glm52_sfa_indexer_scale(sfa_v1),
+    ]
+    status = "applied" if any(patched) else "already present"
+    logger.info("GLM-5.2 vllm-ascend compatibility patch %s", status)
 
 
 def vllm_v013_weight_loader_method_wrapper(fn):
@@ -71,8 +207,33 @@ def patch_vllm013_rotary_emb():
     ApplyRotaryEmb.__init__ = vllm013_npu_rotary_embedding_init_impl
 
 
+def patch_camem_sleep() -> None:
+    """Synchronize pending NPU work before CaMem sleep unmaps tensor memory."""
+    try:
+        import vllm_ascend.device_allocator.camem as camem
+    except ModuleNotFoundError as exc:
+        if exc.name in ("vllm_ascend", "vllm_ascend.device_allocator", "vllm_ascend.device_allocator.camem"):
+            return
+        raise
+
+    original_sleep = camem.CaMemAllocator.sleep
+    if getattr(original_sleep, "_verl_camem_sleep_patched", False):
+        return
+
+    @wraps(original_sleep)
+    def patched_sleep(self, *args, **kwargs):
+        # Graph replay and normal NPU launches are asynchronous. All users of
+        # the virtual mappings must finish before sleep calls unmap_and_release;
+        # synchronizing via empty_cache() after the unmap loop is too late.
+        camem.torch.npu.synchronize()
+        return original_sleep(self, *args, **kwargs)
+
+    patched_sleep._verl_camem_sleep_patched = True
+    camem.CaMemAllocator.sleep = patched_sleep
+
+
 def apply_npu_vllm_patches() -> None:
-    """Apply NPU-specific vLLM patches for weight loading and rotary embedding.
+    """Apply NPU-specific vLLM patches for weight loading, rotary embedding, and sleep.
 
     Must be called before the vLLM engine is created.
     """
@@ -84,3 +245,9 @@ def apply_npu_vllm_patches() -> None:
 
     patch_vllm013_rotary_emb()
     _patch_legacy_fused_moe_weight_loader(FusedMoE)
+
+    if _glm52_patch_enabled():
+        import vllm_ascend.patch.worker.patch_routed_experts_capture  # noqa: F401
+
+        patch_camem_sleep()
+        patch_vllm_ascend_glm52()


### PR DESCRIPTION
### What does this PR do?

Add an opt-in compatibility patch enabled by `VERL_VLLM_ASCEND_GLM52_PATCH=1` to support GLM-5.2 RL training with vllm-ascend.

- Use explicit residual addition before RMS normalization.
- Preserve SFA kv_b_proj weights for subsequent weight updates.
- Apply the missing SFA indexer weight scaling.
- Synchronize pending NPU work before CaMem sleep unmaps memory.
- Load the routed-experts capture patch.

Skip fixes already present and reject unsupported patch targets. Remove this temporary patch once vllm-ascend incorporates these changes.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

GLM5.2 RL training working on Ascend A3.
