### PR TITLE
[training_utils] fix: do not initialize CUDA when no accelerator is present

### DIFF
--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -73,11 +73,17 @@ def get_device_flops(unit="T", device_name=None):
 
     # pass device_name is for testing purpose only
     if device_name is None:
+        from verl.plugin.platform.platform_manager import get_platform
+
         device = get_torch_device()
-        if device == torch.cpu:
+        # get_torch_device() falls back to the nvidia platform module even when no
+        # accelerator is present, so comparing against torch.cpu is not enough —
+        # without the availability check, get_device_name() would try to
+        # initialize CUDA on CPU-only builds/actors.
+        if device == torch.cpu or not get_platform().is_available():
             device_name = "CPU"
         else:
-            device_name = get_torch_device().get_device_name()
+            device_name = device.get_device_name()
 
     flops = float("inf")  # INF flops for unkown gpu type
 


### PR DESCRIPTION
Fixes #7790

`get_torch_device()` returns the nvidia platform module even when no accelerator exists (the platform manager falls back to nvidia), so the `device == torch.cpu` check in `get_device_flops` never fires on CPU-only builds or CPU-only ray actors. The fallback `device.get_device_name()` then tries to initialize CUDA and crashes:

```
AssertionError: Torch not compiled with CUDA enabled
```

All 13 CPU cases in `tests/utils/test_flops_counter.py` fail this way on a CPU-only environment. Check platform availability before querying the device name, so `estimate_flops` is usable (and the tests pass) without a GPU.
