### PR TITLE
[BREAKING][sglang, rollout, cfg, doc] fix: require DP attention for rollout DP

### DIFF
--- a/docs/ascend_tutorial/zh/feature_support/ascend_backend_features.md
+++ b/docs/ascend_tutorial/zh/feature_support/ascend_backend_features.md
@@ -62,8 +62,8 @@ verl中通过rollout config管理推理后端参数使能，包含通用参数�
 | enable_memory_saver| 无，verl中默认设置为True | 允许使用 release_memory_occupation 和 resume_memory_occupation 来节省内存
 | base_gpu_id| 无，根据实际实例和卡数自动计算  |用于分配每个实例上计算卡资源时的初始ID
 | gpu_id_step| 无，默认设置为1| 使用的连续计算卡ID 之间的差值
-| tp_size|  actor_rollout_ref.rollout.tensor_model_parallel_size * data_parallel_size|TP并行度|
-| dp_size| actor_rollout_ref.rollout.data_parallel_size|DP并行度|
+| tp_size|  actor_rollout_ref.rollout.tensor_model_parallel_size * data_parallel_size|SGLang 的全局 TP world size；开启 DP attention 后，每个 DP rank 的 attention TP 并行度为 actor_rollout_ref.rollout.tensor_model_parallel_size|
+| dp_size| actor_rollout_ref.rollout.data_parallel_size|DP 并行度；大于 1 时必须设置 actor_rollout_ref.rollout.engine_kwargs.sglang.enable_dp_attention=True|
 | ep_size| actor_rollout_ref.rollout.expert_parallel_size|EP并行度|
 | node_rank| 无，根据实际实例和卡数自动计算 |实例中的节点排序|
 | load_format|  actor_rollout_ref.rollout.load_format|要加载的模型权重格式|

--- a/docs/ascend_tutorial/zh/get_start/quick_start.rst
+++ b/docs/ascend_tutorial/zh/get_start/quick_start.rst
@@ -149,8 +149,7 @@ vLLM 后端脚本转换为 SGLang
    ++actor_rollout_ref.rollout.engine_kwargs.sglang.moe_a2a_backend="deepep" \
 
    # MoE 模型多 DP 时必须设置为 True
-   +actor_rollout_ref.rollout.engine_kwargs.sglang.enable_dp_attention=False \
+   +actor_rollout_ref.rollout.engine_kwargs.sglang.enable_dp_attention=True \
 
    # chunked_prefill 默认关闭
    +actor_rollout_ref.rollout.engine_kwargs.sglang.chunked_prefill_size=-1
-

--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -387,8 +387,11 @@ Reference model will be enabled when ``actor.use_kl_loss`` or/and ``algorithm.us
   - For vLLM v0.7.0 and later: The fraction of **total** GPU memory to be used for the vLLM instance.
   - For SGLang: Corresponding to ``mem_fraction_static``, the fraction of the free GPU memory used for **static** memory like model weights and KV cache. 
 
-- ``actor_rollout_ref.rollout.tensor_model_parallel_size``: TP size for rollout. Only effective
-  for vllm.
+- ``actor_rollout_ref.rollout.tensor_model_parallel_size``: TP size for rollout. For SGLang,
+  verl passes ``tensor_model_parallel_size * data_parallel_size`` as SGLang's global ``tp_size``;
+  SGLang divides it by ``dp_size`` to obtain the per-DP attention TP size. SGLang configurations
+  with ``data_parallel_size > 1`` must also set
+  ``actor_rollout_ref.rollout.engine_kwargs.sglang.enable_dp_attention=True``.
 
 - ``actor_rollout_ref.rollout.log_prob_micro_batch_size``: [Will be deprecate, use log_prob_micro_batch_size_per_gpu]
   The batch size for one forward pass in the computation of ``log_prob``. The value represent the global num.

--- a/tests/workers/config/test_rollout_config_on_cpu.py
+++ b/tests/workers/config/test_rollout_config_on_cpu.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.workers.config import RolloutConfig
+
+
+@pytest.mark.parametrize("enable_dp_attention", [None, False, "true"])
+def test_sglang_data_parallel_requires_dp_attention(enable_dp_attention):
+    sglang_kwargs = {} if enable_dp_attention is None else {"enable_dp_attention": enable_dp_attention}
+
+    with pytest.raises(ValueError, match=r"engine_kwargs\.sglang\.enable_dp_attention=True"):
+        RolloutConfig(name="sglang", data_parallel_size=2, engine_kwargs={"sglang": sglang_kwargs})
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"name": "sglang", "data_parallel_size": 1},
+        {
+            "name": "sglang",
+            "data_parallel_size": 2,
+            "engine_kwargs": {"sglang": {"enable_dp_attention": True}},
+        },
+        {"name": "vllm", "data_parallel_size": 2},
+    ],
+)
+def test_rollout_data_parallel_supported_configs(config):
+    RolloutConfig(**config)
+
+
+@pytest.mark.parametrize("parallel_arg", ["tp_size", "dp_size"])
+def test_sglang_parallel_sizes_cannot_be_overridden(parallel_arg):
+    with pytest.raises(ValueError, match="tensor_model_parallel_size.*data_parallel_size"):
+        RolloutConfig(name="sglang", engine_kwargs={"sglang": {parallel_arg: 2}})

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -60,10 +60,13 @@ cudagraph_capture_sizes: null
 # Whether to free engine KVCache after generation.
 free_cache_engine: True
 
-# TP size for rollout. Not effective for hf
+# TP size for rollout. Not effective for hf.
+# For SGLang, verl passes tensor_model_parallel_size * data_parallel_size as the global tp_size;
+# SGLang divides it by dp_size to obtain the per-DP attention TP size.
 tensor_model_parallel_size: 2
 
