### PR TITLE
[megatron] fix: keep fused log-prob kernels available with MTP on bshd

### DIFF
--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -278,8 +278,19 @@ def gptmodel_forward_model_engine(
     cp_layout: str = "zigzag",
     router_padding_mask: torch.Tensor | None = None,
     mtp_loss_normalization_factor: float | None = None,
+    fused_output_processor_context=None,
 ):
-    """Default forward pass for GPT models with optional sequence packing."""
+    """Default forward pass for GPT models with optional sequence packing.
+
+    ``fused_output_processor_context`` opts the bshd path into Megatron Core
+    0.18's output-processor hook, so log-probs and entropy are computed straight
+    from hidden states.  Without it the model returns a ``[b, s, vocab]`` logits
+    tensor that the caller then reduces -- for a 248k vocab at 128k sequence that
+    single tensor is ~30 GB per rank (doubled again when entropy forces a clone),
+    which is what makes long-context training OOM.  Only bshd needs this: the thd
+    path already has ``fused_forward_model_engine``, but sequence packing is
+    unavailable for models whose attention (e.g. Qwen3.5 GDN) has no THD kernel.
+    """
 
     assert data_format in ["thd", "bshd"], "data_format must be 'thd' or 'bshd'"
     pre_process = unwrap_model(model).pre_process
