### PR TITLE
[perf, tests] feat: add cohere2_moe MFU estimation and Ulysses coverage

### DIFF
--- a/tests/models/test_transformers_ulysses.py
+++ b/tests/models/test_transformers_ulysses.py
@@ -86,6 +86,36 @@ def test_configs():
             )
         )
 
+    if version.parse(transformers.__version__) >= version.parse("5.8.0"):
+        from transformers import Cohere2MoeConfig
+
+        # Cohere2Moe interleaves sliding-window and full (NoPE) attention and uses a
+        # parallel block; both go through the generic flash-attention integration that
+        # `apply_monkey_patch` patches, so Ulysses must hold without model-specific code.
+        configs.append(
+            SequenceParallelConfig(
+                Cohere2MoeConfig(
+                    num_hidden_layers=4,
+                    num_attention_heads=32,
+                    num_key_value_heads=4,
+                    hidden_size=2048,
+                    intermediate_size=768,
+                    head_dim=128,
+                    num_experts=4,
+                    num_experts_per_tok=2,
+                    first_k_dense_replace=1,
+                    prefix_dense_intermediate_size=1024,
+                    sliding_window=64,
+                    vocab_size=1024,
+                    bos_token_id=1,
+                    eos_token_id=2,
+                    pad_token_id=0,
+                ),
+                sp_size=8,
+                is_valid=True,
+            )
+        )
+
     return configs
 
 

--- a/tests/utils/test_flops_counter.py
+++ b/tests/utils/test_flops_counter.py
@@ -29,6 +29,7 @@ VALID_CONFIG_TYPE = {
     "mistral",
     "gemma3_text",
     "apertus",
+    "cohere2_moe",
 }
 
 
@@ -522,6 +523,38 @@ CONFIG = {
             367622860308480 / 1e12,
         ),
     },
+    "cohere2_moe": {
+        "config": {  # CohereLabs/North-Mini-Code-1.0
+            "model_type": "cohere2_moe",
+            "vocab_size": 262144,
+            "hidden_size": 2048,
+            # routed-expert size; the dense prefix layer uses prefix_dense_intermediate_size
+            "intermediate_size": 768,
+            "prefix_dense_intermediate_size": 3072,
+            "first_k_dense_replace": 1,
+            "num_hidden_layers": 49,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 4,
+            "head_dim": 128,
+            "num_experts": 128,
+            "num_experts_per_tok": 8,
+            "num_shared_experts": 0,
+            "sliding_window": 4096,
+            # 3:1 sliding:full, starting with a full-attention layer
+            "layer_types": ["full_attention" if i % 4 == 0 else "sliding_attention" for i in range(49)],
+        },
+        # first tuple stays under sliding_window (no clamp), second exceeds it (clamp active)
+        "batch_seqlens_tuple": ([512, 1024, 2048], [8192, 8192, 8192]),
+        # attn_linear = hidden*(q+k+v+o) = 2048*(32*128+4*128+4*128+32*128) = 18874368
+        # dense_mlp   = hidden*prefix_dense_inter*3 = 2048*3072*3 = 18874368       (1 layer)
+        # moe_mlp     = hidden*experts + hidden*inter*topk*3
+        #             = 2048*128 + 2048*768*8*3 = 38010880                          (48 layers)
+        # emb+lm_head = 262144*2048*2 = 1073741824
+        # dense_N     = 18874368*49 + 18874368*1 + 38010880*48 + 1073741824 = 3841982464
+        # attn: 13 full layers use seqlen^2, 36 sliding layers use seqlen*min(seqlen, 4096)
+        # flops = 6*dense_N*token_sum + 6*seqlen_square_sum*head_dim*num_attention_heads
+        "expected_flops_tuple": (89.247272927232, 719.905238286336),
+    },
 }
 
 
@@ -541,6 +574,7 @@ CONFIG = {
         "qwen3_5_moe",
         "qwen3_vl",
         "qwen3_vl_moe",
+        "cohere2_moe",
     ],
 )
 def test_flops_counter(config_type: str):

--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -675,6 +675,85 @@ def _estimate_hy_v3_flops(config, tokens_sum, batch_seqlens, delta_time):
     return flops_achieved
 
 
