### PR TITLE
[algo, fsdp] fix: select KL-Cov tokens over the optimizer minibatch

### DIFF
--- a/docs/algo/entropy.md
+++ b/docs/algo/entropy.md
@@ -1,6 +1,6 @@
 # Recipe: Entropy Mechanism
 
-Last updated: 06/27/2025.
+Last updated: 09/10/2026.
 
 
 <div align="center">
@@ -52,6 +52,22 @@ cd verl
 conda activate your_env
 bash recipe/dapo/32b_kl_cov.sh
 ```
+
+### KL-Cov selection with the FSDP actor engine
+
+The FSDP and FSDP2 actor engines select KL-Cov tokens once per PPO optimizer
+minibatch, across the data-parallel group. With `N` valid response tokens, the
+quota is `max(1, int(N * kl_cov_ratio))`; padding is excluded. Every training
+microbatch uses its slice of that selection, so splitting the minibatch does
+not independently round the quota or recompute covariance means.
+
+Selection uses current-policy log probabilities from an additional no-grad
+forward before each optimizer update. It uses the training microbatch settings
+and preserves RNG states. This adds a forward pass and exchanges valid-token
+advantages and log probabilities across the data-parallel group. Entropy loss,
+reference-policy KL loss, and rollout importance weights retain their existing
+behavior. Other engines and direct loss calls retain local selection unless
+they supply a precomputed `kl_cov_mask`.
 
 ## 📖Introduction
 
@@ -112,4 +128,3 @@ For questions, discussion, or collaboration opportunities, feel free to contact:
 - Yuchen Zhang: yuchen.zhang2003@gmail.com
 - Jiacheng Chen: jackchan9345@gmail.com
 - Ning Ding: ningding.cs@gmail.com
-

--- a/tests/special_sanity/check_license.py
+++ b/tests/special_sanity/check_license.py
@@ -22,6 +22,7 @@ license_head_bytedance_26 = "Copyright 2026 Bytedance Ltd. and/or its affiliates
 # Add custom license headers below
 license_head_prime = "Copyright 2024 PRIME team and/or its affiliates"
 license_head_individual = "Copyright 2025 Individual Contributor:"
+license_head_individual_26 = "Copyright 2026 Individual Contributor:"
 license_head_sglang = "Copyright 2023-2024 SGLang Team"
 license_head_modelbest = "Copyright 2025 ModelBest Inc. and/or its affiliates"
 license_head_amazon = "Copyright 2025 Amazon.com Inc and/or its affiliates"
@@ -39,6 +40,7 @@ license_headers = [
     license_head_bytedance_26,
     license_head_prime,
     license_head_individual,
+    license_head_individual_26,
     license_head_sglang,
     license_head_modelbest,
     license_head_amazon,

--- a/tests/trainer/ppo/test_kl_cov_mask_on_cpu.py
+++ b/tests/trainer/ppo/test_kl_cov_mask_on_cpu.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Individual Contributor: gss10282025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check KL-Cov quotas, valid-token statistics, and the direct-call fallback."""
+
+import pytest
+import torch
+
+from verl.trainer.ppo.core_algos import compute_kl_cov_mask, compute_policy_loss_kl_cov
+from verl.workers.config import ActorConfig
+from verl.workers.config.actor import PolicyLossConfig
+
+
+def test_quota_is_one_for_8192_tokens_not_one_per_1024_token_microbatch():
+    adv = torch.linspace(-2, 3, 8192).reshape(64, 128)
+    log_prob = adv.square() * 0.1 - 4
+    valid = torch.ones_like(adv, dtype=torch.bool)
+    assert compute_kl_cov_mask(adv, log_prob, valid, 0.0002).sum() == 1
+    assert (
+        sum(
+            compute_kl_cov_mask(a, p, m, 0.0002).sum()
+            for a, p, m in zip(adv.chunk(8), log_prob.chunk(8), valid.chunk(8), strict=True)
+        )
+        == 8
+    )
+
+
+@pytest.mark.parametrize("ratio", [0.0002, 0.5, 1.0])
+def test_mask_excludes_padding_and_uses_all_valid_statistics(ratio):
+    adv = torch.tensor([[0.0, 2.0, 1e6], [-1.0, 3.0, -1e6]])
+    log_prob = torch.tensor([[0.3, 1.2, 1e6], [-0.8, 2.6, -1e6]])
+    valid = torch.tensor([[True, True, False], [True, True, False]])
+    # Transposed tensors also exercise non-contiguous masks.
+    for a, p, v in [(adv, log_prob, valid), (adv.T, log_prob.T, valid.T)]:
+        actual = compute_kl_cov_mask(a, p, v, ratio)
+        score = (a[v] - a[v].mean()) * (p[v] - p[v].mean())
+        expected = torch.zeros_like(score, dtype=torch.bool)
+        expected[score.argsort(descending=True)[: max(1, int(v.sum() * ratio))]] = True
+        torch.testing.assert_close(actual[v], expected)
+        assert not actual[~v].any()
+    assert not compute_kl_cov_mask(adv, log_prob, torch.zeros_like(valid), ratio).any()
+
+
+def test_precomputed_and_direct_selection_match_for_one_full_batch():
+    generator = torch.Generator().manual_seed(17)
+    advantages = torch.randn(3, 7, generator=generator)
+    log_prob = torch.randn(3, 7, generator=generator, requires_grad=True)
+    old = torch.randn(3, 7, generator=generator)
+    valid = torch.ones_like(advantages, dtype=torch.bool)
+    config = ActorConfig(
+        strategy="fsdp",
+        rollout_n=1,
+        ppo_micro_batch_size_per_gpu=1,
+        policy_loss=PolicyLossConfig(loss_mode="kl_cov", kl_cov_ratio=0.2),
+    )
+    direct, _ = compute_policy_loss_kl_cov(old, log_prob, advantages, valid, config=config)
+    selected = compute_kl_cov_mask(advantages, log_prob, valid, 0.2)
+    prepared, _ = compute_policy_loss_kl_cov(old, log_prob, advantages, valid, config=config, kl_cov_mask=selected)
+    torch.testing.assert_close(direct, prepared)
+    torch.testing.assert_close(torch.autograd.grad(direct, log_prob)[0], torch.autograd.grad(prepared, log_prob)[0])

--- a/tests/workers/test_kl_cov_batch_on_cpu.py
+++ b/tests/workers/test_kl_cov_batch_on_cpu.py
@@ -1,0 +1,322 @@
+# Copyright 2026 Individual Contributor: gss10282025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercise minibatch selection through the worker and native PPO loss on CPU."""
+
+from contextlib import contextmanager
+from functools import partial
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from tensordict import TensorDict
+
+from verl.utils import tensordict_utils as tu
+from verl.workers.config import ActorConfig
+from verl.workers.config.actor import PolicyLossConfig
+from verl.workers.engine_workers import TrainingWorker
+from verl.workers.utils.kl_cov import compute_global_kl_cov_mask, prepare_kl_cov_batch
+from verl.workers.utils.losses import ppo_loss
+from verl.workers.utils.padding import no_padding_2_padding
+
+
+@pytest.fixture(autouse=True)
+def _cpu_prepass(monkeypatch):
+    monkeypatch.setattr("verl.workers.utils.kl_cov.get_device_name", lambda: "cpu")
+
+
+def _nested(rows):
+    return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+
+def _config(mode="token-mean"):
+    return ActorConfig(
+        strategy="fsdp",
+        rollout_n=1,
+        ppo_micro_batch_size_per_gpu=1,
+        policy_loss=PolicyLossConfig(loss_mode="kl_cov", kl_cov_ratio=0.07, ppo_kl_coef=0.8),
+        entropy_coeff=0.13,
+        use_kl_loss=True,
+        kl_loss_coef=0.21,
+        kl_loss_type="mse",
+        loss_agg_mode=mode,
+        loss_scale_factor=5,
+    )
+
+
+def _batch():
+    generator = torch.Generator().manual_seed(29)
+    lengths = [5, 2, 4, 3, 5, 3, 2, 4]
+    features = [torch.randn(n + 2, 2, generator=generator, dtype=torch.float64) for n in lengths]
+    advantages = [torch.randn(n, generator=generator, dtype=torch.float64) for n in lengths]
+    old = [torch.full((n,), -0.6, dtype=torch.float64) for n in lengths]
+    masks = [torch.ones(n, dtype=torch.bool) for n in lengths]
+    masks[0][1] = False  # A masked token inside a response, as in multi-turn data.
+    data = TensorDict(
+        {
+            "prompts": _nested([torch.ones(2, dtype=torch.long) for _ in lengths]),
+            "responses": _nested([torch.ones(n, dtype=torch.long) for n in lengths]),
+            "features": _nested(features),
+            "advantages": _nested(advantages),
+            "response_mask": _nested(masks),
+            "old_log_probs": _nested(old),
+            "ref_log_prob": _nested([row - 0.2 for row in old]),
+            "rollout_is_weights": _nested([torch.linspace(0.6, 1.4, n, dtype=torch.float64) for n in lengths]),
+        },
+        batch_size=[len(lengths)],
+    )
+    tu.assign_non_tensor(data, global_token_num=[n + 2 for n in lengths])
+    return data
+
+
+def _output(parameter, data):
+    features = data["features"]
+    logits = features.values() @ parameter
+    return {
+        "log_probs": torch.nested.nested_tensor_from_jagged(-torch.nn.functional.softplus(logits), features.offsets()),
+        "entropy": torch.nested.nested_tensor_from_jagged(torch.sigmoid(logits), features.offsets()),
+    }
+
+
+def _reference(parameter, data, config):
+    output = _output(parameter, data)
+    log_prob = no_padding_2_padding(output["log_probs"], data)
+    entropy = no_padding_2_padding(output["entropy"], data)
+    padded = data.select(
+        "advantages", "response_mask", "old_log_probs", "ref_log_prob", "rollout_is_weights"
+    ).to_padded_tensor()
+    valid = padded["response_mask"].bool()
+    adv = padded["advantages"]
+    a, p = adv[valid].detach(), log_prob[valid].detach()
+    score = (a - a.mean()) * (p - p.mean())
+    selected = torch.zeros_like(score, dtype=torch.bool)
+    selected[score.argsort(descending=True)[: max(1, int(score.numel() * config.policy_loss.kl_cov_ratio))]] = True
+    mask = torch.zeros_like(valid)
+    mask[valid] = selected
+    delta = log_prob - padded["old_log_probs"]
+    policy = (-adv * delta.exp() + mask.to(log_prob.dtype) * config.policy_loss.ppo_kl_coef * delta.abs()) * padded[
+        "rollout_is_weights"
+    ]
+    loss = (
+        policy
+        - config.entropy_coeff * entropy
+        + config.kl_loss_coef * 0.5 * (log_prob - padded["ref_log_prob"]).square()
+    )
+    mode = config.loss_agg_mode
+    if mode == "token-mean":
+        result = loss[valid].sum() / valid.sum()
+    elif mode == "token-sum":
+        result = loss[valid].sum()
+    elif mode == "seq-mean-token-mean":
+        result = ((loss * valid).sum(-1) / (valid.sum(-1) + 1e-8)).mean()
+    else:
+        result = (loss * valid).sum(-1).mean()
+        if mode == "seq-mean-token-sum-norm":
+            result = result / config.loss_scale_factor
+    return result, mask
+
+
+class _Engine:
+    """A differentiable CPU engine; worker hooks and PPO loss are the real implementations."""
+
+    def __init__(self, partitions, dp_group=None, global_tokens=None, global_size=None):
+        self.parameter = torch.nn.Parameter(torch.tensor([0.31, -0.27], dtype=torch.float64))
+        self.partitions = partitions
+        self.dp_group = dp_group
+        self.global_tokens = global_tokens
+        self.global_size = global_size
+        self.events = []
+        self.training = False
+
+    @contextmanager
+    def train_mode(self, **kwargs):
+        previous = self.training
+        self.training = True
+        try:
+            yield
+        finally:
+            self.training = previous
+
+    def get_data_parallel_group(self):
+        return self.dp_group
+
+    def get_data_parallel_rank(self):
+        return 0 if self.dp_group is None else dist.get_rank(self.dp_group)
+
+    def get_data_parallel_size(self):
+        return 1 if self.dp_group is None else dist.get_world_size(self.dp_group)
+
+    def is_mp_src_rank_with_outputs(self):
+        return False
+
+    def lr_scheduler_step(self):
+        return 0.01
+
+    def infer_batch(self, data, loss_function=None):
+        assert self.training
+        assert not tu.get(data, "distillation_use_topk", default=False)
+        assert tu.get(data, "micro_batch_size_per_gpu") == 1
+        self.events.append(("select", self.parameter.detach().clone(), torch.rand(())))
+        with torch.no_grad():
+            return {"model_output": _output(self.parameter, data)}
+
+    def train_batch(self, data, loss_function):
+        self.events.append(("train", self.parameter.detach().clone(), torch.rand(())))
+        tu.assign_non_tensor(
+            data,
+            dp_size=self.get_data_parallel_size(),
+            batch_num_tokens=self.global_tokens or data["response_mask"].values().sum().item(),
+            global_batch_size=self.global_size or len(data),
+        )
+        self.parameter.grad = None
+        self.selected = data.get("kl_cov_mask")
+        for rows in self.partitions:
+            indices = list(range(len(data)))[rows] if isinstance(rows, slice) else rows
+            micro = tu.index_select_tensor_dict(data, indices)
+            loss, _ = loss_function(model_output=_output(self.parameter, micro), data=micro)
+            loss.backward()
+        if self.dp_group is not None:
+            dist.all_reduce(self.parameter.grad, group=self.dp_group)
+            self.parameter.grad /= self.get_data_parallel_size()
+        with torch.no_grad():
+            self.parameter -= 0.01 * self.parameter.grad
+        return {}
+
+
+def _worker(engine, config, prepare=True):
+    worker = SimpleNamespace(
+        engine=engine,
+        model_config={},
+        profiler=MagicMock(),
+        engine_config=SimpleNamespace(
+            forward_only=False,
+            use_dynamic_bsz=False,
+            max_token_len_per_gpu=128,
+            micro_batch_size_per_gpu=1,
+            use_fused_kernels=False,
+        ),
+    )
+    worker.profiler.check_enable.return_value = False
+    TrainingWorker.set_loss_fn(
+        worker,
+        partial(ppo_loss, config=config),
+        prepare_batch_fn=partial(prepare_kl_cov_batch, config=config) if prepare else None,
+    )
+    worker.train_batch = MethodType(TrainingWorker.train_batch, worker)
+    return worker
+
+
+@pytest.mark.parametrize(
+    "mode", ["token-mean", "token-sum", "seq-mean-token-mean", "seq-mean-token-sum", "seq-mean-token-sum-norm"]
+)
+@pytest.mark.parametrize(
+    "partitions", [[slice(None)], [slice(0, 1), slice(1, 4), slice(4, 5), slice(5, 8)], [[7, 2], [4, 0, 6], [1, 3, 5]]]
+)
+def test_worker_update_matches_full_minibatch_reference(mode, partitions):
+    data, config = _batch(), _config(mode)
+    engine = _Engine(partitions)
+    parameter = engine.parameter.detach().clone().requires_grad_()
+    reference, mask = _reference(parameter, data, config)
+    reference.backward()
+    _worker(engine, config).train_batch(data)
+    torch.testing.assert_close(engine.parameter.grad, parameter.grad, rtol=1e-11, atol=1e-12)
+    torch.testing.assert_close(engine.parameter, parameter - 0.01 * parameter.grad)
+    torch.testing.assert_close(
+        TensorDict({"mask": engine.selected}, batch_size=[engine.selected.size(0)]).to_padded_tensor()["mask"], mask
+    )
+    assert [event[0] for event in engine.events] == ["select", "train"]
+    # The no-grad pass must not consume the training pass's RNG stream.
+    torch.testing.assert_close(engine.events[0][2], engine.events[1][2])
+
+
+def test_local_selection_control_exposes_partition_dependence():
+    config = _config()
+    full = _Engine([slice(None)])
+    split = _Engine([slice(i, i + 1) for i in range(8)])
+    _worker(full, config, prepare=False).train_batch(_batch())
+    _worker(split, config, prepare=False).train_batch(_batch())
+    assert not torch.allclose(full.parameter.grad, split.parameter.grad, rtol=1e-5, atol=1e-7)
+
+
+def test_selection_is_refreshed_for_every_optimizer_minibatch_and_epoch():
+    data, config = _batch(), _config()
+    engine = _Engine([slice(0, 2), slice(2, 4)])
+    worker = _worker(engine, config)
+    tu.assign_non_tensor(data, num_mini_batch=2, epochs=2, dataloader_kwargs={"shuffle": False})
+    TrainingWorker.train_mini_batch(worker, data)
+    assert [event[0] for event in engine.events] == ["select", "train"] * 4
+    for prepass, train in zip(engine.events[::2], engine.events[1::2], strict=True):
+        torch.testing.assert_close(prepass[1], train[1])
+        torch.testing.assert_close(prepass[2], train[2])
+    assert not torch.equal(engine.events[0][1], engine.events[2][1])
+    assert worker.profiler.step.call_count == 4
+
+
+def _distributed_check(rank, rendezvous):
+    torch.set_num_threads(1)
+    dist.init_process_group("gloo", init_method=f"file://{rendezvous}", rank=rank, world_size=2)
+    try:
+        data, config = _batch(), _config()
+        parameter = torch.tensor([0.31, -0.27], dtype=torch.float64, requires_grad=True)
+        reference, mask = _reference(parameter, data, config)
+        reference.backward()
+        slices = [slice(0, 3), slice(3, 8)]
+        local = tu.index_select_tensor_dict(data, list(range(len(data)))[slices[rank]])
+        engine = _Engine(
+            [slice(i, i + 1) for i in range(len(local))],
+            dp_group=dist.group.WORLD,
+            global_tokens=data["response_mask"].values().sum().item(),
+            global_size=len(data),
+        )
+        with patch("verl.workers.utils.kl_cov.get_device_name", return_value="cpu"):
+            _worker(engine, config).train_batch(local)
+        torch.testing.assert_close(engine.parameter.grad, parameter.grad, rtol=1e-11, atol=1e-12)
+        torch.testing.assert_close(
+            TensorDict({"mask": engine.selected}, batch_size=[engine.selected.size(0)]).to_padded_tensor()["mask"],
+            mask[slices[rank]],
+        )
+        # A rank with no valid response tokens still participates in selection.
+        for all_empty in [False, True]:
+            adv = torch.tensor([[1.0, 3.0, -2.0]])
+            log_prob = torch.tensor([[0.2, 1.1, -0.5]])
+            valid = torch.full_like(adv, rank == 1 and not all_empty, dtype=torch.bool)
+            selected = compute_global_kl_cov_mask(adv, log_prob, valid, 0.0002, dp_group=dist.group.WORLD)
+            assert selected.sum().item() == (1 if rank == 1 and not all_empty else 0)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_global_selection_and_update_across_two_cpu_ranks(tmp_path):
+    mp.spawn(_distributed_check, args=(str(tmp_path / "gloo"),), nprocs=2, join=True)
+
+
+def test_prepass_does_not_invoke_or_disable_training_teacher_losses():
+    data, config = _batch(), _config()
+    tu.assign_non_tensor(data, distillation_use_topk=True)
+    engine = _Engine([slice(None)])
+    _worker(engine, config).train_batch(data)
+    assert tu.get(data, "distillation_use_topk") is True
+    assert engine.selected is not None
+
+
+def test_distillation_without_policy_loss_skips_selection():
+    data = _batch()
+    tu.assign_non_tensor(data, distillation_only=True)
+    engine = _Engine([slice(None)])
+    prepare_kl_cov_batch(engine, data, _config())
+    assert engine.events == []
+    assert "kl_cov_mask" not in data

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1845,6 +1845,25 @@ def compute_policy_loss_clip_cov(
     return pg_loss, pg_metrics
 
 
+def compute_kl_cov_mask(advantages, log_prob, response_mask, kl_cov_ratio):
+    """Select KL-Cov tokens over the supplied batch, excluding padding."""
+    if not 0 < kl_cov_ratio <= 1:
+        raise ValueError("kl_cov_ratio must be in (0, 1].")
+    valid = response_mask.to(bool)
+    selected = torch.zeros_like(valid)
+    valid_adv = advantages[valid].detach().cpu()
+    valid_log_prob = log_prob[valid].detach().cpu()
+    if valid_adv.numel() == 0:
+        return selected
+    covariance = (valid_adv - valid_adv.mean()) * (valid_log_prob - valid_log_prob.mean())
+    quota = max(1, int(valid_adv.numel() * kl_cov_ratio))
+    indices = torch.topk(covariance, quota).indices
+    selected_valid = torch.zeros_like(valid_adv, dtype=torch.bool)
+    selected_valid[indices] = True
+    selected[valid] = selected_valid.to(selected.device)
+    return selected
+
+
 @register_policy_loss("kl_cov")
 def compute_policy_loss_kl_cov(
     old_log_prob: torch.Tensor,
@@ -1854,9 +1873,10 @@ def compute_policy_loss_kl_cov(
     loss_agg_mode: str = "token-mean",
     config: Optional[ActorConfig] = None,
     rollout_is_weights: torch.Tensor | None = None,
+    kl_cov_mask: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, dict[str, Any]]:
     """
-    Compute the clipped policy objective and related metrics for Clip-Cov.
+    Compute the policy objective and selective KL penalty for KL-Cov.
 
     Adapted from
     https://github.com/PRIME-RL/Entropy-Mechanism-of-RL/blob/main/verl/trainer/ppo/core_algos.py
@@ -1876,6 +1896,9 @@ def compute_policy_loss_kl_cov(
             Ratio for selecting the top-k covariance values. Defaults to 0.0002.
         ppo_kl_coef (float, optional):
             Coefficient for the KL penalty term in the loss. Defaults to 1.
+        kl_cov_mask (torch.Tensor, optional):
+            This microbatch's slice of the optimizer-minibatch selection. If omitted,
+            selection is computed locally for compatibility with other callers.
     """
     assert config is not None
     assert not isinstance(config, AlgoConfig), "passing AlgoConfig not supported yet"
@@ -1890,27 +1913,12 @@ def compute_policy_loss_kl_cov(
     abs_kl = negative_approx_kl.abs()
     ratio = torch.exp(negative_approx_kl)
     ppo_kl_abs = verl_F.masked_mean(negative_approx_kl.abs(), response_mask)
-    pg_losses1 = -advantages * ratio
-    pg_losses_kl = -advantages * ratio + ppo_kl_coef * abs_kl
-    pg_losses = pg_losses1
-
-    all_valid = response_mask > 0
-    all_valid_idx = torch.nonzero(all_valid.reshape(-1), as_tuple=True)[0]
-    all_valid_adv = advantages[all_valid].detach().reshape(-1).cpu()
-    all_valid_logp = log_prob[all_valid].detach().reshape(-1).cpu()
-
-    k = min(kl_cov_ratio, len(all_valid_adv))
-
-    if k != 0:
-        cov_lst_all = (all_valid_adv - all_valid_adv.mean()) * (all_valid_logp - all_valid_logp.mean())
-        k_percent_nums = max(1, int(len(cov_lst_all) * kl_cov_ratio))
-        large_cov_idxs = torch.topk(cov_lst_all, k_percent_nums, largest=True).indices
-
-        if len(large_cov_idxs) != 0:
-            large_cov_idxs = all_valid_idx[large_cov_idxs]
-            pg_losses[large_cov_idxs // advantages.shape[1], large_cov_idxs % advantages.shape[1]] = pg_losses_kl[
-                large_cov_idxs // advantages.shape[1], large_cov_idxs % advantages.shape[1]
-            ]
+    if kl_cov_mask is None:
+        kl_cov_mask = compute_kl_cov_mask(advantages, log_prob, response_mask, kl_cov_ratio)
+    if kl_cov_mask.shape != response_mask.shape:
+        raise ValueError("kl_cov_mask must have the same shape as response_mask.")
+    selected = kl_cov_mask.to(bool) & response_mask.to(bool)
+    pg_losses = -advantages * ratio + torch.where(selected, ppo_kl_coef * abs_kl, 0.0)
 
     # Apply rollout correction weights if provided
     if rollout_is_weights is not None:

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -52,6 +52,7 @@ from verl.workers.config import (
     TrainingWorkerConfig,
 )
 from verl.workers.rollout.base import BaseRollout, get_rollout_class
+from verl.workers.utils.kl_cov import prepare_kl_cov_batch
 from verl.workers.utils.losses import ppo_loss
 
 logger = logging.getLogger(__file__)
@@ -154,6 +155,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
             self.flops_counter = None
 
         self.loss_fn = None
+        self.prepare_batch_fn = None
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def to(self, device, model=True, optimizer=True, grad=True):
@@ -166,8 +168,9 @@ class TrainingWorker(Worker, DistProfilerExtension):
         self.engine.to(device=device, model=model, optimizer=optimizer, grad=grad)
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def set_loss_fn(self, loss_fn):
+    def set_loss_fn(self, loss_fn, prepare_batch_fn=None):
         self.loss_fn = loss_fn
+        self.prepare_batch_fn = prepare_batch_fn
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def reset(self):
@@ -364,6 +367,8 @@ class TrainingWorker(Worker, DistProfilerExtension):
             self.engine.train_mode(disable_auto_offload=disable_auto_offload),
             Timer(name="train_batch", logger=None) as timer,
         ):
+            if getattr(self, "prepare_batch_fn", None) is not None:
+                self.prepare_batch_fn(self.engine, data)
             output = self.engine.train_batch(data, loss_function=self.loss_fn)
             # containing loss, model_output and metrics
             # for training, we only care about loss and metrics
@@ -642,7 +647,10 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 self.loss_fn = partial(ppo_loss, config=actor_config)
             self.actor = self.actor_worker_cls(config=actor_training_config)
             self.actor.reset()
-            self.actor.set_loss_fn(self.loss_fn)
+            prepare_batch_fn = None
+            if actor_config.policy_loss.loss_mode == "kl_cov" and actor_config.strategy in ("fsdp", "fsdp2"):
+                prepare_batch_fn = partial(prepare_kl_cov_batch, config=actor_config)
+            self.actor.set_loss_fn(self.loss_fn, prepare_batch_fn=prepare_batch_fn)
             self.set_dispatch_collect(mesh_name="actor", **self.actor.get_dispatch_collect())
 
         # 3. build rollout engine

--- a/verl/workers/utils/kl_cov.py
+++ b/verl/workers/utils/kl_cov.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Individual Contributor: gss10282025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optimizer-minibatch token selection for the FSDP KL-Cov actor."""
+
+import torch
+import torch.distributed as dist
+
+from verl.trainer.ppo.core_algos import compute_kl_cov_mask
+from verl.utils import tensordict_utils as tu
+from verl.utils.device import get_device_id, get_device_name
+from verl.workers.utils.padding import no_padding_2_padding, response_to_nested
+
+
+def compute_global_kl_cov_mask(advantages, log_prob, response_mask, kl_cov_ratio, dp_group=None):
+    """Select across DP shards, then return only this rank's response-shaped mask."""
+    valid = response_mask.to(bool)
+    local = (advantages[valid].detach().cpu(), log_prob[valid].detach().cpu())
+    shards = [local]
+    rank = 0
+    if dp_group is not None:
+        shards = [None] * dist.get_world_size(dp_group)
+        dist.all_gather_object(shards, local, group=dp_group)
+        rank = dist.get_rank(dp_group)
+    advantages_all = torch.cat([shard[0] for shard in shards])
+    log_prob_all = torch.cat([shard[1] for shard in shards])
+    selected = compute_kl_cov_mask(
+        advantages_all, log_prob_all, torch.ones_like(advantages_all, dtype=torch.bool), kl_cov_ratio
+    )
+    offset = sum(shard[0].numel() for shard in shards[:rank])
+    result = torch.zeros_like(valid)
+    result[valid] = selected[offset : offset + local[0].numel()].to(result.device)
+    return result
+
+
+def prepare_kl_cov_batch(engine, data, config):
+    """Attach selection before microbatching, using the current actor parameters.
+
+    The caller has entered train mode and supplied the training microbatch settings.
+    Restore RNG states so the additional no-grad forward does not consume the
+    training pass's random stream. Recompute for every optimizer update.
+    """
+    if tu.get(data, "distillation_only", default=False):
+        return
+    prepass_data = data.copy()
+    # The selection pass only needs policy log probabilities, not teacher losses.
+    tu.assign_non_tensor(prepass_data, distillation_use_topk=False)
+    device_name = get_device_name()
+    devices = [] if device_name == "cpu" else [get_device_id()]
+    with torch.random.fork_rng(devices=devices, device_type=device_name):
+        output = engine.infer_batch(prepass_data, loss_function=None)
+    log_prob = no_padding_2_padding(output["model_output"]["log_probs"], data)
+    padded = data.select("advantages", "response_mask").to_padded_tensor()
+    kl_cov_ratio = config.policy_loss.kl_cov_ratio
+    mask = compute_global_kl_cov_mask(
+        padded["advantages"],
+        log_prob,
+        padded["response_mask"],
+        0.0002 if kl_cov_ratio is None else kl_cov_ratio,
+        dp_group=engine.get_data_parallel_group(),
+    )
+    if data["response_mask"].is_nested:
+        mask = response_to_nested(mask, data["response_mask"])
+    data["kl_cov_mask"] = mask

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -88,6 +88,8 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         fields.append("rollout_is_weights")
     if "ref_log_prob" in data:
         fields.append("ref_log_prob")
+    if "kl_cov_mask" in data:
+        fields.append("kl_cov_mask")
     data = data.select(*fields).to_padded_tensor()
 
     response_mask = data["response_mask"].to(bool)
@@ -101,6 +103,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     loss_mode = config.policy_loss.get("loss_mode", "vanilla")
 
     policy_loss_fn = get_policy_loss_fn(loss_mode)
+    policy_loss_kwargs = {"kl_cov_mask": data.get("kl_cov_mask")} if loss_mode == "kl_cov" else {}
     pg_loss, pg_metrics = policy_loss_fn(
         old_log_prob=old_log_prob,
         log_prob=log_prob,
@@ -109,6 +112,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         loss_agg_mode=loss_agg_mode,
         config=config,
         rollout_is_weights=rollout_is_weights,
+        **policy_loss_kwargs,
     )
 
     # AggregationType.MEAN for pg metrics: assumes policy_loss_fn normalizes by local_bsz/local_tokens


### PR DESCRIPTION
## Summary

KL-Cov currently selects tokens separately in each training microbatch. With 8,192 valid tokens and `kl_cov_ratio=0.0002`, one microbatch selects one token, while eight microbatches select eight. The covariance means and candidate sets also change.

For the FSDP/FSDP2 actor, this change selects tokens once per optimizer minibatch across the data-parallel group. Each microbatch receives its mask slice. Entropy regularization, reference-policy KL, and rollout importance weights continue through the existing PPO loss.

Fixes #7829 for the FSDP actor engine.

Replaces closed PR #7828 with the same code commit.

## Design & Code Changes

A no-grad forward obtains current-policy log probabilities before each optimizer update. It uses the training microbatch settings and restores RNG states. Selection excludes padding and shares one token quota across DP ranks. The mask is recomputed after each update, including later PPO epochs.

This costs an extra forward and a DP exchange of valid-token advantages and log probabilities. Other engines and direct loss callers retain local selection unless they provide `kl_cov_mask`. The distillation prepass skips teacher-loss computation; distillation-only batches skip selection.

## Test

I reviewed every changed line and personally ran the following on base `6fc912f07d225d7c96708ab081ef2e6b00db74d7`, with Python 3.12.13 / PyTorch 2.11.0+cpu:

```bash
uv run --no-sync python -m pytest -q \
  tests/workers/test_kl_cov_batch_on_cpu.py \
  tests/trainer/ppo/test_kl_cov_mask_on_cpu.py
