### PR TITLE
[algo, trainer, rollout, vllm] feat: add reverse KL top-k with fixed-token prefill scoring

### DIFF
--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -276,7 +276,7 @@ Distillation divergence to use. Default: `"k3"`.
 
 Two registered families:
 
-- **Top-k** (`forward_kl_topk`): forward KL using the teacher's top-k logits.
+- **Top-k** (`forward_kl_topk`, `reverse_kl_topk`): distributional KL losses on a truncated support. `forward_kl_topk` uses the teacher's top-k support. `reverse_kl_topk` uses the rollout student's top-k support and vLLM fixed-token prefill scoring to request teacher logprobs only for that support.
 - **Single-sample KL estimators** (`kl`, `k1`, `abs`, `mse`, `k2`,
   `low_var_kl`, `k3`): per-token Monte Carlo estimators of reverse KL
   computed from the student's `log_probs` and the teacher's single
@@ -286,9 +286,10 @@ Two registered families:
 
 `k` for top-k distillation losses. Default: `32`.
 
-Only used when `loss_mode` requires top-$k$ (e.g. `forward_kl_topk`). Drives both
+Only used when `loss_mode` requires top-$k$. For `forward_kl_topk`, it drives both
 the teacher's `prompt_logprobs` request size and (for vLLM) the engine's
-`max_logprobs` cap.
+`max_logprobs` cap. For `reverse_kl_topk`, it is the rollout student support
+size. The teacher request uses the request-wise union of those token IDs.
 
 ### `distillation.distillation_loss.use_task_rewards` (bool)
 
@@ -665,8 +666,9 @@ rollouts on other samples.
    sampling params with `max_tokens=1` plus `prompt_logprobs=topk` (or `0`),
    so the teacher computes logprobs for the (prompt + response) sequence rather than
    generating new tokens. `topk` is set to `distillation.distillation_loss.topk`
-   when the loss mode requires top-$k$ (e.g. `forward_kl_topk`); otherwise `0`
-   (single-sample logprob only).
+   for `forward_kl_topk` and `0` otherwise (single-sample logprob only).
+   `reverse_kl_topk` instead sends the response-wise student top-k union through
+   vLLM's `prompt_logprob_token_ids`, starting at the last prompt causal row.
 
    **Temperature is always forced to `1.0`** regardless of the configured value.
    `prompt_logprobs` is computed via a forward pass over the existing (prompt + response)
@@ -677,15 +679,19 @@ rollouts on other samples.
    (e.g. 0.7). The manager ignores the configured value and always uses `temperature=1.0`,
    logging a warning if the configured value is not 1.0.
 
+   The sparse `reverse_kl_topk` path currently requires vLLM PR #54335,
+   single-turn text rollouts, and FSDP/VeOmni. SGLang, multi-turn, multimodal,
+   Megatron, and older vLLM versions are not implemented and fail explicitly.
+
 8. **Server-side load balancing.** The manager calls `client.generate(...)`,
    which acquires a backing server through the shared `GlobalRequestLoadBalancer`
    actor.
 
 9. **Backend execution.** With the vLLM backend the selected server is a
    `vLLMHttpServer` actor; its `generate` method runs the forward pass and
-   returns a `TokenOutput` containing `prompt_ids` and `prompt_logprobs` for
-   the full (prompt + response) sequence. The SGLang backend has an analogous
-   server class.
+   returns a `TokenOutput` containing either the regular prompt logprobs or the
+   compact fixed-token suffix matrix in `prompt_token_id_logprobs`. The SGLang
+   backend supports the regular path, but not fixed-token `reverse_kl_topk` yet.
 
 10. **Return path.** `compute_teacher_logprobs_single` packs the response into
     two tensors `teacher_ids` and `teacher_logprobs`, each of shape `(S, 1 or K)`
