### PR TITLE
[trainer] fix: count failed validation sessions in accuracy

### DIFF
--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -568,6 +568,44 @@ class TestProcessValidationMetrics(unittest.TestCase):
         # For bootstrap with n=2, the majority vote could be either A or B
         # depending on the random sampling, so we don't check the exact value
 
+    def test_process_validation_metrics_counts_missing_sessions_as_incorrect(self):
+        data_sources = ["source1", "source1"]
+        sample_uids = ["prompt1", "prompt1"]
+        infos_dict = {
+            "reward": [0.4, 0.6],
+            "acc": [1.0, 1.0],
+        }
+
+        result = process_validation_metrics(
+            data_sources,
+            sample_uids,
+            infos_dict,
+            expected_acc_counts={
+                ("source1", "prompt1"): 4,
+                ("source1", "prompt2"): 4,
+            },
+        )
+
+        self.assertAlmostEqual(result["source1"]["acc"]["mean@4"], 0.25)
+        self.assertAlmostEqual(result["source1"]["acc_success_only"]["mean@2"], 1.0)
+        self.assertAlmostEqual(result["source1"]["reward"]["mean@2"], 0.5)
+
+    def test_process_validation_metrics_does_not_add_acc_to_reward_only_source(self):
+        result = process_validation_metrics(
+            data_sources=["acc_source", "reward_source"],
+            sample_uids=["acc_prompt", "reward_prompt"],
+            infos_dict={"reward": [1.0, 0.5], "acc": [1.0, None]},
+            expected_acc_counts={
+                ("acc_source", "acc_prompt"): 2,
+                ("reward_source", "reward_prompt"): 2,
+            },
+        )
+
+        self.assertAlmostEqual(result["acc_source"]["acc"]["mean@2"], 0.5)
+        self.assertAlmostEqual(result["acc_source"]["acc_success_only"]["mean@1"], 1.0)
+        self.assertNotIn("acc", result["reward_source"])
+        self.assertNotIn("acc_success_only", result["reward_source"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -894,7 +894,11 @@ def calc_maj_val(data: list[dict[str, Any]], vote_key: str, val_key: str) -> flo
 
 
 def process_validation_metrics(
-    data_sources: list[str], sample_uids: list[str], infos_dict: dict[str, list[Any]], seed: int = 42
+    data_sources: list[str],
+    sample_uids: list[str],
+    infos_dict: dict[str, list[Any]],
+    seed: int = 42,
+    expected_acc_counts: dict[tuple[str, str], int] | None = None,
 ) -> dict[str, dict[str, dict[str, float]]]:
     """
     Process validation metrics into a structured format with statistical analysis.
@@ -909,6 +913,9 @@ def process_validation_metrics(
         sample_uids: List of sample uids corresponding to each sample.
         infos_dict: Dictionary mapping variable names to lists of values for each sample.
         seed: Random seed for bootstrap sampling. Defaults to 42.
+        expected_acc_counts: Expected session count keyed by ``(data_source, uid)``. For data
+            sources that emit ``acc``, failure sessions are included with ``acc=0`` while
+            ``acc_success_only`` preserves the metric over materialized sessions.
 
     Returns:
         A nested dictionary with the structure:
@@ -945,6 +952,24 @@ def process_validation_metrics(
         for var_name, var_vals in infos_dict.items():
             var2vals[var_name].append(var_vals[sample_idx])
 
+    if expected_acc_counts:
+        # Only sources that actually define acc opt into this policy; reward-only evaluators must not
+        # acquire a synthetic accuracy metric merely because another source emits one.
+        acc_data_sources = {
+            data_source
+            for data_source, uid2var2vals in data_src2uid2var2vals.items()
+            if any(value is not None for var2vals in uid2var2vals.values() for value in var2vals.get("acc", []))
+        }
+        for (data_source, uid), expected_count in expected_acc_counts.items():
+            if data_source not in acc_data_sources:
+                continue
+
+            var2vals = data_src2uid2var2vals[data_source][uid]
+            observed_acc = [value for value in var2vals.get("acc", []) if value is not None]
+            var2vals["acc_success_only"] = observed_acc
+            missing_count = max(expected_count - len(observed_acc), 0)
+            var2vals["acc"] = observed_acc + [0.0] * missing_count
+
     np_mean = np.mean
     np_std = np.std
     reduce_fns_best_worst = [np.max, np.min]
@@ -974,13 +999,18 @@ def process_validation_metrics(
 
         for uid, var2vals in uid2var2vals.items():
             pred_vals = var2vals.get("pred")
-            has_pred = pred_vals is not None
             var_dict = uid_dict.setdefault(uid, {})
 
             for var_name, var_vals in var2vals.items():
+                var_vals = [value for value in var_vals if value is not None]
                 # skip empty or string values
                 if not var_vals or isinstance(var_vals[0], str):
                     continue
+                has_pred = (
+                    pred_vals is not None
+                    and len(pred_vals) == len(var_vals)
+                    and all(pred is not None for pred in pred_vals)
+                )
 
                 # compute mean and std
                 n_resps = len(var_vals)

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -984,12 +984,25 @@ class PPOTrainer(ABC):
         dump_all_outputs: list[str] = []
         dump_all_keys: list[str] = []
         session_to_sample_idx: dict[str, int] = {}
+        # To avoid failure sessions
+        expected_acc_counts: dict[tuple[str, str], int] = {}
 
         for batch_dict in self.val_dataloader:
             # 1. put batch to agent loop manager
             batch_dict["uid"] = np.array(
                 [str(uuid.uuid4()) for _ in range(len(batch_dict["raw_prompt"]))], dtype=object
             )
+            batch_size = len(batch_dict["uid"])
+            batch_data_sources = batch_dict.get("data_source", ["unknown"] * batch_size)
+            batch_rollout_ns = batch_dict.get(
+                "__rollout_n__", [self.config.actor_rollout_ref.rollout.val_kwargs.n] * batch_size
+            )
+            for uid, data_source, rollout_n in zip(
+                batch_dict["uid"], batch_data_sources, batch_rollout_ns, strict=True
+            ):
+                rollout_n = int(rollout_n)
+                expected_acc_counts[(str(data_source), str(uid))] = rollout_n
+
             batch = tu.get_tensordict(batch_dict)
             tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
             tu.assign_non_tensor_data(batch, "validate", True)
@@ -1123,7 +1136,13 @@ class PPOTrainer(ABC):
                 dump_path=val_data_dir,
             )
 
-        return self._val_metrics_update(data_sources, sample_uids, reward_extra_infos_dict, sample_turns)
+        return self._val_metrics_update(
+            data_sources,
+            sample_uids,
+            reward_extra_infos_dict,
+            sample_turns,
+            expected_acc_counts=expected_acc_counts,
+        )
 
     def _maybe_log_val_generations(self, inputs, outputs, scores):
         """Log a table of validation samples to the configured logger (wandb or swanlab)"""
@@ -1262,8 +1281,20 @@ class PPOTrainer(ABC):
                 dump_path=rollout_data_dir,
             )
 
-    def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict[str, float]:
-        data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
+    def _val_metrics_update(
+        self,
+        data_sources,
+        sample_uids,
+        reward_extra_infos_dict,
+        sample_turns,
+        expected_acc_counts: dict[tuple[str, str], int] | None = None,
+    ) -> dict[str, float]:
+        data_src2var2metric2val = process_validation_metrics(
+            data_sources,
+            sample_uids,
+            reward_extra_infos_dict,
+            expected_acc_counts=expected_acc_counts,
+        )
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():
             core_var = "acc" if "acc" in var2metric2val else "reward"


### PR DESCRIPTION
### What does this PR do?

Fixes V1 validation accuracy when failed agent-loop sessions do not materialize in TransferQueue.
Missing sessions now count as `acc=0`. The previous success-only accuracy remains available as `val-aux/.../acc_success_only/...`.

### Test

```bash
python -m pytest tests/trainer/ppo/test_metric_utils_on_cpu.py tests/trainer/ppo/v1/test_replay_buffer_on_cpu.py -q
```