### PR TITLE
[reward] feat: allow configuring the gsm8k scoring method via compute_score_kwargs

### DIFF
--- a/docs/preparation/reward_function.rst
+++ b/docs/preparation/reward_function.rst
@@ -52,6 +52,18 @@ We already pre-implemented some reward functions in `reward_score directory <htt
 - In the `MATH example <https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/math_reward.py>`_, we follow
   the implementation in `lm-evaluation-harness repository <https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/hendrycks_math/utils.py>`_.
 
+Some pre-implemented reward functions accept additional keyword arguments through the
+``reward.compute_score_kwargs`` config field (only effective when ``custom_reward_function.path`` is not set).
+For example, the GSM8K scorer supports two answer extraction methods: ``strict`` (the default, which requires
+the final answer after ``####``) and ``flexible`` (which takes the last number in the response). To switch to
+the flexible extraction:
+
+.. code:: yaml
+
+  reward:
+    compute_score_kwargs:
+      method: flexible
+
 Customized
 ~~~~~~~~~~
 

--- a/tests/utils/reward_score/test_default_compute_score_on_cpu.py
+++ b/tests/utils/reward_score/test_default_compute_score_on_cpu.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Individual Contributor: LiFangBo2003
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that config kwargs (e.g. the GSM8K extraction method) reach the default compute_score function."""
+
+from omegaconf import OmegaConf
+
+import verl.experimental.reward_loop.reward_manager  # noqa: F401  # registers the built-in reward managers
+from verl.trainer.ppo.reward import load_reward_manager
+from verl.utils.reward_score import default_compute_score
+
+GSM8K = "openai/gsm8k"
+
+
+class TestGsm8kMethodForwarding:
+    """`default_compute_score` should forward `method` to the GSM8K scorer."""
+
+    def test_default_is_strict(self):
+        """Without the `#### <answer>` marker, strict extraction yields zero reward."""
+        assert default_compute_score(GSM8K, "The answer is 42", "42") == 0.0
+
+    def test_strict_extraction(self):
+        """A well-formatted strict response gets the full reward."""
+        assert default_compute_score(GSM8K, "reasoning... #### 42", "42") == 1.0
+
+    def test_flexible_extraction(self):
+        """With method='flexible', the last number is extracted and no `####` marker is needed."""
+        assert default_compute_score(GSM8K, "The answer is 42", "42", method="flexible") == 1.0
+
+    def test_flexible_wrong_answer(self):
+        """A wrong flexible answer only gets format_score (0 by default)."""
+        assert default_compute_score(GSM8K, "The answer is 43", "42", method="flexible") == 0.0
+
+
+class TestComputeScoreKwargsConfig:
+    """`reward.compute_score_kwargs` in the config should reach the default compute_score function."""
+
+    @staticmethod
+    def _build_reward_manager(compute_score_kwargs=None):
+        reward_config = {"reward_manager": {"source": "register", "name": "naive"}}
+        if compute_score_kwargs is not None:
+            reward_config["compute_score_kwargs"] = compute_score_kwargs
+        config = OmegaConf.create({"reward": reward_config})
+        return load_reward_manager(config, tokenizer=None)
+
+    def test_kwargs_forwarded_to_default_compute_score(self):
+        """method=flexible set through the config makes the scorer accept a bare trailing number."""
+        reward_manager = self._build_reward_manager(compute_score_kwargs={"method": "flexible"})
+        score = reward_manager.compute_score(data_source=GSM8K, solution_str="The answer is 42", ground_truth="42")
+        assert float(score) == 1.0
+
+    def test_default_behaviour_unchanged(self):
+        """Without compute_score_kwargs, the strict behaviour is preserved."""
+        reward_manager = self._build_reward_manager()
+        score = reward_manager.compute_score(data_source=GSM8K, solution_str="The answer is 42", ground_truth="42")
+        assert float(score) == 0.0

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -813,6 +813,7 @@ reward:
   custom_reward_function:
     path: null
     name: compute_score
+  compute_score_kwargs: {}
   reward_manager:
     _target_: verl.workers.config.reward.RewardManagerConfig
     source: register

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -708,6 +708,7 @@ reward:
   custom_reward_function:
     path: null
     name: compute_score
+  compute_score_kwargs: {}
   reward_manager:
     _target_: verl.workers.config.reward.RewardManagerConfig
     source: register

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -777,6 +777,7 @@ reward:
   custom_reward_function:
     path: null
     name: compute_score
+  compute_score_kwargs: {}
   reward_manager:
     _target_: verl.workers.config.reward.RewardManagerConfig
     source: register

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -748,6 +748,7 @@ reward:
   custom_reward_function:
     path: null
     name: compute_score
+  compute_score_kwargs: {}
   reward_manager:
     _target_: verl.workers.config.reward.RewardManagerConfig
     source: register

--- a/verl/trainer/config/reward/reward.yaml
+++ b/verl/trainer/config/reward/reward.yaml
@@ -12,6 +12,11 @@ custom_reward_function:
   # The name of the reward function within the specified file. Default is 'compute_score'.
   name: compute_score
 