+def _estimate_cohere2_moe_flops(config, tokens_sum, batch_seqlens, delta_time):
+    hidden_size = config.hidden_size
+    vocab_size = config.vocab_size
+    num_hidden_layers = config.num_hidden_layers
+    num_key_value_heads = config.num_key_value_heads
+    num_attention_heads = config.num_attention_heads
+    # Cohere2Moe routed experts are sized by `intermediate_size`; the dense prefix
+    # layers use `prefix_dense_intermediate_size` instead.
+    moe_intermediate_size = config.intermediate_size
+    first_k_dense_replace = getattr(config, "first_k_dense_replace", 0)
+    prefix_dense_intermediate_size = getattr(config, "prefix_dense_intermediate_size", None)
+    if prefix_dense_intermediate_size is None:
+        prefix_dense_intermediate_size = moe_intermediate_size
+
+    head_dim = getattr(config, "head_dim", hidden_size // num_attention_heads)
+    q_size = num_attention_heads * head_dim
+    k_size = num_key_value_heads * head_dim
+    v_size = num_key_value_heads * head_dim
+
+    # Cohere2Moe uses a parallel block: attention and MLP read the same layernorm
+    # output and are summed into the residual. That changes neither the linear
+    # shapes nor the attention cost, so the parameter counts below are unaffected.
+    attn_linear_N = hidden_size * (q_size + k_size + v_size + num_attention_heads * head_dim)
+
+    # SwiGLU: gate_proj, up_proj and down_proj.
+    dense_mlp_N = hidden_size * prefix_dense_intermediate_size * 3
+
+    # Only the top-k routed experts are active per token, plus the router itself
+    # and any shared experts (`shared_expert_combination_strategy` scales the
+    # output, not the matmul count).
+    num_experts = config.num_experts
+    moe_topk = config.num_experts_per_tok
+    num_shared_experts = getattr(config, "num_shared_experts", 0)
+    router_N = hidden_size * num_experts
+    routed_expert_N = hidden_size * moe_intermediate_size * moe_topk * 3
+    shared_expert_N = hidden_size * (moe_intermediate_size * num_shared_experts) * 3
+    moe_mlp_N = router_N + routed_expert_N + shared_expert_N
+
+    num_dense_layers = min(first_k_dense_replace, num_hidden_layers)
+    num_moe_layers = num_hidden_layers - num_dense_layers
+
+    emd_and_lm_head_N = vocab_size * hidden_size * 2
+    # non-attn all_layer parm
+    dense_N = (
+        attn_linear_N * num_hidden_layers
+        + dense_mlp_N * num_dense_layers
+        + moe_mlp_N * num_moe_layers
+        + emd_and_lm_head_N
+    )
+    # non-attn all_layer & all_token fwd & bwd flops
+    dense_N_flops = 6 * dense_N * tokens_sum
+
+    # Cohere2Moe interleaves sliding-window and full (NoPE) attention via `layer_types`.
+    sliding_window = getattr(config, "sliding_window", None)
+    layer_types = getattr(config, "layer_types", None)
+
+    seqlen_square_sum = 0
+    if layer_types:
+        for layer_idx in range(num_hidden_layers):
+            is_sliding = layer_idx < len(layer_types) and layer_types[layer_idx] == "sliding_attention"
+            for seqlen in batch_seqlens:
+                if is_sliding and sliding_window:
+                    # A sliding-window token attends to at most `sliding_window` keys.
+                    seqlen_square_sum += seqlen * min(seqlen, sliding_window)
+                else:
+                    seqlen_square_sum += seqlen * seqlen
+    else:
+        for seqlen in batch_seqlens:
+            seqlen_square_sum += seqlen * seqlen
+        seqlen_square_sum *= num_hidden_layers
+
+    attn_qkv_flops = 6 * seqlen_square_sum * head_dim * num_attention_heads
+
+    # all_layer & all_token fwd & bwd flops
+    flops_all_token = dense_N_flops + attn_qkv_flops
+    flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
+    return flops_achieved
+
+
 ESTIMATE_FUNC = {
     "qwen2": _estimate_qwen2_flops,
     "llama": _estimate_qwen2_flops,
@@ -698,6 +777,7 @@ ESTIMATE_FUNC = {
     "gpt_oss": _estimate_gpt_oss_flops,
     "mimo": _estimate_qwen2_flops,
     "hy_v3": _estimate_hy_v3_flops,
+    "cohere2_moe": _estimate_cohere2_moe_flops,
 }
 
 


### PR DESCRIPTION
### What does this PR do?

Adds a FLOPs estimator for the `cohere2_moe` architecture (`Cohere2MoeForCausalLM`,
e.g. [CohereLabs/North-Mini-Code-1.0](https://huggingface.co/CohereLabs/North-Mini-Code-1.0)),
and a Cohere2Moe case to the Ulysses forward/backward test.

`cohere2_moe` was absent from `ESTIMATE_FUNC`, so every run on this family printed
`Only support config type of {...}, but got cohere2_moe. MFU will always be zero.`
and logged MFU 0.

Context: this came out of #7796, which asks whether the family is supported on
FSDP + vLLM GRPO. It is — `transformers` 5.9.0 ships `models/cohere2_moe`, vLLM
0.24.0 registers `Cohere2MoeForCausalLM`, `_no_split_modules` drives the generic
FSDP wrap policy, and the model routes attention through the flash-attention
integration that `apply_monkey_patch` already patches. The missing MFU estimate
was the one real gap, so this PR fixes that rather than adding model support.
It does not close #7796; I've answered the remaining questions there.

### Checklist Before Starting

- [x] Search for similar PRs:
  - [`is:pr cohere`](https://github.com/verl-project/verl/pulls?q=is%3Apr+cohere) — nothing touching this family
  - [`is:pr flops_counter`](https://github.com/verl-project/verl/pulls?q=is%3Apr+flops_counter) — no open PR adds an architecture
  - [`is:pr 7796 in:body`](https://github.com/verl-project/verl/pulls?q=is%3Apr+7796+in%3Abody) — no PR references the issue
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Run on 8x H200 (driver 580.173.02, CUDA 13.0) with the repo's own pins —
`torch 2.11.0+cu130`, `transformers 5.9.0`, `vllm 0.24.0` — on top of `a9f29851`.

```console
$ pytest tests/utils/test_flops_counter.py
14 passed in 6.79s

$ torchrun --nproc_per_node=8 -m pytest tests/models/test_transformers_ulysses.py
# exit 0; each of the 8 ranks reports:
8 passed

# the same job CI re-runs on old transformers, where the >= 5.8.0 gate must skip the new case
$ uv run --with transformers==4.54.1 torchrun --nproc_per_node=8 -m pytest tests/models/test_transformers_ulysses.py
# exit 0; each of the 8 ranks reports:
6 passed
```

8 vs 6 is the gate working: 4.54.1 drops both the Apertus case (gated `>= 4.56.0`)
and this one (gated `>= 5.8.0`). `test_configs()` returns 7 configs on 5.9.0, the
last being `Cohere2MoeConfig sp_size=8`, so the new case is executed rather than
silently skipped.

Sanity check against the published config:

```python
>>> FlopsCounter(AutoConfig.from_pretrained("CohereLabs/North-Mini-Code-1.0")).estimate_flops([2048, 2048], 1.0)
(104.522324115456, 989.0)     # was 0.0 before this PR
```

The expected values in the test are derived independently of the implementation
from that config, with one seqlen tuple below `sliding_window` and one above it so
both sides of the clamp are covered. As a cross-check, the estimator's
`dense_N` is 3.84e9; subtracting the embedding, which is counted twice by the
same `vocab * hidden * 2` convention every other estimator here uses, leaves
2.77e9 in the layers, against the model card's "Model Size: 30B total; 3B
active".

Not covered: I could not complete a real end-to-end GRPO run on the 30B checkpoint.
It is unrelated to this PR — loading it with FSDP on a single node is bounded by
host RAM, not by anything here — and I've written that up separately.

### API and Usage Example

No API change. MFU is reported automatically once the model type is known:

```bash
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.model.path=CohereLabs/North-Mini-Code-1.0 \
    actor_rollout_ref.actor.strategy=fsdp2 \
    actor_rollout_ref.rollout.name=vllm \
    algorithm.adv_estimator=grpo
# perf/mfu now reports a real number instead of 0
```

### Design & Code Changes

`_estimate_cohere2_moe_flops` is a new estimator rather than a reuse of
`_estimate_qwen2_moe_flops`, because three parts of the layout do not match any
existing one:

- **Expert vs dense sizing.** `intermediate_size` is the *routed-expert* size
  (768 for North-Mini). The first `first_k_dense_replace` layers are dense and use
  `prefix_dense_intermediate_size` (3072) instead. Reusing a single MLP term is
  wrong for the model, so dense and MoE layers are counted separately.
- **Mixed attention.** `layer_types` interleaves sliding-window and full (NoPE)
  attention 3:1. Sliding layers are clamped to `min(seqlen, sliding_window)`, the
  same treatment `_estimate_gemma3_flops` already applies.
- **Parallel block.** Attention and MLP read one layernorm and are summed into the
  residual. That changes neither the linear shapes nor the attention cost, so
  parameter counting is unaffected — noted in a comment so the next reader does not
  have to re-derive it.

`num_shared_experts` and a missing `prefix_dense_intermediate_size` are handled via
`getattr` defaults so other checkpoints in the family do not need a special case.

The Ulysses test case is a small synthetic config that keeps the real head layout
(32/4 GQA, `head_dim` 128), the dense-prefix split, and a `sliding_window` smaller
than the test sequence, so the sliding path is actually exercised.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs) — no doc change; `flops_counter` carries no per-architecture docs.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Both touched files are already in CI: `tests/utils/test_flops_counter.py` under `gpu_unit_tests.yml`, and `tests/models/test_transformers_ulysses.py` under `model.yml`.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel
- [ ] If your PR is related to the `recipe` submodule ... — not related.
