### PR TITLE
[trainer] fix: keep raw score for singleton groups in vectorized RLOO

### DIFF
--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -260,6 +260,27 @@ def test_rloo_and_vectorized_equivalence(batch_size: int, seq_len: int, num_grou
     assert torch.allclose(ret1, ret2, rtol=1e-5, atol=1e-6)
 
 
+def test_rloo_and_vectorized_equivalence_with_singleton_groups():
+    r"""Singleton groups (e.g. after filtering drops all but one sample) must keep
+    the raw score in both implementations (#7793)."""
+    token_level_rewards = torch.tensor([[0.7], [0.3], [-0.5], [0.9], [0.1]], dtype=torch.float32)
+    response_mask = torch.ones_like(token_level_rewards)
+    # two multi-sample groups and one singleton group
+    index = np.array(["p1", "p1", "p2", "p2", "p3"], dtype=object)
+
+    adv1, ret1 = compute_rloo_outcome_advantage(
+        token_level_rewards=token_level_rewards, response_mask=response_mask, index=index
+    )
+    adv2, ret2 = compute_rloo_vectorized_outcome_advantage(
+        token_level_rewards=token_level_rewards, response_mask=response_mask, index=index
+    )
+
+    assert torch.allclose(adv1, adv2, rtol=1e-5, atol=1e-6)
+    assert torch.allclose(ret1, ret2, rtol=1e-5, atol=1e-6)
+    # the singleton sample keeps its raw score instead of being zeroed out
+    assert torch.allclose(adv1[4], token_level_rewards[4], rtol=1e-5, atol=1e-6)
+
+
 def test_grpo_vectorized_matches_original_for_low_variance_rewards():
     token_level_rewards = torch.tensor([[1.0], [1.00001], [2.0], [2.00001]], dtype=torch.float32)
     response_mask = torch.ones_like(token_level_rewards)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -861,7 +861,11 @@ def compute_rloo_vectorized_outcome_advantage(
         inv = torch.from_numpy(np.unique(index, return_inverse=True)[1]).to(scores.device)
 
         c = torch.bincount(inv)[inv].to(scores.dtype)
-        adv = ((c * scores - torch.bincount(inv, weights=scores)[inv]) / (c - 1).clamp_min(1)) * (c > 1)
+        adv = (c * scores - torch.bincount(inv, weights=scores)[inv]) / (c - 1).clamp_min(1)
+        # Singleton groups keep the raw score, matching the scalar implementation and
+        # the GRPO singleton convention (they can appear when filtering drops all
+        # other samples of a prompt group).
+        adv = torch.where(c > 1, adv, scores)
 
         adv = adv.unsqueeze(-1) * response_mask
 


### PR DESCRIPTION
Fixes #7793

The scalar and vectorized RLOO implementations disagree on singleton groups, which can appear when filtering (e.g. overlong or dynamic filtering) drops all but one sample of a prompt group:

- scalar: a singleton keeps the raw score as the advantage, so the surviving sample still trains
- vectorized: the final `* (c > 1)` zeroed the advantage, so the surviving sample contributed no gradient at all

Both estimators are selected via `algorithm.adv_estimator` and are otherwise mathematically equivalent, so the silent divergence looks unintended. This passes the raw score through for singletons in the vectorized path, matching the scalar implementation and the GRPO singleton convention (mean=0, std=1).

Extended the equivalence test with singleton groups — it fails on the old vectorized behavior and passes after this change (24 tests pass).
