### PR TITLE
[worker, cfg] fix: thread nccl_timeout into the worker process group

### DIFF
--- a/tests/workers/test_nccl_timeout_wiring_on_cpu.py
+++ b/tests/workers/test_nccl_timeout_wiring_on_cpu.py
@@ -1,0 +1,97 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``nccl_timeout`` must reach the worker's torch process group.
+
+``actor_rollout_ref.nccl_timeout`` and ``critic.nccl_timeout`` are documented public config keys
+for the torch process-group timeout. The FSDP/Megatron workers read them; when those workers were
+replaced by the engine workers every reader disappeared, so ``TrainingWorker.__init__`` created the
+process group with ``timeout_second=None`` (torch's own default) and any configured value was
+silently ignored.
+
+These tests drive the worker constructor with the process-group init mocked out, so no GPU, no ray
+cluster and no real distributed init are needed.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from verl.utils.distributed import initialize_global_process_group_ray
+from verl.workers import engine_workers
+from verl.workers.config import TrainingWorkerConfig
+
+
+class _StopInit(Exception):
+    """Aborts ``TrainingWorker.__init__`` right after the process group is initialized."""
+
+
+def _timeout_second_forwarded_by(config: TrainingWorkerConfig):
+    """Run ``TrainingWorker.__init__`` up to the process-group init and return its timeout.
+
+    Everything after that point needs a real model/engine, so the recorder raises to stop the
+    constructor as soon as the value under test has been observed. ``Worker.__init__`` is stubbed
+    out because it expects the ray-injected worker environment.
+    """
+    recorded = {}
+
+    def _record(timeout_second=None, backend=None):
+        recorded["timeout_second"] = timeout_second
+        raise _StopInit
+
+    with (
+        patch.object(engine_workers.Worker, "__init__", lambda self: None),
+        patch.object(engine_workers, "initialize_global_process_group_ray", _record),
+        patch.object(engine_workers, "set_numa_affinity", lambda: None),
+    ):
+        with pytest.raises(_StopInit):
+            engine_workers.TrainingWorker(config=config)
+
+    assert "timeout_second" in recorded, "TrainingWorker never initialized a process group"
+    return recorded["timeout_second"]
+
+
+@pytest.mark.parametrize("nccl_timeout", [600, 1800])
+def test_training_worker_forwards_configured_nccl_timeout(nccl_timeout):
+    """The value the trainer copies out of ``actor_rollout_ref``/``critic`` must be used verbatim."""
+    config = TrainingWorkerConfig(model_type="language_model", nccl_timeout=nccl_timeout)
+
+    assert _timeout_second_forwarded_by(config) == nccl_timeout
+
+
+def test_training_worker_without_nccl_timeout_keeps_torch_default():
+    """Callers that configure nothing (e.g. SFT) must keep torch's own default timeout."""
+    config = TrainingWorkerConfig(model_type="language_model")
+
+    assert config.nccl_timeout is None
+    assert _timeout_second_forwarded_by(config) is None
+
+
+@pytest.mark.parametrize(
+    ("timeout_second", "expected_timeout"),
+    [(600, timedelta(seconds=600)), (1800, timedelta(seconds=1800)), (None, None)],
+)
+def test_initialize_global_process_group_ray_forwards_timeout(monkeypatch, timeout_second, expected_timeout):
+    """The seconds the worker passes down land on ``torch.distributed.init_process_group``."""
+    calls = []
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.setattr(torch.distributed, "init_process_group", lambda **kwargs: calls.append(kwargs))
+
+    # An explicit backend keeps this off the accelerator-detection path.
+    initialize_global_process_group_ray(timeout_second=timeout_second, backend="gloo")
+
+    assert len(calls) == 1
+    assert calls[0]["timeout"] == expected_timeout

--- a/tests/workers/test_nccl_timeout_wiring_on_cpu.py
+++ b/tests/workers/test_nccl_timeout_wiring_on_cpu.py
@@ -24,7 +24,12 @@ These tests drive the worker constructor with the process-group init mocked out,
 cluster and no real distributed init are needed.
 """
 
+import ast
+import inspect
+import textwrap
+from dataclasses import dataclass
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -32,7 +37,12 @@ import torch
 
 from verl.utils.distributed import initialize_global_process_group_ray
 from verl.workers import engine_workers
-from verl.workers.config import TrainingWorkerConfig
+from verl.workers.config import (
+    FSDPCriticConfig,
+    FSDPEngineConfig,
+    McoreCriticConfig,
+    TrainingWorkerConfig,
+)
 
 
 class _StopInit(Exception):
@@ -95,3 +105,171 @@ def test_initialize_global_process_group_ray_forwards_timeout(monkeypatch, timeo
 
     assert len(calls) == 1
     assert calls[0]["timeout"] == expected_timeout
+
+
+# ---------------------------------------------------------------------------
+# The trainer-side hop: config key -> TrainingWorkerConfig.nccl_timeout
+# ---------------------------------------------------------------------------
+
+# Every place that copies the key out of a user-facing config into a TrainingWorkerConfig.
+_CALL_SITES = [
+    ("verl.workers.engine_workers", "ActorRolloutRefWorker", "init_model", 2),
+    ("verl.trainer.ppo.ray_trainer", "RayPPOTrainer", "init_workers", 1),
+    ("verl.trainer.ppo.v1.trainer_base", "PPOTrainer", "_setup", 1),
+    ("verl.experimental.separation.ray_trainer", "SeparateRayPPOTrainer", "_create_critic_class", 1),
+]
+
+
+def _nccl_timeout_reads_in(module_name: str, class_name: str, method_name: str):
+    """Return one AST call node per ``nccl_timeout=`` keyword argument in a method's body."""
+    import importlib
+
+    method = getattr(getattr(importlib.import_module(module_name), class_name), method_name)
+    tree = ast.parse(textwrap.dedent(inspect.getsource(method)))
+
+    reads = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "nccl_timeout":
+                reads.append(keyword.value)
+    return reads
+
+
+@pytest.mark.parametrize(("module_name", "class_name", "method_name", "expected"), _CALL_SITES)
+def test_call_sites_fall_back_to_torch_default(module_name, class_name, method_name, expected):
+    """No call site may substitute a literal timeout when the config does not carry the key.
+
+    ``critic.nccl_timeout`` only exists on ``McoreCriticConfig``; on an FSDP critic the key is
+    absent and ``BaseConfig.get`` quietly hands back whatever default the caller supplied. A
+    literal default there is a timeout nobody can configure, and one that *shortens* the effective
+    process-group timeout relative to torch's own default - the opposite of what the knob is for.
+    So every read must be a plain ``.get("nccl_timeout")`` whose fallback is ``None``.
+    """
+    reads = _nccl_timeout_reads_in(module_name, class_name, method_name)
+
+    assert len(reads) == expected, f"expected {expected} nccl_timeout read(s) in {class_name}.{method_name}"
+    for read in reads:
+        rendered = ast.unparse(read)
+        assert isinstance(read, ast.Call), f"{rendered} should read the key off the config"
+        assert isinstance(read.func, ast.Attribute) and read.func.attr == "get", rendered
+        assert len(read.args) == 1 and not read.keywords, (
+            f"{rendered} passes a fallback timeout; the fallback must stay None so that an "
+            f"unconfigured run keeps torch's own default"
+        )
+
+
+def test_fsdp_critic_config_cannot_carry_an_nccl_timeout():
+    """The premise of the test above: only the Megatron critic declares the key.
+
+    ``verl/trainer/config/critic/dp_critic.yaml`` has no ``nccl_timeout`` either, so an FSDP
+    critic has no way to set one - which is why the fallback is the *only* value it can ever see.
+    """
+    assert "nccl_timeout" in McoreCriticConfig.__dataclass_fields__
+    assert McoreCriticConfig.__dataclass_fields__["nccl_timeout"].default == 600
+    assert "nccl_timeout" not in FSDPCriticConfig.__dataclass_fields__
+
+    fsdp_critic = _critic_config(FSDPCriticConfig)
+    assert fsdp_critic.get("nccl_timeout") is None
+    # BaseConfig.get swallows the AttributeError, so a literal default is returned verbatim.
+    assert fsdp_critic.get("nccl_timeout", 600) == 600
+
+
+def _critic_config(cls, **kwargs):
+    """A minimal critic config; ``model`` only has to expose ``fsdp_config`` to the trainer."""
+    return cls(
+        ppo_micro_batch_size_per_gpu=1,
+        model=SimpleNamespace(fsdp_config=FSDPEngineConfig()),
+        **kwargs,
+    )
+
+
+@dataclass
+class _CriticConfigWithNcclTimeout(FSDPCriticConfig):
+    """An FSDP critic that declares the key, the way ``McoreCriticConfig`` does."""
+
+    nccl_timeout: int = 1234
+
+
+def _critic_worker_config_built_by_separate_trainer(critic_config):
+    """Run the separate-trainer critic wiring and return the ``TrainingWorkerConfig`` it builds."""
+    from verl.experimental.separation.ray_trainer import SeparateRayPPOTrainer
+    from verl.trainer.ppo.ray_trainer import Role
+
+    built = {}
+
+    trainer = SimpleNamespace(
+        use_critic=True,
+        config=SimpleNamespace(critic=critic_config),
+        resource_pool_manager=SimpleNamespace(get_resource_pool=lambda role: "pool"),
+        resource_pool_to_cls={"pool": {}},
+        role_worker_mapping={Role.Critic: object()},
+    )
+
+    with (
+        patch("verl.experimental.separation.ray_trainer.omega_conf_to_dataclass", lambda cfg: cfg),
+        patch(
+            "verl.experimental.separation.ray_trainer.RayClassWithInitArgs",
+            lambda cls, config: built.setdefault("config", config),
+        ),
+    ):
+        SeparateRayPPOTrainer._create_critic_class(trainer)
+
+    assert "config" in built, "the trainer never built a critic worker config"
+    return built["config"]
+
+
+def test_separate_trainer_keeps_torch_default_for_fsdp_critic():
+    """An FSDP critic has no ``nccl_timeout`` key, so the worker must keep torch's own default."""
+    worker_config = _critic_worker_config_built_by_separate_trainer(_critic_config(FSDPCriticConfig))
+
+    assert isinstance(worker_config, TrainingWorkerConfig)
+    assert worker_config.nccl_timeout is None
+
+
+def test_separate_trainer_forwards_configured_critic_nccl_timeout():
+    """A critic config that does declare the key has it copied over verbatim."""
+    worker_config = _critic_worker_config_built_by_separate_trainer(_critic_config(_CriticConfigWithNcclTimeout))
+
+    assert worker_config.nccl_timeout == 1234
+
+
+# ---------------------------------------------------------------------------
+# Colocation: one process group per process, so one timeout per process
+# ---------------------------------------------------------------------------
+
+
+def test_colocated_workers_share_the_first_workers_timeout(monkeypatch):
+    """``initialize_global_process_group_ray`` is a no-op once the group exists.
+
+    In a colocated PPO run the actor's and the critic's ``TrainingWorker`` live in the same
+    process, so whichever is constructed first decides the timeout for both and the second
+    worker's ``nccl_timeout`` is silently dropped. This pins that behavior rather than endorsing
+    it - see the PR discussion on which role should win.
+    """
+    initialized = {"value": False}
+    calls = []
+
+    def _init_process_group(**kwargs):
+        calls.append(kwargs)
+        initialized["value"] = True
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: initialized["value"])
+    monkeypatch.setattr(torch.distributed, "init_process_group", _init_process_group)
+
+    def _stop():
+        raise _StopInit
+
+    with (
+        patch.object(engine_workers.Worker, "__init__", lambda self: None),
+        # The real initialize_global_process_group_ray runs; abort on the next statement.
+        patch.object(engine_workers, "set_numa_affinity", _stop),
+    ):
+        for nccl_timeout in (1800, 600):
+            config = TrainingWorkerConfig(model_type="language_model", nccl_timeout=nccl_timeout)
+            with pytest.raises(_StopInit):
+                engine_workers.TrainingWorker(config=config)
+
+    assert len(calls) == 1, "the second colocated worker must not create a second process group"
+    assert calls[0]["timeout"] == timedelta(seconds=1800), "the first worker constructed wins"

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -174,6 +174,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                 optimizer_config=self.orig_critic_cfg.optim,
                 checkpoint_config=self.orig_critic_cfg.checkpoint,
                 profiler_config=critic_profiler_config,
