### PR TITLE
[ckpt] fix: fail sharded delta probe on comparison mismatch

### DIFF
--- a/tests/checkpoint_engine/test_sharded_delta_gather_exit_on_cpu.py
+++ b/tests/checkpoint_engine/test_sharded_delta_gather_exit_on_cpu.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test the distributed correctness probe's exit contract, not GPU collectives."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from tests.special_distributed import test_sharded_delta_gather as probe
+
+
+@pytest.mark.parametrize(
+    "world,case_count,rank", [(1, 4, 0), (2, 7, 0), (2, 7, 1), (4, 15, 0), (4, 15, 1), (8, 23, 0), (8, 23, 1)]
+)
+@pytest.mark.parametrize("failure_position", [None, "first", "middle", "last"])
+def test_probe_exit_after_all_cases_and_teardown(monkeypatch, capsys, world, case_count, rank, failure_position):
+    """A failed comparison must survive later passes and be observable by torchrun."""
+    is_comparing_rank = rank == 0
+    events = []
+    monkeypatch.setattr(probe.dist, "init_process_group", Mock())
+    monkeypatch.setattr(probe.dist, "get_rank", lambda: rank)
+    monkeypatch.setattr(probe.dist, "get_world_size", lambda: world)
+    monkeypatch.setattr(probe.torch.cuda, "set_device", Mock())
+    monkeypatch.setattr(probe, "init_device_mesh", Mock())
+    monkeypatch.setattr(probe.dist, "barrier", lambda: events.append("barrier"))
+    monkeypatch.setattr(probe.dist, "destroy_process_group", lambda: events.append("destroy"))
+    failed_index = {None: None, "first": 0, "middle": case_count // 2, "last": case_count - 1}[failure_position]
+
+    def run_case(*args):
+        index = len(events)
+        events.append("case")
+        return not (is_comparing_rank and index == failed_index)
+
+    monkeypatch.setattr(probe, "_run_case", run_case)
+    code = probe.main()
+
+    assert events == ["case"] * case_count + ["barrier", "destroy"]
+    expected_failure = is_comparing_rank and failure_position is not None
+    # Falling through main() is exit 0, just as in the uncorrected CLI.
+    assert (0 if code is None else code) == int(expected_failure)
+    output = capsys.readouterr().out
+    if is_comparing_rank:
+        assert ("OVERALL: FAIL" if expected_failure else "OVERALL: ALL PASS") in output
+    else:
+        assert not output

--- a/tests/special_distributed/test_sharded_delta_gather.py
+++ b/tests/special_distributed/test_sharded_delta_gather.py
@@ -90,7 +90,7 @@ def _run_case(shape, placements, mesh, dev, rank, si):
     return ok
 
 
-def main():
+def main() -> int:
     dist.init_process_group("nccl")
     rank, world = dist.get_rank(), dist.get_world_size()
     torch.cuda.set_device(rank)
@@ -151,7 +151,8 @@ def main():
         print("=" * 50)
     dist.barrier()
     dist.destroy_process_group()
+    return 0 if all_ok else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
### What does this PR do?

Make the sharded-delta correctness probe return a failing process status when
its comparison oracle reports a mismatch. Previously it printed `OVERALL: FAIL`
but exited 0, so the documented torchrun command could silently pass a shell
validation gate. Return 0/1 only after all cases and existing collective teardown,
and propagate the result through `SystemExit(main())`.

Related to #7060 and
[the existing validation discussion](https://github.com/verl-project/verl/issues/7060#issuecomment-5562368448).
Production delta/placement algorithms are unchanged.

### Checklist Before Starting

- [x] Searched [issue references](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7060+in%3Abody)
  and [delta gather](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+delta+gather),
  and reread #7060's comments immediately before submission. #7676 changes DSv4
  FP8 fidelity, not this correctness-probe exit contract; its changed-file list
  does not include either file here. This is a non-competing test-harness fix.
- [x] Title uses `[ckpt] fix: ...`.

### Test

```bash
python -m pytest -q tests/checkpoint_engine/test_sharded_delta_gather_exit_on_cpu.py \
  tests/checkpoint_engine/test_sharded_delta.py tests/checkpoint_engine/test_block_placement.py
```

- New CPU regression on original probe: 12 failed / 16 passed.
- Fixed new regression: 28 passed. With the two existing neighbors above:
  54 passed on macOS and Linux, zero skips.
- The new test imports the real probe, mocking distributed/CUDA setup and case
  outcomes. It covers first/middle/last failure, retention across later passes,
  all-case execution, teardown order, and non-comparing ranks. The 1/2/4/8-rank
  control-flow parameters are not GPU mesh qualification.

Real two-L20 NCCL control:

```bash
python -m torch.distributed.run --nnodes=1 --nproc-per-node=2 \
  --master-addr=127.0.0.1 --master-port=29500 --max-restarts=0 \
  tests/special_distributed/test_sharded_delta_gather.py
```

| Source / input | Comparisons | Summary | torchrun exit |
| --- | --- | --- | --- |
| Original / normal | 7 pass | ALL PASS | 0 |
| Original / deliberate one-bit fault | 6 pass, 1 fail | FAIL | 0 |
| Fixed / normal | 7 pass | ALL PASS | 0 |
| Fixed / same fault | 6 pass, 1 fail | FAIL | 1 |

The negative-control wrapper calls the actual NCCL gather, flips one BF16 bit
in a cloned returned value on rank 0's first case, then lets the unchanged oracle
compare it (`idx=True val=False`). It invokes the real CLI entrypoint via runpy;
all seven cases run and both ranks' records confirm process-group teardown.
This injected fault is not evidence of natural production gather corruption.

Frozen tested upstream: `23af6a7a2e8d6efeeb2adbe5d1689c7a24f503a3`.
Environment: Python 3.12.3, Torch 2.11.0+cu128, NCCL 2.28.9, Transformers 5.9.0,
TensorDict 0.10.0, PEFT 0.18.1. This is not the cu130 CI environment. Two GPUs
qualify Shard(0), uneven shapes, and Shard(0) x Replicate, not 4/8-GPU TP/EP/HSDP,
FP8, training equivalence, performance, or cross-node transfer.

### API and Usage Example

No production API change. The same documented torchrun invocation now returns
nonzero after teardown if rank 0 reports a failed comparison.

### Design & Code Changes

- Return an integer from the probe's `main()` after its final barrier and teardown.
- Raise `SystemExit(main())` in the CLI entrypoint; add no early exit or collective.
- Add a 28-case CPU regression in the existing `*_on_cpu.py` discovery path.

### Checklist Before Submitting

- [x] Read CONTRIBUTING.md and AGENTS.md.
- [x] Installed and ran all applicable pre-commit hooks for both changed files:
  `pre-commit run --files tests/special_distributed/test_sharded_delta_gather.py tests/checkpoint_engine/test_sharded_delta_gather_exit_on_cpu.py`.
  This is scoped-file validation, not a claim of running every repository file.
- [x] Documentation: no public API/docs change; the existing probe invocation is unchanged.
- [x] CPU regression uses the existing `cpu_unit_tests.yml` `tests/**/test_*_on_cpu.py`
  discovery; no new workflow is necessary. Real GPU controls were run separately.
- [ ] CI request in Slack/Feishu: not sent; no connected workspace access in this submission.
- [x] Recipe submodule: not applicable.

### AI assistance and human accountability

OpenAI Codex assisted with the audit, implementation, tests, and submission.
The human submitter confirmed reviewing every changed line and personally
running the relevant tests for commit `42afaefbee7281322c19562237a73e6f9d7800cf`
before this PR was opened. The commit includes AI attribution and DCO sign-off.
