### PR TITLE
[megatron] feat: fuse linear top-k log probabilities

### DIFF
--- a/tests/models/test_model_forward_fused.py
+++ b/tests/models/test_model_forward_fused.py
@@ -285,6 +285,115 @@ def test_output_processor_preserves_config_logger_payload(monkeypatch):
     assert logged["prefix"] == "input_and_logits"
 
 
+def test_output_processor_routes_topk_distillation_without_materializing_label_logprobs(monkeypatch):
+    hidden_states = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    teacher_ids = torch.tensor([[0, 2], [1, 2]])
+    teacher_logprobs = torch.log(torch.tensor([[0.6, 0.3], [0.5, 0.25]]))
+    student_logprobs = torch.log(torch.tensor([[0.5, 0.2], [0.4, 0.1]]))
+    seen = {}
+
+    def fake_linear_topk_log_probs(hidden, output_weight, topk_ids, temperature, group):
+        seen.update(
+            hidden=hidden,
+            weight=output_weight,
+            topk_ids=topk_ids,
+            temperature=temperature,
+            group=group,
+        )
+        return student_logprobs
+
+    def fail_linear_cross_entropy(*_args, **_kwargs):
+        raise AssertionError("pure top-k distillation must not invoke linear_cross_entropy")
+
+    monkeypatch.setattr(mff, "linear_topk_log_probs", fake_linear_topk_log_probs)
+    monkeypatch.setattr(mff, "linear_cross_entropy", fail_linear_cross_entropy)
+    monkeypatch.setattr(mff.parallel_state, "get_tensor_model_parallel_group", lambda: "tp-group")
+
+    output = mff.fused_output_processor(
+        hidden_states=hidden_states,
+        output_layer=SimpleNamespace(weight=weight),
+        output_weight=None,
+        labels=torch.tensor([1, 2]),
+        context=mff.FusedOutputProcessorContext(
+            temperature=0.8,
+            teacher_topk_ids=teacher_ids,
+            teacher_topk_log_probs=teacher_logprobs,
+            distillation_only=True,
+        ),
+        config=SimpleNamespace(sequence_parallel=False),
+    )
+
+    expected_loss = (teacher_logprobs.exp() * (teacher_logprobs - student_logprobs)).sum(dim=-1)
+    torch.testing.assert_close(output.distillation_losses, expected_loss)
+    torch.testing.assert_close(output.student_mass, student_logprobs.exp().sum(dim=-1))
+    torch.testing.assert_close(output.teacher_mass, teacher_logprobs.exp().sum(dim=-1))
+    assert getattr(output, "log_probs", None) is None
+    assert seen["hidden"] is hidden_states
+    assert seen["weight"] is weight
+    assert seen["topk_ids"] is teacher_ids
+    assert seen["temperature"] == pytest.approx(0.8)
+    assert seen["group"] == "tp-group"
+
+
+def test_engine_hook_packs_and_passes_teacher_topk_context(monkeypatch):
+    input_ids = torch.tensor([[1, 2, 3]])
+    labels = torch.tensor([[1, 2, 3]])
+    teacher_ids = torch.tensor([[[2, 3], [3, 4], [4, 5]]])
+    teacher_logprobs = torch.tensor([[[-0.1, -0.2], [-0.3, -0.4], [-0.5, -0.6]]])
+    packed_teacher_ids = teacher_ids.clone()
+    packed_teacher_logprobs = teacher_logprobs.clone()
+    preprocess_calls = []
+
+    def fake_preprocess(value, **kwargs):
+        preprocess_calls.append((value, kwargs))
+        if value is teacher_ids:
+            return packed_teacher_ids, "packed", None
+        if value is teacher_logprobs:
+            return packed_teacher_logprobs, "packed", None
+        return value, "packed", None
+
+    monkeypatch.setattr(mff, "preprocess_thd_engine", fake_preprocess)
+
+    class Model:
+        pre_process = True
+        post_process = False
+        config = SimpleNamespace(fp8=None, experimental_attention_variant=None)
+
+        def __init__(self):
+            setattr(self, mff._FUSED_FORWARD_MODE_ATTR, mff._HOOK_MODE)
+            self.kwargs = None
+
+        def __call__(self, **kwargs):
+            self.kwargs = kwargs
+            return SimpleNamespace()
+
+    model = Model()
+    mff.fused_forward_model_engine()(
+        model,
+        input_ids,
+        labels,
+        {},
+        1.0,
+        False,
+        0,
+        teacher_topk_ids=teacher_ids,
+        teacher_topk_log_probs=teacher_logprobs,
+        distillation_only=True,
+        log_prob_min_clamp=-10.0,
+    )
+
+    context = model.kwargs["output_processor_context"]
+    assert model.kwargs["output_processor"] is mff.fused_output_processor
+    torch.testing.assert_close(context.teacher_topk_ids, packed_teacher_ids)
+    torch.testing.assert_close(context.teacher_topk_log_probs, packed_teacher_logprobs)
+    assert context.distillation_only is True
+    assert context.log_prob_min_clamp == -10.0
+    teacher_calls = [kwargs for value, kwargs in preprocess_calls if value is teacher_ids or value is teacher_logprobs]
+    assert len(teacher_calls) == 2
+    assert all("need_roll" not in kwargs for kwargs in teacher_calls)
+
+
 @pytest.mark.parametrize(
     ("sequence_parallel", "use_tied_weight"),
     [(True, True), (False, False)],

--- a/tests/utils/test_linear_topk_log_probs.py
+++ b/tests/utils/test_linear_topk_log_probs.py
@@ -1,0 +1,388 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+import gc
+
+import pytest
+import torch
+
+import verl.utils.kernel.linear_topk_log_probs as linear_topk_log_probs_module
+from verl.utils.kernel import topk_log_probs_kernels
+from verl.utils.kernel.linear_topk_log_probs import linear_topk_log_probs
+
+
+def _reference(hidden, weight, topk_ids, temperature):
+    logits = torch.mm(hidden.reshape(-1, hidden.shape[-1]).float(), weight.float().T)
+    log_probs = torch.log_softmax(logits / temperature, dim=-1)
+    selected = torch.gather(log_probs, dim=-1, index=topk_ids.reshape(logits.shape[0], -1).long())
+    return selected.view(topk_ids.shape)
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "vocab_size", "expected"),
+    [
+        (1, 1, 128),
+        (32, 32768, 256),
+        (33, 32768, 512),
+        (1024, 32768, 512),
+        (1025, 32768, 1024),
+        (2048, 129, 256),
+        (32, 151936, 1280),
+    ],
+)
+def test_select_forward_vocab_per_split(num_tokens, vocab_size, expected):
+    assert topk_log_probs_kernels._select_forward_vocab_per_split(num_tokens, vocab_size) == expected
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "vocab_size", "element_size", "expected"),
+    [
+        (1, 1, 2, 1),
+        (32, 32768, 2, 32768),
+        (2048, 32768, 2, 8192),
+        (4096, 32768, 2, 4096),
+        (8192, 32768, 2, 2048),
+        (2048, 32768, 4, 4096),
+        (1 << 20, 32768, 4, 128),
+        (32, 1025, 2, 1025),
+        (4096, 5000, 2, 5000),
+    ],
+)
+def test_select_backward_vocab_per_split(num_tokens, vocab_size, element_size, expected):
+    actual = topk_log_probs_kernels._select_backward_vocab_per_split(num_tokens, vocab_size, element_size)
+    assert actual == expected
+    allocated_bytes = num_tokens * actual * element_size
+    minimum_bytes = num_tokens * min(128, vocab_size) * element_size
+    if actual < vocab_size and minimum_bytes <= topk_log_probs_kernels._TARGET_BACKWARD_DLOGITS_BYTES:
+        assert allocated_bytes <= topk_log_probs_kernels._TARGET_BACKWARD_DLOGITS_BYTES
+    if minimum_bytes <= topk_log_probs_kernels._MAX_BACKWARD_DLOGITS_BYTES:
+        assert allocated_bytes <= topk_log_probs_kernels._MAX_BACKWARD_DLOGITS_BYTES
+
+
+def _assert_forward_backward_close(
+    hidden,
+    weight,
+    topk_ids,
+    temperature,
+    *,
+    forward_atol,
+    forward_rtol,
+    backward_atol,
+    backward_rtol,
+    chunk_size=None,
+):
+    actual = linear_topk_log_probs(hidden, weight, topk_ids, temperature, chunk_size=chunk_size)
+    expected = _reference(hidden, weight, topk_ids, temperature)
+    assert actual.shape == topk_ids.shape
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, expected, atol=forward_atol, rtol=forward_rtol)
+
+    upstream = torch.randn_like(actual)
+    actual_grads = torch.autograd.grad(actual, (hidden, weight), upstream, retain_graph=True)
+    expected_grads = torch.autograd.grad(expected, (hidden, weight), upstream)
+    assert actual_grads[0].dtype == hidden.dtype
+    assert actual_grads[1].dtype == weight.dtype
+    torch.testing.assert_close(actual_grads[0], expected_grads[0], atol=backward_atol, rtol=backward_rtol)
+    torch.testing.assert_close(actual_grads[1], expected_grads[1], atol=backward_atol, rtol=backward_rtol)
+
+
+@pytest.mark.parametrize(
+    ("hidden_shape", "ids_shape", "vocab_size", "temperature", "chunk_size"),
+    [
+        ((1, 1), (1, 1), 1, 0.1, 1),
+        ((7, 16), (7, 3), 31, 0.73, 2),
+        ((2, 5, 16), (2, 5, 4), 31, 4.0, 3),
+        ((5, 33), (5, 9), 1025, 1.0, 1),
+    ],
+)
+def test_linear_topk_log_probs_forward_and_backward_matches_reference(
+    hidden_shape, ids_shape, vocab_size, temperature, chunk_size
+):
+    torch.manual_seed(1234)
+    hidden = torch.randn(hidden_shape, dtype=torch.float32, requires_grad=True)
+    weight = torch.randn(vocab_size, hidden_shape[-1], dtype=torch.float32, requires_grad=True)
+    topk_ids = torch.randint(0, weight.shape[0], ids_shape)
+    # Exercise duplicate IDs: their upstream gradients must accumulate.
+    if topk_ids.shape[-1] > 1:
+        topk_ids[..., -1] = topk_ids[..., 0]
+
+    _assert_forward_backward_close(
+        hidden,
+        weight,
+        topk_ids,
+        temperature,
+        forward_atol=2e-5,
+        forward_rtol=2e-5,
+        backward_atol=4e-5,
+        backward_rtol=4e-5,
+        chunk_size=chunk_size,
+    )
+
+
+def test_linear_topk_log_probs_cpu_is_stable_for_large_logits():
+    torch.manual_seed(2345)
+    hidden = (torch.randn(4, 17) * 50).requires_grad_()
+    weight = (torch.randn(67, 17) * 50).requires_grad_()
+    ids = torch.tensor([[0, 66, 33], [1, 1, 65], [2, 40, 3], [66, 0, 66]])
+    actual = linear_topk_log_probs(hidden, weight, ids, 0.25, chunk_size=2)
+    expected = _reference(hidden, weight, ids, 0.25)
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-6)
+
+
+def test_linear_topk_log_probs_accepts_noncontiguous_inputs():
+    torch.manual_seed(3456)
+    hidden = torch.randn(19, 6).T.requires_grad_()
+    weight = torch.randn(19, 43).T.requires_grad_()
+    ids = torch.randint(0, 43, (6, 10))[:, ::2]
+    assert not hidden.is_contiguous()
+    assert not weight.is_contiguous()
+    assert not ids.is_contiguous()
+    _assert_forward_backward_close(
+        hidden,
+        weight,
+        ids,
+        1.7,
+        forward_atol=2e-5,
+        forward_rtol=2e-5,
+        backward_atol=4e-5,
+        backward_rtol=4e-5,
+        chunk_size=2,
+    )
+
+
+def test_linear_topk_log_probs_accepts_int32_ids():
+    torch.manual_seed(3567)
+    hidden = torch.randn(3, 8, requires_grad=True)
+    weight = torch.randn(17, 8, requires_grad=True)
+    ids = torch.tensor([[0, 16], [8, 8], [3, 12]], dtype=torch.int32)
+    actual = linear_topk_log_probs(hidden, weight, ids, 1.0)
+    expected = _reference(hidden, weight, ids, 1.0)
+    torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "match"),
+    [
+        ({"temperature": 0.0}, ValueError, "temperature must be positive"),
+        ({"temperature": -1.0}, ValueError, "temperature must be positive"),
+        ({"temperature": 1}, TypeError, "temperature must be a float"),
+        ({"chunk_size": 0}, ValueError, "chunk_size must be positive"),
+    ],
+)
+def test_linear_topk_log_probs_rejects_invalid_temperature(kwargs, error, match):
+    with pytest.raises(error, match=match):
+        linear_topk_log_probs(torch.randn(2, 4), torch.randn(7, 4), torch.ones(2, 1, dtype=torch.long), **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("hidden", "weight", "ids", "error", "match"),
+    [
+        (torch.empty(0, 4), torch.randn(7, 4), torch.empty(0, 1, dtype=torch.long), ValueError, "at least one token"),
+        (torch.randn(2, 4), torch.empty(0, 4), torch.zeros(2, 1, dtype=torch.long), ValueError, "vocabulary row"),
+        (
+            torch.randn(2, 4),
+            torch.randn(7, 4),
+            torch.empty(2, 0, dtype=torch.long),
+            ValueError,
+            "at least one selected",
+        ),
+        (
+            torch.ones(2, 4, dtype=torch.long),
+            torch.ones(7, 4, dtype=torch.long),
+            torch.zeros(2, 1, dtype=torch.long),
+            TypeError,
+            "floating-point",
+        ),
+        (
+            torch.randn(2, 4, dtype=torch.float32),
+            torch.randn(7, 4, dtype=torch.float64),
+            torch.zeros(2, 1, dtype=torch.long),
+            ValueError,
+            "same dtype",
+        ),
+        (torch.randn(2, 4), torch.randn(7, 5), torch.zeros(2, 1, dtype=torch.long), ValueError, "hidden size mismatch"),
+        (torch.randn(2, 4), torch.randn(7, 4), torch.zeros(3, 1, dtype=torch.long), ValueError, "token count mismatch"),
+        (torch.randn(2, 4), torch.randn(7, 4), torch.zeros(2, 1), TypeError, "int32 or int64"),
+        (torch.randn(2, 4), torch.randn(7, 4), torch.full((2, 1), 7), ValueError, "must be in"),
+        (torch.randn(2, 4), torch.randn(7, 4), torch.full((2, 1), -1), ValueError, "must be in"),
+    ],
+)
+def test_linear_topk_log_probs_rejects_invalid_inputs(hidden, weight, ids, error, match):
+    with pytest.raises(error, match=match):
+        linear_topk_log_probs(hidden, weight, ids, 1.0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_linear_topk_log_probs_bfloat16_cuda_matches_reference(monkeypatch):
+    torch.manual_seed(4321)
+    hidden = torch.randn(29, 130, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(1057, 130, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    topk_ids = torch.randint(0, weight.shape[0], (29, 16), device="cuda")
+    temperature = 1.2
+    assert topk_log_probs_kernels.can_use_triton(hidden, topk_ids.shape[-1])
+
+    def fail_fallback(*_args, **_kwargs):
+        raise AssertionError("CUDA test must execute the Triton path")
+
+    monkeypatch.setattr(linear_topk_log_probs_module, "_linear_fp32", fail_fallback)
+
+    _assert_forward_backward_close(
+        hidden,
+        weight,
+        topk_ids,
+        temperature,
+        forward_atol=2e-2,
+        forward_rtol=2e-3,
+        backward_atol=6e-2,
+        backward_rtol=8e-3,
+        chunk_size=7,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_linear_topk_log_probs_cuda_does_not_call_tensor_item(monkeypatch):
+    """CUDA input validation must not introduce a GPU-to-CPU synchronization."""
+    torch.manual_seed(4432)
+    hidden = torch.randn(5, 32, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(129, 32, device="cuda", dtype=torch.bfloat16)
+    ids = torch.randint(0, 129, (5, 8), device="cuda")
+    original_item = torch.Tensor.item
+
+    def reject_cuda_item(tensor, *args, **kwargs):
+        if tensor.is_cuda:
+            raise AssertionError("linear_topk_log_probs called Tensor.item() on a CUDA tensor")
+        return original_item(tensor, *args, **kwargs)
+
+    with monkeypatch.context() as patch_context:
+        patch_context.setattr(torch.Tensor, "item", reject_cuda_item)
+        output = linear_topk_log_probs(hidden, weight, ids, 1.0)
+        torch.cuda.synchronize()
+
+    expected = _reference(hidden, weight, ids, 1.0)
+    torch.testing.assert_close(output, expected, atol=2e-2, rtol=2e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    ("dtype", "num_tokens", "hidden_size", "vocab_size", "topk", "temperature"),
+    [
+        (torch.float32, 1, 31, 1, 1, 0.5),
+        (torch.float32, 33, 65, 1025, 7, 2.0),
+        (torch.float16, 9, 127, 513, 8, 0.9),
+        (torch.bfloat16, 37, 130, 2051, 16, 1.2),
+        (torch.bfloat16, 8, 256, 257, 32, 0.73),
+        (torch.bfloat16, 1025, 32, 2051, 8, 1.0),
+        (torch.bfloat16, 33, 65, 8201, 16, 1.1),
+        (torch.bfloat16, 4096, 17, 5000, 16, 0.8),
+    ],
+)
+def test_linear_topk_log_probs_triton_shape_matrix(
+    monkeypatch, dtype, num_tokens, hidden_size, vocab_size, topk, temperature
+):
+    torch.manual_seed(4567 + num_tokens + vocab_size)
+    hidden = torch.randn(num_tokens, hidden_size, device="cuda", dtype=dtype, requires_grad=True)
+    weight = torch.randn(vocab_size, hidden_size, device="cuda", dtype=dtype, requires_grad=True)
+    topk_ids = torch.randint(0, vocab_size, (num_tokens, topk), device="cuda")
+    boundary_ids = [0, vocab_size - 1]
+    boundary_ids += [
+        value
+        for value in (127, 128, 255, 256, 511, 512, 1023, 1024, 2047, 2048, 4095, 4096, 8191, 8192)
+        if value < vocab_size
+    ]
+    topk_ids[0, : min(topk, len(boundary_ids))] = torch.tensor(boundary_ids[:topk], device="cuda")
+    if topk > 1:
+        topk_ids[:, -1] = topk_ids[:, 0]
+
+    def fail_fallback(*_args, **_kwargs):
+        raise AssertionError("shape-matrix case must execute the Triton path")
+
+    monkeypatch.setattr(linear_topk_log_probs_module, "_linear_fp32", fail_fallback)
+    if dtype == torch.float32:
+        tolerances = dict(forward_atol=8e-4, forward_rtol=8e-4, backward_atol=2e-3, backward_rtol=2e-3)
+    else:
+        tolerances = dict(forward_atol=3e-2, forward_rtol=3e-3, backward_atol=8e-2, backward_rtol=1e-2)
+    _assert_forward_backward_close(hidden, weight, topk_ids, temperature, **tolerances)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_linear_topk_log_probs_triton_supports_maximum_topk(monkeypatch):
+    torch.manual_seed(5670)
+    hidden = torch.randn(2, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(129, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    ids = torch.arange(128, device="cuda").expand(2, -1).contiguous()
+    assert topk_log_probs_kernels.can_use_triton(hidden, 128)
+
+    def fail_fallback(*_args, **_kwargs):
+        raise AssertionError("topk=128 must execute the Triton path")
+
+    monkeypatch.setattr(linear_topk_log_probs_module, "_linear_fp32", fail_fallback)
+    _assert_forward_backward_close(
+        hidden,
+        weight,
+        ids,
+        1.0,
+        forward_atol=2e-2,
+        forward_rtol=2e-3,
+        backward_atol=8e-2,
+        backward_rtol=1e-2,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_linear_topk_log_probs_topk_above_triton_limit_uses_fallback(monkeypatch):
+    torch.manual_seed(5671)
+    hidden = torch.randn(3, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    weight = torch.randn(257, 32, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    ids = torch.randint(0, 257, (3, 129), device="cuda")
+    assert not topk_log_probs_kernels.can_use_triton(hidden, 129)
+
+    def fail_triton(*_args, **_kwargs):
+        raise AssertionError("topk=129 must use the bounded PyTorch fallback")
+
+    monkeypatch.setattr(topk_log_probs_kernels, "topk_log_probs_forward", fail_triton)
+    _assert_forward_backward_close(
+        hidden,
+        weight,
+        ids,
+        1.3,
+        forward_atol=2e-2,
+        forward_rtol=2e-3,
+        backward_atol=6e-2,
+        backward_rtol=8e-3,
+        chunk_size=1,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_linear_topk_log_probs_forward_uses_less_peak_memory_than_full_logits():
+    torch.manual_seed(5678)
+    hidden = torch.randn(1024, 256, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(32768, 256, device="cuda", dtype=torch.bfloat16)
+    topk_ids = torch.randint(0, weight.shape[0], (1024, 16), device="cuda")
+
+    def measure(callable_):
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        baseline = torch.cuda.memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
+        result = callable_()
+        torch.cuda.synchronize()
+        peak_delta = torch.cuda.max_memory_allocated() - baseline
+        del result
+        return peak_delta
+
+    fused_peak = measure(lambda: linear_topk_log_probs(hidden, weight, topk_ids, 1.0, chunk_size=32))
+    reference_peak = measure(lambda: _reference(hidden, weight, topk_ids, 1.0))
+    print(f"Triton peak={fused_peak / 2**20:.1f} MiB, full-logits peak={reference_peak / 2**20:.1f} MiB")
+
+    assert fused_peak < reference_peak * 0.5, (
+        f"expected chunked operator to use less than half the full-logits peak; "
+        f"chunked={fused_peak / 2**20:.1f} MiB, full={reference_peak / 2**20:.1f} MiB"
+    )

--- a/tests/utils/test_special_linear_topk_log_probs_e2e.py
+++ b/tests/utils/test_special_linear_topk_log_probs_e2e.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""End-to-end GPU test for fused Megatron top-k distillation.
+
+This test deliberately keeps only the transformer body synthetic. Everything
+after its hidden states is real: jagged THD packing, the Megatron output hook,
+the Triton selected-log-probability operator, distillation outputs, THD
+unpacking, and autograd backward.
+
+Run with ``torchrun --standalone --nproc-per-node=<tp-size>`` for TP1--TP4.
+"""
+
+import os
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+from megatron.core import parallel_state
+
+from verl.models.mcore import model_forward_fused as mff
+
+
+def _nested(values: torch.Tensor, lengths: list[int]) -> torch.Tensor:
+    offsets = torch.tensor([0, *torch.tensor(lengths).cumsum(0).tolist()], device=values.device)
+    return torch.nested.nested_tensor_from_jagged(values, offsets=offsets)
+
+
+class _MinimalHookModel:
+    """A minimal transformer-body stand-in that invokes Megatron's real hook."""
+
+    pre_process = True
+    post_process = True
+
+    def __init__(self, embedding: torch.nn.Parameter, output_weight: torch.nn.Parameter):
+        self.embedding = embedding
+        self.output_layer = SimpleNamespace(weight=output_weight)
+        self.config = SimpleNamespace(
+            fp8=None,
+            experimental_attention_variant=None,
+            csa_window_size=None,
+            sequence_parallel=False,
+        )
+        setattr(self, mff._FUSED_FORWARD_MODE_ATTR, mff._HOOK_MODE)
+        self.saw_full_logits = False
+
+    def __call__(
+        self,
+        *,
+        input_ids,
+        attention_mask,
+        position_ids,
+        packed_seq_params,
+        labels,
+        output_processor,
+        output_processor_context,
+        **kwargs,
+    ):
+        del attention_mask, position_ids, packed_seq_params, kwargs
+        hidden_states = torch.nn.functional.embedding(input_ids, self.embedding)
+        output = output_processor(
+            hidden_states=hidden_states,
+            output_layer=self.output_layer,
+            output_weight=None,
+            labels=labels,
+            context=output_processor_context,
+            config=self.config,
+            input_ids=input_ids,
+        )
+        self.saw_full_logits = output.logits is not None
+        return output
+
+
+def _build_inputs(device: torch.device, world_size: int, local_vocab_size: int, topk: int):
+    lengths = [5, 3, 7]
+    num_tokens = sum(lengths)
+    global_vocab_size = local_vocab_size * world_size
+    generator = torch.Generator().manual_seed(20260908 + world_size)
+
+    input_values = torch.randint(0, 97, (num_tokens,), generator=generator).to(device)
+    teacher_ids = torch.randint(
+        0,
+        global_vocab_size,
+        (num_tokens, topk),
+        generator=generator,
+    ).to(device)
+    shard_boundaries = []
+    for shard in range(world_size):
+        shard_boundaries.extend([shard * local_vocab_size, (shard + 1) * local_vocab_size - 1])
+    shard_boundaries = list(dict.fromkeys(shard_boundaries))
+    count = min(topk, len(shard_boundaries))
+    teacher_ids[0, :count] = torch.tensor(shard_boundaries[:count], device=device)
+    teacher_ids[1, -1] = teacher_ids[1, 0]
+
+    # Use a sub-probability distribution to match real teacher top-k mass.
+    teacher_scores = torch.randn(num_tokens, topk, generator=generator)
+    teacher_log_probs = (torch.log_softmax(teacher_scores, dim=-1) + torch.log(torch.tensor(0.85))).to(device)
+    return (
+        lengths,
+        input_values,
+        teacher_ids,
+        teacher_log_probs,
+        _nested(input_values, lengths),
+        _nested(teacher_ids, lengths),
+        _nested(teacher_log_probs, lengths),
+    )
+
+
+def _reference_outputs(hidden, full_weight, teacher_ids, teacher_log_probs, temperature, clamp):
+    logits = torch.mm(hidden.float(), full_weight.float().T) / temperature
+    student_log_probs = torch.gather(torch.log_softmax(logits, dim=-1), -1, teacher_ids.long())
+    student_mass = student_log_probs.exp().sum(dim=-1)
+    teacher_mass = teacher_log_probs.float().exp().sum(dim=-1)
+    student_for_loss = student_log_probs.clamp_min(clamp)
+    teacher_for_loss = teacher_log_probs.float().clamp_min(clamp)
+    losses = (teacher_for_loss.exp() * (teacher_for_loss - student_for_loss)).sum(dim=-1)
+    return losses, student_mass, teacher_mass
+
+
+def main():
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    if not 1 <= world_size <= 4:
+        raise RuntimeError(f"this test supports TP1 through TP4, got TP{world_size}")
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    parallel_state.initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    hidden_size = 130
+    local_vocab_size = 1025
+    topk = 16
+    temperature = 1.2
+    clamp = -10.0
+    try:
+        (
+            lengths,
+            input_values,
+            teacher_ids,
+            teacher_log_probs,
+            input_nested,
+            teacher_ids_nested,
+            teacher_log_probs_nested,
+        ) = _build_inputs(device, world_size, local_vocab_size, topk)
+
+        parameter_generator = torch.Generator().manual_seed(31000)
+        embedding_seed = (torch.randn(97, hidden_size, generator=parameter_generator, dtype=torch.bfloat16) * 0.2).to(
+            device
+        )
+        torch.manual_seed(32000 + rank)
+        local_weight_seed = (
+            torch.randn(
+                local_vocab_size,
+                hidden_size,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            * 0.2
+        )
+        gathered_weights = [torch.empty_like(local_weight_seed) for _ in range(world_size)]
+        dist.all_gather(gathered_weights, local_weight_seed)
+        full_weight_seed = torch.cat(gathered_weights, dim=0)
+
+        embedding_actual = torch.nn.Parameter(embedding_seed.detach().clone())
+        weight_actual = torch.nn.Parameter(local_weight_seed.detach().clone())
+        model = _MinimalHookModel(embedding_actual, weight_actual)
+
+        fused_forward = mff.fused_forward_model_engine()
+        actual = fused_forward(
+            model=model,
+            input_ids=input_nested,
+            labels=input_nested,
+            multi_modal_inputs={},
+            temperature=temperature,
+            calculate_entropy=False,
+            pad_token_id=0,
+            teacher_topk_ids=teacher_ids_nested,
+            teacher_topk_log_probs=teacher_log_probs_nested,
+            distillation_only=True,
+            log_prob_min_clamp=clamp,
+        )
+
+        assert set(actual) == {"distillation_losses", "student_mass", "teacher_mass"}
+        assert not model.saw_full_logits
+        for value in actual.values():
+            assert value.is_nested
+            assert value.offsets().diff().tolist() == lengths
+
+        embedding_expected = embedding_seed.detach().float().requires_grad_()
+        weight_expected = full_weight_seed.detach().float().requires_grad_()
+        hidden_expected = torch.nn.functional.embedding(input_values, embedding_expected)
+        expected_loss, expected_student_mass, expected_teacher_mass = _reference_outputs(
+            hidden_expected,
+            weight_expected,
+            teacher_ids,
+            teacher_log_probs,
+            temperature,
+            clamp,
+        )
+
+        actual_losses = actual["distillation_losses"].values()
+        actual_student_mass = actual["student_mass"].values()
+        actual_teacher_mass = actual["teacher_mass"].values()
+        torch.testing.assert_close(actual_losses, expected_loss, atol=3e-2, rtol=4e-3)
+        torch.testing.assert_close(actual_student_mass, expected_student_mass, atol=2e-3, rtol=5e-3)
+        torch.testing.assert_close(actual_teacher_mass, expected_teacher_mass, atol=2e-5, rtol=2e-5)
+
+        actual_losses.sum().backward()
+        expected_loss.sum().backward()
+        dist.all_reduce(embedding_actual.grad, op=dist.ReduceOp.SUM)
+        weight_start = rank * local_vocab_size
+        weight_end = weight_start + local_vocab_size
+        torch.testing.assert_close(
+            embedding_actual.grad.float(),
+            embedding_expected.grad,
+            atol=8e-2,
+            rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            weight_actual.grad.float(),
+            weight_expected.grad[weight_start:weight_end],
+            atol=8e-2,
+            rtol=1e-2,
+        )
+
+        if rank == 0:
+            print(
+                f"[PASS] E2E TP{world_size}: nested input -> THD pack -> model hook -> "
+                "Triton top-k -> distillation loss -> THD unpack -> backward"
+            )
+    finally:
+        parallel_state.destroy_model_parallel()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/utils/test_special_linear_topk_log_probs_tp.py
+++ b/tests/utils/test_special_linear_topk_log_probs_tp.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Multi-GPU tensor-parallel correctness test for ``linear_topk_log_probs``.
+
+Run with:
+    torchrun --standalone --nnodes=1 --nproc-per-node=<tp-size> \
+        tests/utils/test_special_linear_topk_log_probs_tp.py
+"""
+
+import os
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+
+from verl.utils.kernel.linear_topk_log_probs import linear_topk_log_probs
+
+
+def _run_case(device, rank, world_size, case_index, config):
+    dtype, num_tokens, hidden_size, local_vocab_size, topk, temperature = config
+    torch.manual_seed(9000 + case_index * 100 + rank)
+
+    hidden_seed = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+    dist.broadcast(hidden_seed, src=0)
+    topk_ids = torch.randint(0, local_vocab_size * world_size, (num_tokens, topk), device=device)
+    if rank == 0:
+        # Touch both ends of every vocabulary shard. This catches off-by-one
+        # errors in global-id ownership for TP2, TP3, and TP4.
+        boundary_ids = []
+        for shard in range(world_size):
+            boundary_ids.extend([shard * local_vocab_size, (shard + 1) * local_vocab_size - 1])
+        boundary_ids.extend(value for value in (1023, 1024) if value < local_vocab_size * world_size)
+        boundary_ids = list(dict.fromkeys(boundary_ids))
+        count = min(topk, len(boundary_ids))
+        topk_ids[0, :count] = torch.tensor(boundary_ids[:count], device=device)
+        if topk > 1 and num_tokens > 1:
+            # Keep row 0 for shard-boundary coverage and use row 1 to verify
+            # that duplicate selected ids accumulate their gradients.
+            topk_ids[1, -1] = topk_ids[1, 0]
+    dist.broadcast(topk_ids, src=0)
+
+    local_weight = torch.randn(local_vocab_size, hidden_size, device=device, dtype=dtype)
+    gathered_weights = [torch.empty_like(local_weight) for _ in range(world_size)]
+    dist.all_gather(gathered_weights, local_weight)
+    full_weight_seed = torch.cat(gathered_weights, dim=0)
+
+    hidden_actual = hidden_seed.detach().clone().requires_grad_()
+    weight_actual = local_weight.detach().clone().requires_grad_()
+    # FP32 reference makes BF16 error attributable to kernel arithmetic rather
+    # than to an additional low-precision reference operation.
+    hidden_expected = hidden_seed.detach().float().requires_grad_()
+    weight_expected = full_weight_seed.detach().float().requires_grad_()
+
+    real_all_reduce = dist.all_reduce
+    forward_collectives = []
+
+    def record_all_reduce(tensor, op=dist.ReduceOp.SUM, group=None, async_op=False):
+        forward_collectives.append((op, tuple(tensor.shape)))
+        return real_all_reduce(tensor, op=op, group=group, async_op=async_op)
+
+    with patch.object(dist, "all_reduce", side_effect=record_all_reduce):
+        actual = linear_topk_log_probs(
+            hidden_actual,
+            weight_actual,
+            topk_ids,
+            temperature,
+            dist.group.WORLD,
+            chunk_size=5,
+        )
+    assert forward_collectives == [
+        (dist.ReduceOp.MAX, (num_tokens,)),
+        (dist.ReduceOp.SUM, (num_tokens, topk + 1)),
+    ]
+    logits = torch.mm(hidden_expected, weight_expected.T) / temperature
+    expected = torch.gather(torch.log_softmax(logits, dim=-1), dim=-1, index=topk_ids)
+    if dtype == torch.float32:
+        forward_tolerances = dict(atol=8e-4, rtol=8e-4)
+        backward_tolerances = dict(atol=2e-3, rtol=2e-3)
+    else:
+        forward_tolerances = dict(atol=3e-2, rtol=3e-3)
+        backward_tolerances = dict(atol=8e-2, rtol=1e-2)
+    torch.testing.assert_close(actual, expected, **forward_tolerances)
+
+    upstream = torch.randn_like(actual) if rank == 0 else torch.empty_like(actual)
+    dist.broadcast(upstream, src=0)
+    actual_hidden_grad, actual_weight_grad = torch.autograd.grad(
+        actual,
+        (hidden_actual, weight_actual),
+        upstream,
+    )
+    expected_hidden_grad, expected_weight_grad = torch.autograd.grad(
+        expected,
+        (hidden_expected, weight_expected),
+        upstream,
+    )
+
+    # The operator follows LinearCrossEntropy's contract: each TP rank returns
+    # its local hidden-gradient contribution and the caller performs the sum.
+    dist.all_reduce(actual_hidden_grad, op=dist.ReduceOp.SUM)
+    expected_local_weight_grad = expected_weight_grad[rank * local_vocab_size : (rank + 1) * local_vocab_size]
+    torch.testing.assert_close(actual_hidden_grad.float(), expected_hidden_grad, **backward_tolerances)
+    torch.testing.assert_close(actual_weight_grad.float(), expected_local_weight_grad, **backward_tolerances)
+    if rank == 0:
+        print(
+            f"[PASS] TP case {case_index}: dtype={dtype}, tokens={num_tokens}, "
+            f"hidden={hidden_size}, local_vocab={local_vocab_size}, topk={topk}, T={temperature}"
+        )
+
+
+def main():
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    if world_size < 2:
+        raise RuntimeError(f"this test requires at least two ranks, got {world_size}")
+
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    cases = [
+        (torch.float32, 1, 31, 1, 1, 0.5),
+        (torch.float32, 23, 64, 37, 8, 0.81),
+        (torch.float32, 33, 65, 1025, 8, 2.0),
+        (torch.bfloat16, 17, 130, 1025, 16, 1.2),
+    ]
+    try:
+        for case_index, config in enumerate(cases):
+            _run_case(device, rank, world_size, case_index, config)
+        if rank == 0:
+            print(f"[PASS] TP{world_size}: all {len(cases)} forward/backward cases match the full-vocabulary reference")
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workers/test_megatron_distillation_only_on_cpu.py
+++ b/tests/workers/test_megatron_distillation_only_on_cpu.py
@@ -26,6 +26,7 @@ import os
 
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -33,6 +34,8 @@ import pytest
 import torch
 from tensordict import TensorDict
 
+from verl.utils import tensordict_utils as tu
+from verl.workers.engine.megatron import transformer_impl as mti
 from verl.workers.engine.megatron.transformer_impl import MegatronEngineWithLMHead
 
 _VOCAB_SIZE = 8
@@ -115,3 +118,70 @@ def test_megatron_logits_processor_without_topk_always_computes_log_probs():
     assert "log_probs" in ret
     for k in _DISTILLATION_KEYS:
         assert k not in ret
+
+
+def test_fused_forward_step_routes_teacher_topk_inputs_to_fused_model():
+    eng = object.__new__(MegatronEngineWithLMHead)
+    eng.engine_config = SimpleNamespace(
+        use_fused_kernels=True,
+        pad_to_length=False,
+        use_remove_padding=True,
+        dynamic_context_parallel=False,
+    )
+    eng.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(),
+        tokenizer=SimpleNamespace(pad_token_id=0),
+    )
+    eng.tf_config = SimpleNamespace()
+    eng.prepare_model_inputs = lambda batch: {
+        "input_ids": batch["input_ids"],
+        "attention_mask": None,
+        "loss_mask": batch["loss_mask"],
+        "multi_modal_inputs": {},
+        "routed_experts": None,
+    }
+
+    teacher_ids = torch.tensor([[[2, 3], [3, 4], [4, 5]]])
+    teacher_logprobs = torch.tensor([[[-0.1, -0.2], [-0.3, -0.4], [-0.5, -0.6]]])
+    batch = TensorDict(
+        {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "loss_mask": torch.ones(1, 3, dtype=torch.bool),
+            "temperature": torch.tensor([0.7]),
+            "teacher_ids": teacher_ids,
+            "teacher_logprobs": teacher_logprobs,
+        },
+        batch_size=[1],
+    )
+    tu.assign_non_tensor(batch, distillation_use_topk=True, distillation_only=True)
+
+    clamp = -12.0
+    distillation_config = SimpleNamespace(distillation_loss=SimpleNamespace(log_prob_min_clamp=clamp))
+    loss_function = partial(lambda **_kwargs: None, distillation_config=distillation_config)
+    captured = {}
+
+    def fused_forward(**kwargs):
+        captured.update(kwargs)
+        return {"distillation_losses": torch.zeros(1, 3)}
+
+    model = SimpleNamespace(config=SimpleNamespace(experimental_attention_variant=None))
+    with (
+        patch("verl.workers.engine.megatron.transformer_impl.get_device_id", return_value="cpu"),
+        patch("verl.workers.engine.megatron.transformer_impl.unwrap_model", return_value=model),
+        patch.object(
+            MegatronEngineWithLMHead,
+            "_get_context_parallel_layout",
+            return_value="zigzag",
+        ),
+        patch.object(mti.RouterReplayHelper, "is_replay_backward_action", return_value=False),
+        patch.object(mti.RouterReplayHelper, "is_replay_forward_action", return_value=False),
+        patch.object(mti.RouterReplayHelper, "is_r2_record_action", return_value=False),
+        patch("verl.models.mcore.get_mcore_forward_fused_model_engine_fn", return_value=fused_forward),
+    ):
+        output, _ = eng.forward_step(iter([batch]), model, loss_function, lambda **_kwargs: None)
+
+    assert "distillation_losses" in output
+    torch.testing.assert_close(captured["teacher_topk_ids"], teacher_ids)
+    torch.testing.assert_close(captured["teacher_topk_log_probs"], teacher_logprobs)
+    assert captured["distillation_only"] is True
+    assert captured["log_prob_min_clamp"] == clamp

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -33,6 +33,7 @@ from torch import Tensor
 
 from verl.models.mcore.util import preprocess_packed_seqs, preprocess_thd_engine
 from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
+from verl.utils.kernel.linear_topk_log_probs import linear_topk_log_probs
 from verl.utils.megatron_utils import unwrap_model
 from verl.utils.model import CausalLMOutputForPPO
 
@@ -78,6 +79,38 @@ class FusedOutputProcessorContext:
     """Context passed through Megatron's native output-processor hook."""
 
     temperature: float
+    teacher_topk_ids: Optional[Tensor] = None
+    teacher_topk_log_probs: Optional[Tensor] = None
+    distillation_only: bool = False
+    calculate_entropy: bool = False
+    log_prob_min_clamp: Optional[float] = None
+
+
+def _compute_topk_distillation_outputs(
+    student_topk_log_probs: Tensor,
+    teacher_topk_log_probs: Tensor,
+    log_prob_min_clamp: Optional[float],
+) -> dict[str, Tensor]:
+    """Build the existing OPD output contract from selected student log-probs."""
+    student_topk_log_probs = student_topk_log_probs.float()
+    teacher_topk_log_probs = teacher_topk_log_probs.float()
+
+    # Keep the mass metrics consistent with the existing full-logits path: they
+    # describe the unclamped distributions.
+    student_mass = student_topk_log_probs.exp().sum(dim=-1)
+    teacher_mass = teacher_topk_log_probs.exp().sum(dim=-1)
+
+    if log_prob_min_clamp is not None:
+        student_topk_log_probs = student_topk_log_probs.clamp_min(log_prob_min_clamp)
+        teacher_topk_log_probs = teacher_topk_log_probs.clamp_min(log_prob_min_clamp)
+
+    teacher_topk_probs = teacher_topk_log_probs.exp()
+    distillation_losses = (teacher_topk_probs * (teacher_topk_log_probs - student_topk_log_probs)).sum(dim=-1)
+    return {
+        "distillation_losses": distillation_losses,
+        "student_mass": student_mass,
+        "teacher_mass": teacher_mass,
+    }
 
 
 def fused_output_processor(
@@ -107,14 +140,42 @@ def fused_output_processor(
     weight = output_weight if output_weight is not None else output_layer.weight
 
     temperature = context.temperature
-    logprobs, entropy = linear_cross_entropy(
-        hidden_states,
-        weight,
-        labels,
-        temperature,
-        "none",
-        parallel_state.get_tensor_model_parallel_group(),
-    )
+    tp_group = parallel_state.get_tensor_model_parallel_group()
+
+    if context.teacher_topk_ids is not None:
+        if context.teacher_topk_log_probs is None:
+            raise ValueError("teacher_topk_log_probs is required when teacher_topk_ids is provided")
+        if context.teacher_topk_ids.shape != context.teacher_topk_log_probs.shape:
+            raise ValueError(
+                "teacher_topk_ids and teacher_topk_log_probs must have the same shape, got "
+                f"{context.teacher_topk_ids.shape} and {context.teacher_topk_log_probs.shape}"
+            )
+        student_topk_log_probs = linear_topk_log_probs(
+            hidden_states,
+            weight,
+            context.teacher_topk_ids,
+            temperature,
+            tp_group,
+        )
+        for key, value in _compute_topk_distillation_outputs(
+            student_topk_log_probs,
+            context.teacher_topk_log_probs,
+            context.log_prob_min_clamp,
+        ).items():
+            setattr(output, key, value)
+
+    # Pure supervised top-k distillation does not consume sampled-token
+    # log-probs or entropy. Combined PPO/distillation modes still need them.
+    logprobs = entropy = None
+    if context.teacher_topk_ids is None or not context.distillation_only or context.calculate_entropy:
+        logprobs, entropy = linear_cross_entropy(
+            hidden_states,
+            weight,
+            labels,
+            temperature,
+            "none",
+            tp_group,
+        )
 
     if has_config_logger_enabled(config):
         payload = OrderedDict(
@@ -129,8 +190,10 @@ def fused_output_processor(
         )
         log_config_to_disk(config, payload, prefix="input_and_logits")
 
-    output.entropy = entropy
-    output.log_probs = logprobs
+    if entropy is not None:
+        output.entropy = entropy
+    if logprobs is not None:
+        output.log_probs = logprobs
     return output
 
 
@@ -269,6 +332,10 @@ def fused_forward_model_engine(vision_model: bool = False):
         local_cp_size: int | None = None,
         router_padding_mask: Tensor | None = None,
         pad_to_length_bucket: int | None = None,
+        teacher_topk_ids: Tensor | None = None,
+        teacher_topk_log_probs: Tensor | None = None,
+        distillation_only: bool = False,
+        log_prob_min_clamp: float | None = None,
     ):
         pre_process = unwrap_model(model).pre_process
         post_process = unwrap_model(model).post_process
@@ -323,6 +390,40 @@ def fused_forward_model_engine(vision_model: bool = False):
             local_cp_size=local_cp_size,
         )
         labels_rmpad = labels_rmpad.contiguous()
+
+        if (teacher_topk_ids is None) != (teacher_topk_log_probs is None):
+            raise ValueError("teacher_topk_ids and teacher_topk_log_probs must be provided together")
+        teacher_topk_ids_rmpad = teacher_topk_log_probs_rmpad = None
+        if teacher_topk_ids is not None:
+            teacher_topk_ids_rmpad, _, _ = preprocess_thd_engine(
+                teacher_topk_ids,
+                pre_process=True,
+                use_fp8_padding=use_fp8_padding,
+                min_local_rows=min_local_rows,
+                pad_to_length_bucket=pad_to_length_bucket,
+                cp_layout=cp_layout,
+                local_cp_size=local_cp_size,
+            )
+            teacher_topk_log_probs_rmpad, _, _ = preprocess_thd_engine(
+                teacher_topk_log_probs,
+                pre_process=True,
+                use_fp8_padding=use_fp8_padding,
+                min_local_rows=min_local_rows,
+                pad_to_length_bucket=pad_to_length_bucket,
+                cp_layout=cp_layout,
+                local_cp_size=local_cp_size,
+            )
+            teacher_topk_ids_rmpad = teacher_topk_ids_rmpad.contiguous()
+            teacher_topk_log_probs_rmpad = teacher_topk_log_probs_rmpad.contiguous()
+
+        output_processor_context = FusedOutputProcessorContext(
+            temperature=temperature,
+            teacher_topk_ids=teacher_topk_ids_rmpad,
+            teacher_topk_log_probs=teacher_topk_log_probs_rmpad,
+            distillation_only=distillation_only,
+            calculate_entropy=calculate_entropy,
+            log_prob_min_clamp=log_prob_min_clamp,
+        )
         forward_kwargs = dict(
             input_ids=input_ids_rmpad,
             attention_mask=attention_mask,
@@ -335,28 +436,52 @@ def fused_forward_model_engine(vision_model: bool = False):
             output_orig: CausalLMOutputForPPO = model(
                 **forward_kwargs,
                 output_processor=fused_output_processor,
-                output_processor_context=FusedOutputProcessorContext(temperature=temperature),
+                output_processor_context=output_processor_context,
             )
         else:
-            output_orig: CausalLMOutputForPPO = model(temperature=temperature, **forward_kwargs)
+            output_orig: CausalLMOutputForPPO = model(
+                temperature=temperature,
+                teacher_topk_ids=teacher_topk_ids_rmpad,
+                teacher_topk_log_probs=teacher_topk_log_probs_rmpad,
+                distillation_only=distillation_only,
+                calculate_entropy=calculate_entropy,
+                log_prob_min_clamp=log_prob_min_clamp,
+                **forward_kwargs,
+            )
 
         if not post_process:
             return output_orig
 
-        log_probs = output_orig.log_probs
-        if log_probs.dim() == 1:
-            log_probs = log_probs.unsqueeze(0)
-        log_probs = postprocess_thd_engine(
-            log_probs,
-            packed_seq_params,
-            input_ids,
-            input_ids.shape[0],
-            post_process=post_process,
-            cp_layout=cp_layout,
-            local_cp_size=local_cp_size,
-        )
+        output = {}
+        for key in ("distillation_losses", "student_mass", "teacher_mass"):
+            value = getattr(output_orig, key, None)
+            if value is None:
+                continue
+            if value.dim() == 1:
+                value = value.unsqueeze(0)
+            output[key] = postprocess_thd_engine(
+                value,
+                packed_seq_params,
+                input_ids,
+                input_ids.shape[0],
+                post_process=post_process,
+                cp_layout=cp_layout,
+                local_cp_size=local_cp_size,
+            )
 
-        output = {"log_probs": log_probs}
+        log_probs = getattr(output_orig, "log_probs", None)
+        if log_probs is not None:
+            if log_probs.dim() == 1:
+                log_probs = log_probs.unsqueeze(0)
+            output["log_probs"] = postprocess_thd_engine(
+                log_probs,
+                packed_seq_params,
+                input_ids,
+                input_ids.shape[0],
+                post_process=post_process,
+                cp_layout=cp_layout,
+                local_cp_size=local_cp_size,
+            )
 
         if calculate_entropy:
             entropy = output_orig.entropy
@@ -394,6 +519,11 @@ def _fused_GPTModel_forward(
     loss_mask: Optional[Tensor] = None,
     temperature: float = 1.0,
     padding_mask: Tensor | None = None,
+    teacher_topk_ids: Tensor | None = None,
+    teacher_topk_log_probs: Tensor | None = None,
+    distillation_only: bool = False,
+    calculate_entropy: bool = False,
+    log_prob_min_clamp: float | None = None,
     **kwargs,
 ) -> CausalLMOutputForPPO:
     """
@@ -447,17 +577,6 @@ def _fused_GPTModel_forward(
     if not model.post_process:
         return hidden_states
 
-    output = CausalLMOutputForPPO(
-        loss=None,
-        logits=None,
-        past_key_values=None,
-        hidden_states=hidden_states,
-        attentions=None,
-    )
-
-    if model.config.sequence_parallel:
-        hidden_states = gather_from_sequence_parallel_region(hidden_states)
-
     # Get the output weight - use embedding weight if output_layer is None or weight is shared
     if hasattr(model, "output_layer") and model.output_layer is not None and model.output_layer.weight is not None:
         output_weight = model.output_layer.weight
@@ -465,29 +584,22 @@ def _fused_GPTModel_forward(
         # When embeddings are tied, use the embedding weight
         output_weight = model.embedding.word_embeddings.weight
 
-    logprobs, entropy = linear_cross_entropy(
-        hidden_states,
-        output_weight,
-        labels,
-        temperature,
-        "none",
-        parallel_state.get_tensor_model_parallel_group(),
+    return fused_output_processor(
+        hidden_states=hidden_states,
+        output_layer=getattr(model, "output_layer", None),
+        output_weight=output_weight,
+        labels=labels,
+        context=FusedOutputProcessorContext(
+            temperature=temperature,
+            teacher_topk_ids=teacher_topk_ids,
+            teacher_topk_log_probs=teacher_topk_log_probs,
+            distillation_only=distillation_only,
+            calculate_entropy=calculate_entropy,
+            log_prob_min_clamp=log_prob_min_clamp,
+        ),
+        config=model.config,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        decoder_input=decoder_input,
     )
-
-    if has_config_logger_enabled(model.config):
-        payload = OrderedDict(
-            {
-                "input_ids": input_ids,
-                "position_ids": position_ids,
-                "attention_mask": attention_mask,
-                "decoder_input": decoder_input,
-                "logprobs": logprobs,
-                "entropy": entropy,
-            }
-        )
-        log_config_to_disk(model.config, payload, prefix="input_and_logits")
-
-    output.entropy = entropy
-    output.log_probs = logprobs
-
-    return output

--- a/verl/utils/kernel/linear_topk_log_probs.py
+++ b/verl/utils/kernel/linear_topk_log_probs.py
@@ -1,0 +1,285 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Memory-efficient linear selected-log-probability operator.
+
+The CUDA path uses Triton vocabulary tiles and recomputes logits during
+backward. The portable fallback chunks the token dimension. Neither path
+retains a full ``[num_tokens, vocab_size]`` tensor in autograd.
+"""
+
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+_MAX_LOGITS_CHUNK_BYTES = 64 * 1024 * 1024
+
+
+def _world_info(process_group: Optional[dist.ProcessGroup]) -> tuple[int, int]:
+    if process_group is None:
+        return 0, 1
+    return dist.get_rank(process_group), dist.get_world_size(process_group)
+
+
+def _resolve_chunk_size(num_tokens: int, local_vocab_size: int, chunk_size: Optional[int]) -> int:
+    if chunk_size is not None:
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        return min(num_tokens, chunk_size)
+    # Logits and softmax statistics are computed in FP32. Bound the principal
+    # temporary to 64 MiB; backward may hold logits and their gradient together.
+    rows = _MAX_LOGITS_CHUNK_BYTES // (local_vocab_size * torch.float32.itemsize)
+    return max(1, min(num_tokens, rows))
+
+
+def _linear_fp32(hidden: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Compute ``hidden @ weight.T`` with FP32 output where CUDA supports it."""
+    if hidden.dtype == torch.float32:
+        return torch.mm(hidden, weight.T)
+    if hidden.is_cuda:
+        try:
+            return torch.mm(hidden, weight.T, out_dtype=torch.float32)
+        except TypeError:
+            # Older torch versions do not expose CUDA GEMM's FP32 output.
+            return torch.mm(hidden, weight.T).float()
+    return torch.mm(hidden.float(), weight.float().T)
+
+
+def _validate_topk_ids(topk_ids: torch.Tensor, global_vocab_size: int) -> None:
+    """Validate global vocabulary ids without synchronizing CUDA with the host.
+
+    ``Tensor.item()`` on a CUDA reduction stalls Python until all preceding GPU
+    work completes.  ``torch._assert_async`` keeps the check ordered on the CUDA
+    stream and reports an invalid id asynchronously.  CPU execution retains the
+    eager ``ValueError`` used by the portable fallback and unit tests.
+    """
+    valid = torch.all((topk_ids >= 0) & (topk_ids < global_vocab_size))
+    message = f"topk_ids must be in [0, {global_vocab_size})"
+    if topk_ids.is_cuda:
+        assert_async = getattr(torch, "_assert_async", None)
+        if assert_async is not None:
+            assert_async(valid, message)
+        # Older torch versions without an asynchronous device assertion skip
+        # this optional CUDA validation rather than introduce a host sync.
+        return
+    if not bool(valid):
+        raise ValueError(message)
+
+
+class LinearTopKLogProbs(torch.autograd.Function):
+    """Autograd implementation that saves log-sum-exp instead of full logits."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        hidden: torch.Tensor,
+        weight: torch.Tensor,
+        topk_ids: torch.Tensor,
+        temperature: float = 1.0,
+        dist_process_group: Optional[dist.ProcessGroup] = None,
+        chunk_size: Optional[int] = None,
+    ) -> torch.Tensor:
+        if not isinstance(temperature, float):
+            raise TypeError(f"temperature must be a float, got {type(temperature)}")
+        if temperature <= 0:
+            raise ValueError(f"temperature must be positive, got {temperature}")
+        if hidden.dim() < 2 or weight.dim() != 2 or topk_ids.dim() < 2:
+            raise ValueError(
+                "expected hidden (..., hidden_size), weight (local_vocab_size, hidden_size), and topk_ids (..., topk)"
+            )
+        if hidden.numel() == 0:
+            raise ValueError("hidden must contain at least one token and one hidden element")
+        if weight.shape[0] == 0:
+            raise ValueError("weight must contain at least one vocabulary row")
+        if not hidden.dtype.is_floating_point or not weight.dtype.is_floating_point:
+            raise TypeError(f"hidden and weight must be floating-point tensors, got {hidden.dtype} and {weight.dtype}")
+        if topk_ids.shape[-1] == 0:
+            raise ValueError("topk_ids must contain at least one selected token per row")
+        if hidden.shape[-1] != weight.shape[-1]:
+            raise ValueError(f"hidden size mismatch: hidden={hidden.shape[-1]}, weight={weight.shape[-1]}")
+        if hidden.numel() // hidden.shape[-1] != topk_ids.numel() // topk_ids.shape[-1]:
+            raise ValueError(f"token count mismatch between hidden {hidden.shape} and topk_ids {topk_ids.shape}")
+        if hidden.device != weight.device or hidden.device != topk_ids.device:
+            raise ValueError("hidden, weight, and topk_ids must be on the same device")
+        if hidden.dtype != weight.dtype:
+            raise ValueError(f"hidden and weight must have the same dtype, got {hidden.dtype} and {weight.dtype}")
+        if topk_ids.dtype not in (torch.int32, torch.int64):
+            raise TypeError(f"topk_ids must use int32 or int64, got {topk_ids.dtype}")
+
+        original_hidden_shape = hidden.shape
+        original_topk_shape = topk_ids.shape
+        hidden_2d = hidden.reshape(-1, hidden.shape[-1]).contiguous()
+        weight_2d = weight.contiguous()
+        topk_ids_2d = topk_ids.reshape(hidden_2d.shape[0], -1).to(torch.long).contiguous()
+
+        num_tokens = hidden_2d.shape[0]
+        local_vocab_size = weight_2d.shape[0]
+        rank, world_size = _world_info(dist_process_group)
+        global_vocab_size = local_vocab_size * world_size
+        _validate_topk_ids(topk_ids_2d, global_vocab_size)
+
+        rows_per_chunk = _resolve_chunk_size(num_tokens, local_vocab_size, chunk_size)
+        local_max = torch.empty(num_tokens, device=hidden.device, dtype=torch.float32)
+        local_sum_exp = torch.empty_like(local_max)
+        selected_logits = torch.zeros(topk_ids_2d.shape, device=hidden.device, dtype=torch.float32)
+        vocab_start = rank * local_vocab_size
+        vocab_end = vocab_start + local_vocab_size
+        inv_temperature = 1.0 / temperature
+
+        from . import topk_log_probs_kernels
+
+        use_triton = topk_log_probs_kernels.can_use_triton(hidden_2d, topk_ids_2d.shape[1])
+        if use_triton:
+            local_max, sum_payload = topk_log_probs_kernels.topk_log_probs_forward(
+                hidden_2d,
+                weight_2d,
+                topk_ids_2d,
+                temperature,
+                rank,
+            )
+            local_sum_exp = sum_payload[:, 0]
+            selected_logits = sum_payload[:, 1:]
+        else:
+            for start in range(0, num_tokens, rows_per_chunk):
+                end = min(start + rows_per_chunk, num_tokens)
+                logits = _linear_fp32(hidden_2d[start:end], weight_2d)
+                logits.mul_(inv_temperature)
+
+                chunk_max = logits.max(dim=-1).values
+                local_max[start:end] = chunk_max
+                local_sum_exp[start:end] = torch.exp(logits - chunk_max.unsqueeze(-1)).sum(dim=-1)
+
+                ids = topk_ids_2d[start:end]
+                owned = (ids >= vocab_start) & (ids < vocab_end)
+                local_ids = (ids - vocab_start).masked_fill(~owned, 0)
+                selected = torch.gather(logits, dim=-1, index=local_ids)
+                selected_logits[start:end] = selected.masked_fill(~owned, 0)
+
+        global_max = local_max.clone()
+        if world_size > 1:
+            dist.all_reduce(global_max, op=dist.ReduceOp.MAX, group=dist_process_group)
+
+        # Each rank's sum was normalized by its local maximum. Rescale it to
+        # the global maximum before summing across vocabulary shards.
+        local_sum_exp.mul_(torch.exp(local_max - global_max))
+        if world_size > 1:
+            if not use_triton:
+                # The Triton path writes these values into one contiguous
+                # payload from the start. The fallback is uncommon in OPD and
+                # packs here to preserve the same two-collective TP contract.
+                sum_payload = torch.cat((local_sum_exp.unsqueeze(-1), selected_logits), dim=-1)
+            dist.all_reduce(sum_payload, op=dist.ReduceOp.SUM, group=dist_process_group)
+            global_sum_exp = sum_payload[:, 0]
+            selected_logits = sum_payload[:, 1:]
+        else:
+            global_sum_exp = local_sum_exp
+
+        global_logsumexp = global_max + global_sum_exp.log()
+        output = selected_logits - global_logsumexp.unsqueeze(-1)
+
+        ctx.save_for_backward(hidden_2d, weight_2d, topk_ids_2d, global_logsumexp)
+        ctx.original_hidden_shape = original_hidden_shape
+        ctx.original_topk_shape = original_topk_shape
+        ctx.temperature = temperature
+        ctx.rank = rank
+        ctx.rows_per_chunk = rows_per_chunk
+        ctx.use_triton = use_triton
+        return output.view(original_topk_shape)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        hidden, weight, topk_ids, global_logsumexp = ctx.saved_tensors
+        grad_output_2d = grad_output.reshape(topk_ids.shape).float().contiguous()
+        num_tokens, hidden_size = hidden.shape
+        local_vocab_size = weight.shape[0]
+        vocab_start = ctx.rank * local_vocab_size
+        vocab_end = vocab_start + local_vocab_size
+        inv_temperature = 1.0 / ctx.temperature
+
+        if ctx.use_triton:
+            from .topk_log_probs_kernels import topk_log_probs_backward
+
+            grad_hidden, grad_weight = topk_log_probs_backward(
+                hidden,
+                weight,
+                topk_ids,
+                global_logsumexp,
+                grad_output_2d,
+                ctx.temperature,
+                ctx.rank,
+            )
+            return grad_hidden.view(ctx.original_hidden_shape), grad_weight, None, None, None, None
+
+        grad_hidden = torch.zeros((num_tokens, hidden_size), device=hidden.device, dtype=hidden.dtype)
+        grad_weight = torch.zeros_like(weight)
+
+        for start in range(0, num_tokens, ctx.rows_per_chunk):
+            end = min(start + ctx.rows_per_chunk, num_tokens)
+            hidden_chunk = hidden[start:end]
+            ids = topk_ids[start:end]
+            upstream = grad_output_2d[start:end]
+
+            logits = _linear_fp32(hidden_chunk, weight)
+            logits.mul_(inv_temperature)
+            probabilities = torch.exp(logits - global_logsumexp[start:end].unsqueeze(-1))
+
+            # For y_i = z_i - logsumexp(z), accumulate all selected numerator
+            # gradients and subtract softmax(z) times their row-wise sum.
+            grad_logits = -probabilities * upstream.sum(dim=-1, keepdim=True)
+            owned = (ids >= vocab_start) & (ids < vocab_end)
+            local_ids = (ids - vocab_start).masked_fill(~owned, 0)
+            grad_logits.scatter_add_(dim=-1, index=local_ids, src=upstream * owned)
+            grad_logits.mul_(inv_temperature)
+
+            grad_logits_model_dtype = grad_logits.to(hidden.dtype)
+            grad_hidden[start:end] = torch.mm(grad_logits_model_dtype, weight)
+            grad_weight.addmm_(grad_logits_model_dtype.T, hidden_chunk)
+
+        return grad_hidden.view(ctx.original_hidden_shape), grad_weight, None, None, None, None
+
+
+def linear_topk_log_probs(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    temperature: float = 1.0,
+    dist_process_group: Optional[dist.ProcessGroup] = None,
+    chunk_size: Optional[int] = None,
+) -> torch.Tensor:
+    """Return globally normalized student log probabilities at ``topk_ids``.
+
+    Args:
+        hidden: Hidden states with shape ``(..., hidden_size)``.
+        weight: This tensor-parallel rank's output-weight shard with shape
+            ``(vocab_size_per_partition, hidden_size)``.
+        topk_ids: Global-vocabulary token ids with shape ``(..., topk)``.
+        temperature: Scalar temperature applied to logits.
+        dist_process_group: Tensor-parallel process group, or ``None`` for a
+            non-sharded vocabulary.
+        chunk_size: Optional number of token rows used by the non-Triton
+            fallback. By default its principal FP32 logits temporary is
+            limited to 64 MiB.
+
+    Returns:
+        A float32 tensor with the same shape as ``topk_ids``.
+    """
+    return LinearTopKLogProbs.apply(
+        hidden,
+        weight,
+        topk_ids,
+        temperature,
+        dist_process_group,
+        chunk_size,
+    )

--- a/verl/utils/kernel/topk_log_probs_kernels.py
+++ b/verl/utils/kernel/topk_log_probs_kernels.py
@@ -1,0 +1,457 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for selected log probabilities over a linear vocabulary head."""
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+
+_BLOCK_N = 128
+_MAX_FORWARD_SPLITS = 128
+_TARGET_BACKWARD_DLOGITS_BYTES = 32 * 1024 * 1024
+_MAX_BACKWARD_DLOGITS_BYTES = 40 * 1024 * 1024
+_MAX_TRITON_TOPK = 128
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+def _round_up_to_block(value: int) -> int:
+    return _ceil_div(value, _BLOCK_N) * _BLOCK_N
+
+
+def _limit_split_to_vocab(vocab_per_split: int, vocab_size: int) -> int:
+    """Avoid iterating far past the final vocabulary tile."""
+    padded_vocab_size = max(_BLOCK_N, _round_up_to_block(vocab_size))
+    return min(vocab_per_split, padded_vocab_size)
+
+
+def _select_forward_vocab_per_split(num_tokens: int, vocab_size: int) -> int:
+    """Choose forward split width from B300 token-parallelism measurements."""
+    if num_tokens <= 32:
+        vocab_per_split = 256
+    elif num_tokens <= 1024:
+        vocab_per_split = 512
+    else:
+        vocab_per_split = 1024
+    # Bound the second-stage reduction width for unusually large local
+    # vocabularies. This keeps BLOCK_SPLITS at 128 or below.
+    min_for_reduction = _round_up_to_block(_ceil_div(vocab_size, _MAX_FORWARD_SPLITS))
+    vocab_per_split = max(vocab_per_split, min_for_reduction)
+    return _limit_split_to_vocab(vocab_per_split, vocab_size)
+
+
+def _select_backward_vocab_per_split(num_tokens: int, vocab_size: int, element_size: int) -> int:
+    """Reduce sequential launches while bounding the materialized dlogits tile."""
+    full_dlogits_bytes = num_tokens * vocab_size * element_size
+    if full_dlogits_bytes <= _MAX_BACKWARD_DLOGITS_BYTES:
+        return vocab_size
+
+    max_by_memory = _TARGET_BACKWARD_DLOGITS_BYTES // (num_tokens * element_size)
+    max_by_memory = max(_BLOCK_N, max_by_memory // _BLOCK_N * _BLOCK_N)
+    return min(max_by_memory, vocab_size)
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _linear_stats_kernel(
+        hidden_ptr,
+        weight_ptr,
+        topk_ids_ptr,
+        selected_logits_ptr,
+        num_tokens,
+        hidden_size,
+        vocab_size,
+        num_splits,
+        vocab_start,
+        stride_hidden_m: tl.int64,
+        stride_hidden_k: tl.int64,
+        stride_weight_n: tl.int64,
+        stride_weight_k: tl.int64,
+        stride_ids_m: tl.int64,
+        stride_ids_k: tl.int64,
+        stride_selected_m: tl.int64,
+        stride_selected_k: tl.int64,
+        split_max_ptr,
+        split_sum_ptr,
+        rcp_temperature: tl.float32,
+        TOPK: tl.constexpr,
+        BLOCK_TOPK: tl.constexpr,
+        VOCAB_PER_SPLIT: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        """Compute stable softmax statistics without storing the logits matrix."""
+        pid = tl.program_id(0)
+        num_pid_m = tl.cdiv(num_tokens, BLOCK_M)
+        pid_m = pid % num_pid_m
+        split_idx = pid // num_pid_m
+
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_k = tl.arange(0, BLOCK_K)
+        split_start = split_idx * VOCAB_PER_SPLIT
+        split_end = tl.minimum(split_start + VOCAB_PER_SPLIT, vocab_size)
+
+        running_max = tl.full((BLOCK_M,), -float("inf"), tl.float32)
+        running_sum = tl.zeros((BLOCK_M,), tl.float32)
+
+        for n_offset in range(0, VOCAB_PER_SPLIT, BLOCK_N):
+            offs_n = split_start + n_offset + tl.arange(0, BLOCK_N)
+            hidden_ptrs = hidden_ptr + offs_m[:, None] * stride_hidden_m + offs_k[None, :] * stride_hidden_k
+            weight_ptrs = weight_ptr + offs_n[:, None] * stride_weight_n + offs_k[None, :] * stride_weight_k
+            logits = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+
+            for k in range(0, tl.cdiv(hidden_size, BLOCK_K)):
+                hidden_values = tl.load(
+                    hidden_ptrs,
+                    mask=(offs_m[:, None] < num_tokens) & (offs_k[None, :] < hidden_size - k * BLOCK_K),
+                    other=0.0,
+                )
+                weight_values = tl.load(
+                    weight_ptrs,
+                    mask=(offs_n[:, None] < split_end) & (offs_k[None, :] < hidden_size - k * BLOCK_K),
+                    other=0.0,
+                )
+                # IEEE input precision is required for FP32 model weights.  It
+                # also keeps this path aligned with torch.mm when TP tests use
+                # FP32 inputs; BF16 operands still use FP32 accumulation.
+                logits = tl.dot(hidden_values, weight_values.T, logits, input_precision="ieee")
+                hidden_ptrs += BLOCK_K * stride_hidden_k
+                weight_ptrs += BLOCK_K * stride_weight_k
+
+            logits *= rcp_temperature
+
+            # Extract selected logits from the exact GEMM tile used by the
+            # logsumexp calculation.  A separate row-wise dot product uses a
+            # different reduction order and can drift noticeably for BF16.
+            # Exactly one vocabulary tile owns each valid global token id, so
+            # direct stores are race-free.  Other TP ranks retain their zero.
+            tile_global_start = vocab_start + split_start + n_offset
+            tile_global_end = vocab_start + tl.minimum(split_start + n_offset + BLOCK_N, split_end)
+            valid_rows = offs_m < num_tokens
+            offs_topk = tl.arange(0, BLOCK_TOPK)
+            for topk_offset in range(0, TOPK, BLOCK_TOPK):
+                topk_indices = topk_offset + offs_topk
+                valid_selected = valid_rows[:, None] & (topk_indices[None, :] < TOPK)
+                selected_ids = tl.load(
+                    topk_ids_ptr + offs_m[:, None] * stride_ids_m + topk_indices[None, :] * stride_ids_k,
+                    mask=valid_selected,
+                    other=-1,
+                )
+                owned_by_tile = valid_selected & (selected_ids >= tile_global_start) & (selected_ids < tile_global_end)
+                # Convert global ids to columns of the current register tile.
+                # Non-owned entries use column zero only to keep gather indices
+                # in range; their stores remain masked out below.
+                selected_columns = tl.where(
+                    owned_by_tile,
+                    selected_ids - tile_global_start,
+                    0,
+                ).to(tl.int32)
+                selected = tl.gather(logits, selected_columns, axis=1)
+                tl.store(
+                    selected_logits_ptr
+                    + offs_m[:, None] * stride_selected_m
+                    + topk_indices[None, :] * stride_selected_k,
+                    selected,
+                    mask=owned_by_tile,
+                )
+
+            logits = tl.where(offs_n[None, :] < split_end, logits, -float("inf"))
+
+            block_max = tl.max(logits, axis=1)
+            new_max = tl.maximum(running_max, block_max)
+            running_sum = running_sum * tl.exp(running_max - new_max) + tl.sum(
+                tl.exp(logits - new_max[:, None]), axis=1
+            )
+            running_max = new_max
+
+        stats_offset = offs_m * num_splits + split_idx
+        valid_rows = offs_m < num_tokens
+        tl.store(split_max_ptr + stats_offset, running_max, mask=valid_rows)
+        tl.store(split_sum_ptr + stats_offset, running_sum, mask=valid_rows)
+
+    @triton.jit
+    def _reduce_stats_kernel(
+        split_max_ptr,
+        split_sum_ptr,
+        local_max_ptr,
+        local_sum_ptr,
+        num_tokens,
+        num_splits,
+        stride_local_sum_m: tl.int64,
+        BLOCK_M: tl.constexpr,
+        BLOCK_SPLITS: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_s = tl.arange(0, BLOCK_SPLITS)
+        mask = (offs_m[:, None] < num_tokens) & (offs_s[None, :] < num_splits)
+        offsets = offs_m[:, None] * num_splits + offs_s[None, :]
+        split_max = tl.load(split_max_ptr + offsets, mask=mask, other=-float("inf"))
+        split_sum = tl.load(split_sum_ptr + offsets, mask=mask, other=0.0)
+        local_max = tl.max(split_max, axis=1)
+        local_sum = tl.sum(split_sum * tl.exp(split_max - local_max[:, None]), axis=1)
+        valid_rows = offs_m < num_tokens
+        tl.store(local_max_ptr + offs_m, local_max, mask=valid_rows)
+        tl.store(local_sum_ptr + offs_m * stride_local_sum_m, local_sum, mask=valid_rows)
+
+    @triton.jit
+    def _topk_dlogits_split_kernel(
+        hidden_ptr,
+        weight_ptr,
+        topk_ids_ptr,
+        grad_output_ptr,
+        global_lse_ptr,
+        dlogits_ptr,
+        num_tokens,
+        hidden_size,
+        vocab_size,
+        vocab_start,
+        stride_hidden_m: tl.int64,
+        stride_hidden_k: tl.int64,
+        stride_weight_n: tl.int64,
+        stride_weight_k: tl.int64,
+        stride_ids_m: tl.int64,
+        stride_ids_k: tl.int64,
+        stride_grad_m: tl.int64,
+        stride_grad_k: tl.int64,
+        stride_dlogits_m: tl.int64,
+        stride_dlogits_n: tl.int64,
+        rcp_temperature: tl.float32,
+        SPLIT_IDX: tl.constexpr,
+        TOPK: tl.constexpr,
+        VOCAB_PER_SPLIT: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        num_pid_m = tl.cdiv(num_tokens, BLOCK_M)
+        pid_m = pid % num_pid_m
+        pid_n = pid // num_pid_m
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        result_offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_n = SPLIT_IDX * VOCAB_PER_SPLIT + result_offs_n
+        offs_k = tl.arange(0, BLOCK_K)
+        split_end = tl.minimum((SPLIT_IDX + 1) * VOCAB_PER_SPLIT, vocab_size)
+
+        hidden_ptrs = hidden_ptr + offs_m[:, None] * stride_hidden_m + offs_k[None, :] * stride_hidden_k
+        weight_ptrs = weight_ptr + offs_n[:, None] * stride_weight_n + offs_k[None, :] * stride_weight_k
+        logits = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+        for k in range(0, tl.cdiv(hidden_size, BLOCK_K)):
+            hidden_values = tl.load(
+                hidden_ptrs,
+                mask=(offs_m[:, None] < num_tokens) & (offs_k[None, :] < hidden_size - k * BLOCK_K),
+                other=0.0,
+            )
+            weight_values = tl.load(
+                weight_ptrs,
+                mask=(offs_n[:, None] < split_end) & (offs_k[None, :] < hidden_size - k * BLOCK_K),
+                other=0.0,
+            )
+            logits = tl.dot(hidden_values, weight_values.T, logits, input_precision="ieee")
+            hidden_ptrs += BLOCK_K * stride_hidden_k
+            weight_ptrs += BLOCK_K * stride_weight_k
+
+        logits *= rcp_temperature
+        global_lse = tl.load(global_lse_ptr + offs_m, mask=offs_m < num_tokens, other=0.0)
+        grad_sum = tl.zeros((BLOCK_M,), tl.float32)
+        numerator_grad = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+        global_vocab_ids = vocab_start + offs_n
+        for k in range(0, TOPK):
+            ids = tl.load(
+                topk_ids_ptr + offs_m * stride_ids_m + k * stride_ids_k,
+                mask=offs_m < num_tokens,
+                other=-1,
+            )
+            grad = tl.load(
+                grad_output_ptr + offs_m * stride_grad_m + k * stride_grad_k,
+                mask=offs_m < num_tokens,
+                other=0.0,
+            )
+            grad_sum += grad
+            numerator_grad += tl.where(global_vocab_ids[None, :] == ids[:, None], grad[:, None], 0.0)
+
+        probabilities = tl.exp(logits - global_lse[:, None])
+        dlogits = (numerator_grad - probabilities * grad_sum[:, None]) * rcp_temperature
+        valid = (offs_m[:, None] < num_tokens) & (offs_n[None, :] < split_end)
+        tl.store(
+            dlogits_ptr + offs_m[:, None] * stride_dlogits_m + result_offs_n[None, :] * stride_dlogits_n,
+            dlogits,
+            mask=valid,
+        )
+
+
+def can_use_triton(hidden: torch.Tensor, topk: int) -> bool:
+    return HAVE_TRITON and hidden.is_cuda and 0 < topk <= _MAX_TRITON_TOPK
+
+
+def topk_log_probs_forward(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    temperature: float,
+    rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return local max and a packed ``[exp-sum, selected logits]`` buffer."""
+    if not can_use_triton(hidden, topk_ids.shape[1]):
+        raise RuntimeError("Triton selected-log-probability kernel is unavailable for these inputs")
+
+    num_tokens, hidden_size = hidden.shape
+    vocab_size = weight.shape[0]
+    topk = topk_ids.shape[1]
+    vocab_per_split = _select_forward_vocab_per_split(num_tokens, vocab_size)
+    num_splits = triton.cdiv(vocab_size, vocab_per_split)
+    split_max = torch.empty((num_tokens, num_splits), device=hidden.device, dtype=torch.float32)
+    split_sum = torch.empty_like(split_max)
+    # Column zero is reserved for local_sum. Keeping it adjacent to selected
+    # logits lets the caller reduce all SUM-valued TP data in one collective.
+    sum_payload = torch.zeros(
+        (num_tokens, topk + 1),
+        device=hidden.device,
+        dtype=torch.float32,
+    )
+    selected_logits = sum_payload[:, 1:]
+
+    grid = (triton.cdiv(num_tokens, 32) * num_splits,)
+    _linear_stats_kernel[grid](
+        hidden,
+        weight,
+        topk_ids,
+        selected_logits,
+        num_tokens,
+        hidden_size,
+        vocab_size,
+        num_splits,
+        rank * vocab_size,
+        hidden.stride(0),
+        hidden.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        selected_logits.stride(0),
+        selected_logits.stride(1),
+        split_max,
+        split_sum,
+        1.0 / temperature,
+        TOPK=topk,
+        BLOCK_TOPK=16,
+        VOCAB_PER_SPLIT=vocab_per_split,
+        BLOCK_M=32,
+        BLOCK_N=128,
+        BLOCK_K=32,
+        num_warps=8,
+        num_stages=3,
+    )
+
+    local_max = torch.empty(num_tokens, device=hidden.device, dtype=torch.float32)
+    local_sum = sum_payload[:, 0]
+    reduce_grid = (triton.cdiv(num_tokens, 32),)
+    _reduce_stats_kernel[reduce_grid](
+        split_max,
+        split_sum,
+        local_max,
+        local_sum,
+        num_tokens,
+        num_splits,
+        local_sum.stride(0),
+        BLOCK_M=32,
+        BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+        num_warps=4,
+    )
+
+    return local_max, sum_payload
+
+
+def topk_log_probs_backward(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    topk_ids: torch.Tensor,
+    global_lse: torch.Tensor,
+    grad_output: torch.Tensor,
+    temperature: float,
+    rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Recompute logits by vocab split and accumulate linear-input gradients."""
+    num_tokens, hidden_size = hidden.shape
+    vocab_size = weight.shape[0]
+    topk = topk_ids.shape[1]
+    vocab_per_split = _select_backward_vocab_per_split(num_tokens, vocab_size, hidden.element_size())
+    num_splits = triton.cdiv(vocab_size, vocab_per_split)
+    dlogits = torch.empty(
+        (num_tokens, vocab_per_split),
+        device=hidden.device,
+        dtype=hidden.dtype,
+    )
+    grad_hidden = torch.empty_like(hidden)
+    grad_weight = torch.empty_like(weight)
+
+    for split_idx in range(num_splits):
+        split_width = min(vocab_per_split, vocab_size - split_idx * vocab_per_split)
+        grid = (triton.cdiv(num_tokens, 32) * triton.cdiv(split_width, 128),)
+        _topk_dlogits_split_kernel[grid](
+            hidden,
+            weight,
+            topk_ids,
+            grad_output,
+            global_lse,
+            dlogits,
+            num_tokens,
+            hidden_size,
+            vocab_size,
+            rank * vocab_size,
+            hidden.stride(0),
+            hidden.stride(1),
+            weight.stride(0),
+            weight.stride(1),
+            topk_ids.stride(0),
+            topk_ids.stride(1),
+            grad_output.stride(0),
+            grad_output.stride(1),
+            dlogits.stride(0),
+            dlogits.stride(1),
+            1.0 / temperature,
+            SPLIT_IDX=split_idx,
+            TOPK=topk,
+            VOCAB_PER_SPLIT=vocab_per_split,
+            BLOCK_M=32,
+            BLOCK_N=128,
+            BLOCK_K=32,
+            num_warps=8,
+            num_stages=3,
+        )
+        dlogits_view = dlogits[:, :split_width]
+        if split_width != vocab_per_split:
+            dlogits_view = dlogits_view.contiguous()
+        weight_start = split_idx * vocab_per_split
+        weight_end = weight_start + split_width
+        if split_idx == 0:
+            torch.mm(dlogits_view, weight[weight_start:weight_end], out=grad_hidden)
+        else:
+            grad_hidden.addmm_(dlogits_view, weight[weight_start:weight_end])
+        torch.mm(dlogits_view.T, hidden, out=grad_weight[weight_start:weight_end])
+
+    return grad_hidden, grad_weight

--- a/verl/utils/kernel/topk_log_probs_kernels.py
+++ b/verl/utils/kernel/topk_log_probs_kernels.py
@@ -222,7 +222,7 @@ if HAVE_TRITON:
         tl.store(local_max_ptr + offs_m, local_max, mask=valid_rows)
         tl.store(local_sum_ptr + offs_m * stride_local_sum_m, local_sum, mask=valid_rows)
 
-    @triton.jit
+    @triton.jit(do_not_specialize=["split_idx"])
     def _topk_dlogits_split_kernel(
         hidden_ptr,
         weight_ptr,
@@ -245,22 +245,24 @@ if HAVE_TRITON:
         stride_dlogits_m: tl.int64,
         stride_dlogits_n: tl.int64,
         rcp_temperature: tl.float32,
-        SPLIT_IDX: tl.constexpr,
+        split_idx: tl.int32,
         TOPK: tl.constexpr,
         VOCAB_PER_SPLIT: tl.constexpr,
         BLOCK_M: tl.constexpr,
         BLOCK_N: tl.constexpr,
         BLOCK_K: tl.constexpr,
     ):
+        # Keep the shard index runtime-only, including Triton value/alignment
+        # specialization, so equal-shaped vocabulary splits reuse one kernel.
         pid = tl.program_id(0)
         num_pid_m = tl.cdiv(num_tokens, BLOCK_M)
         pid_m = pid % num_pid_m
         pid_n = pid // num_pid_m
         offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
         result_offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-        offs_n = SPLIT_IDX * VOCAB_PER_SPLIT + result_offs_n
+        offs_n = split_idx * VOCAB_PER_SPLIT + result_offs_n
         offs_k = tl.arange(0, BLOCK_K)
-        split_end = tl.minimum((SPLIT_IDX + 1) * VOCAB_PER_SPLIT, vocab_size)
+        split_end = tl.minimum((split_idx + 1) * VOCAB_PER_SPLIT, vocab_size)
 
         hidden_ptrs = hidden_ptr + offs_m[:, None] * stride_hidden_m + offs_k[None, :] * stride_hidden_k
         weight_ptrs = weight_ptr + offs_n[:, None] * stride_weight_n + offs_k[None, :] * stride_weight_k
@@ -439,7 +441,7 @@ def topk_log_probs_backward(
             dlogits.stride(0),
             dlogits.stride(1),
             1.0 / temperature,
-            SPLIT_IDX=split_idx,
+            split_idx=split_idx,
             TOPK=topk,
             VOCAB_PER_SPLIT=vocab_per_split,
             BLOCK_M=32,

--- a/verl/utils/kernel/topk_log_probs_kernels.py
+++ b/verl/utils/kernel/topk_log_probs_kernels.py
@@ -86,9 +86,9 @@ if HAVE_TRITON:
         num_splits,
         vocab_start,
         stride_hidden_m: tl.int64,
-        stride_hidden_k: tl.int64,
+        stride_hidden_k: tl.constexpr,
         stride_weight_n: tl.int64,
-        stride_weight_k: tl.int64,
+        stride_weight_k: tl.constexpr,
         stride_ids_m: tl.int64,
         stride_ids_k: tl.int64,
         stride_selected_m: tl.int64,
@@ -103,7 +103,12 @@ if HAVE_TRITON:
         BLOCK_N: tl.constexpr,
         BLOCK_K: tl.constexpr,
     ):
-        """Compute stable softmax statistics without storing the logits matrix."""
+        """Compute stable softmax statistics without storing the logits matrix.
+
+        Specialize H-axis strides to expose contiguous loads to Triton's
+        layout analysis and asynchronous load pipeline. Row strides remain
+        runtime values; no extra pointer-alignment assumptions are required.
+        """
         pid = tl.program_id(0)
         num_pid_m = tl.cdiv(num_tokens, BLOCK_M)
         pid_m = pid % num_pid_m

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -848,3 +848,6 @@ def get_lora_rank_from_adapter(adapter_path: str | os.PathLike) -> int:
 class CausalLMOutputForPPO(CausalLMOutputWithPast):
     log_probs: Optional[torch.FloatTensor] = None
     entropy: Optional[torch.FloatTensor] = None
+    distillation_losses: Optional[torch.FloatTensor] = None
+    student_mass: Optional[torch.FloatTensor] = None
+    teacher_mass: Optional[torch.FloatTensor] = None

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -1319,6 +1319,21 @@ class MegatronEngineWithLMHead(MegatronEngine):
         if use_fused_kernels:
             temperature_value = _resolve_fused_temperature(temperature)
 
+        teacher_topk_ids = teacher_topk_log_probs = None
+        log_prob_min_clamp = None
+        if use_fused_kernels and distillation_use_topk:
+            if "teacher_ids" not in batch.keys() or "teacher_logprobs" not in batch.keys():
+                raise ValueError(
+                    "Top-k distillation requires both teacher_ids and teacher_logprobs in the training batch"
+                )
+            teacher_topk_ids = batch["teacher_ids"]
+            teacher_topk_log_probs = batch["teacher_logprobs"]
+            loss_keywords = getattr(logits_processor_func, "keywords", {}) or {}
+            distillation_config = loss_keywords.get("distillation_config")
+            if distillation_config is None:
+                raise ValueError("Top-k distillation requires a loss function carrying distillation_config")
+            log_prob_min_clamp = distillation_config.distillation_loss.log_prob_min_clamp
+
         if use_fused_kernels:
             from verl.models.mcore import get_mcore_forward_fused_model_engine_fn
 
@@ -1335,6 +1350,10 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 local_cp_size=local_cp_size,
                 router_padding_mask=router_padding_mask,
                 pad_to_length_bucket=pad_to_length_bucket,
+                teacher_topk_ids=teacher_topk_ids,
+                teacher_topk_log_probs=teacher_topk_log_probs,
+                distillation_only=distillation_only,
+                log_prob_min_clamp=log_prob_min_clamp,
             )
         else:
             if not isinstance(temperature, torch.Tensor):


### PR DESCRIPTION
### What does this PR do?

Megatron top-k forward-KL distillation currently materializes the tensor-parallel student logits before retaining only the teacher-selected positions. For long sequences and large vocabularies, these full-vocabulary buffers dominate forward and backward memory.

This PR adds a fused `linear_topk_log_probs` path. It consumes packed student hidden states, the tensor-parallel LM-head weight shard, and teacher top-k token IDs, then returns globally normalized student log-probabilities only at those IDs. The full student-logits tensor is never materialized. The Megatron fused-forward hook routes top-k distillation through this path and keeps the existing output contract for the loss code.

Duplicate-work check: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+megatron+top-k+distillation

This is materially different from #7733. That PR chunks the KL computation after the LM head has produced tensor-parallel logits, while this PR fuses the LM-head projection with selected-log-probability extraction so those logits do not exist. #6737 wires fused top-k outputs for FSDP/VeOmni, #6194 uses a different teacher-hidden-state/SVD signal, and #5130 implements label-only linear cross entropy. 

### Test

GPU test suites passed during development:

```bash
python -m pytest -q tests/utils/test_linear_topk_log_probs.py

torchrun --standalone --nproc-per-node=2 tests/utils/test_special_linear_topk_log_probs_tp.py
torchrun --standalone --nproc-per-node=3 tests/utils/test_special_linear_topk_log_probs_tp.py
torchrun --standalone --nproc-per-node=4 tests/utils/test_special_linear_topk_log_probs_tp.py

torchrun --standalone --nproc-per-node=1 tests/utils/test_special_linear_topk_log_probs_e2e.py
torchrun --standalone --nproc-per-node=2 tests/utils/test_special_linear_topk_log_probs_e2e.py
torchrun --standalone --nproc-per-node=3 tests/utils/test_special_linear_topk_log_probs_e2e.py
torchrun --standalone --nproc-per-node=4 tests/utils/test_special_linear_topk_log_probs_e2e.py
```

Coverage includes FP32/FP16/BF16 forward and gradient parity, non-contiguous inputs, int32 IDs, duplicate teacher IDs, numerical stability, TP2/TP3/TP4 shard boundaries, exactly two forward collectives, adaptive forward/backward split policies, removal of CUDA scalar synchronization, and an end-to-end nested-input path where `output.logits is None`. 

### API and Usage Example

There is no new public configuration option. Existing Megatron top-k distillation requests use the fused path when fused kernels and remove-padding are enabled. The internal primitive is:

```python
student_topk_log_probs = linear_topk_log_probs(
    hidden_states,
    lm_head_weight,
    teacher_topk_ids,
    temperature=temperature,
    process_group=tensor_parallel_group,
)
```

For `hidden_states: [M, H]`, a TP-local `lm_head_weight: [V_local, H]`, and `teacher_topk_ids: [M, K]`, the result has shape `[M, K]` and contains log-probabilities normalized across the global vocabulary.

### Design & Code Changes

- Add a custom autograd function that computes selected global log-probabilities from hidden states and TP-sharded LM-head weights.
- Use Triton vocabulary tiles to compute local row maxima, exponent sums, and selected logits without writing `[M, V_local]` logits.
- Reduce tensor-parallel forward communication to two collectives: MAX over `[M]`, then SUM over a contiguous `[M, K + 1]` payload.
- Recompute vocabulary tiles in backward, emit `dlogits` split by split, and immediately apply GEMMs for hidden-state and weight gradients to avoid retaining a full-vocabulary activation.
- Select forward and backward vocabulary split sizes adaptively for small and large token counts.
- Route the Megatron fused-forward hook through the operator for packed top-k distillation, including sequence-parallel gather and tied/untied output weights.
- Preserve CPU/reference fallbacks and the previous behavior for unsupported modes. The optimized Triton top-k matching path supports `K <= 128`; larger K values use the fallback.

### Checklist Before Starting

- [x] Search for similar PRs. Query and differences are documented above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Run the repository-wide pre-commit suite. Targeted Ruff formatting/linting passed
- [x] Documentation impact reviewed. This is an internal optimization with no new public option; the API and activation conditions are documented in this PR.
- [x] Add unit and end-to-end tests. GPU-only distributed cases are included in the test files; maintainers can decide the appropriate CI job based on runner capacity.
- [ ] Request CI in Slack/Feishu after the PR is ready for maintainer review.
- [x] Recipe submodule update is not applicable.