+                nccl_timeout=self.orig_critic_cfg.get("nccl_timeout", 600),
             )
 
             critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -174,7 +174,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                 optimizer_config=self.orig_critic_cfg.optim,
                 checkpoint_config=self.orig_critic_cfg.checkpoint,
                 profiler_config=critic_profiler_config,
-                nccl_timeout=self.orig_critic_cfg.get("nccl_timeout", 600),
+                nccl_timeout=self.orig_critic_cfg.get("nccl_timeout"),
             )
 
             critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -828,7 +828,7 @@ class RayPPOTrainer:
                 optimizer_config=orig_critic_cfg.optim,
                 checkpoint_config=orig_critic_cfg.checkpoint,
                 profiler_config=critic_profiler_config,
-                nccl_timeout=orig_critic_cfg.get("nccl_timeout", 600),
+                nccl_timeout=orig_critic_cfg.get("nccl_timeout"),
                 extra_context=getattr(self, "_critic_extra_context", {}),
             )
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -828,6 +828,7 @@ class RayPPOTrainer:
                 optimizer_config=orig_critic_cfg.optim,
                 checkpoint_config=orig_critic_cfg.checkpoint,
                 profiler_config=critic_profiler_config,
+                nccl_timeout=orig_critic_cfg.get("nccl_timeout", 600),
                 extra_context=getattr(self, "_critic_extra_context", {}),
             )
 

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -276,7 +276,7 @@ class PPOTrainer(ABC):
                 optimizer_config=critic_cfg.optim,
                 checkpoint_config=critic_cfg.checkpoint,
                 profiler_config=critic_profiler_config,