uv run --no-sync pre-commit run --all-files --show-diff-on-failure --color=never
```

25 tests passed in 16.80s, with one Ray API deprecation warning. All 14 pre-commit hooks passed.

The code agent also ran the broader set below: 87 tests passed, including those 25 new cases.

<details>
<summary>Broader CPU test command run by the code agent</summary>


```bash
uv run --no-sync python -m pytest -q \
  tests/workers/test_kl_cov_batch_on_cpu.py \
  tests/trainer/ppo/test_kl_cov_mask_on_cpu.py \
  tests/workers/test_engine_workers_mini_batch_trace_on_cpu.py \
  tests/workers/test_engine_return_model_output_on_cpu.py \
  tests/workers/test_engine_forward_step_detach_on_cpu.py \
  tests/trainer/ppo/test_dynamic_policy_losses_on_cpu.py \
  tests/trainer/ppo/test_core_algos_on_cpu.py \
  tests/trainer/ppo/test_loss_aggregation_on_cpu.py \
  tests/trainer/ppo/test_value_loss_normalization_on_cpu.py
uv run --no-sync pre-commit run --all-files --show-diff-on-failure --color=never
```

</details>

The new tests compare native worker/PPO-loss gradients with a full-minibatch reference using a small CPU engine. They cover five aggregation modes, uneven and reordered microbatches, nonzero entropy and reference KL coefficients, importance weights, repeated optimizer updates, and two Gloo ranks. Selection checks include empty DP shards and masked tokens.

A separate CPU comparison using the unmodified loss bodies from the base commit gives a one-vs-eight-microbatch gradient relative L2 difference of `1.4026`; the integrated fix gives `3.20e-16`. This is a small synthetic fixture, separate from the pinned GPU experiment in the issue. GPU/FSDP training has not been rerun on this branch.

## API and Usage Example

No configuration change is needed for `policy_loss.loss_mode=kl_cov` with the FSDP/FSDP2 actor. The worker accepts an optional batch-preparation callback, and the KL-Cov loss accepts an optional selection mask.

## Checklist Before Starting

- [x] Checked [PRs referencing #7829](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7829+in%3Abody) and [open KL-Cov PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+kl_cov). No duplicate found. #6538 clamps probability-ratio inputs; it does not change selection scope or quota.
- [x] Title follows `[{modules}] {type}: {description}`.

## Checklist Before Submitting

- [x] Read the contribution guide and AGENTS.md.
- [x] Run the full pre-commit checks.
- [x] Update the entropy recipe documentation.
- [x] Add tests picked up by the existing CPU test workflow (`*_on_cpu.py`).
- [x] The submitting human has reviewed every changed line.
- [x] The submitting human has personally run the relevant tests.
- [ ] Request upstream CI through the project's [ci-request channel](https://verl-project.slack.com/archives/C091TCESWB1).

AI assistance was used in the investigation, implementation, tests, and this description. I reviewed the complete diff and personally ran the 25 regression tests and full pre-commit checks reported above. The broader 87-test run and synthetic gradient comparison were run by the code agent.
