### PR TITLE
[fsdp, perf] feat: offload optimizer states around each update

### DIFF
--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -1,7 +1,7 @@
 Performance Tuning Guide
 ==============================
 
-Last updated: 07/17/2025.
+Last updated: 09/07/2026.
 
 Author: `Guangming Sheng <https://github.com/PeterSH6>`_, `Jiali Zheng <https://github.com/CurryRice233>`_
 
@@ -24,6 +24,8 @@ In this section, we will discuss how to tune the performance of all the stages i
 8. Reduce FSDP gradient synchronization during gradient accumulation
 
 9. Memory optimization for entropy calculation from logits
+
+10. Offload FSDP2 optimizer states between updates
 
 Rollout Generation Tuning
 --------------------------
@@ -258,3 +260,32 @@ This processes the tensor in chunks of shape ``[chunk_size, voc]`` (e.g., 2048) 
 Additionally, during training, standard gradient checkpointing (``enable_gradient_checkpointing=True``) does not apply to entropy calculations. To reduce memory peaks in this context, set:
 ``actor_rollout_ref.actor.entropy_checkpointing = True``
 This enables entropy recomputation specifically for the entropy calculation, lowering memory usage during training.
+
+Offload FSDP2 optimizer states between updates
+---------------------------------------------
+
+When manual optimizer offloading is enabled, the FSDP engine normally loads
+optimizer states on entry to the training context and keeps them on the device
+until that context exits. To keep Adam states on the CPU during forward and
+backward computation, enable the following option::
+
+    actor_rollout_ref.actor.strategy=fsdp2
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload_step=True
+
+``optimizer_offload_step`` defaults to ``False``. When enabled, the engine loads
+optimizer states after gradient clipping, immediately before each finite-gradient
+update, and offloads them when that update returns or raises an exception.
+Non-finite gradients retain the existing skip-update behavior. This can reduce
+peak device memory when optimizer states would otherwise overlap with activations,
+but adds CPU/device transfers for every optimizer update. Measure both peak memory
+and training time for the intended batch size and number of updates.
+
+This option requires the FSDP2 training engine, ``optimizer_offload=True``, and
+``offload_policy=False``. It supports ordinary ``torch.optim.AdamW`` without a
+gradient scaler. Parameter offloading can be enabled or disabled independently.
+Other optimizer implementations and FP16 gradient scaling are not supported by
+this option. The default configuration and explicit manual transfers remain
+unchanged. A top-level ``train_mode(disable_auto_offload=True)`` leaves transfers to the
+caller. Nested contexts retain an outer automatic context's per-update policy,
+as required by the training worker's mini-batch loop.

--- a/tests/special_distributed/run_all.sh
+++ b/tests/special_distributed/run_all.sh
@@ -25,3 +25,5 @@ torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_cp
 # Regression for colocated FSDP2 full-parameter model transfers. It locks in
 # PyTorch's implicit pinned allocation for non-blocking D2H Module.to().
 torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_pinned_model_transfer.py
+# Per-update optimizer offload: sharded Adam parity, residency, skipped updates, and state reload.
+torchrun --nproc-per-node=2 --standalone tests/special_distributed/test_fsdp2_optimizer_offload_step.py