-                nccl_timeout=critic_cfg.get("nccl_timeout", 600),
+                nccl_timeout=critic_cfg.get("nccl_timeout"),
             )
             resource_pool = self.resource_pool_manager.get_resource_pool(Role.Critic)
             critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=worker_cfg)

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -276,6 +276,7 @@ class PPOTrainer(ABC):
                 optimizer_config=critic_cfg.optim,
                 checkpoint_config=critic_cfg.checkpoint,
                 profiler_config=critic_profiler_config,
+                nccl_timeout=critic_cfg.get("nccl_timeout", 600),
             )
             resource_pool = self.resource_pool_manager.get_resource_pool(Role.Critic)
             critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=worker_cfg)

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -689,6 +689,8 @@ class TrainingWorkerConfig(BaseConfig):
     optimizer_config: OptimizerConfig = None
     checkpoint_config: CheckpointConfig = None
     profiler_config: ProfilerConfig = None
+    # timeout in seconds for the worker's torch process group. None keeps torch's own default.
+    nccl_timeout: Optional[int] = None
     # automatically select engine and optimizer function.
     # This function takes model config and the device name as parameter.
     # Users can pass in a higher-order function to take more parameters

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -85,11 +85,12 @@ class TrainingWorker(Worker, DistProfilerExtension):
 
         from verl.workers.engine import BaseEngine, EngineRegistry
 
