### PR TITLE
[ci] fix: nightlyCI_grpo_qwen3_5_2b_fsdp2_vllm_ascend

### DIFF
--- a/.github/workflows/nightly_ascend.yml
+++ b/.github/workflows/nightly_ascend.yml
@@ -342,12 +342,6 @@ jobs:
       - name: Check final pip list
         run: |
           pip list
-      - name: Clone Megatron Bridge
-        run: |
-          git clone --depth 1 https://github.com/NVIDIA-NeMo/Megatron-Bridge.git /Megatron-Bridge
-          cd /Megatron-Bridge
-          git fetch --depth 1 origin de93536e9028ecf1e4dc28608dc80f336dcdfe59
-          git checkout de93536e9028ecf1e4dc28608dc80f336dcdfe59
       - name: Prepare weights
         run: |
           ln -s /root/.cache/models ~/models
@@ -357,7 +351,6 @@ jobs:
       - name: Running nightlyCI_grpo_qwen3_5_2b_fsdp2_vllm_ascend
         run: |
           ray stop --force
-          export PYTHONPATH=/Megatron-Bridge/src:$PYTHONPATH
           bash tests/special_npu/nightly_ci_ascend/run_grpo_qwen3_5_2b_fsdp2_npu.sh
 
   # Test grpo qwen3_5_2b fsdp_turbo vllm


### PR DESCRIPTION
### What does this PR do?

Remove redundant installation of megatron-bridge in workflow file.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
https://github.com/verl-project/verl/actions/runs/34303974621/job/102316869365?pr=7800 passed.