-# DP size for rollout
+# DP size for rollout.
+# SGLang requires engine_kwargs.sglang.enable_dp_attention: true when data_parallel_size > 1.
 data_parallel_size: 1
 
 # EP size for rollout
@@ -135,7 +138,8 @@ over_sample_rate: 0
 # This is only effective for SGLang rollout.
 multi_stage_wake_up: false
 
-# Extra inference engine arguments (vllm, sglang, trtllm), please refer vllm/sglang/trtllm official doc for detail
+# Extra inference engine arguments (vllm, sglang, trtllm), please refer vllm/sglang/trtllm official doc for detail.
+# SGLang tp_size and dp_size are managed by the generic fields above and must not be set here.
 engine_kwargs:
 
   # vllm engine config

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -291,6 +291,22 @@ class RolloutConfig(BaseConfig):
                 stacklevel=2,
             )
 
+        if self.name == "sglang":
+            sglang_kwargs = self.engine_kwargs.get("sglang", {})
+            if "tp_size" in sglang_kwargs or "dp_size" in sglang_kwargs:
+                raise ValueError(
+                    "SGLang `tp_size` and `dp_size` are managed by verl; use "
+                    "`tensor_model_parallel_size` and `data_parallel_size` instead of overriding them in "
+                    "`engine_kwargs.sglang`."
+                )
+            if self.data_parallel_size > 1 and sglang_kwargs.get("enable_dp_attention") is not True:
+                raise ValueError(
+                    "SGLang rollout with `data_parallel_size > 1` requires "
+                    "`engine_kwargs.sglang.enable_dp_attention=True`: verl passes "
+                    "`tensor_model_parallel_size * data_parallel_size` as SGLang `tp_size`, and SGLang weight "
+                    "updates require `dp_size == 1` or DP attention."
+                )
+
         if self.name != "trtllm" and self.expert_parallel_size > 1:
             assert self.expert_parallel_size == (self.tensor_model_parallel_size * self.data_parallel_size), (
                 "expert_parallel_size must be equal to tensor_model_parallel_size * data_parallel_size"


### PR DESCRIPTION
### What does this PR do?

This PR makes SGLang rollout data parallelism fail fast unless DP attention is explicitly enabled.

verl maps SGLang `tp_size` to `tensor_model_parallel_size * data_parallel_size` while passing `data_parallel_size` as SGLang `dp_size`. SGLang weight updates require `dp_size == 1` or DP attention, but verl previously did not validate that invariant. As a result, an invalid configuration could pass verl initialization and fail later during weight synchronization.

This PR:

- Requires `engine_kwargs.sglang.enable_dp_attention=True` when SGLang `data_parallel_size > 1`.
- Rejects `engine_kwargs.sglang.tp_size` and `engine_kwargs.sglang.dp_size` overrides because verl derives them from the generic rollout parallelism fields.
- Documents the SGLang TP × DP mapping and the DP-attention requirement.
- Fixes an Ascend quick-start example that said DP attention was required while setting it to `False`.
- Adds CPU unit tests for accepted and rejected configurations.

The TP × DP mapping was introduced in #4715.

Duplicate-work note: the open PR searches below found no PR addressing this validation and documentation gap.

AI assistance disclosure: OpenAI Codex was used for investigation, implementation, testing, and drafting this description.

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [SGLang DP attention](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+sglang+%22dp+attention%22), [references to #4715](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+4715+in%3Abody)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

```bash
uv run --frozen --all-packages --extra cpu pytest -q tests/workers/config/test_rollout_config_on_cpu.py tests/workers/rollout/test_pd_disaggregation.py tests/special_sanity/test_config_docs.py
# 39 passed, 1 skipped

uv run --frozen --all-packages --extra cpu pre-commit run --all-files --show-diff-on-failure --color=always
# All hooks passed
```

A targeted pre-commit run passed Ruff, Ruff formatting, mypy, generated-config verification, documentation checks, license checks, test-structure validation, and compilation. The repository-wide naming hook reported a false positive from Ray inside the locally generated `.venv` (`ServeRLlibRLModule`); the changed files contain no prohibited naming variants.

### API and Usage Example

SGLang rollout DP must now explicitly enable DP attention:

```bash
actor_rollout_ref.rollout.name=sglang \
actor_rollout_ref.rollout.tensor_model_parallel_size=4 \
actor_rollout_ref.rollout.data_parallel_size=2 \
+actor_rollout_ref.rollout.engine_kwargs.sglang.enable_dp_attention=True
```

`data_parallel_size=1` remains valid without `enable_dp_attention`.

The following overrides are no longer accepted:

```bash
# Invalid: use the generic rollout fields instead.
+actor_rollout_ref.rollout.engine_kwargs.sglang.tp_size=8
+actor_rollout_ref.rollout.engine_kwargs.sglang.dp_size=2
```

### Design & Code Changes

- Add the invariant check to `RolloutConfig.__post_init__`, so all rollout construction paths share the same validation.
- Require the DP-attention value to be the boolean `True`; missing, false, and non-boolean truthy values are rejected.
- Keep the existing SGLang `tp_size = tensor_model_parallel_size * data_parallel_size` mapping unchanged.
- Cover SGLang DP=1, valid DP>1, invalid DP>1, forbidden parallelism overrides, and unaffected vLLM DP configurations.
- Update the rollout configuration reference and the general and Ascend documentation.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. The new `test_rollout_config_on_cpu.py` file is automatically collected by the existing CPU unit-test workflow.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable: this PR does not modify the `recipe` submodule.