-        initialize_global_process_group_ray(timeout_second=None)
+        self.config = config
+
+        initialize_global_process_group_ray(timeout_second=self.config.nccl_timeout)
 
         set_numa_affinity()
 
-        self.config = config
         self.model_config = self.config.model_config
         self.engine_config = self.config.engine_config
         self.optimizer_config = self.config.optimizer_config
@@ -573,6 +574,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 optimizer_config=ref_config.optim,
                 checkpoint_config=ref_config.checkpoint,
                 profiler_config=ref_profiler_config,
+                nccl_timeout=self.config.get("nccl_timeout", 600),
             )
 
             # assign engine configs
@@ -610,6 +612,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 optimizer_config=actor_config.optim,
                 checkpoint_config=actor_config.checkpoint,
                 profiler_config=actor_profiler_config,
+                nccl_timeout=self.config.get("nccl_timeout", 600),
             )
 
             assert self.config.actor.use_dynamic_bsz == self.config.rollout.log_prob_use_dynamic_bsz

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -574,7 +574,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 optimizer_config=ref_config.optim,
                 checkpoint_config=ref_config.checkpoint,
                 profiler_config=ref_profiler_config,
-                nccl_timeout=self.config.get("nccl_timeout", 600),
+                nccl_timeout=self.config.get("nccl_timeout"),
             )
 
             # assign engine configs
