### PR TITLE
[training_utils] fix: preserve failed MLflow run status

### DIFF
--- a/tests/utils/test_mlflow_key_sanitization.py
+++ b/tests/utils/test_mlflow_key_sanitization.py
@@ -64,14 +64,25 @@ class TestMlflowLoggingAdapter(unittest.TestCase):
         adapter = _MlflowLoggingAdapter()
         with patch("mlflow.active_run", return_value=object()), patch("mlflow.end_run") as mock_end_run:
             adapter.finish()
-        mock_end_run.assert_called_once()
+        mock_end_run.assert_called_once_with(status="FINISHED")
+
+    def test_finish_marks_nonzero_exit_codes_failed(self):
+        """Preserve training failures instead of marking failed runs as finished."""
+        adapter = _MlflowLoggingAdapter()
+        for exit_code in (1, 130):
+            with self.subTest(exit_code=exit_code):
+                with patch("mlflow.active_run", return_value=object()), patch("mlflow.end_run") as mock_end_run:
+                    adapter.finish(exit_code=exit_code)
+                mock_end_run.assert_called_once_with(status="FAILED")
 
     def test_finish_skips_when_no_active_run(self):
         """Test that finish() does not call mlflow.end_run() when no run is active."""
         adapter = _MlflowLoggingAdapter()
-        with patch("mlflow.active_run", return_value=None), patch("mlflow.end_run") as mock_end_run:
-            adapter.finish()
-        mock_end_run.assert_not_called()
+        for exit_code in (0, 1):
+            with self.subTest(exit_code=exit_code):
+                with patch("mlflow.active_run", return_value=None), patch("mlflow.end_run") as mock_end_run:
+                    adapter.finish(exit_code=exit_code)
+                mock_end_run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -16,6 +16,8 @@ import sys
 import types
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 from verl.utils.tracking import DapoFilteredRewardTableLogger, Tracking, ValidationGenerationsLogger
 
 
@@ -30,15 +32,16 @@ def test_tracking_finish_finalizes_wandb_once():
     tracking.logger["wandb"].finish.assert_called_once_with(exit_code=1)
 
 
-def test_tracking_finish_finalizes_mlflow_once():
+@pytest.mark.parametrize("exit_code", [0, 1, 130])
+def test_tracking_finish_finalizes_mlflow_once(exit_code):
     tracking = Tracking.__new__(Tracking)
     tracking.logger = {"mlflow": MagicMock()}
     tracking._finished = False
 
-    tracking.finish()
+    tracking.finish(exit_code=exit_code)
     tracking.finish()
 
-    tracking.logger["mlflow"].finish.assert_called_once()
+    tracking.logger["mlflow"].finish.assert_called_once_with(exit_code=exit_code)
 
 
 def test_dapo_filtered_reward_table_logs_incremental_rows():

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -211,7 +211,7 @@ class Tracking:
         if "clearml" in loggers:
             loggers["clearml"].finish()
         if "mlflow" in loggers:
-            loggers["mlflow"].finish()
+            loggers["mlflow"].finish(exit_code=exit_code)
         if "trackio" in loggers:
             loggers["trackio"].finish()
         if "file" in loggers:
@@ -618,11 +618,11 @@ class _MlflowLoggingAdapter:
                 else:
                     self.logger.warning(msg, *args)
 
-    def finish(self):
+    def finish(self, exit_code: int = 0):
         import mlflow
 
         if mlflow.active_run() is not None:
-            mlflow.end_run()
+            mlflow.end_run(status="FINISHED" if exit_code == 0 else "FAILED")
 
 
 def _compute_mlflow_params_from_objects(params) -> dict[str, Any]:


### PR DESCRIPTION
### What does this PR do?

Preserve the training outcome when finalizing an MLflow run. The PPO entry point already calls `Tracking.finish(exit_code=0 if succeeded else 1)`, but the MLflow branch drops that argument and calls `mlflow.end_run()`, which defaults to FINISHED even when training failed.

This follows #7740, which added MLflow finalization. It forwards the exit code to the MLflow adapter and uses FINISHED for zero, FAILED otherwise. Normal completion, no-active-run handling, and exactly-once finalization are preserved.

Duplicate checks: [MLflow exit_code](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+mlflow+exit_code), [MLflow failed](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+mlflow+failed), and [references to #7740](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7740+in%3Abody) found no direct implementation. #7474 touches the same finish method but addresses backend exception isolation, not run status. #5135 addresses tracking resumption and other logging behavior.

### Test

Local validation on Python 3.12, pytest 9.1.1, MLflow 3.16.0:

```python
# CPU module-level runner; bypasses the heavyweight verl package initializers,
# while importing the actual tracking module and running its existing test files.
import pathlib
import sys
import types
import pytest

root = pathlib.Path.cwd() / "verl"
pkg = types.ModuleType("verl")
pkg.__path__ = [str(root)]
utils = types.ModuleType("verl.utils")
utils.__path__ = [str(root / "utils")]
sys.modules.update({"verl": pkg, "verl.utils": utils})
raise SystemExit(pytest.main([
    "tests/utils/test_tracking_on_cpu.py",
    "tests/utils/test_mlflow_key_sanitization.py",
    "-q",
]))
```

Result: **11 passed, 4 subtests passed**. The regression checks fail before the production fix.

A separate check using the real Tracking constructor and a temporary local MLflow file store confirmed exit codes 0/1/130 produce FINISHED/FAILED/FAILED respectively; before this fix all three were FINISHED. This is not an end-to-end Ray/GPU training validation.

```bash
uvx ruff@0.12.2 check verl/utils/tracking.py tests/utils/test_tracking_on_cpu.py tests/utils/test_mlflow_key_sanitization.py
uvx ruff@0.12.2 format --check verl/utils/tracking.py tests/utils/test_tracking_on_cpu.py tests/utils/test_mlflow_key_sanitization.py
git diff --check HEAD^ HEAD
```

All three checks passed.

### Checklist Before Starting

- [x] Searched for similar PRs; links above.
- [x] Used the required PR title format.

### Checklist Before Submitting

- [x] Read the contribution guide.
- [ ] Full repository pre-commit suite. Focused pinned Ruff check/format and diff check passed as listed above.
- [ ] Documentation update: not applicable; no new configuration or user-facing API.
- [x] Extended existing regression tests, collected by the repository's existing test workflows.
- [ ] Requested CI in the community channel.

AI assistance was used to investigate, implement, and test this change. I reviewed the complete diff and authorized submission.

