### PR TITLE
[megatron, ci] fix: configure Megatron integration in Ascend images and tests

### DIFF
--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -84,6 +84,7 @@ jobs:
     env:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
+      VERL_USE_EXTERNAL_MODULES: "megatron_adaptor" # import megatron_adaptor to patch megatron-lm
     steps:
       - name: Check npu and CANN info
         run: |

--- a/docker/ascend/Dockerfile.ascend_9.1.0_a2
+++ b/docker/ascend/Dockerfile.ascend_9.1.0_a2
@@ -21,9 +21,8 @@ RUN ARCH=$(uname -m) && \
     # Clone libs
     git clone --depth 1 --branch v0.23.0 https://github.com/vllm-project/vllm.git && \
     git clone -b releases/v0.23.0 https://github.com/vllm-project/vllm-ascend.git && \
-    git clone https://gitcode.com/Ascend/MindSpeed.git && \
-    cd MindSpeed && git checkout core_r0.18.0 && cd .. && \
-    git clone --depth 1 --branch core_r0.18.0 https://github.com/NVIDIA/Megatron-LM.git && \
+    git clone --branch core_r0.18.0 https://gitcode.com/Ascend/MindSpeed.git && \
+    git clone --depth 1 --branch core_v0.18.0 https://github.com/NVIDIA/Megatron-LM.git && \
     git clone --depth 1 --branch core_r0.18.0 https://gitcode.com/ascend/MegatronAdaptor.git && \
     git clone --depth 1 https://gitcode.com/ascend/TransformerEngineNPU.git && \
     git clone --depth 1 https://gitcode.com/ascend/MindSpeed-Ops.git && \
@@ -79,6 +78,9 @@ RUN git clone --recursive https://github.com/verl-project/verl.git && \
 
 # Show install results
 RUN pip list
+
+# Patch megatron-lm unconditionally
+ENV VERL_USE_EXTERNAL_MODULES=megatron_adaptor
 
 # Setting Default Commands
 CMD ["/bin/bash"]

--- a/docker/ascend/Dockerfile.ascend_9.1.0_a3
+++ b/docker/ascend/Dockerfile.ascend_9.1.0_a3
@@ -22,9 +22,8 @@ RUN ARCH=$(uname -m) && \
     # Clone libs
     git clone --depth 1 --branch v0.23.0 https://github.com/vllm-project/vllm.git && \
     git clone -b releases/v0.23.0 https://github.com/vllm-project/vllm-ascend.git && \
-    git clone https://gitcode.com/Ascend/MindSpeed.git && \
-    cd MindSpeed && git checkout core_r0.18.0 && cd .. && \
-    git clone --depth 1 --branch core_r0.18.0 https://github.com/NVIDIA/Megatron-LM.git && \
+    git clone --branch core_r0.18.0 https://gitcode.com/Ascend/MindSpeed.git && \
+    git clone --depth 1 --branch core_v0.18.0 https://github.com/NVIDIA/Megatron-LM.git && \
     git clone --depth 1 --branch core_r0.18.0 https://gitcode.com/ascend/MegatronAdaptor.git && \
     git clone --depth 1 https://gitcode.com/ascend/TransformerEngineNPU.git && \
     git clone --depth 1 https://gitcode.com/ascend/MindSpeed-Ops.git && \
@@ -80,6 +79,9 @@ RUN git clone --recursive https://github.com/verl-project/verl.git && \
 
 # Show install results
 RUN pip list
+
+# Patch megatron-lm unconditionally
+ENV VERL_USE_EXTERNAL_MODULES=megatron_adaptor
 
 # Setting Default Commands
 CMD ["/bin/bash"]


### PR DESCRIPTION
### What does this PR do?

Load `megatron_adaptor` by default in the Ascend A2/A3 images and NPU unit tests through `VERL_USE_EXTERNAL_MODULES`.

Correct the `Megatron-LM` ref to `core_v0.18.0` and simplify the `MindSpeed` clone while preserving its ref and full history.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`