@@ -612,7 +612,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 optimizer_config=actor_config.optim,
                 checkpoint_config=actor_config.checkpoint,
                 profiler_config=actor_profiler_config,
-                nccl_timeout=self.config.get("nccl_timeout", 600),
+                nccl_timeout=self.config.get("nccl_timeout"),
             )
 
             assert self.config.actor.use_dynamic_bsz == self.config.rollout.log_prob_use_dynamic_bsz


### PR DESCRIPTION
### What does this PR do?

Fixes #7815.

`actor_rollout_ref.nccl_timeout` / `critic.nccl_timeout` are public, documented knobs for the worker's torch process-group timeout, but nothing has read them since #6067 (`044bbba2`, "deprecate workers, migrate to engines"). That commit deleted all four consumers — `fsdp_workers.py:166`, `:1333` and `megatron_workers.py:298`, `:1051`, each doing `timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600))` — and the engine workers that replaced them never picked the value back up. `verl/workers/engine_workers.py` hardcoded `initialize_global_process_group_ray(timeout_second=None)`, so torch's default always applied.

Seven official scripts under `examples/` still set the key (`run_deepseek_v3_671b_megatron.sh`, `run_qwen3_235b_a22b_megatron.sh`, `run_qwen3_next_80b_a3b_fsdp.sh`, `run_deepseek_v4_flash_megatron.sh`, `run_qwen3_5_122b_a10b_megatron.sh`, `run_glm5_2_megatron.sh`, `run_qwen3_next_80b_fsdp.sh`), and `critic/megatron_critic.yaml:22` actively tells users to raise it for 32B/72B megatron runs. This PR restores the wiring so those overrides take effect again.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+nccl_timeout
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

Not a duplicate: the only PR matching `nccl_timeout` is #2321, the original feature whose consumer #6067 removed. No open PR or issue reports the regression, though several open reports describe the symptom it prevents (#3704, #2325, #3873, #5750, #2106).

### Test

```bash
pytest tests/workers/test_nccl_timeout_wiring_on_cpu.py -q
```

CPU only. The test drives the real `TrainingWorker.__init__`, patching only `Worker.__init__`, `set_numa_affinity`, and `initialize_global_process_group_ray` (the last records `timeout_second` and then raises to abort before engine construction — the pattern already used by `tests/workers/test_engine_workers_mini_batch_trace_on_cpu.py`). A parametrized case also asserts `initialize_global_process_group_ray` forwards `timedelta(seconds=n)` / `None` to `torch.distributed.init_process_group`.

Written before the implementation. Pre-fix: `3 failed, 3 passed`, with

```
TypeError: TrainingWorkerConfig.__init__() got an unexpected keyword argument 'nccl_timeout'
AttributeError: 'TrainingWorkerConfig' object has no attribute 'nccl_timeout'
```

Post-fix: `14 passed`. The added tests cover the five trainer/worker call sites (an AST guard that each passes `.get("nccl_timeout")` with no fallback), the FSDP-critic case where the key does not exist on the config at all, a real `SeparateRayPPOTrainer._create_critic_class` call asserting `None` for a plain `FSDPCriticConfig` and the configured value for a subclass that declares the key, and the colocation behavior in point 1. The login Python here has no `torch`, so this was run in a throwaway CPU venv; nothing was installed into the repo. Also run: `scripts/generate_trainer_config.sh` → `All good` (all four generated YAMLs regenerate byte-identical), `tests/special_sanity/check_docstrings.py` → OK, and `tests/workers` → `153 passed, 2 failed` where both failures also reproduce on unmodified `upstream/main` in that venv (newer-than-pinned transformers/torch). Please run the CPU test in CI.

### API and Usage Example

No public config key is added, renamed or removed, and the four `_generated_ppo_*_trainer.yaml` files are unchanged (verified by regenerating them).

```bash
# these now take effect again, as they did before #6067
actor_rollout_ref.nccl_timeout=3600
critic.nccl_timeout=3600     # megatron critic
```

`TrainingWorkerConfig` gains an internal `nccl_timeout: Optional[int] = None` field. That dataclass is assembled programmatically at every call site (never through hydra), and all 12 sites pass keyword arguments, so the added field is not part of the public surface and does not depend on positional ordering.

### Design & Code Changes

