### PR TITLE
[megatron] fix: make R2 router replay model-scoped and opt-in

### DIFF
--- a/tests/special_distributed/test_router_replay_empty_pp.py
+++ b/tests/special_distributed/test_router_replay_empty_pp.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run with torchrun --nproc-per-node=4 -m pytest to exercise real PP collectives."""
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytest.importorskip("megatron.core")
+
+from megatron.core import parallel_state as mpu  # noqa: E402
+from megatron.core.transformer.transformer_config import TransformerConfig  # noqa: E402
+
+from verl.utils.distributed import destroy_global_process_group, initialize_global_process_group  # noqa: E402
+from verl.utils.megatron.router_replay_utils import (  # noqa: E402
+    get_current_rank_layer_info,
+    is_moe_layer,
+    pp_gather,
+    reorder_and_merge_vpp_layers,
+)
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires four CUDA devices")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _parallel_groups():
+    _, _, world_size = initialize_global_process_group()
+    assert world_size == 4
+    mpu.initialize_model_parallel(pipeline_model_parallel_size=4)
+    yield
+    dist.barrier()
+    mpu.destroy_model_parallel()
+    destroy_global_process_group()
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("vpp_size", [None, 2])
+@pytest.mark.parametrize("all_dense", [False, True])
+def test_empty_and_uneven_pp_collectives(nested, vpp_size, all_dense):
+    frequency = [0] * 8 if all_dense else [0, 0, 1, 0, 0, 0, 1, 1]
+    config = TransformerConfig(
+        num_layers=8,
+        hidden_size=8,
+        num_attention_heads=1,
+        num_moe_experts=4,
+        moe_router_topk=2,
+        moe_layer_freq=frequency,
+        pipeline_model_parallel_size=4,
+        pipeline_dtype=torch.bfloat16,
+        virtual_pipeline_model_parallel_size=vpp_size,
+    )
+
+    def make_routes(layer_numbers):
+        lengths = [3, 5] if nested else [5, 5]
+        samples = []
+        for sample_id, length in enumerate(lengths):
+            routes = torch.empty(length, len(layer_numbers), 2, dtype=torch.int16)
+            for column, layer in enumerate(layer_numbers):
+                routes[:, column, :] = layer * 100 + sample_id * 10 + torch.arange(length).unsqueeze(-1)
+            samples.append(routes)
+        return torch.nested.as_nested_tensor(samples, layout=torch.jagged) if nested else torch.stack(samples)
+
+    chunks = []
+    for vp_stage in range(vpp_size or 1):
+        layer_range = get_current_rank_layer_info(config, vp_stage)
+        layers = [idx + 1 for idx in range(layer_range["start"], layer_range["end"]) if is_moe_layer(config, idx)]
+        chunks.append(make_routes(layers))
+    local_routes = reorder_and_merge_vpp_layers(chunks, 1, vpp_size, 1) if vpp_size else chunks[0]
+    gathered = pp_gather(local_routes, config)
+    expected = make_routes([idx + 1 for idx, flag in enumerate(frequency) if flag])
+
+    assert gathered.dtype == torch.int16
+    assert gathered.device.type == "cpu"
+    for actual_sample, expected_sample in zip(gathered.unbind(), expected.unbind(), strict=True):
+        torch.testing.assert_close(actual_sample, expected_sample, atol=0, rtol=0)

--- a/tests/special_distributed/test_router_replay_empty_pp.py
+++ b/tests/special_distributed/test_router_replay_empty_pp.py
@@ -23,7 +23,9 @@ from megatron.core import parallel_state as mpu  # noqa: E402
 from megatron.core.transformer.transformer_config import TransformerConfig  # noqa: E402
 
 from verl.utils.distributed import destroy_global_process_group, initialize_global_process_group  # noqa: E402
+from verl.utils.megatron.router_replay_patch import RouterReplay  # noqa: E402
 from verl.utils.megatron.router_replay_utils import (  # noqa: E402
+    RouterReplayHelper,
     get_current_rank_layer_info,
     is_moe_layer,
     pp_gather,
@@ -47,7 +49,7 @@ def _parallel_groups():
 @pytest.mark.parametrize("nested", [False, True])
 @pytest.mark.parametrize("vpp_size", [None, 2])
 @pytest.mark.parametrize("all_dense", [False, True])
-def test_empty_and_uneven_pp_collectives(nested, vpp_size, all_dense):
+def test_empty_and_uneven_pp_collectives(monkeypatch, nested, vpp_size, all_dense):
     frequency = [0] * 8 if all_dense else [0, 0, 1, 0, 0, 0, 1, 1]
     config = TransformerConfig(
         num_layers=8,
@@ -72,10 +74,12 @@ def test_empty_and_uneven_pp_collectives(nested, vpp_size, all_dense):
         return torch.nested.as_nested_tensor(samples, layout=torch.jagged) if nested else torch.stack(samples)
 
     chunks = []
+    layers_by_chunk = []
     for vp_stage in range(vpp_size or 1):
         layer_range = get_current_rank_layer_info(config, vp_stage)
         layers = [idx + 1 for idx in range(layer_range["start"], layer_range["end"]) if is_moe_layer(config, idx)]
         chunks.append(make_routes(layers))
+        layers_by_chunk.append(layers)
     local_routes = reorder_and_merge_vpp_layers(chunks, 1, vpp_size, 1) if vpp_size else chunks[0]
     gathered = pp_gather(local_routes, config)
     expected = make_routes([idx + 1 for idx, flag in enumerate(frequency) if flag])
@@ -84,3 +88,11 @@ def test_empty_and_uneven_pp_collectives(nested, vpp_size, all_dense):
     assert gathered.device.type == "cpu"
     for actual_sample, expected_sample in zip(gathered.unbind(), expected.unbind(), strict=True):
         torch.testing.assert_close(actual_sample, expected_sample, atol=0, rtol=0)
+
+    for registry in (
+        [layer for layers in layers_by_chunk for layer in layers],
+        [idx + 1 for idx, flag in enumerate(frequency) if flag],
+    ):
+        monkeypatch.setattr(RouterReplay, "router_instances", registry)
+        for vp_stage, layers in enumerate(layers_by_chunk):
+            assert RouterReplayHelper.get_micro_batch_router_list(config, vp_stage) == layers

--- a/tests/utils/megatron/test_router_replay_model_walk_on_cpu.py
+++ b/tests/utils/megatron/test_router_replay_model_walk_on_cpu.py
@@ -108,7 +108,8 @@ def test_targets_are_written_to_the_forwarded_models_own_routers(orphans_then_mo
     for layer in range(NUM_LAYERS):
         layers_topk_idx[:, :, layer, :] = layer
 
-    router_replay_utils.set_router_replay_data(layers_topk_idx, None, tf_config, vp_rank=0, model=model)
+    attention_mask = torch.ones(1, NUM_TOKENS, dtype=torch.bool)
+    router_replay_utils.set_router_replay_data(layers_topk_idx, attention_mask, tf_config, vp_rank=0, model=model)
 
     for layer, router in enumerate(_routers(model)):
         assert torch.equal(router.target_topk_idx, torch.full((NUM_TOKENS, TOPK), layer, dtype=torch.int64))

--- a/tests/utils/test_config_router_replay_on_cpu.py
+++ b/tests/utils/test_config_router_replay_on_cpu.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from verl.utils.config import _validate_router_replay_config
+
+
+def _actor_config(mode):
+    return SimpleNamespace(engine=SimpleNamespace(router_replay=SimpleNamespace(mode=mode)))
+
+
+def test_r2_rejects_bypass_mode_before_worker_startup():
+    with pytest.raises(ValueError, match="R2 records routes while recomputing actor old_log_probs"):
+        _validate_router_replay_config(_actor_config("R2"), {"bypass_mode": True})
+
+
+@pytest.mark.parametrize("mode", ["disabled", "R3"])
+def test_non_r2_modes_allow_bypass(mode):
+    _validate_router_replay_config(_actor_config(mode), {"bypass_mode": True})
+
+
+def test_r2_allows_decoupled_old_log_prob():
+    _validate_router_replay_config(_actor_config("R2"), {"bypass_mode": False})

--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -161,6 +161,24 @@ def test_preprocess_thd_engine_pads_to_minimum_rows(monkeypatch):
     torch.testing.assert_close(local_positions[0, 100:], torch.zeros(28, dtype=torch.long))
 
 
+def test_thd_router_replay_drops_record_padding_and_restores_expert_zero(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size=2, cp_size=1)
+    input_ids = _nested_tensor([torch.arange(7, dtype=torch.long)])
+    recorded_routes = torch.tensor([[[[1]], [[2]], [[3]], [[4]], [[5]], [[6]], [[7]], [[9]]]], dtype=torch.uint8)
+
+    _, packed_seq_params, _ = mcore_util.preprocess_thd_engine(input_ids)
+    exported_routes = mcore_util.postprocess_thd_engine(
+        recorded_routes,
+        packed_seq_params,
+        input_ids,
+        batch_size=1,
+    )
+    replay_routes, _, _ = mcore_util.preprocess_thd_engine(exported_routes)
+
+    torch.testing.assert_close(replay_routes[0, :7], recorded_routes[0, :7])
+    assert replay_routes[0, 7].item() == 0
+
+
 @pytest.mark.parametrize("cp_rank", [0, 1])
 def test_preprocess_thd_engine_pads_multidimensional_router_data(monkeypatch, cp_rank):
     mcore_util = _load_mcore_util_with_stubbed_megatron(

--- a/tests/utils/test_megatron_router_replay_dcp.py
+++ b/tests/utils/test_megatron_router_replay_dcp.py
@@ -125,3 +125,42 @@ def test_pp_gather_normalizes_nested_routes_to_cpu(monkeypatch):
     assert routes.device.type == "cpu"
     assert routes.dtype == torch.int16
     assert [part.tolist() for part in routes.unbind()] == [[[[1], [3]], [[2], [4]]]]
+
+
+def test_pp_gather_supports_zero_layer_bshd_stage(monkeypatch):
+    local = torch.empty((1, 3, 0, 2), dtype=torch.int16)
+    remote = torch.arange(12, dtype=torch.int16).reshape(1, 3, 2, 2)
+    collective_calls = []
+
+    monkeypatch.setattr(router_utils, "device_name", "cpu")
+    monkeypatch.setattr(router_utils.mpu, "get_pipeline_model_parallel_group", lambda: object())
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda _group: 2)
+
+    def fake_all_gather(tensor_list, tensor, group, async_op=False):
+        collective_calls.append((tuple(tensor.shape), async_op))
+        if tensor.numel() == 1:
+            tensor_list[0].fill_(0)
+            tensor_list[1].fill_(2)
+            return
+        tensor_list[0].zero_()
+        tensor_list[1].copy_(remote.contiguous().view(torch.uint8))
+
+    monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+    config = SimpleNamespace(pipeline_model_parallel_size=2, virtual_pipeline_model_parallel_size=None)
+
+    routes = router_utils.pp_gather(local, config)
+
+    assert collective_calls == [((1,), False), ((1, 3, 2, 4), False)]
+    assert routes.shape == remote.shape
+    torch.testing.assert_close(routes, remote)
+
+
+def test_reorder_and_merge_vpp_layers_keeps_dense_chunk_placeholder(monkeypatch):
+    empty_chunk = torch.empty((1, 3, 0, 2), dtype=torch.int16)
+    moe_chunk = torch.arange(6, dtype=torch.int16).reshape(1, 3, 1, 2)
+    monkeypatch.setattr(router_utils, "get_schedule_table", lambda *_args: [(0, 0), (0, 1)])
+
+    routes = router_utils.reorder_and_merge_vpp_layers([empty_chunk, moe_chunk], 1, 2, 1)
+
+    assert routes.shape == moe_chunk.shape
+    torch.testing.assert_close(routes, moe_chunk)

--- a/tests/utils/test_megatron_utils_nested_config.py
+++ b/tests/utils/test_megatron_utils_nested_config.py
@@ -75,6 +75,27 @@ def test_get_hf_config_attr_prefers_direct_text_config_over_root():
     assert get_hf_config_attr(config, "hidden_size") == 4096
 
 
+def test_nested_config_lookup_does_not_fall_back_to_multimodal_sibling():
+    class CompositeConfig:
+        sub_configs = {"audio_config": object, "code2wav_config": object}
+
+        def __init__(self):
+            self.audio_config = SimpleNamespace(hidden_size=1024)
+            self.code2wav_config = SimpleNamespace(rope_theta=10_000.0)
+
+    with pytest.raises(AttributeError, match="has no nested hidden_size"):
+        get_hf_config_attr(CompositeConfig(), "hidden_size")
+    with pytest.raises(AttributeError, match="has no rope_theta"):
+        get_hf_rope_theta(CompositeConfig())
+
+
+def test_get_hf_config_attr_preserves_falsey_text_values():
+    config = SimpleNamespace(text_config=SimpleNamespace(flag=False, count=0))
+
+    assert get_hf_config_attr(config, "flag") is False
+    assert get_hf_config_attr(config, "count") == 0
+
+
 def test_nested_config_lookup_rejects_missing_attributes():
     config = SimpleNamespace(text_config=SimpleNamespace())
 

--- a/tests/utils/test_megatron_utils_nested_config.py
+++ b/tests/utils/test_megatron_utils_nested_config.py
@@ -1,0 +1,82 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from verl.utils.megatron_utils import get_hf_config_attr, get_hf_rope_theta
+
+
+def test_get_hf_rope_theta_from_nested_omni_text_config():
+    text_config = SimpleNamespace(rope_theta=1_000_000.0)
+
+    class OmniConfig:
+        sub_configs = {"thinker_config": object, "code2wav_config": object}
+
+        def __init__(self):
+            self.thinker_config = SimpleNamespace(text_config=text_config)
+            self.code2wav_config = SimpleNamespace(rope_theta=10_000.0)
+
+        def get_text_config(self):
+            return text_config
+
+    assert get_hf_rope_theta(OmniConfig()) == 1_000_000.0
+
+
+def test_get_hf_rope_theta_from_nested_transformers_v5_parameters():
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            language_config=SimpleNamespace(rope_parameters={"full_attention": {"rope_theta": 10_000.0}}),
+        )
+    )
+
+    assert get_hf_rope_theta(config) == 10_000.0
+
+
+def test_get_hf_config_attr_handles_nested_configs_and_cycles():
+    config = SimpleNamespace()
+    config.thinker_config = SimpleNamespace(text_config=SimpleNamespace(hidden_size=4096))
+    config.model_config = config
+
+    assert get_hf_config_attr(config, "hidden_size") == 4096
+
+
+def test_get_hf_config_attr_uses_standard_sub_configs_and_text_accessor():
+    text_config = SimpleNamespace(hidden_size=8192)
+
+    class CompositeConfig:
+        sub_configs = {"decoder_config": object}
+
+        def __init__(self):
+            self.hidden_size = 1024
+            self.decoder_config = SimpleNamespace(hidden_size=2048)
+
+        def get_text_config(self):
+            return text_config
+
+    assert get_hf_config_attr(CompositeConfig(), "hidden_size") == 8192
+
+
+def test_get_hf_config_attr_prefers_direct_text_config_over_root():
+    config = SimpleNamespace(hidden_size=1024, text_config=SimpleNamespace(hidden_size=4096))
+
+    assert get_hf_config_attr(config, "hidden_size") == 4096
+
+
+def test_nested_config_lookup_rejects_missing_attributes():
+    config = SimpleNamespace(text_config=SimpleNamespace())
+
+    with pytest.raises(AttributeError, match="has no nested hidden_size"):
+        get_hf_config_attr(config, "hidden_size")

--- a/tests/workers/engine/megatron/test_router_replay_utils_on_cpu.py
+++ b/tests/workers/engine/megatron/test_router_replay_utils_on_cpu.py
@@ -47,6 +47,7 @@ def _config(num_layers=48, moe_layer_freq=1, virtual_pipeline_model_parallel_siz
     return SimpleNamespace(
         fp8=None,
         moe_layer_freq=moe_layer_freq,
+        moe_router_topk=2,
         num_layers=num_layers,
         pipeline_model_parallel_size=2,
         virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
@@ -102,6 +103,16 @@ def test_get_micro_batch_router_list_supports_local_only_vpp_registry(monkeypatc
     assert rr_utils.RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank=1) == [2, 3]
 
 
+def test_get_micro_batch_router_list_rejects_short_nonempty_registry(monkeypatch):
+    RouterReplay.router_instances = [object()]
+    tf_config = _config(num_layers=4)
+
+    monkeypatch.setattr(rr_utils, "get_moe_num_layers_to_build", lambda _config, _vp_rank=None: 2)
+
+    with pytest.raises(RuntimeError, match="registry does not cover"):
+        rr_utils.RouterReplayHelper.get_micro_batch_router_list(tf_config)
+
+
 def test_merge_router_topk_indices_uses_forwarded_model_with_leftover_vpp_recordings(monkeypatch):
     stale_a = torch.tensor([[12, 13], [14, 15], [16, 17]], dtype=torch.int64)
     stale_b = torch.tensor([[18, 19], [20, 21], [22, 23]], dtype=torch.int64)
@@ -125,7 +136,7 @@ def test_merge_router_topk_indices_uses_forwarded_model_with_leftover_vpp_record
     monkeypatch.setattr(
         rr_utils,
         "iter_model_routers",
-        lambda model: iter([(1, RouterReplay.router_instances[2]), (2, RouterReplay.router_instances[5])]),
+        lambda model: iter([(2, RouterReplay.router_instances[5]), (1, RouterReplay.router_instances[2])]),
     )
     monkeypatch.setattr(rr_utils, "gather_from_sequence_parallel_region", lambda tensor, **_kwargs: tensor)
     monkeypatch.setattr(
@@ -152,6 +163,75 @@ def test_merge_router_topk_indices_uses_forwarded_model_with_leftover_vpp_record
     assert merged[0].shape == (1, 3, 2, 2)
     assert torch.equal(merged[0][0, :, 0, :], recorded_a.to(torch.uint8))
     assert torch.equal(merged[0][0, :, 1, :], recorded_b.to(torch.uint8))
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_merge_router_topk_indices_emits_zero_layer_map_for_dense_stage(monkeypatch, nested):
+    tf_config = _config(num_layers=2)
+    if nested:
+        input_ids = torch.nested.as_nested_tensor([torch.ones(3, dtype=torch.int64)], layout=torch.jagged)
+        attention_mask = None
+    else:
+        input_ids = torch.ones(1, 3, dtype=torch.int64)
+        attention_mask = torch.ones(1, 3, dtype=torch.bool)
+    merged = []
+
+    monkeypatch.setattr(rr_utils, "iter_model_routers", lambda _model: iter(()))
+    monkeypatch.setattr(rr_utils, "get_moe_num_layers_to_build", lambda *_args: 0)
+
+    rr_utils.merge_router_topk_indices(
+        attention_mask,
+        input_ids,
+        merged,
+        tf_config,
+        model=object(),
+    )
+
+    assert len(merged) == 1
+    assert merged[0].dtype == torch.int16
+    assert merged[0].shape[0] == 1
+    assert merged[0].shape[2:] == (0, 2)
+    if nested:
+        assert merged[0].is_nested
+        assert merged[0].unbind()[0].shape == (3, 0, 2)
+    else:
+        assert merged[0].shape == (1, 3, 0, 2)
+
+
+def test_merge_router_topk_indices_requires_bshd_attention_mask(monkeypatch):
+    router = _FakeRouter(torch.ones(3, 2, dtype=torch.int64))
+    tf_config = _config(num_layers=1)
+
+    monkeypatch.setattr(rr_utils, "device_name", "cpu")
+    monkeypatch.setattr(rr_utils, "iter_model_routers", lambda _model: iter([(1, router)]))
+    monkeypatch.setattr(rr_utils, "gather_from_sequence_parallel_region", lambda tensor, **_kwargs: tensor)
+
+    with pytest.raises(RuntimeError, match="RECORD requires attention_mask"):
+        rr_utils.merge_router_topk_indices(
+            None,
+            torch.ones(1, 3, dtype=torch.int64),
+            [],
+            tf_config,
+            model=object(),
+        )
+
+
+def test_empty_model_does_not_hide_missing_moe_routers(monkeypatch):
+    monkeypatch.setattr(rr_utils, "iter_model_routers", lambda _model: iter(()))
+    monkeypatch.setattr(rr_utils, "get_moe_num_layers_to_build", lambda *_args: 2)
+    with pytest.raises(RuntimeError, match="stage that expects MoE layers"):
+        rr_utils.merge_router_topk_indices(
+            torch.ones(1, 3, dtype=torch.bool), torch.ones(1, 3, dtype=torch.long), [], _config(), model=object()
+        )
+
+
+def test_record_rejects_duplicate_layer_numbers(monkeypatch):
+    routers = [(1, _FakeRouter()), (1, _FakeRouter())]
+    monkeypatch.setattr(rr_utils, "iter_model_routers", lambda _model: iter(routers))
+    with pytest.raises(RuntimeError, match="duplicate layer numbers"):
+        rr_utils.merge_router_topk_indices(
+            torch.ones(1, 3, dtype=torch.bool), torch.ones(1, 3, dtype=torch.long), [], _config(), model=object()
+        )
 
 
 def test_merge_router_topk_indices_hard_fails_when_record_count_mismatches(monkeypatch):
@@ -234,6 +314,13 @@ def test_set_router_replay_data_uses_forwarded_vp_model(monkeypatch):
 def test_set_router_replay_data_rejects_missing_routes():
     with pytest.raises(RuntimeError, match="requires routed_experts"):
         rr_utils.set_router_replay_data(None, torch.ones(1, 1, dtype=torch.bool), _config())
+
+
+def test_set_router_replay_data_requires_bshd_attention_mask():
+    routes = torch.ones(1, 3, 1, 2, dtype=torch.int16)
+
+    with pytest.raises(RuntimeError, match="REPLAY requires attention_mask"):
+        rr_utils.set_router_replay_data(routes, None, _config(num_layers=1), model=object())
 
 
 def test_set_router_replay_data_rejects_incomplete_model_routes(monkeypatch):

--- a/tests/workers/engine/megatron/test_router_replay_utils_on_cpu.py
+++ b/tests/workers/engine/megatron/test_router_replay_utils_on_cpu.py
@@ -113,6 +113,93 @@ def test_get_micro_batch_router_list_rejects_short_nonempty_registry(monkeypatch
         rr_utils.RouterReplayHelper.get_micro_batch_router_list(tf_config)
 
 
+@pytest.mark.parametrize("frequency", [1, [0, 1, 0, 0, 1, 0, 1, 1], [0] * 8])
+@pytest.mark.parametrize("vpp_size", [None, 2])
+@pytest.mark.parametrize("pp_rank", [0, 1])
+@pytest.mark.parametrize("registry_layout", ["local", "global"])
+def test_registry_layouts_select_exact_moe_layers(monkeypatch, frequency, vpp_size, pp_rank, registry_layout):
+    config = _config(num_layers=8, moe_layer_freq=frequency, virtual_pipeline_model_parallel_size=vpp_size)
+
+    def layer_range(vp_rank):
+        width = 8 // (2 * (vpp_size or 1))
+        start = ((vp_rank or 0) * 2 + pp_rank) * width
+        return {"start": start, "end": start + width}
+
+    def stage_layers(vp_rank):
+        bounds = layer_range(vp_rank)
+        return [idx for idx in range(bounds["start"], bounds["end"]) if rr_utils.is_moe_layer(config, idx)]
+
+    monkeypatch.setattr(rr_utils, "get_current_rank_layer_info", lambda _config, vp_rank=None: layer_range(vp_rank))
+    monkeypatch.setattr(
+        rr_utils, "get_moe_num_layers_to_build", lambda _config, vp_rank=None: len(stage_layers(vp_rank))
+    )
+    RouterReplay.router_instances = (
+        [idx for idx in range(8) if rr_utils.is_moe_layer(config, idx)]
+        if registry_layout == "global"
+        else [idx for vp_rank in range(vpp_size or 1) for idx in stage_layers(vp_rank)]
+    )
+
+    for vp_rank in range(vpp_size or 1):
+        assert rr_utils.RouterReplayHelper.get_micro_batch_router_list(config, vp_rank) == stage_layers(vp_rank)
+
+
+@pytest.mark.parametrize("registry_size", [1, 3, 5, 9])
+def test_registry_rejects_incomplete_or_extra_model_layout(monkeypatch, registry_size):
+    config = _config(num_layers=8, virtual_pipeline_model_parallel_size=2)
+    RouterReplay.router_instances = list(range(registry_size))
+    monkeypatch.setattr(rr_utils, "get_moe_num_layers_to_build", lambda _config, vp_rank=None: 2)
+
+    with pytest.raises(RuntimeError, match="registry does not cover"):
+        rr_utils.RouterReplayHelper.get_micro_batch_router_list(config, vp_rank=0)
+
+
+@pytest.mark.parametrize("vp_rank", [-1, 2])
+def test_registry_rejects_invalid_vp_rank(vp_rank):
+    RouterReplay.router_instances = list(range(4))
+    config = _config(num_layers=8, virtual_pipeline_model_parallel_size=2)
+    with pytest.raises(ValueError, match="outside the configured VPP size"):
+        rr_utils.RouterReplayHelper.get_micro_batch_router_list(config, vp_rank)
+
+
+@pytest.mark.parametrize("registry_layout", ["local", "global"])
+@pytest.mark.parametrize("frequency", [1, [0, 1, 0, 0, 1, 0, 1, 1]])
+def test_positional_record_and_replay_use_the_same_routers(monkeypatch, registry_layout, frequency):
+    config = _config(num_layers=8, moe_layer_freq=frequency, virtual_pipeline_model_parallel_size=2)
+    global_layers = [idx for idx in range(8) if rr_utils.is_moe_layer(config, idx)]
+    local_layers = [idx for idx in global_layers if idx in (2, 3, 6, 7)]
+    registered_layers = local_layers if registry_layout == "local" else global_layers
+    routers = {
+        idx: _FakeRouter(torch.full((3, 2), 256 + idx, dtype=torch.int64), RouterReplayAction.RECORD)
+        for idx in registered_layers
+    }
+    RouterReplay.router_instances = list(routers.values())
+    monkeypatch.setattr(rr_utils, "device_name", "cpu")
+    monkeypatch.setattr(rr_utils, "get_current_rank_layer_info", lambda _config, vp_rank=None: {"start": 6, "end": 8})
+    monkeypatch.setattr(
+        rr_utils,
+        "get_moe_num_layers_to_build",
+        lambda _config, vp_rank=None: sum(idx in ((2, 3) if vp_rank == 0 else (6, 7)) for idx in global_layers),
+    )
+    monkeypatch.setattr(rr_utils, "gather_from_sequence_parallel_region", lambda tensor, **_kwargs: tensor)
+    monkeypatch.setattr(rr_utils, "scatter_to_sequence_parallel_region", lambda tensor: tensor)
+    monkeypatch.setattr(rr_utils, "preprocess_packed_seqs", lambda tensor, *_args, **_kwargs: (tensor, object()))
+    monkeypatch.setattr(rr_utils, "postprocess_packed_seqs", lambda tensor, *_args, **_kwargs: tensor)
+    mask = torch.ones(1, 3, dtype=torch.bool)
+    recorded = []
+    rr_utils.merge_router_topk_indices(mask, torch.ones(1, 3, dtype=torch.long), recorded, config, vp_rank=1)
+    expected_local = torch.stack([routers[idx].recorded_topk_idx for idx in (6, 7)], dim=1).unsqueeze(0)
+    assert recorded[0].dtype == torch.int16
+    torch.testing.assert_close(recorded[0], expected_local.to(torch.int16))
+
+    global_routes = torch.stack([torch.full((3, 2), 256 + idx) for idx in global_layers], dim=1).unsqueeze(0)
+    rr_utils.set_router_replay_data(global_routes, mask, config, vp_rank=1)
+    for idx, router in routers.items():
+        if idx in (6, 7):
+            torch.testing.assert_close(router.target_topk_idx, router.recorded_topk_idx)
+        else:
+            assert router.target_topk_idx is None
+
+
 def test_merge_router_topk_indices_uses_forwarded_model_with_leftover_vpp_recordings(monkeypatch):
     stale_a = torch.tensor([[12, 13], [14, 15], [16, 17]], dtype=torch.int64)
     stale_b = torch.tensor([[18, 19], [20, 21], [22, 23]], dtype=torch.int64)

--- a/tests/workers/engine/megatron/test_router_replay_utils_on_cpu.py
+++ b/tests/workers/engine/megatron/test_router_replay_utils_on_cpu.py
@@ -1,0 +1,255 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("megatron.core")
+
+from verl.utils.megatron import router_replay_utils as rr_utils  # noqa: E402
+from verl.utils.megatron.router_replay_patch import RouterReplay, RouterReplayAction  # noqa: E402
+
+
+class _FakeRouter:
+    def __init__(self, recorded_topk_idx=None, router_replay_action=None):
+        self.recorded_topk_idx = recorded_topk_idx
+        self.router_replay_action = router_replay_action
+        self.target_topk_idx = None
+        self.target_replay_mask = None
+
+    def set_target_indices(self, topk_indices, replay_mask=None):
+        self.target_topk_idx = topk_indices
+        self.target_replay_mask = replay_mask
+
+
+@pytest.fixture(autouse=True)
+def _restore_router_registry():
+    old_instances = RouterReplay.router_instances
+    RouterReplay.router_instances = []
+    yield
+    RouterReplay.router_instances = old_instances
+
+
+def _config(num_layers=48, moe_layer_freq=1, virtual_pipeline_model_parallel_size=None):
+    return SimpleNamespace(
+        fp8=None,
+        moe_layer_freq=moe_layer_freq,
+        num_layers=num_layers,
+        pipeline_model_parallel_size=2,
+        virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
+        pipeline_model_parallel_layout=None,
+        num_layers_in_first_pipeline_stage=None,
+        num_layers_in_last_pipeline_stage=None,
+        account_for_embedding_in_pipeline_split=False,
+        account_for_loss_in_pipeline_split=False,
+    )
+
+
+def test_get_micro_batch_router_list_supports_local_only_registry(monkeypatch):
+    RouterReplay.router_instances = list(range(24))
+    tf_config = _config()
+
+    monkeypatch.setattr(rr_utils, "get_moe_num_layers_to_build", lambda _config, _vp_rank=None: 24)
+    assert rr_utils.RouterReplayHelper.get_micro_batch_router_list(tf_config) == list(range(24))
+
+
+def test_empty_registry_is_a_noop_for_replay_disabled_engine():
+    tf_config = _config()
+
+    assert rr_utils.RouterReplayHelper.get_micro_batch_router_list(tf_config) == []
+    assert rr_utils.RouterReplayHelper.is_r2_record_action(tf_config) is False
+    assert rr_utils.RouterReplayHelper.is_replay_forward_action(tf_config) is False
+    assert rr_utils.RouterReplayHelper.is_replay_backward_action(tf_config) is False
+
+
+def test_action_queries_use_forwarded_model_instead_of_global_registry(monkeypatch):
+    stale_router = _FakeRouter(router_replay_action=RouterReplayAction.REPLAY_FORWARD)
+    live_router = _FakeRouter(router_replay_action=RouterReplayAction.RECORD)
+    RouterReplay.router_instances = [stale_router]
+    forwarded_model = object()
+    tf_config = _config()
+
+    monkeypatch.setattr(rr_utils, "iter_model_routers", lambda model: iter([(1, live_router)]))
+
+    assert rr_utils.RouterReplayHelper.is_r2_record_action(tf_config, model=forwarded_model)
+    assert not rr_utils.RouterReplayHelper.is_replay_forward_action(tf_config, model=forwarded_model)
+
+
+def test_get_micro_batch_router_list_supports_local_only_vpp_registry(monkeypatch):
+    RouterReplay.router_instances = list(range(4))
+    tf_config = _config(num_layers=8, virtual_pipeline_model_parallel_size=2)
+
+    monkeypatch.setattr(rr_utils, "get_moe_num_layers_to_build", lambda _config, _vp_rank=None: 2)
+    monkeypatch.setattr(
+        rr_utils,
+        "get_current_rank_layer_info",
+        lambda _config, vp_rank=None: {"start": 2 if vp_rank == 0 else 6, "end": 4 if vp_rank == 0 else 8},
+    )
+
+    assert rr_utils.RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank=1) == [2, 3]
+
+
+def test_merge_router_topk_indices_uses_forwarded_model_with_leftover_vpp_recordings(monkeypatch):
+    stale_a = torch.tensor([[12, 13], [14, 15], [16, 17]], dtype=torch.int64)
+    stale_b = torch.tensor([[18, 19], [20, 21], [22, 23]], dtype=torch.int64)
+    recorded_a = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.int64)
+    recorded_b = torch.tensor([[7, 8], [9, 10], [11, 12]], dtype=torch.int64)
+    RouterReplay.router_instances = [
+        _FakeRouter(stale_a),
+        _FakeRouter(stale_b),
+        _FakeRouter(recorded_a),
+        _FakeRouter(),
+        _FakeRouter(),
+        _FakeRouter(recorded_b),
+    ]
+    forwarded_model = object()
+    tf_config = _config(num_layers=2)
+    attention_mask = torch.ones(1, 3, dtype=torch.bool)
+    input_ids = torch.ones(1, 3, dtype=torch.int64)
+    merged = []
+
+    monkeypatch.setattr(rr_utils, "device_name", "cpu")
+    monkeypatch.setattr(
+        rr_utils,
+        "iter_model_routers",
+        lambda model: iter([(1, RouterReplay.router_instances[2]), (2, RouterReplay.router_instances[5])]),
+    )
+    monkeypatch.setattr(rr_utils, "gather_from_sequence_parallel_region", lambda tensor, **_kwargs: tensor)
+    monkeypatch.setattr(
+        rr_utils,
+        "preprocess_packed_seqs",
+        lambda input_ids, attention_mask, **_kwargs: (input_ids, object()),
+    )
+    monkeypatch.setattr(
+        rr_utils,
+        "postprocess_packed_seqs",
+        lambda tensor, _packed_seq_params, _attention_mask, _batch_size, _seq_len, **_kwargs: tensor,
+    )
+
+    rr_utils.merge_router_topk_indices(
+        attention_mask,
+        input_ids,
+        merged,
+        tf_config,
+        vp_rank=1,
+        model=forwarded_model,
+    )
+
+    assert len(merged) == 1
+    assert merged[0].shape == (1, 3, 2, 2)
+    assert torch.equal(merged[0][0, :, 0, :], recorded_a.to(torch.uint8))
+    assert torch.equal(merged[0][0, :, 1, :], recorded_b.to(torch.uint8))
+
+
+def test_merge_router_topk_indices_hard_fails_when_record_count_mismatches(monkeypatch):
+    RouterReplay.router_instances = [
+        _FakeRouter(torch.tensor([[1, 2]], dtype=torch.int64)),
+        _FakeRouter(),
+        _FakeRouter(),
+    ]
+    tf_config = _config(num_layers=2)
+
+    monkeypatch.setattr(rr_utils, "get_moe_num_layers_to_build", lambda _config, _vp_rank=None: 2)
+    monkeypatch.setattr(
+        rr_utils.RouterReplayHelper,
+        "get_micro_batch_router_list",
+        staticmethod(lambda _config, _vp_rank=None: RouterReplay.router_instances[:2]),
+    )
+    monkeypatch.setattr(rr_utils, "get_current_rank_layer_info", lambda _config, _vp_rank=None: {"start": 0, "end": 2})
+    monkeypatch.setattr(rr_utils.mpu, "get_pipeline_model_parallel_rank", lambda: 0)
+
+    with pytest.raises(RuntimeError, match="router replay RECORD did not capture all local routers") as exc_info:
+        rr_utils.merge_router_topk_indices(
+            torch.ones(1, 1, dtype=torch.bool),
+            torch.ones(1, 1, dtype=torch.int64),
+            [],
+            tf_config,
+        )
+
+    message = str(exc_info.value)
+    assert "missing_local_positions=[1]" in message
+    assert "recorded_local_positions=[0]" in message
+
+
+def test_set_router_replay_data_uses_forwarded_vp_model(monkeypatch):
+    routers = [
+        _FakeRouter(),
+        _FakeRouter(),
+        _FakeRouter(),
+        _FakeRouter(),
+        _FakeRouter(),
+        _FakeRouter(),
+    ]
+    RouterReplay.router_instances = routers
+    tf_config = _config(num_layers=4, virtual_pipeline_model_parallel_size=2)
+    forwarded_model = object()
+    attention_mask = torch.ones(1, 3, dtype=torch.bool)
+    routed_experts = torch.tensor(
+        [
+            [
+                [[1, 2], [3, 4], [5, 6], [7, 8]],
+                [[9, 10], [11, 12], [13, 14], [15, 16]],
+                [[17, 18], [19, 20], [21, 22], [23, 24]],
+            ]
+        ],
+        dtype=torch.int64,
+    )
+
+    monkeypatch.setattr(rr_utils, "device_name", "cpu")
+    monkeypatch.setattr(
+        rr_utils,
+        "preprocess_packed_seqs",
+        lambda tensor, attention_mask, **_kwargs: (tensor, object()),
+    )
+    monkeypatch.setattr(rr_utils, "scatter_to_sequence_parallel_region", lambda tensor: tensor)
+    monkeypatch.setattr(rr_utils, "iter_model_routers", lambda model: iter([(3, routers[2]), (4, routers[5])]))
+
+    rr_utils.set_router_replay_data(
+        routed_experts,
+        attention_mask,
+        tf_config,
+        vp_rank=1,
+        model=forwarded_model,
+    )
+
+    assert torch.equal(routers[2].target_topk_idx, routed_experts[0, :, 2, :])
+    assert torch.equal(routers[5].target_topk_idx, routed_experts[0, :, 3, :])
+    untouched = set(range(len(routers))) - {2, 5}
+    assert all(routers[idx].target_topk_idx is None for idx in untouched)
+
+
+def test_set_router_replay_data_rejects_missing_routes():
+    with pytest.raises(RuntimeError, match="requires routed_experts"):
+        rr_utils.set_router_replay_data(None, torch.ones(1, 1, dtype=torch.bool), _config())
+
+
+def test_set_router_replay_data_rejects_incomplete_model_routes(monkeypatch):
+    router = _FakeRouter()
+    tf_config = _config(num_layers=4)
+    routed_experts = torch.ones(1, 3, 2, 1, dtype=torch.int64)
+
+    monkeypatch.setattr(rr_utils, "device_name", "cpu")
+    monkeypatch.setattr(rr_utils, "preprocess_packed_seqs", lambda tensor, _mask, **_kwargs: (tensor, object()))
+    monkeypatch.setattr(rr_utils, "scatter_to_sequence_parallel_region", lambda tensor: tensor)
+    monkeypatch.setattr(rr_utils, "iter_model_routers", lambda model: iter([(4, router)]))
+
+    with pytest.raises(RuntimeError, match="does not cover every forwarded MoE layer"):
+        rr_utils.set_router_replay_data(
+            routed_experts,
+            torch.ones(1, 3, dtype=torch.bool),
+            tf_config,
+            model=object(),
+        )

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -126,7 +126,8 @@ router_replay:
   _target_: verl.workers.config.EngineRouterReplayConfig
 
   # Router replay mode: disabled, R2, R3
-  # - R2: Use R2 routing strategy (record mode)
+  # - R2: Record actor old-logprob routes and replay them during update.
+  #       Requires algorithm.rollout_correction.bypass_mode=false.
   # - R3: Use R3 routing strategy (record mode)
   mode: disabled
 

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -71,6 +71,20 @@ def update_dict_with_config(dictionary: dict, config: DictConfig):
             dictionary[key] = getattr(config, key)
 
 
+def _validate_router_replay_config(actor_config: Any, rollout_correction: Any) -> None:
+    engine_config = getattr(actor_config, "engine", None)
+    router_replay = getattr(engine_config, "router_replay", None)
+    if (
+        getattr(router_replay, "mode", "disabled") == "R2"
+        and rollout_correction
+        and rollout_correction.get("bypass_mode", False)
+    ):
+        raise ValueError(
+            "router_replay.mode='R2' requires algorithm.rollout_correction.bypass_mode=False: "
+            "R2 records routes while recomputing actor old_log_probs, but bypass mode skips that forward."
+        )
+
+
 def validate_config(
     config: DictConfig,
     use_reference_policy: bool,
@@ -149,6 +163,7 @@ def validate_config(
     # Actor validation done in ActorConfig.__post_init__ and validate()
     actor_config = omega_conf_to_dataclass(config.actor_rollout_ref.actor)
     actor_config.validate(n_gpus, config.data.train_batch_size, config.actor_rollout_ref.model)
+    _validate_router_replay_config(actor_config, config.algorithm.get("rollout_correction", None))
 
     if not config.actor_rollout_ref.actor.use_dynamic_bsz:
         if use_reference_policy:

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -784,8 +784,9 @@ class RouterReplayHelper:
         Return the list of RouterReplay instances corresponding to the current micro-batch and local
         (pp_rank, vp_stage) layer range.
 
-        When virtual pipeline (VPP) is enabled, routers for earlier local VP stages precede the
-        current stage in the process-global registry.
+        Accept either one PP rank's complete registry in local VPP order, or one complete
+        model's registry in global layer order. These positional layouts must not contain
+        stale routers or routers from other models; use the model-scoped helpers for those cases.
 
         Args:
             tf_config: Configuration object used to compute layer assignments.
@@ -797,22 +798,27 @@ class RouterReplayHelper:
         if not RouterReplay.router_instances:
             return []
 
-        vp_size = tf_config.virtual_pipeline_model_parallel_size
-        if vp_size is not None:
-            vp_rank = 0 if vp_rank is None else vp_rank
-            offset = sum(get_moe_num_layers_to_build(tf_config, stage) for stage in range(vp_rank))
-        else:
-            offset = 0
+        vp_size = tf_config.virtual_pipeline_model_parallel_size or 1
+        vp_rank = 0 if vp_rank is None else vp_rank
+        if not 0 <= vp_rank < vp_size:
+            raise ValueError(f"vp_rank={vp_rank} is outside the configured VPP size {vp_size}.")
 
-        num_layers_to_build = get_moe_num_layers_to_build(tf_config, vp_rank)
-        router_instances_list = RouterReplay.router_instances[offset : offset + num_layers_to_build]
-        if len(router_instances_list) != num_layers_to_build:
+        local_counts = [get_moe_num_layers_to_build(tf_config, stage) for stage in range(vp_size)]
+        local_total = sum(local_counts)
+        global_total = sum(is_moe_layer(tf_config, idx) for idx in range(tf_config.num_layers))
+        registry_size = len(RouterReplay.router_instances)
+        if registry_size == local_total:
+            offset = sum(local_counts[:vp_rank])
+        elif registry_size == global_total:
+            layer_start = get_current_rank_layer_info(tf_config, vp_rank)["start"]
+            offset = sum(is_moe_layer(tf_config, idx) for idx in range(layer_start))
+        else:
             raise RuntimeError(
-                "router replay registry does not cover the current PP/VPP stage: "
-                f"registry={len(RouterReplay.router_instances)}, offset={offset}, "
-                f"expected={num_layers_to_build}, actual={len(router_instances_list)}, vp_rank={vp_rank}"
+                "router replay registry does not cover a complete local PP/VPP or global model layout: "
+                f"registry={registry_size}, local_expected={local_total}, global_expected={global_total}, "
+                f"vp_rank={vp_rank}. Use model-scoped replay for non-positional registries."
             )
-        return router_instances_list
+        return RouterReplay.router_instances[offset : offset + local_counts[vp_rank]]
 
     @staticmethod
     def _get_action_router_list(tf_config, vp_rank=None, model=None):

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -264,18 +264,45 @@ def merge_router_topk_indices(
         [1, dynamic_bs_all, layer_num, topk] to mini_layer_topk_idx_list.
     """
     with torch.no_grad():