--- a/tests/special_distributed/test_fsdp2_optimizer_offload_step.py
+++ b/tests/special_distributed/test_fsdp2_optimizer_offload_step.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise real sharded Adam states through FSDPEngine's automatic train context.
+
+Launch with torchrun --standalone --nproc-per-node=2
+    tests/special_distributed/test_fsdp2_optimizer_offload_step.py
+"""
+
+import io
+from contextlib import nullcontext
+from dataclasses import replace
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+from torch.distributed import init_device_mesh
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.tensor import DTensor
+
+from verl.utils.device import get_device_name, get_torch_device
+from verl.utils.distributed import initialize_global_process_group
+from verl.workers.config.engine import FSDPEngineConfig
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
+
+
+def build_engine(mesh, enabled, param_offload, foreach, fused):
+    torch.manual_seed(5282)
+    engine = object.__new__(FSDPEngine)
+    engine.module = torch.nn.Sequential(torch.nn.Linear(32, 32), torch.nn.GELU(), torch.nn.Linear(32, 8))
+    engine.module.to(get_device_name())
+    fully_shard(engine.module, mesh=mesh)
+    assert all(isinstance(p, DTensor) for p in engine.module.parameters())
+    engine.optimizer = torch.optim.AdamW(engine.module.parameters(), lr=0.01, foreach=foreach, fused=fused)
+    engine.optimizer_config = SimpleNamespace(clip_grad=1.0)
+    engine.engine_config = FSDPEngineConfig(
+        strategy="fsdp2", optimizer_offload=True, optimizer_offload_step=enabled, param_offload=param_offload
+    )
+    engine._is_offload_param = param_offload
+    engine._is_offload_optimizer = True
+    engine._qat_enabled = False
+    engine.scaler = None
+    engine.mode = None
+    engine.ulysses_parallel_group = None
+    engine.to(device="cpu", model=param_offload, optimizer=True, grad=param_offload)
+    return engine
+
+
+def snapshot(engine):
+    # Every rank checks its entire parameter and optimizer shards. The collective
+    # exit barrier makes a failure on either rank fail the distributed test.
+    get_torch_device().synchronize()
+
+    def local_copy(tensor):
+        if isinstance(tensor, DTensor):
+            tensor = tensor.to_local()
+        return tensor.detach().cpu().clone()
+
+    result = {f"param/{name}": local_copy(p) for name, p in engine.module.named_parameters()}
+    for index, state in enumerate(engine.optimizer.state.values()):
+        for name, value in state.items():
+            result[f"optim/{index}/{name}"] = local_copy(value) if torch.is_tensor(value) else value
+    return result
+
+
+def assert_equal(actual, expected):
+    assert actual.keys() == expected.keys()
+    for key in actual:
+        torch.testing.assert_close(actual[key], expected[key], rtol=0, atol=0, msg=key)
+
+
+def assert_state_device(engine, device):
+    for state in engine.optimizer.state.values():
+        for name in ("exp_avg", "exp_avg_sq"):
+            assert isinstance(state[name], DTensor), "test must cover actual sharded optimizer states"
+            assert state[name].to_local().device.type == device
+
+
+def update(engine, index, nonfinite=False, nested=False):
+    with engine.train_mode():
+        if engine.optimizer.state:
+            assert_state_device(engine, "cpu" if engine.engine_config.optimizer_offload_step else get_device_name())
+        with engine.train_mode(disable_auto_offload=True) if nested else nullcontext():
+            generator = torch.Generator(device=get_device_name()).manual_seed(1000 + index + dist.get_rank())
+            # Two backward calls verify that state residency covers gradient accumulation.
+            for _ in range(2):
+                inputs = torch.randn(4, 32, device=get_device_name(), generator=generator)
+                engine.module(inputs).square().mean().div(2).backward()
+            if nonfinite and dist.get_rank() == 0:
+                next(engine.module.parameters()).grad.to_local().fill_(float("inf"))
+            grad_norm = engine.optimizer_step()
+            assert torch.isfinite(torch.tensor(grad_norm)).item() is not nonfinite
+            assert_state_device(engine, "cpu" if engine.engine_config.optimizer_offload_step else get_device_name())
+    assert_state_device(engine, "cpu")
+    assert engine._optimizer_offload_step is False
+    assert all(p.grad is None for p in engine.module.parameters())
+    return snapshot(engine)
+
+
+def round_trip(engine, enabled):
+    # Serialize real DTensor optimizer state, then switch the option on resume.
+    buffer = io.BytesIO()
+    torch.save(engine.optimizer.state_dict(), buffer)
+    buffer.seek(0)
+    engine.optimizer.load_state_dict(torch.load(buffer, weights_only=False))
+    engine.to(device="cpu", model=False, optimizer=True, grad=False)
+    engine.engine_config = replace(engine.engine_config, optimizer_offload_step=enabled)
+
+
+def main():
+    _, rank, world_size = initialize_global_process_group()
+    mesh = init_device_mesh(get_device_name(), (world_size,), mesh_dim_names=("dp",))
+    for param_offload in (False, True):
+        for foreach, fused in ((False, False), (True, False), (False, True)):
+            baseline = build_engine(mesh, False, param_offload, foreach, fused)
+            offloaded = build_engine(mesh, True, param_offload, foreach, fused)
+            for index in range(4):
+                assert_equal(update(offloaded, index), update(baseline, index))
+            before = snapshot(offloaded)
+            assert_equal(update(offloaded, 4, nonfinite=True), before)
+            # Both directions resume against an uninterrupted baseline.
+            round_trip(offloaded, False)
+            assert_equal(update(offloaded, 5), update(baseline, 5))
+            round_trip(offloaded, True)
+            assert_equal(update(offloaded, 6), update(baseline, 6))
+            assert_equal(update(offloaded, 7, nested=True), update(baseline, 7, nested=True))
+            if rank == 0:
+                print(
+                    f"PASS world_size={world_size} param_offload={param_offload} foreach={foreach} fused={fused}",
+                    flush=True,
+                )
+            del baseline, offloaded
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0:
+        print("test_fsdp2_optimizer_offload_step passed", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workers/config/test_engine_config_on_cpu.py
+++ b/tests/workers/config/test_engine_config_on_cpu.py
@@ -70,3 +70,26 @@ class TestFSDPEngineConfigCPU:
         test_policy = {"layer_class": "TransformerBlock"}
         config = FSDPEngineConfig(wrap_policy=test_policy)
         assert config.wrap_policy == test_policy
+
+
+@pytest.mark.parametrize("param_offload", [False, True])
+def test_step_optimizer_offload_config(param_offload):
+    config = FSDPEngineConfig(
+        strategy="fsdp2", optimizer_offload=True, optimizer_offload_step=True, param_offload=param_offload
+    )
+    assert config.optimizer_offload_step is True
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{"strategy": "fsdp"}, {"optimizer_offload": False}, {"offload_policy": True}, {"forward_only": True}],
+)
+def test_step_optimizer_offload_rejects_unsupported_config(overrides):
+    kwargs = {"strategy": "fsdp2", "optimizer_offload": True, "optimizer_offload_step": True}
+    kwargs.update(overrides)
+    with pytest.raises(ValueError, match="manual optimizer_offload"):
+        FSDPEngineConfig(**kwargs)
+
+
+def test_step_optimizer_offload_is_opt_in():
+    assert FSDPEngineConfig().optimizer_offload_step is False

--- a/tests/workers/test_fsdp_optimizer_offload_step_on_cpu.py
+++ b/tests/workers/test_fsdp_optimizer_offload_step_on_cpu.py
@@ -1,0 +1,179 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from verl.workers.engine import base
+from verl.workers.engine.fsdp import transformer_impl
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
+
+
+def _make_engine(monkeypatch, *, enabled=False, param_offload=False, foreach=False):
+    engine = object.__new__(FSDPEngine)
+    engine.module = torch.nn.Linear(2, 1, bias=False)
+    with torch.no_grad():
+        engine.module.weight.fill_(0.5)
+    engine.optimizer = torch.optim.AdamW(engine.module.parameters(), lr=0.01, foreach=foreach)
+    engine.optimizer_config = SimpleNamespace(clip_grad=1.0)
+    engine.engine_config = SimpleNamespace(optimizer_offload_step=enabled)
+    engine._is_offload_param = param_offload
+    engine._is_offload_optimizer = True
+    engine._qat_enabled = False
+    engine.scaler = None
+    engine.mode = None
+    engine.ulysses_parallel_group = None
+    events = []
+    engine.to = lambda **kwargs: events.append(("transfer", kwargs))
+    step = engine.optimizer.step
+
+    def record_step():
+        events.append(("step",))
+        return step()
+
+    engine.optimizer.step = record_step
+    monkeypatch.setattr(base, "get_device_name", lambda: "cuda")
+    monkeypatch.setattr(transformer_impl, "get_device_name", lambda: "cuda")
+    monkeypatch.setattr(transformer_impl, "get_ulysses_sequence_parallel_group", lambda: None)
+    monkeypatch.setattr(transformer_impl, "set_ulysses_sequence_parallel_group", lambda _: None)
+    return engine, events
+
+
+def _optimizer_transfers(events):
+    return [event[1]["device"] for event in events if event[0] == "transfer" and event[1]["optimizer"]]
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("param_offload", [False, True])
+def test_optimizer_residency_and_parameter_transfers(monkeypatch, enabled, param_offload):
+    engine, events = _make_engine(monkeypatch, enabled=enabled, param_offload=param_offload)
+    with engine.train_mode():
+        assert _optimizer_transfers(events) == ([] if enabled else ["cuda"])
+        assert any(e[0] == "transfer" and e[1]["model"] for e in events) == param_offload
+        engine.module(torch.ones(1, 2)).sum().backward()
+        before_step = len(events)
+        engine.optimizer_step()
+        step_events = events[before_step:]
+        assert [e[0] for e in step_events] == (["transfer", "step", "transfer"] if enabled else ["step"])
+        assert _optimizer_transfers(step_events) == (["cuda", "cpu"] if enabled else [])
+    assert _optimizer_transfers(events)[-1] == "cpu"
+    assert engine._optimizer_offload_step is False
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_manual_offload_control_is_preserved(monkeypatch, enabled):
+    engine, events = _make_engine(monkeypatch, enabled=enabled, param_offload=True)
+    with engine.train_mode(disable_auto_offload=True):
+        engine.module(torch.ones(1, 2)).sum().backward()
+        engine.optimizer_step()
+    assert events == [("step",)]
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("nan")])
+def test_nonfinite_gradients_skip_update_without_state_transfer(monkeypatch, value):
+    engine, events = _make_engine(monkeypatch, enabled=True)
+    initial = engine.module.weight.detach().clone()
+    with engine.train_mode():
+        engine.module.weight.grad = torch.full_like(engine.module.weight, value)
+        engine.optimizer_step()
+        assert events == []
+        assert not engine.optimizer.state
+        torch.testing.assert_close(engine.module.weight, initial, rtol=0, atol=0)
+    assert engine.module.weight.grad is None
+
+
+def test_state_offloaded_when_optimizer_step_raises(monkeypatch):
+    engine, events = _make_engine(monkeypatch, enabled=True)
+
+    def fail_step():
+        events.append(("step",))
+        raise RuntimeError("update failed")
+
+    engine.optimizer.step = fail_step
+    with pytest.raises(RuntimeError, match="update failed"):
+        with engine.train_mode():
+            engine.module(torch.ones(1, 2)).sum().backward()
+            engine.optimizer_step()
+    assert [e[0] for e in events[:3]] == ["transfer", "step", "transfer"]
+    assert _optimizer_transfers(events)[:2] == ["cuda", "cpu"]
+    assert engine._optimizer_offload_step is False
+    assert engine.module.weight.grad is None
+
+
+@pytest.mark.parametrize("unsupported", ["optimizer", "scaler"])
+def test_unsupported_opt_in_fails_before_loading(monkeypatch, unsupported):
+    engine, events = _make_engine(monkeypatch, enabled=True)
+    if unsupported == "optimizer":
+        engine.optimizer = torch.optim.SGD(engine.module.parameters(), lr=0.1)
+    else:
+        engine.scaler = object()
+    with pytest.raises(ValueError, match="ordinary AdamW"):
+        with engine.train_mode():
+            pytest.fail("unsupported configuration entered training")
+    assert events == []
+    assert engine.mode is None
+
+
+def test_default_context_does_not_restrict_other_optimizers(monkeypatch):
+    engine, _ = _make_engine(monkeypatch)
+    engine.optimizer = torch.optim.SGD(engine.module.parameters(), lr=0.1)
+    with engine.train_mode():
+        engine.module(torch.ones(1, 2)).sum().backward()
+        engine.optimizer_step()
+    assert torch.all(engine.module.weight < 0.5)
+
+
+@pytest.mark.parametrize("foreach", [False, True])
+def test_scheduling_does_not_change_adamw_updates(monkeypatch, foreach):
+    baseline, _ = _make_engine(monkeypatch, foreach=foreach)
+    optimized, _ = _make_engine(monkeypatch, enabled=True, foreach=foreach)
+    for engine in (baseline, optimized):
+        with engine.train_mode():
+            for _ in range(3):
+                engine.optimizer_zero_grad()
+                engine.module(torch.ones(1, 2)).square().sum().backward()
+                engine.optimizer_step()
+    torch.testing.assert_close(baseline.module.weight, optimized.module.weight, rtol=0, atol=0)
+    a = baseline.optimizer.state[baseline.module.weight]
+    b = optimized.optimizer.state[optimized.module.weight]
+    for key in a:
+        torch.testing.assert_close(a[key], b[key], rtol=0, atol=0)
+
+
+def test_step_offload_context_restores_previous_state(monkeypatch):
+    engine, _ = _make_engine(monkeypatch, enabled=True)
+    engine._optimizer_offload_step = True
+    with engine.train_mode(disable_auto_offload=True):
+        assert engine._optimizer_offload_step is True
+    assert engine._optimizer_offload_step is True
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("param_offload", [False, True])
+def test_nested_worker_context_preserves_outer_policy(monkeypatch, enabled, param_offload):
+    engine, events = _make_engine(monkeypatch, enabled=enabled, param_offload=param_offload)
+    with engine.train_mode():
+        for _ in range(3):
+            before_inner = len(events)
+            # TrainingWorker.train_mini_batch delegates to train_batch this way.
+            with engine.train_mode(disable_auto_offload=True):
+                engine.module(torch.ones(1, 2)).sum().backward()
+                engine.optimizer_step()
+            inner_events = events[before_inner:]
+            assert _optimizer_transfers(inner_events) == (["cuda", "cpu"] if enabled else [])
+            assert engine._optimizer_offload_step is enabled
+            assert not any(e[0] == "transfer" and e[1]["model"] for e in inner_events)
+    assert engine._optimizer_offload_step is False

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -30,6 +30,7 @@ actor_rollout_ref:
         min_num_params: 0
       param_offload: false
       optimizer_offload: false
+      optimizer_offload_step: false
       offload_policy: false
       reshard_after_forward: true
       fsdp_size: -1
@@ -238,6 +239,7 @@ actor_rollout_ref:
         min_num_params: 0
       param_offload: false
       optimizer_offload: false
+      optimizer_offload_step: false
       offload_policy: false
       reshard_after_forward: true
       fsdp_size: -1
@@ -557,6 +559,7 @@ critic:
       min_num_params: 0
     param_offload: false
     optimizer_offload: false
+    optimizer_offload_step: false
     offload_policy: false
     reshard_after_forward: true
     fsdp_size: -1

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -15,6 +15,9 @@ param_offload: false
 # Note that this differs from the offload_policy in FSDP
 optimizer_offload: false
 
+# Load optimizer states only during updates. Requires FSDP2 and manual optimizer_offload.
+optimizer_offload_step: false
+
 # Only for FSDP2: offload param/grad/optimizer during train
 offload_policy: false
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -246,6 +246,8 @@ class FSDPEngineConfig(EngineConfig):
         wrap_policy (Dict[str, Any]): Configuration for FSDP wrap policy.
         param_offload (bool): Whether to offload parameters to CPU, default False
         optimizer_offload (bool): Whether to offload optimizer states to CPU, default False
+        optimizer_offload_step (bool): Load optimizer states only for each update inside automatic train mode.
+            Requires FSDP2 with manual optimizer offloading. default False
         offload_policy (bool): Whether to offload policy model parameters, default False
         reshard_after_forward (bool): Whether to reshard parameters after forward pass, default True
         fsdp_size (int): FSDP group size. -1 means use all available GPUs.
@@ -301,9 +303,16 @@ class FSDPEngineConfig(EngineConfig):
     qat: QATEngineConfig = field(default_factory=QATEngineConfig)
     turbo_config: dict[str, Any] = field(default_factory=dict)
 
+    # Load optimizer states only for parameter updates inside automatic train mode.
+    optimizer_offload_step: bool = False
+
     def __post_init__(self):
         super().__post_init__()
         assert self.strategy in ["fsdp", "fsdp2", "fsdp_turbo"], f"strategy {self.strategy} not supported"
+        if self.optimizer_offload_step and (
+            self.strategy != "fsdp2" or not self.optimizer_offload or self.offload_policy or self.forward_only
+        ):
+            raise ValueError("optimizer_offload_step requires training FSDP2 with manual optimizer_offload")
 
 
 @dataclass

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -818,6 +818,13 @@ class FSDPEngine(BaseEngine):
             if not torch.isfinite(grad_norm):
                 print(f"WARN: grad_norm is not finite: {grad_norm}")
                 self.optimizer.zero_grad()
+            elif getattr(self, "_optimizer_offload_step", False):
+                # Gradients are already clipped and finite; only the update needs Adam states.
+                try:
+                    self.to(device=get_device_name(), model=False, optimizer=True, grad=False)
+                    self.optimizer.step()
+                finally:
+                    self.to(device="cpu", model=False, optimizer=True, grad=False)
             else:
                 self.optimizer.step()
 
@@ -1118,22 +1125,43 @@ class EngineEvalModeCtx(BaseEngineCtx):
 
 
 class EngineTrainModeCtx(BaseEngineCtx):
+    def _context_switch(self, device):
+        if self.disable_auto_offload:
+            return
+        if device != "cpu" and getattr(self.engine.engine_config, "optimizer_offload_step", False):
+            # Preserve the normal parameter/gradient transfer without preloading optimizer states.
+            if self.engine.is_param_offload_enabled:
+                self.engine.to(device=device, model=True, optimizer=False, grad=True)
+            return
+        super()._context_switch(device)
+
     def __init__(self, engine: FSDPEngine, **kwargs):
         super().__init__(engine=engine, mode="train", **kwargs)
 
     def __enter__(self):
         assert isinstance(self.engine, FSDPEngine)
+        step_offload = getattr(self.engine.engine_config, "optimizer_offload_step", False)
+        if step_offload and not self.disable_auto_offload:
+            if type(self.engine.optimizer) is not torch.optim.AdamW or getattr(self.engine, "scaler", None) is not None:
+                raise ValueError("optimizer_offload_step supports ordinary AdamW without a gradient scaler")
+        self.prev_step_offload = getattr(self.engine, "_optimizer_offload_step", False)
         super().__enter__()
         self.prev_sp_group = get_ulysses_sequence_parallel_group()
         set_ulysses_sequence_parallel_group(self.engine.ulysses_parallel_group)
         self.engine.module.train()
+        # TrainingWorker nests a manual context inside its automatic mini-batch context.
+        # The inner context must retain the outer context's per-update policy.
+        self.engine._optimizer_offload_step = self.prev_step_offload or (step_offload and not self.disable_auto_offload)
 
     def __exit__(self, exc_type, exc_value, traceback):
         assert isinstance(self.engine, FSDPEngine)
-        set_ulysses_sequence_parallel_group(self.prev_sp_group)
-        if self.zero_grad_on_exit or exc_type is not None:
-            self.engine.optimizer_zero_grad()
-        super().__exit__(exc_type, exc_value, traceback)
+        try:
+            set_ulysses_sequence_parallel_group(self.prev_sp_group)
+            if self.zero_grad_on_exit or exc_type is not None:
+                self.engine.optimizer_zero_grad()
+            super().__exit__(exc_type, exc_value, traceback)
+        finally:
+            self.engine._optimizer_offload_step = self.prev_step_offload
 
 
 @EngineRegistry.register(model_type="language_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])


### PR DESCRIPTION
### What does this PR do?

With manual optimizer offloading, the FSDP Engine loads optimizer states on entering a training context. When that context spans several mini-batches or epochs, Adam states remain on the GPU during forward and backward computation. Add `optimizer_offload_step=False` so memory-constrained users can keep those states on CPU until an actual parameter update.

The behavior lives in the FSDP Engine's training context and finite-gradient update branch. It reuses existing transfers, loads states after gradient clipping, and offloads them in `finally` after `optimizer.step()`. Nested manual contexts retain the outer automatic context's policy; a top-level `disable_auto_offload=True` keeps caller-managed transfers. The default path, shared BaseEngine, training algorithms, and checkpoint format are unchanged.

The option requires FSDP2, manual `optimizer_offload=True`, `offload_policy=False`, and standard `torch.optim.AdamW` without a gradient scaler. Parameter offloading is independent. Ordinary, foreach, and fused AdamW variants are covered. Unsupported opt-in configurations fail explicitly.

Related to #5282. This builds on the direction explored in the closed #5657 and follows the maintainer's request to implement it in the new FSDP Engine.

### Test

- 58 selected CPU configuration and Engine regression tests passed; all repository pre-commit hooks passed for the changed files. Both passed on the current base, main `7cb6501`.
- Real two-rank DTensor tests cover six parameter-offload/AdamW combinations, complete local parameter and optimizer equality, gradient accumulation, global nonfinite-gradient skipping, nested contexts, and state reload across the option change.
- Full Qwen2.5-1.5B fixed-input checks compare single-GPU upstream/off/on and dual-GPU off/on fingerprints. Final-source dual-GPU 128-token repetition and 8192-token checks match complete parameter, optimizer, buffer, scheduler, parameter-group and RNG fingerprints on both ranks.
- Two A800 GRPO trials completed 100 steps / 400 global Adam updates each, with validation and checkpoints at 50/100. Both actual checkpoint resume directions passed through step 102: complete actor state restored, Adam counters 400→408, scheduler 100→102, and the next 16 dataset examples consumed.

### Benchmark

Same host, 2×A800 80GB PCIe (SYS topology, no NVLink), Qwen2.5-1.5B-Instruct, GSM8K, two-rank FSDP2 actor/reference and two TP=1 rollout replicas. Each trial consumed 800 prompts and generated four responses per prompt; each actor window performed four global Adam updates. Only the option and output paths/names differ in the effective configuration.

| Metric | Off | On |
|---|---:|---:|
| Full actor-window allocated peak, maximum rank | 14.693 GiB | 12.372 GiB |
| Whole-run sampled NVML peak, maximum GPU | 21.621 GiB | 21.623 GiB |
| Steady actor-window median, including transfers | 10.566 s | 11.577 s |
| Steady training-step median | 27.925 s | 26.398 s |

Actor peak decreases by 15.80%, with +9.56% actor median time. Actor and whole-GPU peaks measure different scopes; rollout memory can dominate the latter.

These are one GRPO trial per arm, with different generated trajectories despite matching sampling requests; they do not establish a quality improvement or a general speedup. Steady actor statistics exclude the first five steps; steady training-step statistics also exclude checkpoint steps. Full wall times include initialization, validation and checkpoint auditing, including baseline checkpoint relocation for disk capacity, so they are not used for pure performance attribution. Strict numerical equivalence is checked separately with fixed inputs. The original 100-step and checkpoint GPU runs use `c80729f`. The initial delivery alignment to `d040717` only adds an Ascend vLLM patch; current-main reviewer-entrypoint acceptance is recorded separately below.

The off/on trials generated 872551 / 693670 response tokens respectively. The shorter enabled trajectory means the GRPO timing comparison does not isolate transfer overhead; its lower overall step time is not evidence of a speedup.

### Benchmark figures

The figures below are derived from existing raw measurements. Each experiment
has one trial per arm. [Plotted values, source hashes and regeneration script](https://github.com/yue-zeng-yue/verl/blob/891e089710b7acb4bd097e279dbd02c91868e9aa/review-artifacts/figures/README.md)
are available alongside the original evidence archives.

#### Controlled fixed-input Engine A/B (current-main acceptance)

![Controlled fixed-input actor memory and runtime comparison](https://raw.githubusercontent.com/yue-zeng-yue/verl/891e089710b7acb4bd097e279dbd02c91868e9aa/review-artifacts/figures/fixed_input_ab.png)

On base `7cb6501`, the six-update, 128-token check reduced actor peak allocated
memory from 15.703 to 12.472 GiB (−20.58%) and increased the complete actor window
from 10.771 to 13.910 s (+29.15%). Full state fingerprints and input streams match
on both ranks. This uses the SFT loss to isolate the Engine; it is a bounded
memory/correctness check, not an end-to-end GRPO throughput measurement.

#### Original 100-step GRPO memory

![Actor memory across all 100 GRPO steps and whole-GPU peak comparison](https://raw.githubusercontent.com/yue-zeng-yue/verl/891e089710b7acb4bd097e279dbd02c91868e9aa/review-artifacts/figures/grpo_memory.png)

These are the original `c80729f` runs described in the table above. All 100 raw
per-step actor peaks are shown without smoothing. Actor allocated peak drops
15.80%; sampled whole-GPU peak is essentially unchanged. The line chart has a
12 GiB lower bound to show variation; the accompanying bars use a zero baseline.

#### Original GRPO runtime and held-out validation

![Raw actor-window time and three measured GSM8K validation points](https://raw.githubusercontent.com/yue-zeng-yue/verl/891e089710b7acb4bd097e279dbd02c91868e9aa/review-artifacts/figures/grpo_runtime_validation.png)

Actor median time over steps 6–100 rises from 10.566 to 11.577 s in this pair.
The two arms generated different response lengths, so this is observational
timing. Validation is measured only at steps 0, 50 and 100 on 128 held-out
examples. The initial scores already differ; the final result is 96/128 off and
97/128 on. These three points do not establish quality equivalence, improvement,
or convergence. Fixed-input tests provide the strict state comparison.

### Reviewer reproduction

See the [reviewer quick start](https://github.com/yue-zeng-yue/verl/blob/b89db31633c39bdbf3cb32d193d3f1bffc6d61d9/review-artifacts/reviewer_kit/README.md) for setup, downloads, and commands to run the two-GPU fixed-input and GRPO checks.

The small regression requires no downloaded model or dataset:

```bash
torchrun --standalone --nproc-per-node=2 \
  tests/special_distributed/test_fsdp2_optimizer_offload_step.py
```

With `REVIEW_KIT`, `VERL_SOURCE` and `REVIEW_MODEL` set as described in the kit:

```bash
python "$REVIEW_KIT/review.py" fixed \
  --source "$VERL_SOURCE" --model "$REVIEW_MODEL" \
  --out ./review-fixed --steps 6 --seq 128

python "$REVIEW_KIT/review.py" grpo \
  --source "$VERL_SOURCE" --model "$REVIEW_MODEL" \
  --out ./review-grpo-smoke --steps 3
```

The fixed-input A/B compares complete state fingerprints on both ranks and
reports actor memory and full-window time including transfers. The short GRPO
pair checks actual integration. The README also gives the optional 100-step
command, pinned dependencies and assets, expected output, and measurement limits.
Launchers retain failed logs, refuse to overwrite output, and use private local
Ray sessions without a machine-wide `ray stop`.

CPU regression command (58 passed):

```bash
python -m pytest \
  tests/workers/config/test_engine_config_on_cpu.py \
  tests/workers/test_fsdp_optimizer_offload_step_on_cpu.py \
  tests/workers/test_fsdp_gradient_accumulation_sync_on_cpu.py \
  tests/workers/test_fsdp_temperature_scaling_on_cpu.py \
  tests/workers/test_engine_forward_step_detach_on_cpu.py \
  tests/workers/test_engine_return_model_output_on_cpu.py -q
```

All repository pre-commit hooks passed with:

```bash
pre-commit run --files \
  docs/perf/perf_tuning.rst \
  tests/special_distributed/run_all.sh \
  tests/special_distributed/test_fsdp2_optimizer_offload_step.py \
  tests/workers/config/test_engine_config_on_cpu.py \
  tests/workers/test_fsdp_optimizer_offload_step_on_cpu.py \
  verl/trainer/config/_generated_ppo_trainer.yaml \
  verl/trainer/config/engine/fsdp.yaml \
  verl/workers/config/engine.py \
  verl/workers/engine/fsdp/transformer_impl.py
```

### Current-main entrypoint acceptance

The unchanged feature patch also applies to main `7cb6501` (2026-09-08). On a
clean source directory at that commit, all 58 selected CPU regressions and all
repository pre-commit hooks passed. The portable six-case distributed test,
six-update 128-token fixed-input A/B, and three-step-per-arm GRPO A/B all passed
on two A800 GPUs. Fixed-input peak allocated memory was 15.703/12.472 GiB off/on,
with complete state fingerprints equal on both ranks. Each short GRPO arm
completed twelve global Adam updates; enabled post-step optimizer CUDA storage
was zero throughout the observed updates. These checks are separate from the
original 100-step benchmark above. The kit's [VALIDATION.md](https://github.com/yue-zeng-yue/verl/blob/ec26aee09ef6f736cee2d5685bab3bea4c140eaa/review-artifacts/reviewer_kit/VALIDATION.md) states the environment
reuse and the fact that the portable 100-step command was not rerun.

### Checklist Before Starting

On 2026-09-08, #5282 remained open. Searches for open PRs with `5282 in:body`
returned no results. Reviewing the open `"optimizer" "offload"` results found no
implementation of the same per-step state lifetime in the new FSDP Engine.
#1349 concerns initial optimizer-state allocation for rollout sizing; #5651 is
Megatron FP32 parameter offload. The closed #5657 is acknowledged above as prior
work.


- [ ] Search for similar PRs: [issue reference](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+5282+in%3Abody), [optimizer/offload](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22optimizer%22+%22offload%22). Issue comments were also checked.
- [ ] Use the required module/type title format.

### API and Usage Example

Enable the option for a FSDP2 actor using the new Engine:

```bash
actor_rollout_ref.actor.strategy=fsdp2 \
actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
actor_rollout_ref.actor.fsdp_config.offload_policy=False \
actor_rollout_ref.actor.fsdp_config.optimizer_offload_step=True
```

### Design & Code Changes

- `FSDPEngineConfig` and the source/generated YAML expose the default-off option and reject unsupported configuration combinations.
- `EngineTrainModeCtx` controls optimizer-state residency; the finite-gradient branch in `FSDPEngine.optimizer_step()` performs the transfers around AdamW. Standard AdamW type/scaler checks apply only to automatic opt-in contexts.
- The existing CPU discovery includes the new `_on_cpu.py` regressions. The two-GPU regression is added to `tests/special_distributed/run_all.sh`, already invoked by `model.yml`.
- The performance guide describes activation, transfer cost, limitations and manual/nested-context behavior.

### Checklist Before Submitting

- [ ] Read the contribution guide.
- [ ] Run all pre-commit hooks on the 9 changed files (exact command above; full-repository lint was not rerun).
- [ ] Add user-facing documentation.
- [ ] Add CPU and two-rank regression tests to existing CI discovery/entrypoints.
- [ ] The submitting human has reviewed every changed line, understands the change end-to-end, and has run relevant tests, as required by AGENTS.md.
- [ ] Request upstream CI in the project channel once the PR is ready. No channel message has been sent.
- Recipe submodule: not applicable; no recipe change.