The actor/ref process group is created by the inner `TrainingWorker`, which receives only a `TrainingWorkerConfig` — that dataclass had no timeout field, which is the missing link. The critic is a bare `ray.remote(TrainingWorker)` whose config is assembled in three different trainers. Hence:

- `verl/workers/config/engine.py` — add `nccl_timeout: Optional[int] = None` to `TrainingWorkerConfig`. `None` means "keep torch's own default", so SFT and any other builder is untouched.
- `verl/workers/engine_workers.py` — `initialize_global_process_group_ray(timeout_second=self.config.nccl_timeout)`. `self.config = config` is moved above that call (it previously sat below it); nothing between the two positions depends on it. `ActorRolloutRefWorker.init_model` also passes `nccl_timeout=self.config.get("nccl_timeout", 600)` into the actor and ref `TrainingWorkerConfig` builds — `ActorRolloutRefWorker` is constructed with `config=self.config.actor_rollout_ref`, so that is where the key lives.
- `verl/trainer/ppo/ray_trainer.py`, `verl/trainer/ppo/v1/trainer_base.py`, `verl/experimental/separation/ray_trainer.py` — one line each, passing `nccl_timeout=<critic_cfg>.get("nccl_timeout", 600)` into the critic's `TrainingWorkerConfig`. Fixing only one would have left the other two critic paths on the default.

The `.get(..., 600)` fallback is exactly what the pre-#6067 code used.

### Two things reviewers should know

**1. There is exactly one process group per worker process, so this knob is per-process, not per-role.** `initialize_global_process_group_ray` returns early when `torch.distributed.is_initialized()`, and in a colocated PPO run `WorkerDict.__init__` instantiates the sub-workers in `cls_dict` order: `ActorRolloutRefWorker.__init__` creates no group, so the **critic's** bare `TrainingWorker.__init__` is what creates it. The actor/ref values are computed later, inside `init_model()`, and their `initialize_global_process_group_ray` calls are no-ops.

So: with a critic present, `critic.nccl_timeout` decides the timeout for the whole process and `actor_rollout_ref.nccl_timeout` is still ignored. Without a critic (GRPO/DAPO — 5 of the 7 example scripts in #7815), the ref worker creates the group and `actor_rollout_ref.nccl_timeout` does apply. `tests/workers/test_nccl_timeout_wiring_on_cpu.py::test_colocated_workers_share_the_first_workers_timeout` pins this: two workers at 1800 s then 600 s in one process yield a single `init_process_group` call with 1800 s.

I have deliberately **not** tried to resolve which role should win — taking a max, letting the actor's value take precedence, or hoisting the timeout to a single process-level key are all plausible and all change behavior beyond this fix. Please tell me which semantics you want and I will follow up. This PR restores the wiring and pins the current behavior.

**2. An unconfigured run is byte-for-byte unchanged.** An earlier revision of this branch used `.get("nccl_timeout", 600)`, which was wrong: `nccl_timeout` is declared only on `McoreCriticConfig`, so `FSDPCriticConfig` has no such field and `BaseConfig.get` returned the literal `600` — a value an FSDP user could not override, and (combined with point 1) the timeout for the whole process. Since the backend is `cpu:gloo,<device>:nccl` and gloo's default is 1800 s, that would have *shortened* the effective timeout on a knob whose documented purpose is to raise it, risking new aborts in slow checkpoint gathers. All five call sites now fall back to `None`, which `verl/utils/distributed.py` already treats as "use torch's own default", matching `TrainingWorkerConfig.nccl_timeout: Optional[int] = None`'s docstring.

A small correction to the issue text: `critic.nccl_timeout` is declared only on `McoreCriticConfig` today, so it is a megatron-only key. Pre-#6067 `FSDPCriticConfig` declared it too (`044bbba2^:verl/workers/config/critic.py:294`); all call sites use the `.get` fallback, so both paths behave as they did.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): ruff `0.12.2` (the pinned version) `check` and `format --check` pass on all changed files.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU unit tests assert the configured value reaches `initialize_global_process_group_ray` through the real `TrainingWorker.__init__`, and that it is converted to a `timedelta` for `init_process_group`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

Not verified: no real multi-GPU or multi-node run. Nothing here was exercised against an actual NCCL process group.

AI assistance was used to locate the bug and draft the patch. A human author reviewed every changed line.