+# Extra keyword arguments passed to the built-in compute_score function (only used when
+# custom_reward_function.path is not set). For example, `{method: flexible}` makes the GSM8K
+# scorer take the last number in the response as the answer instead of requiring '#### <answer>'.
+compute_score_kwargs: {}
+
 # reward manager, see `verl/trainer/config/reward_manager.yaml` for details.
 reward_manager:
   _target_: verl.workers.config.reward.RewardManagerConfig

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -132,6 +132,9 @@ def load_reward_manager(config: DictConfig, tokenizer: Any, **reward_kwargs: Any
     default_compute_score_ = get_default_compute_score(reward_manager_cfg.name)
 
     if compute_score is None:
+        # Extra keyword arguments forwarded to the default compute_score function, e.g.
+        # `compute_score_kwargs: {method: flexible}` switches the GSM8K scorer to flexible answer extraction.
+        compute_score_kwargs = dict(config.reward.get("compute_score_kwargs", None) or {})
         sandbox_config = config.reward.get("sandbox_fusion")
         sandbox_url = sandbox_config.get("url") if sandbox_config else None
         memory_limit_mb = sandbox_config.get("memory_limit_mb", 1024) if sandbox_config else 1024
@@ -144,9 +147,10 @@ def load_reward_manager(config: DictConfig, tokenizer: Any, **reward_kwargs: Any
                 sandbox_fusion_url=sandbox_url,
                 concurrent_semaphore=_concurrent_semaphore,
                 memory_limit_mb=memory_limit_mb,
+                **compute_score_kwargs,
             )
         else:
-            final_compute_score = default_compute_score_
+            final_compute_score = partial(default_compute_score_, **compute_score_kwargs)
 
     # Instantiate and return the reward manager with the specified parameters
     return reward_manager_cls(

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -24,6 +24,7 @@ def default_compute_score(
     sandbox_fusion_url=None,
     concurrent_semaphore=None,
     memory_limit_mb=None,
+    method="strict",
     **kwargs,
 ):
     """Compute the score for a given solution based on the data source.
@@ -33,6 +34,9 @@ def default_compute_score(
         solution_str (str): The solution string to be evaluated.
         ground_truth (str): The ground truth answer for comparison.
         extra_info (dict, optional): Additional information that might be needed for scoring. Defaults to None.
+        method (str, optional): Answer extraction method for scorers that support it (currently the GSM8K scorer),
+            either "strict" (requires the `#### <answer>` marker) or "flexible" (takes the last number in the
+            response). Defaults to "strict". Configurable through the `reward.compute_score_kwargs` config field.
 
     Returns:
         float: The computed score as a floating point number. If the result is a dictionary,
@@ -44,7 +48,7 @@ def default_compute_score(
     if data_source == "openai/gsm8k":
         from . import gsm8k
 
-        res = gsm8k.compute_score(solution_str, ground_truth)
+        res = gsm8k.compute_score(solution_str, ground_truth, method=method)
     elif data_source in ["lighteval/MATH", "DigitalLearningGmbH/MATH-lighteval", "HuggingFaceH4/MATH-500"]:
         from . import math_reward
 


### PR DESCRIPTION
### What does this PR do?

The built-in GSM8K scorer supports two answer extraction methods — `strict` (requires the `#### <answer>` marker) and `flexible` (takes the last number in the response) — but the `method` argument of `gsm8k.compute_score` was unreachable from outside: `default_compute_score` invoked it with the defaults only, and no config entry point existed to select it. When model responses are not formatted with the `####` marker, every GSM8K reward silently becomes 0 and users had to fork the scorer to work around it.

This PR exposes the knob through a new `reward.compute_score_kwargs` config field — a generic extra-keyword channel to the built-in `compute_score`, mirroring the existing `reward_kwargs` of `custom_reward_function`. Training can now switch extraction via `+reward.compute_score_kwargs.method=flexible` without any code change, and future scorer options (e.g. `format_score`) can reuse the same channel. Default behaviour is unchanged (the field defaults to `{}`).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+gsm8k+compute_score+method
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI) — modules: `reward`, type: `feat`, no breaking API change (new optional config field, default unchanged)

### Test

New unit tests in `tests/utils/reward_score/test_default_compute_score_on_cpu.py` (6 cases, CPU-only so they run in the `cpu_unit_tests` workflow): `default_compute_score` forwards `method` to the GSM8K scorer (strict default / strict extraction / flexible extraction / flexible wrong answer), plus config-level integration tests that build the reward manager through `load_reward_manager` with `reward.compute_score_kwargs={method: flexible}` and verify both the forwarded behaviour and the unchanged default. Regression over `tests/utils/reward_score/`: 14 passed, 13 skipped.

### API and Usage Example

```yaml
reward:
  compute_score_kwargs:
    method: flexible # strict (default) | flexible
```

or on the CLI:

```bash
python main_ppo.py ... +reward.compute_score_kwargs.method=flexible
```

Custom reward functions are unaffected: `compute_score_kwargs` is only consumed when `custom_reward_function.path` is not set (that path already has its own `reward_kwargs`).

### Design & Code Changes

- `verl/utils/reward_score/__init__.py`: add `method="strict"` parameter to `default_compute_score` and forward it to `gsm8k.compute_score`.
- `verl/trainer/ppo/reward.py`: in `load_reward_manager`, merge `config.reward.compute_score_kwargs` into the `partial` wrapping the default compute score (same pattern as the existing `sandbox_fusion` arguments).
- `verl/trainer/config/reward/reward.yaml`: declare `compute_score_kwargs: {}` with comments; the four `verl/trainer/config/_generated_*.yaml` reference files are regenerated accordingly via `scripts/generate_trainer_config.sh` (one line each).
- `docs/preparation/reward_function.rst`: document the new field with the GSM8K strict/flexible example.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` — the dev environment is offline (no ruff/mypy installable); `check_license`, `check_docstrings` and `check_docs_time_info` were run clean and the diff was formatted to the repo ruff rules manually; CI will run the full pre-commit.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: test file follows the `*_on_cpu.py` naming picked up by `cpu_unit_tests.yml`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