@@ -450,13 +461,52 @@ def gptmodel_forward_model_engine(
         else:
             attention_mask = attention_mask_bshd
 
+        use_fused_output_processor = fused_output_processor_context is not None and post_process
+        if use_fused_output_processor:
+            from verl.models.mcore.model_forward_fused import fused_output_processor
+
+            # The hook needs labels, but they must NOT go in as ``model_kwargs["labels"]``:
+            # GPTModel forwards that straight into _postprocess, where the MTP patch
+            # gates its drafter forward on ``labels is not None``.  With
+            # mtp.enable_train=False that branch is meant to stay dormant, and waking
+            # it hits MultiTokenPredictionLayer._checkpointed_forward(padding_mask=...),
+            # which older Megatron builds do not accept.  Carry them on the context
+            # instead; mtp_patch reads them from there when invoking the processor.
+            fused_output_processor_context.labels = preprocess_bshd_engine(
+                logits_processor_args["label"],
+                pre_process=True,
+                need_roll=True,
+                use_fp8_padding=use_fp8_padding,
+                forced_max_seqlen=forced_max_seqlen,
+            )[0].contiguous()
+            model_kwargs["output_processor"] = fused_output_processor
+            model_kwargs["output_processor_context"] = fused_output_processor_context
+
         output_orig = model(
             input_ids=input_ids_bshd,
             attention_mask=attention_mask,
             position_ids=None if vision_model else position_ids_bshd,
             **model_kwargs,
         )
-        if post_process and logits_processor is not None:
+        if use_fused_output_processor:
+            # output_orig is a CausalLMOutputForPPO; mirror the key names the
+            # logits_processor branch produces so downstream code is unchanged.
+            # linear_cross_entropy returns flat (num_tokens,) tensors, while the
+            # bshd postprocess asserts output.shape[:2] == attention_mask.shape,
+            # so restore the [b, s] layout the rest of the path expects.
+            bshd_shape = input_ids_bshd.shape
+
+            def _to_bshd(t):
+                return t.view(bshd_shape) if t.dim() == 1 else t
+
+            output_dict = {"log_probs": _to_bshd(output_orig.log_probs)}
+            if output_orig.entropy is not None:
+                output_dict["entropy"] = _to_bshd(output_orig.entropy)
+            output = {
+                k: postprocess_bshd_engine(v, attention_mask_bshd, post_process=post_process)
+                for k, v in output_dict.items()
+            }
+        elif post_process and logits_processor is not None:
             args = {
                 k: preprocess_bshd_engine(
                     v,

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -17,7 +17,7 @@
 import inspect
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 import megatron.core as mcore
 import torch
@@ -78,6 +78,11 @@ class FusedOutputProcessorContext:
     """Context passed through Megatron's native output-processor hook."""
 
     temperature: float
+    # bshd carries labels here rather than through ``model(labels=...)``: that
+    # argument also drives the MTP patch's drafter branch, which must stay dormant
+    # when mtp.enable_train is False. Unused by the thd path, which has labels in
+    # scope at the call site.
+    labels: Any = None
 
 
 def fused_output_processor(
@@ -105,6 +110,12 @@ def fused_output_processor(
     # Megatron passes the shared embedding as output_weight for tied models. For
     # untied models the weight lives on output_layer.
     weight = output_weight if output_weight is not None else output_layer.weight
+
+    # bshd routes labels through the context instead of ``model(labels=...)``, which
+    # would also wake the MTP patch's drafter branch. Megatron's native _postprocess
+    # forwards its own (None) labels here, so fall back to the context copy.
+    if labels is None:
+        labels = getattr(context, "labels", None)
 
     temperature = context.temperature
     logprobs, entropy = linear_cross_entropy(

--- a/verl/models/mcore/mtp_patch.py
+++ b/verl/models/mcore/mtp_patch.py
@@ -253,6 +253,33 @@ def _megatron_gptmodel_postprocess(
                     safe_num_tokens = num_tokens.clamp(min=1)
                     hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * mtp_loss / safe_num_tokens)
 
+    # Honour Megatron Core 0.18's output-processor hook, which this patch replaced
+    # along with the rest of GPTModel._postprocess.  Without it the MTP path always
+    # materialises a [s, b, vocab] logits tensor (plus a second copy for the
+    # transpose), which for Qwen3.5's 248k vocab is ~30 GB per copy per rank at a
+    # 128k sequence -- the dominant term in long-context training OOMs.  The fused
+    # processor consumes hidden_states directly, so nothing of that size is built.
+    # Argument list mirrors GPTModel._postprocess in megatron/core/models/gpt/gpt_model.py.
+    if output_processor is not None:
+        return output_processor(
+            hidden_states=hidden_states,
+            output_layer=self.output_layer,
+            output_weight=output_weight,
+            labels=labels,
+            loss_mask=loss_mask,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            decoder_input=decoder_input,
+            inference_context=inference_context,
+            packed_seq_params=packed_seq_params,
+            runtime_gather_output=runtime_gather_output,
+            context=output_processor_context,
+            compute_language_model_loss=self.compute_language_model_loss,
+            scale_logits=getattr(self, "_scale_logits", None),
+            config=self.config,
+        )
+
     logits, _ = self.output_layer(hidden_states, weight=output_weight, runtime_gather_output=runtime_gather_output)
     # [s b h] => [b s h]
     return logits.transpose(0, 1).contiguous()

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -523,15 +523,33 @@ class MegatronEngine(BaseEngine):
         if not self.engine_config.use_fused_kernels:
             return
 
-        if not self.engine_config.use_remove_padding or self.is_value_model or self.model_config.mtp.enable:
-            logger.warning_once(
-                "Fused kernels require remove-padding and are not supported for value models or when MTP is enabled "
-                "in Megatron engine; disabling."
-            )
+        if self.is_value_model:
+            logger.warning_once("Fused kernels are not supported for value models in Megatron engine; disabling.")
             self.engine_config.use_fused_kernels = False
             return
 
-        from verl.models.mcore.model_forward_fused import patch_fused_forward
+        from verl.models.mcore.model_forward_fused import (
+            _get_patching_model,
+            _supports_output_processor_hook,
+            patch_fused_forward,
+        )
+
+        # Without sequence packing the thd-only `fused_forward_model_engine` entry
+        # point is unusable, but Megatron Core 0.18's output-processor hook is not:
+        # it hands the processor hidden states, which are layout-agnostic. Models
+        # whose attention has no THD kernel (Qwen3.5 GDN) are forced onto bshd and
+        # would otherwise be stuck materialising full logits.
+        if not self.engine_config.use_remove_padding:
+            # Resolve the inner GPTModel the same way the fused module does; the
+            # hook lives on it, not on the wrapper mbridge hands us.
+            inner = [_get_patching_model(model) for model in self.module]
+            if not all(m is not None and _supports_output_processor_hook(m) for m in inner):
+                logger.warning_once(
+                    "Fused kernels without remove-padding require Megatron Core >= 0.18 "
+                    "(output-processor hook); disabling."
+                )
+                self.engine_config.use_fused_kernels = False
+            return
 
         for model in self.module:
             patch_fused_forward(model)
@@ -1319,6 +1337,14 @@ class MegatronEngineWithLMHead(MegatronEngine):
         if use_fused_kernels:
             temperature_value = _resolve_fused_temperature(temperature)
 
+        # bshd has no packed fused entry point; it goes through the regular forward
+        # with the output-processor hook attached instead (see _maybe_enable_fused_kernels).
+        use_fused_bshd = use_fused_kernels and not self.engine_config.use_remove_padding
+        if use_fused_bshd:
+            from verl.models.mcore.model_forward_fused import FusedOutputProcessorContext
+
+            use_fused_kernels = False
+
         if use_fused_kernels:
             from verl.models.mcore import get_mcore_forward_fused_model_engine_fn
 
@@ -1396,6 +1422,9 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
                 pad_to_length_bucket=pad_to_length_bucket,
                 cp_layout=cp_layout,
+                fused_output_processor_context=(
+                    FusedOutputProcessorContext(temperature=temperature_value) if use_fused_bshd else None
+                ),
             )
 
         # Router replay: record routing decisions for R2 mode


### PR DESCRIPTION
> **Draft.** Opened early so a user hitting this OOM can test the branch. AI assistance
> was used (see disclosure at the end); the end-to-end 128k run is still in progress and
> the numbers below state exactly what has and has not been verified.

### What does this PR do?

Enabling MTP rollout disables fused kernels outright, so the Megatron training forward
falls back to materialising a full `[s, b, vocab]` logits tensor. For Qwen3.5
(`vocab_size=248320`) at a 128k sequence that is ~30 GB per rank, doubled by the
`transpose(0, 1).contiguous()` copy. Long-context runs OOM on 96 GB cards **regardless
of world size** — each rank still processes one sequence, so adding GPUs does not help.

Three things combine to force the fallback:

1. **`mtp.enable` gates the fused path even when `mtp.enable_train=False`.**
   `patch_engine_mtp` is applied on the master switch alone (`transformer_impl.py:608`).
   Its `_postprocess` replacement accepts `output_processor` / `output_processor_context`
   in the signature but never invokes them, dropping the Megatron Core 0.18 contract that
   `GPTModel._postprocess` honours at `gpt_model.py:690`. With `mtp_num_layers` unset the
   patch does no MTP work at all, yet still costs the fused path.
2. **The fused entry point is thd-only.** `fused_forward_model_engine` calls
   `preprocess_thd_engine` unconditionally. Qwen3.5's GDN linear attention has no THD
   kernel in Megatron-LM, so the model is forced onto bshd
   (see the note in `examples/grpo_trainer/run_qwen3_5_35b_megatron.sh`).
3. **`use_remove_padding` therefore gates fused kernels off** — although
   `linear_cross_entropy` itself does `hidden.view(-1, hidden.shape[-1])` and is
   layout-agnostic. The requirement belongs to the thd *entry point*, not to the kernel.

Rather than widening the thd path, this wires the hook through the existing bshd forward:

- `mtp_patch`: invoke `output_processor` before projecting logits, mirroring
  `GPTModel._postprocess`'s argument list.
- `model_forward`: the bshd branch accepts a processor context and maps the fused output
  onto the same `{log_probs, entropy}` keys the `logits_processor` branch produces.
- `model_forward_fused`: the context carries labels and the processor falls back to them.
- `transformer_impl`: gate on hook availability rather than on `mtp.enable`; the
  value-model exclusion is unchanged.

Labels deliberately ride on the context rather than `model(labels=...)`: that argument
also drives the MTP patch's drafter branch, which must stay dormant when
`enable_train=False` — waking it hits
`MultiTokenPredictionLayer._checkpointed_forward(padding_mask=...)`, which the Megatron
build here does not accept.

### Not a duplicate

- **#7686 (`response_only_lm_head`)** targets the same memory pressure by a different
  mechanism: it reduces the *number of rows* projected via `loss_mask`, still producing
  `O(active_rows × vocab)` logits, and works on the unfused path. This PR removes the
  logits tensor entirely (`O(block)`, independent of sequence length) by unblocking the
  fused path. They are complementary — #7686 helps most when padding dominates, this PR
  also helps when generations fill the window.
- **#4539** patches `_postprocess` to add MTP *training* modes. It is a draft and does not
  address the output-processor contract; if it lands first this change reduces to keeping
  the hook call in the new structure.
- **#5332 / #7499** handle `labels=None` in the fused forward (#5273). Related but
  distinct: they fix a crash in the thd path, this PR is about the gate and the bshd path.

### Test

Numerical parity was checked on identical tensors rather than by comparing training runs
— rollout samples at `temperature=1.0`, so two runs see different data and the metric
spread is dominated by data variance, not by the computation path.

```
python3 fused_parity_test.py --seq {2048,8192,32768} --vocab 248320 --hidden 2048
```

| seq | logprob max_rel | entropy max_rel | fused peak | naive peak |
|---|---|---|---|---|
| 2,048 | 3.950e-05 | 6.142e-07 | 0.962 GB | 7.62 GB |
| 8,192 | 3.792e-05 | 6.142e-07 | 1.005 GB | 27.5 GB |
| 32,768 | 3.950e-05 | 6.910e-07 | 1.177 GB | 107.2 GB |

Relative error is ~200x below bf16 machine epsilon (7.8e-3) and does not grow with
sequence length — consistent with accumulation-order differences only; the fused kernel
accumulates in fp32. Fused peak memory is essentially the weight tensor itself
(248320 × 2048 × 2 B = 0.95 GB); the logits blocks never leave SRAM.

End-to-end on 8x H20-3e, Qwen3.5-35B-A3B, TP=2 EP=8, GRPO on DAPO-Math:

- 8k response, 2 steps, `use_fused_kernels=True`: completes, no gate warning.
- **128k response: run in progress; this PR will not be marked ready until it is reported.**

### Caveats

- Only the bshd path is touched; thd behaviour is unchanged.
- `mtp.enable_train=True` is untested here.
- Verified against Megatron Core 0.18.0; the gate falls back with a warning when the hook
  is absent.

### AI assistance disclosure

Investigation, patch and tests were produced with AI assistance (Claude). The failure
analysis above was derived from reading the code paths and confirmed by the measurements
shown. Reviewers should treat the 128k end-to-end claim as pending.