@@ -709,12 +715,12 @@ Using the `DataProto` produced by the Agent Loop (rollouts + teacher logprobs in
    (`distillation_use_topk=True`), invokes `distillation_ppo_loss` **as a
    logits processor** while the full logits tensor is still in memory; this is
    the `student_logits is not None` branch of `distillation_ppo_loss`. The
-   logits-processor branch dispatches to `compute_forward_kl_topk`, which has a
-   separate implementation per training engine (FSDP and Megatron). Per-token
-   `distillation_losses`, `student_mass`, `teacher_mass`, `overlap_count`, and
-   `overlap_token_advantage` tensors are written back into `model_output` so the
-   full logits can be freed before the final loss step. The overlap tensors are
-   used only for logging.
+   logits-processor branch dispatches to the selected top-$k$ loss, which has a
+   separate implementation per training engine. `reverse_kl_topk` is currently
+   implemented for FSDP/VeOmni only, using the student's top-$k$ support. Per-token
+   `distillation_losses`, `student_mass`, `teacher_mass`, and optional overlap
+   tensors are written back into `model_output` so the full logits can be freed
+   before the final loss step. The overlap tensors are used only for logging.
 
 3. **Final loss.** After the forward, the engine calls the loss function with
    `model_output` (full logits already freed); this is the
@@ -746,7 +752,7 @@ The returned scalar loss is what `engine.train_batch` backpropagates.
 - `verl/experimental/teacher_loop/teacher_model.py` — `MultiTeacherModelManager` and `TeacherModelManager`; spin up teacher inference replicas on the dedicated teacher resource pool and expose per-teacher `LLMServerClient` factories
 - `verl/experimental/teacher_loop/teacher_manager.py` — `AsyncTeacherLLMServerManager`; routes per-sample teacher calls (single- or multi-teacher) and builds teacher sampling params
 - `verl/experimental/agent_loop/agent_loop.py` — `AgentLoopWorker._compute_teacher_logprobs`; per-sample teacher dispatch from `_agent_loop_postprocess`, packs `teacher_logprobs` into the rollout output
-- `verl/trainer/distillation/fsdp/losses.py` — FSDP backend `compute_forward_kl_topk`
+- `verl/trainer/distillation/fsdp/losses.py` — FSDP backend `compute_forward_kl_topk` and `compute_reverse_kl_topk`
 - `verl/trainer/distillation/megatron/losses.py` — Megatron backend `compute_forward_kl_topk`
 - `verl/workers/engine_workers.py` — `ActorRolloutRefWorker.init_model`; binds `distillation_ppo_loss` as the actor's `loss_fn` when distillation is enabled
 - `verl/workers/engine/{fsdp,megatron}/transformer_impl.py` — training-engine forward steps; invoke `distillation_ppo_loss` first as a logits processor (top-$k$ modes) and again as the final loss

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -483,6 +483,7 @@ class AgentLoopWorker:
 
         # Online policy distillation
         self.distillation_enabled = is_distillation_enabled(config.distillation)
+        self.reverse_kl_topk_enabled = False
         if self.distillation_enabled:
             from verl.experimental.teacher_loop.teacher_manager import AsyncTeacherLLMServerManager
 
@@ -491,6 +492,13 @@ class AgentLoopWorker:
                 config=config,
                 teacher_client=teacher_client,
             )
+            self.reverse_kl_topk_enabled = config.distillation.distillation_loss.loss_mode == "reverse_kl_topk"
+            if self.reverse_kl_topk_enabled and self.rollout_config.name != "vllm":
+                raise NotImplementedError("reverse_kl_topk fixed-token scoring is currently implemented for vLLM only.")
+            if self.reverse_kl_topk_enabled and self.rollout_config.multi_turn.enable:
+                raise NotImplementedError(
+                    "reverse_kl_topk fixed-token scoring currently supports single-turn text rollouts only."
+                )
 
         # Load tools once per worker; each trajectory just reuses self.tools.
         tool_config_path = self.rollout_config.multi_turn.tool_config_path
@@ -524,6 +532,14 @@ class AgentLoopWorker:
             trace_config.get("token2text", False),
             trace_config.get("max_samples_per_step_per_worker", None),
         )
+
+    def _generation_logprobs(self, validate: bool) -> bool | int:
+        if self.reverse_kl_topk_enabled and not validate:
+            topk = self.config.distillation.distillation_loss.topk
+            if topk is None or topk <= 0:
+                raise ValueError("reverse_kl_topk requires distillation.distillation_loss.topk > 0.")
+            return int(topk)
+        return self.rollout_config.calculate_log_probs
 
     def _get_mm_processor_kwargs(self, audio_data: Optional[list[Any]] = None) -> dict[str, Any]:
         """Return multimodal processor kwargs with audio sampling-rate defaults."""
@@ -562,7 +578,7 @@ class AgentLoopWorker:
             top_p=config.top_p,
             top_k=config.top_k,
             repetition_penalty=1.0,
-            logprobs=config.calculate_log_probs,
+            logprobs=self._generation_logprobs(validate=validate),
         )
 
         def apply_greedy_sampling_params(params: dict[str, Any]) -> None:
@@ -1014,8 +1030,28 @@ class AgentLoopWorker:
                 if routing_value is not None:
                     # Non-tensor batch values arrive as 0-d numpy objects / arrays; normalize to Python.
                     routing_key = routing_value.item() if hasattr(routing_value, "item") else routing_value
