### PR TITLE
[trainer, cfg] feat: filter V1 DAPO groups by canonical reward by default

### DIFF
--- a/tests/trainer/ppo/v1/test_replay_buffer_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_replay_buffer_on_cpu.py
@@ -146,6 +146,7 @@ class PromptSpec:
     sessions: int = 1
     global_steps: int = 0
     rewards: list[float] | None = None
+    canonical_rewards: list[float | list[float]] | None = None
     trajectory_keys: list[str] = field(default_factory=list)
 
 
@@ -167,6 +168,11 @@ class RolloutProducer(threading.Thread):
                     tag = {"is_prompt": False, "seq_len": 3, "global_steps": spec.global_steps}
                     if spec.rewards is not None:
                         fields["extra_fields"] = {"reward_extra_info": {"acc": float(spec.rewards[session_id])}}
+                    if spec.canonical_rewards is not None:
+                        reward = spec.canonical_rewards[session_id]
+                        fields["rm_scores"] = torch.tensor(
+                            reward if isinstance(reward, list) else [reward], dtype=torch.float32
+                        )
                     tq.kv_put(
                         key=key,
                         partition_id=self.partition_id,
@@ -933,6 +939,34 @@ def test_dapo_classification_cache_fetches_only_new_finished_groups(tq_init, par
             set(first_filtered.trajectory_keys + mixed.trajectory_keys),
             set(second_filtered.trajectory_keys),
         ]
+    finally:
+        _clear_partition(partition_id)
+
+
+def test_dapo_reward_metric_uses_canonical_rm_scores(tq_init, partition_id):
+    same_reward = PromptSpec(
+        uid=_uid(),
+        status="finished",
+        sessions=2,
+        rewards=[0.0, 1.0],
+        canonical_rewards=[[0.25, 0.75], [1.0]],
+    )
+    different_reward = PromptSpec(
+        uid=_uid(),
+        status="finished",
+        sessions=2,
+        rewards=[1.0, 1.0],
+        canonical_rewards=[0.0, 1.0],
+    )
+    _produce(partition_id, [same_reward, different_reward]).join_and_check()
+
+    rb = _make_rb(filter_groups_metric="reward", refill_fn=lambda _n: None)
+    try:
+        rb._sync_metadata_from_transfer_queue()
+        filtered_uids, filtered_counts = rb._dapo_filtered_keys(partition_id)
+
+        assert filtered_uids == {same_reward.uid}
+        assert dict(filtered_counts) == {1.0: 1}
     finally:
         _clear_partition(partition_id)
 

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -896,7 +896,7 @@ algorithm:
   filter_groups:
     _target_: verl.trainer.config.FilterGroupsConfig
     enable: false
-    metric: null
+    metric: reward
     max_num_gen_batches: 0
     max_inflight_gen_batches: 1
   use_kl_in_reward: false

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -791,7 +791,7 @@ algorithm:
   filter_groups:
     _target_: verl.trainer.config.FilterGroupsConfig
     enable: false
-    metric: null
+    metric: reward
     max_num_gen_batches: 0
     max_inflight_gen_batches: 1
   use_kl_in_reward: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -860,7 +860,7 @@ algorithm:
   filter_groups:
     _target_: verl.trainer.config.FilterGroupsConfig
     enable: false
-    metric: null
+    metric: reward
     max_num_gen_batches: 0
     max_inflight_gen_batches: 1
   use_kl_in_reward: false

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -831,7 +831,7 @@ algorithm:
   filter_groups:
     _target_: verl.trainer.config.FilterGroupsConfig
     enable: false
-    metric: null
+    metric: reward
     max_num_gen_batches: 0
     max_inflight_gen_batches: 1
   use_kl_in_reward: false

--- a/verl/trainer/config/algorithm.py
+++ b/verl/trainer/config/algorithm.py
@@ -47,7 +47,8 @@ class FilterGroupsConfig(BaseConfig):
 
     Args:
         enable (bool): Whether to enable filter groups.
-        metric (Optional[str]): Metric to use for filtering: "acc", "score", "seq_reward", "seq_final_reward", etc.
+        metric (Optional[str]): Metric to use for filtering. "reward" selects the canonical pre-KL reward from
+            rm_scores; "acc", "score", "seq_reward", etc. select a reward_extra_info field.
         max_num_gen_batches (int): Non-positive values mean no upper limit.
         max_inflight_gen_batches (int): Maximum Sync DAPO prompt batches concurrently pending or running,
             measured in ``data.train_batch_size`` units.

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -85,8 +85,8 @@ algorithm:
     # Whether to enable group filtering
     enable: False
 
-    # Metric used to identify groups with uniform rewards, acc / score / seq_reward / seq_final_reward / ...
-    metric: null
+    # "reward" selects canonical pre-KL rm_scores; other names like "acc" select a reward_extra_info field.
+    metric: reward
 
     # Maximum number of generation batches; non-positive values mean no upper limit
     max_num_gen_batches: 0

--- a/verl/trainer/ppo/v1/replay_buffer.py
+++ b/verl/trainer/ppo/v1/replay_buffer.py
@@ -29,6 +29,7 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 VERL_REPLAY_BUFFER_DEBUG_INTERVAL_SECONDS = int(os.getenv("VERL_REPLAY_BUFFER_DEBUG_INTERVAL_SECONDS", "60"))
 
 DAPO_FILTERED_REWARD_COUNTS_KEY = "_dapo_filtered_reward_counts"
+FILTER_GROUPS_REWARD_METRIC = "reward"
 
 
 def _accumulate_eviction_metrics(acc: dict, new: dict, stale_count: int) -> None:
@@ -120,7 +121,8 @@ class ReplayBuffer:
         sampler_kwargs (dict): Additional kwargs for the custom sampler.
         poll_interval (float, optional): Poll interval in seconds. Defaults to 2.0.
         refill_fn (callable, optional): Trainer-injected function that submits an exact number of fresh prompts.
-        filter_groups_metric (str, optional): DAPO group-filtering metric read from each trajectory's
+        filter_groups_metric (str, optional): DAPO group-filtering metric. ``"reward"`` reads the canonical
+            pre-KL reward from ``rm_scores``; other names read each trajectory's
             ``extra_fields.reward_extra_info``. ``None`` disables DAPO filtering.
         train_batch_size (int, optional): Prompt count represented by one Sync DAPO in-flight batch.
         gen_batch_size (int, optional): Dataloader fetch granularity for refill dispatches.
@@ -262,6 +264,7 @@ class ReplayBuffer:
 
         new_finished_uids = finished_uids - classification_cache.keys()
         trajectory_keys = [key for key in self.partitions[partition_id] if key.split("_")[0] in new_finished_uids]
+        use_canonical_reward = self.filter_groups_metric == FILTER_GROUPS_REWARD_METRIC
         metrics_by_uid: dict[str, list[float]] = defaultdict(list)
         missing_metric_uids = new_finished_uids - {key.split("_")[0] for key in trajectory_keys}
 
@@ -269,20 +272,23 @@ class ReplayBuffer:
             data = tq.kv_batch_get(
                 keys=trajectory_keys,
                 partition_id=partition_id,
-                select_fields=["extra_fields"],
+                select_fields=["rm_scores"] if use_canonical_reward else ["extra_fields"],
             )
-            extra_fields_list = list(data["extra_fields"])
+            metric_data = list(data["rm_scores"] if use_canonical_reward else data["extra_fields"])
         else:
-            extra_fields_list = []
+            metric_data = []
 
-        for key, extra_fields in zip(trajectory_keys, extra_fields_list, strict=True):
+        for key, value in zip(trajectory_keys, metric_data, strict=True):
             uid = key.split("_")[0]
-            extra_fields = getattr(extra_fields, "data", extra_fields)
-            reward_extra_info = extra_fields.get("reward_extra_info", {}) if isinstance(extra_fields, dict) else {}
-            if self.filter_groups_metric not in reward_extra_info:
-                missing_metric_uids.add(uid)
+            if use_canonical_reward:
+                metrics_by_uid[uid].append(float(value.sum().item()))
             else:
-                metrics_by_uid[uid].append(float(reward_extra_info[self.filter_groups_metric]))
+                extra_fields = getattr(value, "data", value)
+                reward_extra_info = extra_fields.get("reward_extra_info", {}) if isinstance(extra_fields, dict) else {}
+                if self.filter_groups_metric not in reward_extra_info:
+                    missing_metric_uids.add(uid)
+                else:
+                    metrics_by_uid[uid].append(float(reward_extra_info[self.filter_groups_metric]))
 
         if missing_metric_uids:
             raise RuntimeError(


### PR DESCRIPTION
### What does this PR do?

This PR allows the V1 DAPO group filter to use the canonical pre-KL reward stored in `rm_scores`.
When `algorithm.filter_groups.metric=reward`, the ReplayBuffer compares each trajectory's summed `rm_scores`. Other metric names, such as `acc`, continue to read from `reward_extra_info`.
The default filter metric is changed to `reward`, so dynamic sampling can be enabled with a single:
```bash
algorithm.filter_groups.enable=True
```

### Test

E2E 1 step tested.