+        if not input_ids.is_nested and attention_mask is None:
+            raise RuntimeError("router replay RECORD requires attention_mask for non-nested BSHD inputs.")
         vp_rank = 0 if vp_rank is None else vp_rank
         if model is not None:
-            router_instances_list = [router for _, router in iter_model_routers(model)]
+            model_routers = sorted(iter_model_routers(model), key=lambda item: item[0])
+            layer_numbers = [layer_number for layer_number, _ in model_routers]
+            if len(layer_numbers) != len(set(layer_numbers)):
+                raise RuntimeError(
+                    "router replay RECORD found duplicate layer numbers in the forwarded model: "
+                    f"layer_numbers={layer_numbers}, vp_rank={vp_rank}"
+                )
+            router_instances_list = [router for _, router in model_routers]
         else:
             router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
 
         if not router_instances_list:
-            raise RuntimeError(
-                "router replay RECORD found no routers in the forwarded model: "
-                f"registry={len(RouterReplay.router_instances)}, "
-                f"pp_rank={mpu.get_pipeline_model_parallel_rank()}, vp_rank={vp_rank}"
-            )
+            expected = get_moe_num_layers_to_build(tf_config, vp_rank)
+            if expected:
+                raise RuntimeError(
+                    "router replay RECORD found no routers in a stage that expects MoE layers: "
+                    f"expected={expected}, vp_rank={vp_rank}"
+                )
+            topk = getattr(tf_config, "moe_router_topk", None)
+            if not isinstance(topk, int) or topk <= 0:
+                raise RuntimeError(
+                    "router replay RECORD cannot build an empty local route map without a positive "
+                    f"moe_router_topk, got {topk!r}."
+                )
+            if input_ids.is_nested:
+                empty_routes = [
+                    torch.empty((tokens.shape[0], 0, topk), dtype=torch.int16) for tokens in input_ids.unbind()
+                ]
+                mini_layer_topk_idx_list.append(torch.nested.as_nested_tensor(empty_routes, layout=torch.jagged))
+            else:
+                batch_size, seq_len = attention_mask.shape[:2]
+                mini_layer_topk_idx_list.append(
+                    torch.empty((batch_size, seq_len, 0, topk), dtype=torch.int16, device="cpu")
+                )
+            return
 
         recorded_local_positions = [
             idx for idx, router in enumerate(router_instances_list) if router.recorded_topk_idx is not None
@@ -469,6 +496,8 @@ def set_router_replay_data(
                     cp_layout=cp_layout,
                 )
         else:
+            if attention_mask is None:
+                raise RuntimeError("router replay REPLAY requires attention_mask for non-nested BSHD inputs.")
             layers_topk_idx_rmpad, _ = preprocess_packed_seqs(
                 layers_topk_idx, attention_mask, pre_process=True, use_fp8_padding=use_fp8_padding
             )
@@ -598,6 +627,11 @@ def reorder_and_merge_vpp_layers(
     """
     # 1) Build schedule table: map each virtual_microbatch_id -> (microbatch_id, model_chunk_id)
     schedule_table = get_schedule_table(num_microbatches, vpp_size, microbatch_group_size_per_vp_stage)
+    if len(micro_batch_tensor_list) != len(schedule_table):
+        raise RuntimeError(
+            "R2 RECORD must capture every scheduled microbatch/chunk, including zero-layer chunks: "
+            f"captured={len(micro_batch_tensor_list)}, expected={len(schedule_table)}"
+        )
 
     # 2) Group by model_chunk_id to build reorder indices so entries of the same chunk become contiguous along dim 0
     tensor_by_chunk = [[] for _ in range(vpp_size)]
@@ -655,7 +689,6 @@ def get_current_rank_layer_info(tf_config, vp_rank=None):
 
 
 def pp_gather(local_layers_router_map, tf_config):
-    # TODO: Consider non-uniform layer allocation cases.
     """
     Gather local router maps from all PP ranks into a global router map.
 
@@ -673,6 +706,8 @@ def pp_gather(local_layers_router_map, tf_config):
 
     pp_group = mpu.get_pipeline_model_parallel_group()
     world_size = torch.distributed.get_world_size(pp_group)
+    if world_size != pp_size:
+        raise RuntimeError(f"pipeline group size {world_size} does not match configured PP size {pp_size}.")
     if local_layers_router_map.is_nested:
         # all_gather_object preserves each sender's CUDA device, so normalize
         # jagged route maps before concatenating routes from local PP ranks.
@@ -680,18 +715,40 @@ def pp_gather(local_layers_router_map, tf_config):
         layers_topk_idx_global_list = [None] * world_size
         torch.distributed.all_gather_object(layers_topk_idx_global_list, local_layers_router_map, pp_group)
     else:
-        # NCCL has no int16 datatype, so gather a bit-identical uint8 view and undo it
-        # before the layer-dimension concat below. The nested branch above needs none
-        # of this: all_gather_object pickles the tensor.
+        # PP stages may own different numbers of MoE layers, including zero. Exchange
+        # layer counts, pad only that dimension for NCCL, then remove the padding.
+        # NCCL has no int16 datatype, so payloads travel as bit-identical uint8 views.
         payload = local_layers_router_map.to(device_name).contiguous().view(torch.uint8)
-        layers_topk_idx_global_list = [torch.empty_like(payload) for _ in range(world_size)]
+        local_layer_count = torch.tensor([local_layers_router_map.shape[2]], dtype=torch.int64, device=payload.device)
+        gathered_layer_counts = [torch.empty_like(local_layer_count) for _ in range(world_size)]
         torch.distributed.all_gather(
-            tensor=payload,
-            tensor_list=layers_topk_idx_global_list,
+            tensor=local_layer_count,
+            tensor_list=gathered_layer_counts,
             group=pp_group,
             async_op=False,
         )
-        layers_topk_idx_global_list = [t.view(torch.int16) for t in layers_topk_idx_global_list]
+        layer_counts = [int(count.item()) for count in gathered_layer_counts]
+        max_layer_count = max(layer_counts)
+        if max_layer_count == 0:
+            layers_topk_idx_global_list = [local_layers_router_map for _ in range(world_size)]
+        else:
+            if payload.shape[2] != max_layer_count:
+                padded_shape = list(payload.shape)
+                padded_shape[2] = max_layer_count
+                padded_payload = torch.zeros(padded_shape, dtype=payload.dtype, device=payload.device)
+                padded_payload[:, :, : payload.shape[2], :].copy_(payload)
+                payload = padded_payload
+            gathered_payloads = [torch.empty_like(payload) for _ in range(world_size)]
+            torch.distributed.all_gather(
+                tensor=payload,
+                tensor_list=gathered_payloads,
+                group=pp_group,
+                async_op=False,
+            )
+            layers_topk_idx_global_list = [
+                tensor[:, :, :layer_count, :].contiguous().view(torch.int16)
+                for tensor, layer_count in zip(gathered_payloads, layer_counts, strict=True)
+            ]
     vp_size = tf_config.virtual_pipeline_model_parallel_size
     if vp_size is not None:
         vpp_router_map_offset = [[] for _ in range(pp_size)]
@@ -749,6 +806,12 @@ class RouterReplayHelper:
 
         num_layers_to_build = get_moe_num_layers_to_build(tf_config, vp_rank)
         router_instances_list = RouterReplay.router_instances[offset : offset + num_layers_to_build]
+        if len(router_instances_list) != num_layers_to_build:
+            raise RuntimeError(
+                "router replay registry does not cover the current PP/VPP stage: "
+                f"registry={len(RouterReplay.router_instances)}, offset={offset}, "
+                f"expected={num_layers_to_build}, actual={len(router_instances_list)}, vp_rank={vp_rank}"
+            )
         return router_instances_list
 
     @staticmethod

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -234,7 +234,13 @@ def _context_parallel_layout(tf_config) -> str:
 
 
 def merge_router_topk_indices(
-    attention_mask, input_ids, mini_layer_topk_idx_list, tf_config, vp_rank=None, local_cp_size=None
+    attention_mask,
+    input_ids,
+    mini_layer_topk_idx_list,
+    tf_config,
+    vp_rank=None,
+    local_cp_size=None,
+    model=None,
 ):
     """
     Merge recorded router top-k indices across sequence-parallel ranks for all router instances,
@@ -250,13 +256,41 @@ def merge_router_topk_indices(
             the current micro-batch.
         vp_rank (Optional[int]): Virtual pipeline stage rank override. If None, the current VP rank from
             Megatron parallel state will be used.
+        model: The forwarded model chunk. When given, routes are collected from its own routers instead
+            of inferring their location in the process-global router registry.
 
     Returns:
         None: The function has side effects only; it appends a tensor of shape
         [1, dynamic_bs_all, layer_num, topk] to mini_layer_topk_idx_list.
     """
     with torch.no_grad():
-        router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
+        vp_rank = 0 if vp_rank is None else vp_rank
+        if model is not None:
+            router_instances_list = [router for _, router in iter_model_routers(model)]
+        else:
+            router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
+
+        if not router_instances_list:
+            raise RuntimeError(
+                "router replay RECORD found no routers in the forwarded model: "
+                f"registry={len(RouterReplay.router_instances)}, "
+                f"pp_rank={mpu.get_pipeline_model_parallel_rank()}, vp_rank={vp_rank}"
+            )
+
+        recorded_local_positions = [
+            idx for idx, router in enumerate(router_instances_list) if router.recorded_topk_idx is not None
+        ]
+        missing = [idx for idx, router in enumerate(router_instances_list) if router.recorded_topk_idx is None]
+        if missing:
+            local_rank_info = get_current_rank_layer_info(tf_config, vp_rank)
+            raise RuntimeError(
+                "router replay RECORD did not capture all local routers: "
+                f"missing_local_positions={missing}, selected={len(router_instances_list)}, "
+                f"registry={len(RouterReplay.router_instances)}, "
+                f"recorded_local_positions={recorded_local_positions}, local_layer_range={local_rank_info}, "
+                f"pp_rank={mpu.get_pipeline_model_parallel_rank()}, vp_rank={vp_rank}"
+            )
+
         layers_topk_idx = []
         for router in router_instances_list:
             layers_topk_idx.append(router.recorded_topk_idx.to(torch.int16))  # dynamic_bs, topk
@@ -279,8 +313,6 @@ def merge_router_topk_indices(
             if getattr(tf_config, "experimental_attention_variant", None) == "dsv4_hybrid"
             else None
         )
-
-        cp_layout = _context_parallel_layout(tf_config)
 
         if input_ids.is_nested:
             batch_size = input_ids.shape[0]
@@ -403,7 +435,11 @@ def set_router_replay_data(
     Returns:
         None: The function updates internal RouterReplay instances in-place.
     """
+    if layers_topk_idx is None:
+        raise RuntimeError("router_replay REPLAY requires routed_experts from the preceding RECORD forward.")
+
     with torch.no_grad():
+        vp_rank = 0 if vp_rank is None else vp_rank
         fp8 = tf_config.fp8
         use_fp8_padding = fp8 in ["e4m3", "hybrid"]
         cp_layout = _context_parallel_layout(tf_config)
@@ -412,8 +448,6 @@ def set_router_replay_data(
             if getattr(tf_config, "experimental_attention_variant", None) == "dsv4_hybrid"
             else None
         )
-
-        cp_layout = _context_parallel_layout(tf_config)
 
         replay_mask_rmpad = None
         if layers_topk_idx.is_nested:
@@ -460,14 +494,27 @@ def set_router_replay_data(
         index_by_layer = len(layers_topk_idx_reshape) == tf_config.num_layers
 
         if model is not None:
-            for layer_number, router in iter_model_routers(model):
+            model_routers = list(iter_model_routers(model))
+            if not model_routers:
+                raise RuntimeError("router_replay REPLAY found no routers in the forwarded model.")
+
+            missing_layer_numbers = []
+            for layer_number, router in model_routers:
                 layer_idx = layer_number - 1
                 idx = layer_idx if index_by_layer else sum(1 for i in range(layer_idx) if is_moe_layer(tf_config, i))
-                if 0 <= idx < layers_topk_idx_reshape.shape[0]:
-                    router.set_target_indices(
-                        layers_topk_idx_reshape[idx].to(torch.int64),
-                        replay_mask=replay_mask_rmpad_split,
-                    )
+                if not 0 <= idx < layers_topk_idx_reshape.shape[0]:
+                    missing_layer_numbers.append(layer_number)
+                    continue
+                router.set_target_indices(
+                    layers_topk_idx_reshape[idx].to(torch.int64),
+                    replay_mask=replay_mask_rmpad_split,
+                )
+            if missing_layer_numbers:
+                raise RuntimeError(
+                    "router_replay REPLAY data does not cover every forwarded MoE layer: "
+                    f"missing_layer_numbers={missing_layer_numbers}, route_layers={layers_topk_idx_reshape.shape[0]}, "
+                    f"vp_rank={vp_rank}"
+                )
             return
 
         local_rank_info = get_current_rank_layer_info(tf_config, vp_rank)
@@ -680,9 +727,8 @@ class RouterReplayHelper:
         Return the list of RouterReplay instances corresponding to the current micro-batch and local
         (pp_rank, vp_stage) layer range.
 
-        When virtual pipeline (VPP) is enabled, the local range for the PP rank is expanded to include
-        all VP stages by multiplying the per-VP count by vp_size. The returned slice is taken from the
-        global RouterReplay.router_instances list.
+        When virtual pipeline (VPP) is enabled, routers for earlier local VP stages precede the
+        current stage in the process-global registry.
 
         Args:
             tf_config: Configuration object used to compute layer assignments.
@@ -691,14 +737,13 @@ class RouterReplayHelper:
         Returns:
             list: A contiguous sublist of RouterReplay.router_instances for the local layer range.
         """
+        if not RouterReplay.router_instances:
+            return []
+
         vp_size = tf_config.virtual_pipeline_model_parallel_size
         if vp_size is not None:
             vp_rank = 0 if vp_rank is None else vp_rank
-            offset = 0
-            for pre_vp_stage in range(vp_size):
-                if pre_vp_stage == vp_rank:
-                    break
-                offset += get_moe_num_layers_to_build(tf_config, pre_vp_stage)
+            offset = sum(get_moe_num_layers_to_build(tf_config, stage) for stage in range(vp_rank))
         else:
             offset = 0
 
@@ -707,36 +752,45 @@ class RouterReplayHelper:
         return router_instances_list
 
     @staticmethod
-    def is_r2_record_action(tf_config, vp_rank=None) -> bool:
+    def _get_action_router_list(tf_config, vp_rank=None, model=None):
+        if model is not None:
+            return [router for _, router in iter_model_routers(model)]
+        return RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
+
+    @staticmethod
+    def is_r2_record_action(tf_config, vp_rank=None, model=None) -> bool:
         """Return True if the current router_replay_action is RECORD (R2) for the local router instances.
 
         This inspects the first local RouterReplay instance's router_replay_action and compares it to
         RouterReplayAction.RECORD.
         """
-        router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
-        return router_instances_list and router_instances_list[0].router_replay_action == RouterReplayAction.RECORD
+        router_instances_list = RouterReplayHelper._get_action_router_list(tf_config, vp_rank, model)
+        return bool(router_instances_list) and (
+            router_instances_list[0].router_replay_action == RouterReplayAction.RECORD
+        )
 
     @staticmethod
-    def is_replay_forward_action(tf_config, vp_rank=None) -> bool:
+    def is_replay_forward_action(tf_config, vp_rank=None, model=None) -> bool:
         """Return True if the current router_replay_action is REPLAY_FORWARD for the local router instances.
 
         This inspects the first local RouterReplay instance's router_replay_action and compares it to
         RouterReplayAction.REPLAY_FORWARD.
         """
-        router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
+        router_instances_list = RouterReplayHelper._get_action_router_list(tf_config, vp_rank, model)
         return (
-            router_instances_list and router_instances_list[0].router_replay_action == RouterReplayAction.REPLAY_FORWARD
+            bool(router_instances_list)
+            and router_instances_list[0].router_replay_action == RouterReplayAction.REPLAY_FORWARD
         )
 
     @staticmethod
-    def is_replay_backward_action(tf_config, vp_rank=None) -> bool:
+    def is_replay_backward_action(tf_config, vp_rank=None, model=None) -> bool:
         """Return True if the current router_replay_action is REPLAY_BACKWARD for the local router instances.
 
         This inspects the first local RouterReplay instance's router_replay_action and compares it to
         RouterReplayAction.REPLAY_BACKWARD.
         """
-        router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
+        router_instances_list = RouterReplayHelper._get_action_router_list(tf_config, vp_rank, model)
         return (
-            router_instances_list
+            bool(router_instances_list)
             and router_instances_list[0].router_replay_action == RouterReplayAction.REPLAY_BACKWARD
         )

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -251,6 +251,58 @@ def get_model(
     return model
 
 
+_HF_CONFIG_CHILD_NAMES = ("text_config", "thinker_config", "model_config", "language_config")
+
+
+def _get_hf_text_config(hf_config: PretrainedConfig):
+    get_text_config = getattr(hf_config, "get_text_config", None)
+    if callable(get_text_config):
+        text_config = get_text_config()
+        if text_config is not None:
+            return text_config
+    return getattr(hf_config, "text_config", None)
+
+
+def _iter_hf_config_tree(hf_config: PretrainedConfig):
+    config_queue = [hf_config]
+    seen = set()
+    while config_queue:
+        config = config_queue.pop(0)
+        if id(config) in seen:
+            continue
+        seen.add(id(config))
+        yield config
+
+        # Prefer the model's canonical text config over multimodal siblings such
+        # as an audio decoder, which may expose conflicting model attributes.
+        text_config = _get_hf_text_config(config)
+        if text_config is not None and text_config is not config:
+            config_queue.append(text_config)
+
+        sub_configs = getattr(type(config), "sub_configs", {}) or {}
+        child_names = list(sub_configs)
+        child_names.extend(name for name in _HF_CONFIG_CHILD_NAMES if name not in child_names)
+        for child_name in child_names:
+            child_config = getattr(config, child_name, None)
+            if child_config is not None and child_config is not text_config:
+                config_queue.append(child_config)
+
+
+def get_hf_config_attr(hf_config: PretrainedConfig, attr_name: str) -> Any:
+    """Find an attribute in a nested Hugging Face model configuration."""
+    text_config = _get_hf_text_config(hf_config)
+    if text_config is not None:
+        value = getattr(text_config, attr_name, None)
+        if value is not None:
+            return value
+
+    for config in _iter_hf_config_tree(hf_config):
+        value = getattr(config, attr_name, None)
+        if value is not None:
+            return value
+    raise AttributeError(f"{type(hf_config).__name__} has no nested {attr_name}.")
+
+
 def get_hf_rope_theta(hf_config: PretrainedConfig) -> float:
     """Return RoPE base frequency theta.
 
@@ -258,24 +310,26 @@ def get_hf_rope_theta(hf_config: PretrainedConfig) -> float:
     ``rope_parameters["rope_theta"]``, optionally nested per attention pattern when ``rope_parameters`` maps names
     to parameter dicts.
     """
-    # For transformers <= 4.57.6
-    if hasattr(hf_config, "rope_theta"):
-        return hf_config.rope_theta
-    if hasattr(hf_config, "text_config") and hasattr(hf_config.text_config, "rope_theta"):
-        return hf_config.text_config.rope_theta
 
-    # For transformers >= 5.0.0, check rope_parameters dict (optionally nested) for rope_theta
-    rp = None
-    if hasattr(hf_config, "rope_parameters"):
-        rp = hf_config.rope_parameters
-    elif hasattr(hf_config, "text_config") and hasattr(hf_config.text_config, "rope_parameters"):
-        rp = hf_config.text_config.rope_parameters
-    if isinstance(rp, dict):
-        if "rope_theta" in rp:
-            return rp["rope_theta"]
-        for v in rp.values():
-            if isinstance(v, dict) and "rope_theta" in v:
-                return v["rope_theta"]
+    def _maybe_get_theta(config: Any) -> float | None:
+        theta = getattr(config, "rope_theta", None)
+        if theta is not None:
+            return theta
+
+        rope_parameters = getattr(config, "rope_parameters", None)
+        if isinstance(rope_parameters, dict):
+            if "rope_theta" in rope_parameters:
+                return rope_parameters["rope_theta"]
+            for value in rope_parameters.values():
+                if isinstance(value, dict) and "rope_theta" in value:
+                    return value["rope_theta"]
+        return None
+
+    for config in _iter_hf_config_tree(hf_config):
+        theta = _maybe_get_theta(config)
+        if theta is not None:
+            return theta
+
     raise AttributeError(
         f"{type(hf_config).__name__} has no rope_theta and no rope_parameters['rope_theta'] — "
         "cannot determine RoPE base."
@@ -325,9 +379,7 @@ def make_megatron_module(
         else:
             from verl.models.mcore.bridge import freeze_moe_router, make_value_model
 
-            hidden_size = (
-                hf_config.text_config.hidden_size if hasattr(hf_config, "text_config") else hf_config.hidden_size
-            )
+            hidden_size = get_hf_config_attr(hf_config, "hidden_size")
             value_model_hook = make_value_model(hidden_size, provider.sequence_parallel)
 
         post_model_creation_callbacks = []

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -251,7 +251,7 @@ def get_model(
     return model
 
 
-_HF_CONFIG_CHILD_NAMES = ("text_config", "thinker_config", "model_config", "language_config")
+_HF_CONFIG_CHILD_NAMES = ("text_config", "language_config", "thinker_config", "model_config")
 
 
 def _get_hf_text_config(hf_config: PretrainedConfig):
@@ -264,28 +264,27 @@ def _get_hf_text_config(hf_config: PretrainedConfig):
 
 
 def _iter_hf_config_tree(hf_config: PretrainedConfig):
-    config_queue = [hf_config]
     seen = set()
-    while config_queue:
-        config = config_queue.pop(0)
-        if id(config) in seen:
-            continue
-        seen.add(id(config))
-        yield config
 
-        # Prefer the model's canonical text config over multimodal siblings such
-        # as an audio decoder, which may expose conflicting model attributes.
+    def _visit(config):
+        if id(config) in seen:
+            return
+        seen.add(id(config))
+
+        # Visit the canonical text config and known language-model wrappers before
+        # the composite root. Never walk arbitrary sub_configs: audio/code2wav
+        # siblings can expose conflicting model attributes.
         text_config = _get_hf_text_config(config)
         if text_config is not None and text_config is not config:
-            config_queue.append(text_config)
+            yield from _visit(text_config)
 
-        sub_configs = getattr(type(config), "sub_configs", {}) or {}
-        child_names = list(sub_configs)
-        child_names.extend(name for name in _HF_CONFIG_CHILD_NAMES if name not in child_names)
-        for child_name in child_names:
+        for child_name in _HF_CONFIG_CHILD_NAMES:
             child_config = getattr(config, child_name, None)
             if child_config is not None and child_config is not text_config:
-                config_queue.append(child_config)
+                yield from _visit(child_config)
+        yield config
+
+    yield from _visit(hf_config)
 
 
 def get_hf_config_attr(hf_config: PretrainedConfig, attr_name: str) -> Any:

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -920,8 +920,17 @@ class MegatronEngine(BaseEngine):
         # compute input shapes for pp stages
         n_micro_batch = len(micro_batches)
 
+        enable_routing_replay = tu.get_non_tensor_data(data, key="enable_routing_replay", default=False)
+        record_r2_routes = (
+            enable_routing_replay
+            and forward_only
+            and self.engine_config.router_replay.mode == "R2"
+            and data.get("routed_experts", None) is None
+        )
+
         for micro_batch in micro_batches:
             tu.assign_non_tensor(micro_batch, num_micro_batch=n_micro_batch)
+            tu.assign_non_tensor(micro_batch, record_r2_routes=record_r2_routes)
             if global_max_seqlen is not None:
                 tu.assign_non_tensor(micro_batch, forced_max_seqlen=global_max_seqlen)
 
@@ -939,14 +948,6 @@ class MegatronEngine(BaseEngine):
             self.forward_step,
             logits_processor_func=loss_function,
             postprocess_micro_batch_func=postprocess_micro_batch_func,
-        )
-
-        enable_routing_replay = tu.get_non_tensor_data(data, key="enable_routing_replay", default=False)
-        record_r2_routes = (
-            enable_routing_replay
-            and forward_only
-            and self.engine_config.router_replay.mode == "R2"
-            and data.get("routed_experts", None) is None
         )
 
         if enable_routing_replay:
@@ -1413,9 +1414,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
             )
 
         # Router replay: record routing decisions for R2 mode
-        if self.enable_routing_replay and RouterReplayHelper.is_r2_record_action(
-            self.tf_config, vp_rank, model=unwrapped_model
-        ):
+        if tu.get_non_tensor_data(batch, key="record_r2_routes", default=False):
             merge_router_topk_indices(
                 attention_mask,
                 input_ids,

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -942,11 +942,17 @@ class MegatronEngine(BaseEngine):
         )
 
         enable_routing_replay = tu.get_non_tensor_data(data, key="enable_routing_replay", default=False)
+        record_r2_routes = (
+            enable_routing_replay
+            and forward_only
+            and self.engine_config.router_replay.mode == "R2"
+            and data.get("routed_experts", None) is None
+        )
 
         if enable_routing_replay:
             # Set to REPLAY mode: for R3 mode or actor update phase in R2 mode
             RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
-            if forward_only and self.engine_config.router_replay.mode == "R2":
+            if record_r2_routes:
                 # In R2 mode, forward_only calls (e.g., compute_log_probs) need to record routing information
                 RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
 
@@ -975,7 +981,9 @@ class MegatronEngine(BaseEngine):
                     losses_reduced[0]["metrics"] = {}
                 losses_reduced[0]["metrics"].update(metrics)
 
-        if RouterReplayHelper.is_r2_record_action(self.tf_config):
+        if record_r2_routes:
+            if not self.mini_layer_topk_idx_list:
+                raise RuntimeError("R2 RECORD completed without capturing any router routes.")
             if self.tf_config.virtual_pipeline_model_parallel_size is not None:
                 # config = self.actor_module[0].module.module.config
                 vp_size = len(self.module)
@@ -1006,7 +1014,7 @@ class MegatronEngine(BaseEngine):
                 )
             else:
                 output = postprocess_batch_func(output_lst=losses_reduced, indices=indices, data=data)
-            if RouterReplayHelper.is_r2_record_action(self.tf_config) and dcp_group is None:
+            if record_r2_routes and dcp_group is None:
                 output["model_output"]["routed_experts"] = layers_topk_idx
         if enable_routing_replay:
             RouterReplay.clear_global_indices()
@@ -1289,21 +1297,27 @@ class MegatronEngineWithLMHead(MegatronEngine):
         else:
             vp_rank = 0
 
-        if RouterReplayHelper.is_replay_backward_action(self.tf_config, vp_rank):
-            router_instance_list = RouterReplayHelper.get_micro_batch_router_list(self.tf_config, vp_rank)
-            for router in router_instance_list:
-                router.set_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+        if self.enable_routing_replay and RouterReplayHelper.is_replay_backward_action(
+            self.tf_config, vp_rank, model=unwrapped_model
+        ):
             set_model_router_replay_action(unwrapped_model, RouterReplayAction.REPLAY_FORWARD)
 
-        if RouterReplayHelper.is_replay_forward_action(self.tf_config, vp_rank):
+        if self.enable_routing_replay and RouterReplayHelper.is_replay_forward_action(
+            self.tf_config, vp_rank, model=unwrapped_model
+        ):
             layers_topk_idx = model_inputs["routed_experts"]
+            if layers_topk_idx is None:
+                raise RuntimeError(
+                    "router_replay REPLAY: micro_batch has no routed_experts. "
+                    "R2 compute_log_prob must record and preserve routes before actor update."
+                )
             replay_mask = None
             if self.engine_config.router_replay.mode == "R3":
                 layers_topk_idx = align_r3_router_replay_data(layers_topk_idx, input_ids)
                 replay_mask = build_r3_replay_mask(input_ids, batch["response_mask"])
             set_router_replay_data(
                 layers_topk_idx,
-                None,
+                attention_mask,
                 self.tf_config,
                 vp_rank,
                 replay_mask=replay_mask,
@@ -1399,16 +1413,23 @@ class MegatronEngineWithLMHead(MegatronEngine):
             )
 
         # Router replay: record routing decisions for R2 mode
-        if RouterReplayHelper.is_r2_record_action(self.tf_config, vp_rank):
+        if self.enable_routing_replay and RouterReplayHelper.is_r2_record_action(
+            self.tf_config, vp_rank, model=unwrapped_model
+        ):
             merge_router_topk_indices(
-                None, input_ids, self.mini_layer_topk_idx_list, self.tf_config, vp_rank, local_cp_size=local_cp_size
+                attention_mask,
+                input_ids,
+                self.mini_layer_topk_idx_list,
+                self.tf_config,
+                vp_rank,
+                local_cp_size=local_cp_size,
+                model=unwrapped_model,
             )
 
         # Router replay: switch to backward replay mode for next backward pass
-        if RouterReplayHelper.is_replay_forward_action(self.tf_config, vp_rank):
-            router_instance_list = RouterReplayHelper.get_micro_batch_router_list(self.tf_config, vp_rank)
-            for router in router_instance_list:
-                router.set_router_replay_action(RouterReplayAction.REPLAY_BACKWARD)
+        if self.enable_routing_replay and RouterReplayHelper.is_replay_forward_action(
+            self.tf_config, vp_rank, model=unwrapped_model
+        ):
             set_model_router_replay_action(unwrapped_model, RouterReplayAction.REPLAY_BACKWARD)
 
         return output, partial(postprocess_micro_batch_func, data=batch, local_cp_size=local_cp_size)


### PR DESCRIPTION
### What does this PR do?

This PR reintroduces the R2 router replay correctness fix from #7106 after addressing the regression that caused it to be reverted by #7786.

The reverted implementation queried the process-global router registry even when router replay was disabled. Normal Megatron SFT and RL jobs therefore failed when the registry was empty.

This version makes router replay explicitly opt-in and scopes RECORD, REPLAY, and action transitions to the routers owned by the currently forwarded model.

### Design and Code Changes

- Guard the complete router replay lifecycle behind the configured replay mode.
- Treat an empty router registry as a no-op when replay is disabled.
- Preserve hard failures when R2 is active but routing data is missing or incomplete.
- Collect recorded routes from the currently forwarded model instead of scanning the process-global registry.
- Apply replay targets and action transitions to the forwarded model's routers.
- Support PP/VPP without shared mutable per-VP router caches.
- Reuse the existing THD preprocess/postprocess padding semantics.
- Reject R2 with `rollout_correction.bypass_mode=True`, since R2 requires the actor old-logprob forward.
- Resolve Megatron attributes from nested multimodal Hugging Face text configs.

The existing `model=None` positional helper path remains available for backward compatibility.

### Regression Addressed

The previous implementation caused replay-disabled Megatron jobs to fail with errors such as:

```text
RuntimeError: cannot map router replay registry to the current PP/VPP stage:
registry=0, ...
```

The corrected implementation does not inspect replay state on the default disabled path.

### Validation

- Focused router replay, THD, nested-config, and model-walk tests: **39 passed**
- Targeted pre-commit checks:
  - ruff
  - ruff-format
  - mypy
  - compileall
  - license and repository structure checks
  - generated trainer configs
- Local pruned replay-disabled fully-async E2E:
  - **1/1 actor update completed**
  - rollout parameter version advanced from `0` to `1`
- 4-node, 32-GPU Qwen3-Omni R2 PP2/VPP2 fully-async E2E:
  - R2 enabled on the actor workers
  - 48 replay layers discovered
  - **1/1 actor update completed**
  - post-update weight synchronization completed
  - rollout parameter version advanced from `0` to `1`
  - process exited successfully

### Relationship to Previous Work

- Supersedes the reverted implementation in #7106.
- Addresses the regression documented by #7786.
- Reuses the forwarded-model router addressing design already merged in #7340.

### Non-goals

- Changing R3 routing semantics.
- Changing Megatron-Core routing or all-to-all kernels.
- Changing rollout-server or weight-transfer behavior.
