### PR TITLE
[trainer] fix: measure length clip_ratio against the configured caps

### DIFF
--- a/tests/trainer/ppo/test_length_clip_ratio_on_cpu.py
+++ b/tests/trainer/ppo/test_length_clip_ratio_on_cpu.py
@@ -18,6 +18,8 @@ equals the configured cap. V1 stores jagged tensors and pads to the *batch* maxi
 so the width is data dependent and cannot be used as the truncation threshold.
 """
 
+import math
+
 import pytest
 import torch
 
@@ -153,3 +155,45 @@ def test_v0_shape_is_unchanged_by_the_fallback():
         "prompt_length/clip_ratio",
     ):
         assert explicit[key] == fallback[key]
+
+
+def test_v1_all_aborted_batch_reports_nan_clip_ratio():
+    # Every response is aborted, so the padded response width is 0 and the tensors are
+    # ``(bsz, 0)`` -- a shape the V0 padding path can never produce. The non-aborted
+    # statistics have no samples to average over and must fall back to NaN rather than
+    # raising.
+    batch = _make_v1_batch(prompt_lengths=[3, 4, 2, 4], response_lengths=[0, 0, 0, 0])
+    assert batch.batch["responses"].shape == (4, 0)
+
+    metrics = compute_data_metrics(
+        batch,
+        use_critic=False,
+        max_prompt_length=8,
+        max_response_length=6,
+    )
+
+    assert math.isnan(metrics["response_length_non_aborted/clip_ratio"])
+    assert metrics["response/aborted_ratio"] == 1.0
+    # the all-sample clip_ratio still has samples to average, none of which hit the cap
+    assert metrics["response_length/clip_ratio"] == 0.0
+    assert metrics["prompt_length/clip_ratio"] == 0.0
+
+
+def test_over_cap_length_is_not_counted_as_clipped():
+    # A true length above the passed cap yields 0.0, because the metric uses
+    # ``torch.eq`` and ``eq(10, 8)`` is False. No rollout path produces this today --
+    # every registered agent loop slices at the cap -- but V1 stores prompts jagged, so
+    # an over-cap prompt would flow through silently where V0 would crash on the shape.
+    # This test pins the chosen equality semantics so that switching to ``torch.ge``
+    # becomes a deliberate decision rather than an accident.
+    batch = _make_v1_batch(prompt_lengths=[10], response_lengths=[4])
+
+    metrics = compute_data_metrics(
+        batch,
+        use_critic=False,
+        max_prompt_length=8,
+        max_response_length=6,
+    )
+
+    assert metrics["prompt_length/clip_ratio"] == 0.0
+    assert metrics["prompt_length/max"] == 10.0

--- a/tests/trainer/ppo/test_length_clip_ratio_on_cpu.py
+++ b/tests/trainer/ppo/test_length_clip_ratio_on_cpu.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests that the length clip_ratio metrics measure against the configured caps.
+
+V0 pads every sample to the configured length before stacking, so the tensor width
+equals the configured cap. V1 stores jagged tensors and pads to the *batch* maximum,
+so the width is data dependent and cannot be used as the truncation threshold.
+"""
+
+import pytest
+import torch
+
+from verl import DataProto
+from verl.trainer.ppo.metric_utils import compute_data_metrics
+
+
+def _make_v1_batch(prompt_lengths, response_lengths):
+    """Build a batch shaped the way the V1 trainer produces it.
+
+    ``prompts``/``responses`` are padded to the batch maximum (not to the configured
+    cap) and the true lengths are carried in explicit ``prompt_length`` /
+    ``response_length`` columns, mirroring ``to_padded_tensor()`` in
+    ``verl/trainer/ppo/v1/trainer_base.py``.
+    """
+    bsz = len(response_lengths)
+    padded_prompt_width = max(prompt_lengths)
+    padded_response_width = max(response_lengths)
+
+    response_mask = torch.zeros((bsz, padded_response_width), dtype=torch.int64)
+    for i, length in enumerate(response_lengths):
+        response_mask[i, :length] = 1
+
+    tensors = {
+        "prompts": torch.zeros((bsz, padded_prompt_width), dtype=torch.int64),
+        "responses": torch.zeros((bsz, padded_response_width), dtype=torch.int64),
+        "response_mask": response_mask,
+        "token_level_scores": torch.zeros((bsz, padded_response_width)),
+        "token_level_rewards": torch.zeros((bsz, padded_response_width)),
+        "advantages": torch.zeros((bsz, padded_response_width)),
+        "returns": torch.zeros((bsz, padded_response_width)),
+        "prompt_length": torch.tensor(prompt_lengths, dtype=torch.float32),
+        "response_length": torch.tensor(response_lengths, dtype=torch.float32),
+    }
+    return DataProto.from_dict(tensors=tensors)
+
+
+def _make_v0_batch(prompt_lengths, response_lengths, max_prompt_length, max_response_length):
+    """Build a batch shaped the way V0 produces it: padded to the configured caps.
+
+    There are no ``prompt_length``/``response_length`` columns, so
+    ``_compute_response_info`` derives the true lengths from ``attention_mask``.
+    """
+    bsz = len(response_lengths)
+
+    prompt_mask = torch.zeros((bsz, max_prompt_length), dtype=torch.int64)
+    response_mask = torch.zeros((bsz, max_response_length), dtype=torch.int64)
+    for i, length in enumerate(prompt_lengths):
+        # prompts are left padded
+        prompt_mask[i, max_prompt_length - length :] = 1
+    for i, length in enumerate(response_lengths):
+        # responses are right padded
+        response_mask[i, :length] = 1
+
+    tensors = {
+        "prompts": torch.zeros((bsz, max_prompt_length), dtype=torch.int64),
+        "responses": torch.zeros((bsz, max_response_length), dtype=torch.int64),
+        "attention_mask": torch.cat([prompt_mask, response_mask], dim=-1),
+        "response_mask": response_mask,
+        "token_level_scores": torch.zeros((bsz, max_response_length)),
+        "token_level_rewards": torch.zeros((bsz, max_response_length)),
+        "advantages": torch.zeros((bsz, max_response_length)),
+        "returns": torch.zeros((bsz, max_response_length)),
+    }
+    return DataProto.from_dict(tensors=tensors)
+
+
+def test_v1_clip_ratio_is_zero_when_nothing_is_truncated():
+    # Caps are 8/6, nothing reaches them. V1 pads prompts to 5 and responses to 4,
+    # so comparing against the tensor width would report 0.5 for both.
+    batch = _make_v1_batch(prompt_lengths=[3, 5, 5, 2], response_lengths=[2, 3, 4, 4])
+
+    metrics = compute_data_metrics(
+        batch,
+        use_critic=False,
+        max_prompt_length=8,
+        max_response_length=6,
+    )
+
+    assert metrics["response_length/clip_ratio"] == 0.0
+    assert metrics["response_length_non_aborted/clip_ratio"] == 0.0
+    assert metrics["prompt_length/clip_ratio"] == 0.0
+    # the mean/max/min statistics are computed over true lengths and stay unchanged
+    assert metrics["response_length/max"] == 4.0
+    assert metrics["prompt_length/max"] == 5.0
+
+
+def test_v1_clip_ratio_reports_the_truncated_fraction():
+    # Responses: two of four samples hit the cap of 6, one is aborted (length 0).
+    # Prompts: nothing reaches the cap of 8 even though the padded width is 4.
+    batch = _make_v1_batch(prompt_lengths=[4, 4, 3, 4], response_lengths=[6, 3, 0, 6])
+
+    metrics = compute_data_metrics(
+        batch,
+        use_critic=False,
+        max_prompt_length=8,
+        max_response_length=6,
+    )
+
+    assert metrics["response_length/clip_ratio"] == 0.5
+    # non-aborted samples are [6, 3, 6] -> 2/3 truncated
+    assert metrics["response_length_non_aborted/clip_ratio"] == pytest.approx(2.0 / 3.0)
+    assert metrics["response/aborted_ratio"] == 0.25
+    assert metrics["prompt_length/clip_ratio"] == 0.0
+
+
+def test_v0_shape_is_unchanged_by_the_fallback():
+    # V0 pads to the configured caps, so width == cap and the fallback must reproduce
+    # exactly what is reported today.
+    batch = _make_v0_batch(
+        prompt_lengths=[3, 5],
+        response_lengths=[4, 2],
+        max_prompt_length=5,
+        max_response_length=4,
+    )
+
+    fallback = compute_data_metrics(batch, use_critic=False)
+
+    assert fallback["response_length/clip_ratio"] == 0.5
+    assert fallback["response_length_non_aborted/clip_ratio"] == 0.5
+    assert fallback["prompt_length/clip_ratio"] == 0.5
+
+    # passing the caps explicitly must agree with the fallback when width == cap
+    explicit = compute_data_metrics(
+        batch,
+        use_critic=False,
+        max_prompt_length=5,
+        max_response_length=4,
+    )
+    for key in (
+        "response_length/clip_ratio",
+        "response_length_non_aborted/clip_ratio",
+        "prompt_length/clip_ratio",
+    ):
+        assert explicit[key] == fallback[key]

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -446,6 +446,10 @@ def compute_data_metrics(
             ``prompt_length/clip_ratio``. Defaults to the width of ``batch["prompts"]``.
         max_response_length: Configured response length cap used as the threshold for
             ``response_length/clip_ratio``. Defaults to the width of ``batch["responses"]``.
+            Note that the effective rollout cap may additionally be bounded per sample by
+            ``rollout.max_model_len``, which the rollout servers subtract the prompt length
+            from; while that bound binds, no sample reaches the configured cap and the
+            clip_ratio metrics under-report.
 
     Returns:
         A dictionary of metrics including:

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -426,7 +426,12 @@ class RolloutMoELoadBalanceMetricsAccumulator:
         return metrics
 
 
-def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str, Any]:
+def compute_data_metrics(
+    batch: DataProto,
+    use_critic: bool = True,
+    max_prompt_length: int | None = None,
+    max_response_length: int | None = None,
+) -> dict[str, Any]:
     """
     Computes various metrics from a batch of data for PPO training.
 
@@ -437,6 +442,10 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
     Args:
         batch: A DataProto object containing batch data with token-level scores, rewards, advantages, etc.
         use_critic: Whether to include critic-specific metrics. Defaults to True.
+        max_prompt_length: Configured prompt length cap used as the threshold for
+            ``prompt_length/clip_ratio``. Defaults to the width of ``batch["prompts"]``.
+        max_response_length: Configured response length cap used as the threshold for
+            ``response_length/clip_ratio``. Defaults to the width of ``batch["responses"]``.
 
     Returns:
         A dictionary of metrics including:
@@ -456,8 +465,14 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
     advantages = batch.batch["advantages"]
     returns = batch.batch["returns"]
 
-    max_prompt_length = batch.batch["prompts"].shape[-1]
-    max_response_length = batch.batch["responses"].shape[-1]
+    # The clip_ratio metrics report the truncation rate, so they must be measured
+    # against the configured length caps. V0 pads every sample to those caps before
+    # stacking, so the tensor width is an exact fallback; V1 keeps jagged tensors and
+    # pads to the batch maximum, where the width would make the metric never reach 0.
+    if max_prompt_length is None:
+        max_prompt_length = batch.batch["prompts"].shape[-1]
+    if max_response_length is None:
+        max_response_length = batch.batch["responses"].shape[-1]
 
     response_mask = batch.batch["response_mask"].bool()
 

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1877,7 +1877,16 @@ class PPOTrainer(ABC):
                 accumulator=self._rollout_moe_lb_metrics_accumulator,
             )
         )
-        metrics.update(compute_data_metrics(batch=metrics_batch, use_critic=self.use_critic))
+        # V1 pads to the batch maximum, so pass the configured caps explicitly: the
+        # tensor width is not the truncation threshold. See #7817.
+        metrics.update(
+            compute_data_metrics(
+                batch=metrics_batch,
+                use_critic=self.use_critic,
+                max_prompt_length=self.config.actor_rollout_ref.rollout.prompt_length,
+                max_response_length=self.config.actor_rollout_ref.rollout.response_length,
+            )
+        )
         metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
         n_gpus = self._get_n_gpus_for_throughput()
         metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))


### PR DESCRIPTION
### What does this PR do?

Fixes #7817.

`response_length/clip_ratio`, `response_length_non_aborted/clip_ratio` and `prompt_length/clip_ratio` are meant to report the truncation rate, but `compute_data_metrics` derived the threshold from the tensor width:

```python
max_prompt_length = batch.batch["prompts"].shape[-1]
max_response_length = batch.batch["responses"].shape[-1]
```

That identity holds on V0, where the agent loop pads every sample to the configured length before stacking (`agent_loop.py:723-735`). It does not hold on the default V1 trainer: V1 keeps jagged tensors, calls `to_padded_tensor()` — which pads to the **batch maximum** — and carries the true lengths in separate `prompt_length` / `response_length` columns that `_compute_response_info` then prefers (`metric_utils.py:75-79`). So V1 compared the true length against the longest sample in the batch. Some row always attains the batch maximum, which means the metric could never report 0 and was wrong precisely when nothing was truncated.

This PR passes the configured caps in explicitly, and falls back to `.shape[-1]` when they are absent so V0 and any external caller behave exactly as before.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+clip_ratio+length
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

Not a duplicate: `gh pr list --search "7817 in:body"` is empty, and a keyword search for length/clip_ratio work surfaces only unrelated PRs (#3479 GFPO, #7519 MXFP8). Issue #7412 ("repsonse_length_cliprate is so height") is a V0 user asking about a genuinely high clip rate, not this bug — its own log shows `response_length/max` equal to the configured cap, i.e. the padded-to-cap width V1 lost.

### Test

```bash
pytest tests/trainer/ppo/test_length_clip_ratio_on_cpu.py -q
```

`compute_data_metrics` is a pure function, so this is cheap and CPU-only: three cases, two building a V1-shaped `DataProto` (explicit length columns, tensors padded to the batch max) and one building the V0 shape to guard the fallback.

Written before the implementation. Pre-fix the new tests failed on the signature, so I additionally called the **unpatched** function on the V1-shaped fixtures to record the actual wrong numbers (caps 8/6, nothing truncated):

```
response_length/clip_ratio              = 0.5     <- should be 0.0
response_length_non_aborted/clip_ratio  = 0.5     <- should be 0.0
prompt_length/clip_ratio                = 0.5     <- should be 0.0
```

Post-fix: `41 passed` — 5 tests in the new file plus all 36 pre-existing tests in `tests/trainer/ppo/test_metric_utils_on_cpu.py`, which required no edits. This ran in a throwaway CPU venv (the login Python here has no `torch`); nothing was installed into the repo. Please run the CPU test in CI.

**Correction to an earlier revision of this description:** it claimed `tests/trainer/ppo/test_metric_utils_on_cpu.py` still guards the V0 fallback. That is wrong — `grep -c clip_ratio` on that file returns `0`. Its `TestComputeDataMetrics` builds the batch as a `MagicMock` and asserts only key presence plus two critic means, so it would pass even if the fallback were deleted. The fallback is guarded solely by `test_v0_shape_is_unchanged_by_the_fallback` in the new file, which drives a real `DataProto` padded to the cap and asserts all three ratios.

### API and Usage Example

No config key is added, renamed or removed, and the generated `_generated_ppo_*_trainer.yaml` files are unchanged. `compute_data_metrics` gains two optional keyword arguments, so existing callers keep working unchanged:

```python
# unchanged - infers the caps from tensor width, correct for V0-shaped batches
compute_data_metrics(batch=batch, use_critic=self.use_critic)

# V1 - the width is the batch max, so the caps are passed explicitly
compute_data_metrics(
    batch=metrics_batch,
    use_critic=self.use_critic,
    max_prompt_length=self.config.actor_rollout_ref.rollout.prompt_length,
    max_response_length=self.config.actor_rollout_ref.rollout.response_length,
)
```

### Design & Code Changes

- `verl/trainer/ppo/metric_utils.py` — `compute_data_metrics` takes `max_prompt_length` / `max_response_length` (both `int | None = None`); the two `.shape[-1]` reads become `if ... is None:` fallbacks. Nothing else in the function changes, so all three clip-ratio metrics are fixed together.
- `verl/trainer/ppo/v1/trainer_base.py` — `_compute_metrics` passes `rollout.prompt_length` / `rollout.response_length`.
- `tests/trainer/ppo/test_length_clip_ratio_on_cpu.py` — new, 5 CPU tests: the two V1 cases, the V0 fallback guard, an all-aborted V1 batch (zero-width `responses`, `NaN` non-aborted ratio, `aborted_ratio == 1.0`), and one pinning the `torch.eq` semantics when a length exceeds the cap.

Two deliberate choices worth flagging:

1. **Explicit kwargs rather than `batch.meta_info`.** The issue suggested `meta_info`, but the sibling calls in the same method already pass config-derived scalars as explicit arguments (`compute_throughout_metrics(..., n_gpus=...)`, `compute_moe_lb_metrics(..., moe_lb_metrics_interval=...)`), whereas `meta_info` there carries data-plane state like `global_token_num`. A `meta_info` lookup would also have broken `tests/trainer/ppo/test_metric_utils_on_cpu.py:293`, which builds the batch as a bare `MagicMock` — `batch.meta_info.get(...)` would return a truthy `MagicMock` and `torch.eq` would raise. With kwargs that test passes untouched and now doubles as a fallback guard.
2. **Which caps.** `rollout.yaml:35,39` shows `prompt_length: ${oc.select:data.max_prompt_length,512}`, i.e. interpolation runs from `data.*` into `rollout.*`, so `rollout.prompt_length` is the resolved value — and it is exactly what V0's agent loop pads to, which is what makes V0 and V1 agree after this change.

Callers left on the fallback deliberately: `verl/trainer/ppo/ray_trainer.py:1772` and `verl/experimental/separation/ray_trainer.py:739`. I checked both — neither calls `to_padded_tensor()` nor writes the `prompt_length`/`response_length` columns, so their batches are V0-shaped and their width *is* the cap. Their behavior is byte-identical.

There is a third cap this PR does **not** account for, and I want to flag it rather than leave it implied: all three rollout servers additionally clamp per sample to `max_model_len - len(prompt_ids)` (`vllm_async_server.py:591,615`, `async_sglang_server.py:588,609`, `trtllm_async_server.py:332`), and `rollout.max_model_len` defaults to the model's `max_position_embeddings`. While that bound binds, every truncated sample lands strictly below `rollout.response_length` at a different value, so the metric reports `0.0`. That is pre-existing — V0 pads to `rollout.response_length` and fails equality identically — so I have only documented it in the new kwargs' docstring rather than changing behavior here. Fixing it properly needs a truncation flag (`finish_reason == "length"` is already plumbed) rather than a length comparison, which is filed separately as #7823.

For reviewers: I kept `torch.eq` rather than widening to `torch.ge`, to keep the diff minimal. I verified this is safe today because the agent loops cap both sides at the configured values (`single_turn_agent_loop.py:34-35,89` and `tool_agent_loop.py:120-121,192` slice `response_ids[: self.response_length]`; `agent_loop.py:347` caps the prompt), and V1 builds from that same path, so a true length can never exceed the cap and `eq` is equivalent to `ge`. If a future rollout backend could emit longer sequences, `torch.ge` would be the safer form — happy to change it if you prefer defensiveness here.

Note that this changes the reported value for existing V1 runs — that is the point of the fix, but dashboards spanning the change will show a discontinuity, usually downward.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): ruff `0.12.2` (the pinned version) `check` and `format --check` pass on all changed files.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: CPU unit tests assert the clip ratios are 0 on a V1-shaped batch where nothing hit the cap, are correct when some samples do, and that a V0-shaped batch with no caps supplied is unchanged.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

Not verified: no GPU or end-to-end V1 training step was run. The `trainer_base.py` change is verified by reading and `py_compile`; the metric arithmetic is verified by the new CPU test.

AI assistance was used to locate the bug and draft the patch. A human author reviewed every changed line.