+            student_topk_ids = None
+            if self.reverse_kl_topk_enabled:
+                if output.num_turns != 2 or any(mask != 1 for mask in output.response_mask):
+                    raise NotImplementedError(
+                        "reverse_kl_topk fixed-token scoring currently supports single-turn text rollouts only."
+                    )
+                if output.multi_modal_data:
+                    raise NotImplementedError(
+                        "reverse_kl_topk fixed-token scoring currently supports single-turn text rollouts only."
+                    )
+                student_topk_ids = output.extra_fields.pop("sample_topk_ids", None)
+                if student_topk_ids is None or len(student_topk_ids) != len(response_ids):
+                    raise RuntimeError(
+                        "Missing response-aligned student top-k IDs from the vLLM rollout. "
+                        "Set actor_rollout_ref.rollout.engine_kwargs.vllm.max_logprobs >= "
+                        "distillation.distillation_loss.topk."
+                    )
+
             teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(
                 sequence_ids=prompt_ids + response_ids,
+                prompt_length=len(prompt_ids),
+                student_topk_ids=student_topk_ids,
                 multi_modal_data=output.multi_modal_data,
                 mm_processor_kwargs=output.mm_processor_kwargs,
                 routing_key=routing_key,

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -31,10 +31,14 @@ from verl.workers.rollout.llm_server import LLMServerClient
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
+_MAX_PROMPT_LOGPROB_TOKEN_IDS = 16384
+
 
 def _get_teacher_sampling_params(
     teacher_model_config: DistillationTeacherModelConfig,
     distillation_loss_config: DistillationLossConfig,
+    prompt_length: Optional[int] = None,
+    prompt_logprob_token_ids: Optional[list[int]] = None,
 ) -> dict[str, Any]:
     """Get sampling parameters for teacher model when computing log probabilities for distillation."""
     # Temperature has no effect on prompt_logprobs: the teacher performs a forward pass over
@@ -48,12 +52,103 @@ def _get_teacher_sampling_params(
             "on prompt_logprobs (forward pass only). Using temperature=1.0.",
             teacher_model_config.inference.temperature,
         )
-    num_logprobs = distillation_loss_config.topk if distillation_loss_config.loss_settings.use_topk else 0
+    if distillation_loss_config.loss_mode == "reverse_kl_topk":
+        if prompt_length is None or prompt_length <= 0:
+            raise ValueError("reverse_kl_topk requires a positive prompt length for causal suffix scoring.")
+        if not prompt_logprob_token_ids:
+            raise ValueError("reverse_kl_topk requires non-empty student top-k token IDs.")
+        return {
+            "max_tokens": 1,
+            "temperature": 1.0,
+            "prompt_logprob_token_ids": prompt_logprob_token_ids,
+            "prompt_logprob_start": prompt_length - 1,
+        }
+
+    if not distillation_loss_config.loss_settings.use_topk:
+        num_logprobs = 0
+    else:
+        num_logprobs = distillation_loss_config.topk
     return {
         "max_tokens": 1,
         "temperature": 1.0,
         "prompt_logprobs": num_logprobs,
     }
+
+
+def _prepare_student_topk_ids(
+    student_topk_ids: list[list[int]], response_length: int, topk: int
+) -> tuple[torch.Tensor, list[int]]:
+    support_ids = torch.tensor(student_topk_ids, dtype=torch.int32)
+    expected_shape = (response_length, topk)
+    if tuple(support_ids.shape) != expected_shape:
+        raise ValueError(
+            f"Expected response-aligned student top-k IDs with shape {expected_shape}, got {support_ids.shape}."
+        )
+
+    # Preserve first-seen order while satisfying vLLM's no-duplicates contract.
+    union_ids = list(dict.fromkeys(int(token_id) for token_id in support_ids.flatten().tolist()))
+    if len(union_ids) > _MAX_PROMPT_LOGPROB_TOKEN_IDS:
+        raise ValueError(
+            f"Student top-k union has {len(union_ids)} IDs, exceeding vLLM PR #54335's "
+            f"{_MAX_PROMPT_LOGPROB_TOKEN_IDS}-ID request limit. Reduce topk or response length."
+        )
+    return support_ids, union_ids
+
+
+def _gather_teacher_logprobs(prompt_token_id_logprobs: dict[str, Any], support_ids: torch.Tensor) -> torch.Tensor:
+    fixed_token_ids = [int(token_id) for token_id in prompt_token_id_logprobs["token_ids"]]
+    fixed_logprobs = torch.as_tensor(prompt_token_id_logprobs["logprobs"], dtype=torch.float32)
+    expected_shape = (support_ids.shape[0], len(fixed_token_ids))
+    if tuple(fixed_logprobs.shape) != expected_shape:
+        raise RuntimeError(f"Expected vLLM fixed-token scores with shape {expected_shape}, got {fixed_logprobs.shape}.")
+
+    token_to_column = {token_id: column for column, token_id in enumerate(fixed_token_ids)}
+    try:
+        support_columns = torch.tensor(
+            [[token_to_column[int(token_id)] for token_id in row] for row in support_ids.tolist()],
+            dtype=torch.int64,
+        )
+    except KeyError as exc:
+        raise RuntimeError(f"vLLM fixed-token result is missing requested token ID {exc.args[0]}.") from exc
+    return torch.gather(fixed_logprobs, dim=1, index=support_columns)
+
+
+def _align_response_teacher_outputs(
+    prompt_length: int,
+    support_ids: torch.Tensor,
+    response_logprobs: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Place response scores on the causal source rows used by the training loss."""
+    if prompt_length <= 0:
+        raise ValueError("Teacher output alignment requires a positive prompt length.")
+    if support_ids.shape != response_logprobs.shape:
+        raise ValueError(
+            f"Teacher support IDs and logprobs must have the same shape, got "
+            f"{support_ids.shape} and {response_logprobs.shape}."
+        )
+
+    # no_padding_2_padding left-shifts model outputs: source row i predicts token i + 1.
+    # The first response token is therefore scored at prompt_length - 1. Keep a final
+    # dummy row so the tensors still span the complete prompt + response sequence.
+    prefix_shape = (prompt_length - 1, support_ids.shape[1])
+    dummy_shape = (1, support_ids.shape[1])
+    teacher_ids = torch.cat(
+        (
+            torch.zeros(prefix_shape, dtype=support_ids.dtype),
+            support_ids,
+            torch.zeros(dummy_shape, dtype=support_ids.dtype),
+        ),
+        dim=0,
+    )
+    teacher_logprobs = torch.cat(
+        (
+            torch.zeros(prefix_shape, dtype=response_logprobs.dtype),
+            response_logprobs,
+            torch.zeros(dummy_shape, dtype=response_logprobs.dtype),
+        ),
+        dim=0,
+    )
+    return teacher_ids, teacher_logprobs
 
 
 def _pad_teacher_outputs(
@@ -115,6 +210,8 @@ class AsyncTeacherLLMServerManager:
     async def compute_teacher_logprobs_single(
         self,
         sequence_ids: list[int],
+        prompt_length: Optional[int] = None,
+        student_topk_ids: Optional[list[list[int]]] = None,
         multi_modal_data: Optional[dict[str, Any]] = None,
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
         routing_key: Optional[str] = None,
@@ -124,15 +221,48 @@ class AsyncTeacherLLMServerManager:
         teacher_key = self._resolve_teacher_key(routing_key)
         teacher_model_config = self.teacher_model_configs[teacher_key]
         client = self.teacher_client[teacher_key]
+        support_ids = None
+        prompt_logprob_token_ids = None
+        if self.distillation_loss_config.loss_mode == "reverse_kl_topk":
+            if teacher_model_config.inference.name != "vllm":
+                raise NotImplementedError("reverse_kl_topk fixed-token scoring is currently implemented for vLLM only.")
+            if prompt_length is None or student_topk_ids is None:
+                raise ValueError("reverse_kl_topk requires prompt_length and response-aligned student_topk_ids.")
+            response_length = len(sequence_ids) - prompt_length
+            topk = self.distillation_loss_config.topk
+            if topk is None:
+                raise ValueError("reverse_kl_topk requires distillation_loss.topk.")
+            support_ids, prompt_logprob_token_ids = _prepare_student_topk_ids(
+                student_topk_ids=student_topk_ids,
+                response_length=response_length,
+                topk=topk,
+            )
+
         teacher_output = await client.generate(
             request_id=uuid4().hex,
             prompt_ids=sequence_ids,
-            sampling_params=_get_teacher_sampling_params(teacher_model_config, self.distillation_loss_config),
+            sampling_params=_get_teacher_sampling_params(
+                teacher_model_config,
+                self.distillation_loss_config,
+                prompt_length=prompt_length,
+                prompt_logprob_token_ids=prompt_logprob_token_ids,
+            ),
             image_data=multi_modal_data.get("images"),
             video_data=multi_modal_data.get("videos"),
             audio_data=multi_modal_data.get("audios"),
             mm_processor_kwargs=mm_processor_kwargs,
         )
+        if self.distillation_loss_config.loss_mode == "reverse_kl_topk":
+            prompt_token_id_logprobs = teacher_output.extra_fields.get("prompt_token_id_logprobs")
+            if prompt_token_id_logprobs is None:
+                raise NotImplementedError(
+                    "reverse_kl_topk fixed-token scoring requires the current vLLM PR #54335 API "
+                    "and RequestOutput.prompt_token_id_logprobs."
+                )
+            assert support_ids is not None and prompt_length is not None
+            response_logprobs = _gather_teacher_logprobs(prompt_token_id_logprobs, support_ids)
+            return _align_response_teacher_outputs(prompt_length, support_ids, response_logprobs)
+
         # Shapes: # S, (1 or K), where S is the response length, K is either 1 or topk depending on
         # the distillation loss settings.
         teacher_ids = torch.tensor(teacher_output.extra_fields["prompt_ids"], dtype=torch.int32)

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -23,7 +23,10 @@ distillation_loss:
   # Loss function mode for distillation
   loss_mode: k3
 
-  # If distillation loss requires top-k logits, this is the value of k
+  # If distillation loss requires top-k logits, this is the value of k.
+  # For forward_kl_topk, this is the teacher top-k request/support size.
+  # For reverse_kl_topk, this is the rollout student's top-k support size;
+  # vLLM fixed-token prefill scoring returns teacher logprobs only on that support.
   topk: 32
 
   # Whether to include task rewards alongside distillation loss.

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -72,6 +72,15 @@ def kl_divergence(log_q: torch.Tensor, log_p: torch.Tensor) -> torch.Tensor:
     return kld.sum(dim=-1)
 
 
+def reverse_kl_divergence(log_q: torch.Tensor, log_p: torch.Tensor) -> torch.Tensor:
+    """Compute KL(q || p) from log probabilities on a truncated support."""
+    log_p = log_p.float()
+    log_q = log_q.float()
+    q = log_q.exp()
+    kld = q * (log_q - log_p)
+    return kld.sum(dim=-1)
+
+
 def compute_forward_kl_topk(
     student_logits: torch.Tensor,
     teacher_topk_log_probs: torch.Tensor,
@@ -146,4 +155,61 @@ def compute_forward_kl_topk(
         "teacher_mass": teacher_mass,
         "overlap_count": overlap_count,
         "overlap_token_advantage": overlap_token_advantage,
+    }
+
+
+def compute_reverse_kl_topk(
+    student_logits: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> dict[str, torch.Tensor]:
+    """Compute reverse KL on the rollout student's fixed top-k support."""
+    assert teacher_topk_log_probs.is_nested and teacher_topk_ids.is_nested
+    teacher_topk_log_probs = teacher_topk_log_probs.values().unsqueeze(0)  # (1, total_nnz, topk)
+    teacher_topk_ids = teacher_topk_ids.values().unsqueeze(0)  # (1, total_nnz, topk)
+
+    if get_ulysses_sequence_parallel_world_size() > 1:
+        teacher_topk_log_probs = slice_input_tensor(teacher_topk_log_probs, dim=1)
+        teacher_topk_ids = slice_input_tensor(teacher_topk_ids, dim=1)
+    assert teacher_topk_log_probs.shape[:2] == teacher_topk_ids.shape[:2] == student_logits.shape[:2]
+
+    loss_config: DistillationLossConfig = config.distillation_loss
+    student_topk = loss_config.topk
+    if student_topk is None:
+        raise ValueError("reverse_kl_topk requires distillation_loss.topk.")
+    if teacher_topk_ids.shape[-1] != student_topk:
+        raise ValueError(
+            f"reverse_kl_topk expected {student_topk} support IDs per token, but got {teacher_topk_ids.shape[-1]}."
+        )
+
+    support_ids = teacher_topk_ids.long()
+    if getattr(loss_config, "use_chunked_topk", False):
+        student_topk_log_probs = _chunked_topk_log_probs(
+            student_logits,
+            support_ids,
+            chunk_size=getattr(loss_config, "chunked_topk_chunk_size", 4096),
+        )
+    else:
+        student_log_probs = F.log_softmax(student_logits, dim=-1)
+        student_topk_log_probs = torch.gather(student_log_probs, dim=-1, index=support_ids)
+    teacher_log_probs_on_student_topk = teacher_topk_log_probs
+
+    student_mass = student_topk_log_probs.exp().sum(dim=-1)
+    teacher_mass = teacher_log_probs_on_student_topk.exp().sum(dim=-1)
+
+    if loss_config.log_prob_min_clamp is not None:
+        student_topk_log_probs = student_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
+        teacher_log_probs_on_student_topk = teacher_log_probs_on_student_topk.clamp_min(loss_config.log_prob_min_clamp)
+
+    distillation_losses = reverse_kl_divergence(
+        log_q=student_topk_log_probs,
+        log_p=teacher_log_probs_on_student_topk,
+    )
+
+    return {
+        "distillation_losses": distillation_losses,
+        "student_mass": student_mass,
+        "teacher_mass": teacher_mass,
     }

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -139,11 +139,27 @@ def compute_topk_loss(
         case "fsdp" | "veomni":
             import verl.trainer.distillation.fsdp.losses as fsdp_losses
 
-            distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
+            match distillation_config.distillation_loss.loss_mode:
+                case "forward_kl_topk":
+                    distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
+                case "reverse_kl_topk":
+                    distillation_loss_fn = fsdp_losses.compute_reverse_kl_topk
+                case _:
+                    raise NotImplementedError(
+                        f"Unsupported top-k distillation loss mode: {distillation_config.distillation_loss.loss_mode}"
+                    )
         case "megatron":
             import verl.trainer.distillation.megatron.losses as megatron_losses
 
-            distillation_loss_fn = megatron_losses.compute_forward_kl_topk
+            match distillation_config.distillation_loss.loss_mode:
+                case "forward_kl_topk":
+                    distillation_loss_fn = megatron_losses.compute_forward_kl_topk
+                case "reverse_kl_topk":
+                    distillation_loss_fn = megatron_losses.compute_reverse_kl_topk
+                case _:
+                    raise NotImplementedError(
+                        f"Unsupported top-k distillation loss mode: {distillation_config.distillation_loss.loss_mode}"
+                    )
         case _:
             raise NotImplementedError(f"Unsupported strategy: {config.strategy=}")
 
@@ -302,7 +318,7 @@ def distillation_loss(
     return distillation_loss, distillation_metrics
 
 
-@register_distillation_loss(DistillationLossSettings(names=["forward_kl_topk"], use_topk=True))  # type: ignore[arg-type]
+@register_distillation_loss(DistillationLossSettings(names=["forward_kl_topk", "reverse_kl_topk"], use_topk=True))  # type: ignore[arg-type]
 def compute_forward_kl_topk(
     config: ActorConfig,
     distillation_config: DistillationConfig,

--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -310,3 +310,13 @@ def compute_forward_kl_topk(
         "overlap_count": overlap_count,
         "overlap_token_advantage": overlap_token_advantage,
     }
+
+
+def compute_reverse_kl_topk(
+    student_logits: torch.Tensor,
+    teacher_topk_log_probs: torch.Tensor,
+    teacher_topk_ids: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> dict[str, torch.Tensor]:
+    raise NotImplementedError("reverse_kl_topk is currently implemented for fsdp/veomni only.")

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1341,6 +1341,11 @@ class RayPPOTrainer:
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_loss_mode = (
+            self.distillation_config.distillation_loss.loss_mode
+            if is_distillation_enabled(self.config.get("distillation"))
+            else None
+        )
         distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
         if is_distillation_enabled(self.config.get("distillation")):
             distillation_loss_cfg = self.distillation_config.distillation_loss
@@ -1358,6 +1363,7 @@ class RayPPOTrainer:
             batch_td,
             calculate_entropy=calculate_entropy,
             distillation_use_topk=distillation_use_topk,
+            distillation_loss_mode=distillation_loss_mode,
             distillation_only=distillation_only,
             global_batch_size=ppo_mini_batch_size,
             mini_batch_size=ppo_mini_batch_size,

--- a/verl/trainer/ppo/v1/agent_loop_tq.py
+++ b/verl/trainer/ppo/v1/agent_loop_tq.py
@@ -66,7 +66,7 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             top_p=config.top_p,
             top_k=config.top_k,
             repetition_penalty=1.0,
-            logprobs=config.calculate_log_probs,
+            logprobs=self._generation_logprobs(validate=validate),
         )
 
         # override sampling params for validation

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1743,6 +1743,11 @@ class PPOTrainer(ABC):
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_loss_mode = (
+            self.distillation_config.distillation_loss.loss_mode
+            if is_distillation_enabled(self.config.get("distillation"))
+            else None
+        )
         distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
         if is_distillation_enabled(self.config.get("distillation")):
             distillation_loss_cfg = self.distillation_config.distillation_loss
@@ -1754,6 +1759,7 @@ class PPOTrainer(ABC):
         extra_info = {
             "calculate_entropy": calculate_entropy,
             "distillation_use_topk": distillation_use_topk,
+            "distillation_loss_mode": distillation_loss_mode,
             "distillation_only": distillation_only,
             "global_batch_size": ppo_mini_batch_size,
             "mini_batch_size": ppo_mini_batch_size,

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -49,7 +49,8 @@ class DistillationLossConfig(BaseConfig):
         Whether to incorporate distillation loss as a reward, as done
         by https://thinkingmachines.ai/blog/on-policy-distillation/. Recommended to use loss_mode=k1.
         Otherwise, distillation loss is directly backpropagated as a supervised loss,
-        as in https://arxiv.org/abs/2306.13649. Recommended to use loss_mode=k3 or forward_kl_topk.
+        as in https://arxiv.org/abs/2306.13649. Recommended to use loss_mode=k3, forward_kl_topk, or
+        reverse_kl_topk.
     policy_loss_mode (str):
         Name of the policy loss to use when use_policy_gradient is true.
     clip_ratio (float):
@@ -70,7 +71,7 @@ class DistillationLossConfig(BaseConfig):
     log_prob_min_clamp: Optional[float] = -10.0
 
     # Chunked top-K log-probs (opt-in, avoids [B, T, V] log_softmax buffer
-    # at long context). Only consumed by ``loss_mode='forward_kl_topk'``.
+    # at long context). Consumed by top-k distributional losses.
     # Default ``False`` to preserve short-context performance (chunked path
     # has ~6x time overhead at N=14K, V=152K). Set ``True`` when hitting OOM
     # at long context (>=64K tokens, V=152K) where the baseline path OOMs.
@@ -116,6 +117,12 @@ class DistillationLossConfig(BaseConfig):
                 " token's logprob ∇logπ(a), so the top-k distributional signal (how non-sampled logits "
                 "should move) is largely unused."
             )
+        if self.use_policy_gradient and self.loss_mode == "reverse_kl_topk":
+            raise ValueError(
+                "reverse_kl_topk is a distributional top-k loss and should be used with use_policy_gradient=False."
+            )
+        if self.loss_mode == "reverse_kl_topk" and (self.topk is None or self.topk <= 0):
+            raise ValueError("reverse_kl_topk requires distillation_loss.topk to be a positive integer.")
 
         if not self.use_policy_gradient and self.loss_mode == "k1":
             raise ValueError(
@@ -202,7 +209,7 @@ class DistillationTeacherModelConfig(BaseConfig):
                     max_logprobs = topk
                 if max_logprobs < topk:
                     raise ValueError(
-                        f"VLLM max_logprobs ({max_logprobs}) must be >= distillation_loss topk "
+                        f"VLLM max_logprobs ({max_logprobs}) must be >= requested teacher logprob top-k "
                         f"({topk}) to enable distillation loss computation."
                     )
                 engine_kwargs["vllm"] = vllm_engine_kwargs
@@ -273,9 +280,15 @@ class DistillationConfig(BaseConfig):
         self.teacher_models = self._resolve_teacher_models()
         teacher_world_size_sum = 0
         for teacher_model in self.teacher_models.values():
+            if self.distillation_loss.loss_mode == "reverse_kl_topk" and teacher_model.inference.name != "vllm":
+                raise NotImplementedError(
+                    "reverse_kl_topk fixed-token scoring is currently implemented for vLLM only; "
+                    "SGLang support is not implemented."
+                )
+            teacher_logprob_topk = self.distillation_loss.topk
             teacher_model.validate_and_prepare_for_distillation(
                 use_topk=self.distillation_loss.loss_settings.use_topk,
-                topk=self.distillation_loss.topk,
+                topk=teacher_logprob_topk,
             )
             teacher_world_size_sum += teacher_model.world_size
         total_pool_size = self.n_gpus_per_node * self.nnodes

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -827,6 +827,17 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
         if use_fused_kernels and use_remove_padding:
+            distillation_loss_mode = tu.get_non_tensor_data(
+                data=micro_batch, key="distillation_loss_mode", default=None
+            )
+            distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
+            if distillation_use_topk and distillation_loss_mode is None:
+                raise ValueError("Top-k distillation with fused kernels requires distillation_loss_mode in the batch.")
+            if distillation_loss_mode == "reverse_kl_topk":
+                raise NotImplementedError(
+                    "reverse_kl_topk needs student logits to build the student top-k support. "
+                    "Set actor_rollout_ref.model.use_fused_kernels=False for this loss mode."
+                )
             input_ids_rmpad = model_inputs["input_ids"]
             shift_labels = output_args["input_ids_rmpad_rolled"].unsqueeze(0)
             model_inputs["labels"] = input_ids_rmpad
@@ -837,7 +848,6 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             # chunk_topk_distill_function for fused distillation. TD keys
             # teacher_ids / teacher_logprobs are populated by verl's native
             # distillation pipeline (see verl/trainer/distillation/losses.py).
-            distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
             if distillation_use_topk and "teacher_ids" in micro_batch.keys():
                 if "teacher_logprobs" not in micro_batch.keys():
                     raise ValueError(

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -545,3 +545,47 @@ def extract_prompt_logprobs(output: RequestOutput, num_prompt_logprobs: Optional
 
     result_dict["prompt_ids"] = prompt_ids_ls
     result_dict["prompt_logprobs"] = prompt_logprobs_ls
+
+
+def extract_sample_topk_ids(output: RequestOutput, num_logprobs: Optional[int], result_dict: dict[str, list]):
+    """Extract rank-ordered top-k token IDs for every sampled position."""
+    if num_logprobs is None or num_logprobs <= 0:
+        return
+
+    sample_logprobs = output.outputs[0].logprobs
+    if sample_logprobs is None:
+        raise RuntimeError("vLLM did not return sampled-token logprobs for a top-k request.")
+
+    sample_topk_ids = []
+    for position, logprobs_dict in enumerate(sample_logprobs):
+        topk_ids = [None] * num_logprobs
+        for token_id, token_logprob in logprobs_dict.items():
+            rank = token_logprob.rank
+            if rank is not None and 1 <= rank <= num_logprobs:
+                topk_ids[rank - 1] = int(token_id)
+        if any(token_id is None for token_id in topk_ids):
+            raise RuntimeError(f"vLLM returned an incomplete top-{num_logprobs} set at sampled position {position}.")
+        sample_topk_ids.append(topk_ids)
+
+    result_dict["sample_topk_ids"] = sample_topk_ids
+
+
+def extract_prompt_token_id_logprobs(
+    output: RequestOutput,
+    prompt_logprob_token_ids: Optional[list[int]],
+    result_dict: dict[str, Any],
+):
+    """Expose vLLM PR #54335 fixed-token prefill scores to rollout clients."""
+    if prompt_logprob_token_ids is None:
+        return
+
+    prompt_token_id_logprobs = getattr(output, "prompt_token_id_logprobs", None)
+    if prompt_token_id_logprobs is None:
+        raise NotImplementedError(
+            "Fixed-token prefill scoring requires the current vLLM PR #54335 API "
+            "(RequestOutput.prompt_token_id_logprobs)."
+        )
+    result_dict["prompt_token_id_logprobs"] = {
+        "token_ids": prompt_token_id_logprobs.token_ids,
+        "logprobs": prompt_token_id_logprobs.logprobs,
+    }

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -66,6 +66,8 @@ from verl.workers.rollout.vllm_rollout.utils import (
     build_cli_args_from_config,
     build_mtp_speculative_config,
     extract_prompt_logprobs,
+    extract_prompt_token_id_logprobs,
+    extract_sample_topk_ids,
     get_vllm_max_lora_rank,
 )
 
@@ -596,7 +598,20 @@ class vLLMHttpServer:
         assert 1 <= max_tokens <= max_possible_tokens, (
             f"max_tokens {max_tokens} not in valid range [1, {max_possible_tokens}]"
         )
-        sampling_params["logprobs"] = 0 if sampling_params.pop("logprobs", False) else None
+        requested_logprobs = sampling_params.pop("logprobs", False)
+        if isinstance(requested_logprobs, bool):
+            sampling_params["logprobs"] = 0 if requested_logprobs else None
+        else:
+            sampling_params["logprobs"] = requested_logprobs
+
+        if sampling_params.get("prompt_logprob_token_ids") is not None:
+            supports_fixed_token_input = hasattr(SamplingParams(), "prompt_logprob_token_ids")
+            supports_compact_output = "prompt_token_id_logprobs" in inspect.signature(RequestOutput.__init__).parameters
+            if not supports_fixed_token_input or not supports_compact_output:
+                raise NotImplementedError(
+                    "Fixed-token prefill scoring requires the current vLLM PR #54335 API "
+                    "(SamplingParams.prompt_logprob_token_ids and RequestOutput.prompt_token_id_logprobs)."
+                )
         sampling_params.setdefault("repetition_penalty", self.config.get("repetition_penalty", 1.0))
         sampling_params.setdefault("ignore_eos", self.config.get("ignore_eos", False))
         # Inject per-request seed for deterministic sampling when full_determinism is enabled.
@@ -670,6 +685,16 @@ class vLLMHttpServer:
         extract_prompt_logprobs(
             output=final_res,
             num_prompt_logprobs=sampling_params.prompt_logprobs,
+            result_dict=extra_fields,
+        )
+        extract_prompt_token_id_logprobs(
+            output=final_res,
+            prompt_logprob_token_ids=getattr(sampling_params, "prompt_logprob_token_ids", None),
+            result_dict=extra_fields,
+        )
+        extract_sample_topk_ids(
+            output=final_res,
+            num_logprobs=sampling_params.logprobs,
             result_dict=extra_fields,
         )
         token_ids = final_res.outputs[0].token_ids


### PR DESCRIPTION
### What does this PR do?

This PR adds `reverse_kl_topk` for on-policy distillation using the rollout student's top-k token support.

Instead of transferring full-vocabulary teacher log probabilities, the implementation:

- Collects response-aligned student top-k token IDs during rollout.
- Builds a request-wise union of those token IDs.
- Requests teacher prefill log probabilities only for that fixed token set through vLLM.
- Gathers the returned scores back into the per-token student top-k support.
- Aligns the sparse teacher outputs with the causal source rows consumed by the training loss.
- Computes truncated reverse KL on the student top-k support in the FSDP and VeOmni training paths.
- Supports optional chunking when computing student top-k log probabilities to reduce peak memory usage.

This PR supersedes #7590 and addresses its reviewer feedback by replacing the full-vocabulary teacher payload with fixed-token prefill scoring.

Related to #6676. This PR implements the non-renormalized truncated reverse-KL variant and therefore does not close the renormalized objective proposed in that issue.

> [!IMPORTANT]
> This PR temporarily depends on vLLM PR https://github.com/vllm-project/vllm/pull/54335.
>
> The current implementation was validated against vLLM commit `3f2b51e348190bb3382962a013860516db25bce8`. Until that PR is merged and the corresponding API is available in verl's supported vLLM environment, tests and experiments must use a vLLM wheel built from that exact commit.
>
> Stock vLLM currently does not expose the required fixed-token prefill scoring fields. The verl vLLM adapter performs an explicit feature check and fails with a clear error when the API is unavailable.
>
> Before this PR is merged, the implementation should be synchronized with the final API merged by vLLM PR #54335, and this dependency note should be replaced with the minimum supported vLLM commit or release.

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+reverse+kl+distillation+topk
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Local-only CPU validation tests were run against the clean branch.

The configured pre-commit hooks passed for all files changed by this commit, including Ruff, Ruff format, mypy, configuration generation checks, documentation checks, license checks, device API checks, repository structure checks, and Python compilation.

End-to-end GPU validation used:

- Qwen3-0.6B student.
- Qwen3-1.7B teacher.
- GSM8K.
- vLLM fixed-token prefill scoring from commit `3f2b51e348190bb3382962a013860516db25bce8`.
- VeOmni with PR https://github.com/ByteDance-Seed/VeOmni/pull/806.
- `topk=32`.
- Three actor/rollout GPUs and one teacher GPU.
- W&B online logging.

The Reverse-KL top-k full-training run passed rollout and optimization and advanced beyond 279 training steps in the validated environment without a CPU/GPU OOM or full-vocabulary teacher transfer.

The exact W&B run link and final evaluation metrics will be added before requesting review.

### API and Usage Example

Enable the loss through Hydra configuration:

```bash
python3 -m verl.trainer.main_ppo \
  actor_rollout_ref.rollout.name=vllm \
  actor_rollout_ref.model.use_fused_kernels=False \
  +actor_rollout_ref.rollout.engine_kwargs.vllm.max_logprobs=32 \
  distillation.enabled=True \
  distillation.distillation_loss.loss_mode=reverse_kl_topk \
  distillation.distillation_loss.topk=32 \
  distillation.distillation_loss.use_policy_gradient=False
```

The vLLM environment must contain the fixed-token prefill scoring API from vLLM PR #54335. The implementation currently expects:

```python
SamplingParams.prompt_logprob_token_ids
SamplingParams.prompt_logprob_start
RequestOutput.prompt_token_id_logprobs
```

Current limitations:

- Only vLLM rollout is supported.
- Only single-turn text rollouts are supported.
- SGLang, multi-turn agent loops, and multimodal inputs are rejected explicitly.
- Megatron training is not implemented for `reverse_kl_topk`.
- VeOmni fused kernels must be disabled for this loss mode.

### Design & Code Changes

- Add the `reverse_kl_topk` loss mode and configuration validation.
- Request student top-k token IDs from the rollout engine during training.
- Propagate response-aligned student support through the single-turn agent loop.
- Extend the teacher manager to request fixed-token prefill scores from vLLM.
- Deduplicate student support IDs while preserving first-seen order.
- Gather request-wise teacher scores back into the per-position student top-k support.
- Align teacher tensors with the causal source rows expected by the training loss.
- Add sparse reverse-KL loss support to FSDP and VeOmni workers.
- Add documentation and example configuration for Reverse-KL top-k.
- Fail early with actionable messages for unsupported engines and missing vLLM APIs.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
  - The configured hooks passed on the files changed by this commit; the complete `--all-files` run is still pending.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
  - Local-only CPU tests and GPU experiments were run, but the test files are intentionally not included in this revision.
  - Upstream CI cannot exercise fixed-token prefill scoring until vLLM PR #54335 is available in the CI environment.
- [ ] Once the PR is ready for CI, send a message in [the ci-request channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the verl Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). If unavailable, use the linked Feishu group.
- [x] Not applicable: this PR does not modify the `recipe` submodule.

AI assistance was used to help prepare this PR. Before requesting review, the human submitter will review every changed line and take responsibility for understanding, validating, and defending the change end-to-end.