### PR TITLE
[fsdp] fix: keep FSDP2 meta init for tied-embedding models, and re-tie after to_empty

### DIFF
--- a/tests/utils/test_fsdp2_tied_weights_on_cpu.py
+++ b/tests/utils/test_fsdp2_tied_weights_on_cpu.py
@@ -1,0 +1,102 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Weight tying must survive the meta-init path used by ``fsdp2_load_full_state_dict``.
+
+Ranks other than 0 build the module on meta and are materialized with
+``Module.to_empty()``, which hands every parameter fresh storage and therefore
+drops the aliasing that makes ``lm_head.weight`` *be* the input embedding. That
+failure is silent: the model still runs and still converges, but the embedding
+only receives the input-side half of its gradient, so the broadcast ranks train a
+different model from rank 0.
+"""
+
+import pytest
+import torch
+from accelerate import init_empty_weights
+from transformers import AutoModelForCausalLM, LlamaConfig
+
+
+def _tied_config():
+    return LlamaConfig(
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+        hidden_size=128,
+        intermediate_size=64,
+        vocab_size=64,
+        tie_word_embeddings=True,
+    )
+
+
+def _is_tied(model) -> bool:
+    return model.lm_head.weight.data_ptr() == model.model.embed_tokens.weight.data_ptr()
+
+
+def test_rank0_path_is_tied():
+    """The rank-0 branch materializes on CPU directly and keeps the tie."""
+    model = AutoModelForCausalLM.from_config(_tied_config())
+    assert _is_tied(model)
+
+
+def test_to_empty_drops_the_tie_and_tie_weights_restores_it():
+    """This is the hazard the meta-init path has to compensate for."""
+    with init_empty_weights():
+        model = AutoModelForCausalLM.from_config(_tied_config())
+    assert _is_tied(model), "tie should hold while still on meta"
+
+    model = model.to_empty(device="cpu")
+    assert not _is_tied(model), (
+        "to_empty is expected to drop the tie; if this ever starts passing, "
+        "the re-tie in fsdp2_load_full_state_dict can go"
+    )
+
+    model.tie_weights()
+    assert _is_tied(model)
+
+
+@pytest.mark.parametrize("retie", [True, False])
+def test_embedding_gradient_matches_rank0_only_when_retied(retie: bool):
+    """A dropped tie halves the embedding gradient -- silently."""
+    torch.manual_seed(0)
+    reference = AutoModelForCausalLM.from_config(_tied_config())
+
+    with init_empty_weights():
+        broadcast_rank = AutoModelForCausalLM.from_config(_tied_config())
+    broadcast_rank = broadcast_rank.to_empty(device="cpu")
+    # stands in for set_model_state_dict(..., broadcast_from_rank0=True): rank 0's
+    # state dict carries lm_head.weight, so values agree either way -- only the
+    # aliasing differs.
+    broadcast_rank.load_state_dict(reference.state_dict(), strict=False)
+    # buffers (e.g. rotary inv_freq) are not in the state dict and to_empty leaves
+    # them uninitialized, which is why fsdp2_load_full_state_dict broadcasts them
+    # separately. Mirror that here so the only difference under test is the tie.
+    ref_buffers = dict(reference.named_buffers())
+    for name, buf in broadcast_rank.named_buffers():
+        buf.copy_(ref_buffers[name])
+    if retie:
+        broadcast_rank.tie_weights()
+
+    ids = torch.randint(0, 64, (2, 8))
+    grads = []
+    for model in (reference, broadcast_rank):
+        model.zero_grad()
+        model(input_ids=ids, labels=ids).loss.backward()
+        grads.append(model.model.embed_tokens.weight.grad.clone())
+
+    if retie:
+        torch.testing.assert_close(grads[0], grads[1])
+    else:
+        assert not torch.allclose(grads[0], grads[1]), (
+            "an untied lm_head must change the embedding gradient, otherwise this test proves nothing"
+        )

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -512,6 +512,14 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
     options = StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload, broadcast_from_rank0=True)
     set_model_state_dict(model, full_state, options=options)
 
+    # `to_empty()` gives every parameter fresh storage, so a tied lm_head stops
+    # aliasing the input embedding. Left alone the model still trains and still
+    # converges -- it just silently trains untied, and the embedding only receives
+    # the input-side half of its gradient. Re-tie so the broadcast ranks match the
+    # rank-0 module they were built from.
+    if getattr(getattr(model, "config", None), "tie_word_embeddings", False) and hasattr(model, "tie_weights"):
+        model.tie_weights()
+
     # rotary_emb is not in state_dict, so we need to broadcast it manually
     # Sort by name to ensure deterministic order across ranks. FSDP2 can return
     # named_buffers() in different order on different ranks. Gemma4 has heterogeneous

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -258,9 +258,19 @@ class FSDPEngine(BaseEngine):
 
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
-        init_context = get_init_weight_context_manager(
-            use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings, mesh=self.device_mesh
-        )
+        # Only rank 0 materializes real weights; every other rank builds on meta and
+        # receives them by broadcast in fsdp2_load_full_state_dict. Skipping that for
+        # tied-embedding models makes all N ranks materialize the full checkpoint on
+        # host RAM, which is what actually bounds single-node loading: a 61 GB
+        # tied-embedding checkpoint on 8 ranks needs >1.4 TB and is OOM-killed long
+        # before any GPU is touched. FSDP2 supports meta init for tied weights as long
+        # as the tie is restored after to_empty(), which fsdp2_load_full_state_dict
+        # now does.
+        if self.engine_config.strategy == "fsdp2":
+            use_meta_tensor = True
+        else:
+            use_meta_tensor = not self.model_config.hf_config.tie_word_embeddings
+        init_context = get_init_weight_context_manager(use_meta_tensor=use_meta_tensor, mesh=self.device_mesh)
 
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")


### PR DESCRIPTION
### What does this PR do?

Closes #7834.

On `fsdp2`, tied-embedding models currently skip verl's rank0-only weight
materialisation because `_build_module` derives `use_meta_tensor` from
`tie_word_embeddings`. Every rank then loads the full checkpoint on host RAM,
so host RAM — not VRAM — bounds single-node loading, and scales with GPU count.
A 61 GB tied MoE (CohereLabs/North-Mini-Code-1.0) on 8 ranks peaked at
1437 GB of 1511 GB and was killed inside `from_pretrained`, before any GPU
was touched. Full reproduction and scope in #7834.

This PR makes two changes, and they only work together:

1. **`transformer_impl.py`** — on `fsdp2`, take meta init unconditionally.
   FSDP2 already materialises non-zero ranks with `to_empty()` and fills them
   via `set_model_state_dict(..., broadcast_from_rank0=True)`, so the guard is
   an FSDP1-era leftover there. The FSDP1 branch is unchanged.
2. **`fsdp_utils.py`** — re-tie after `to_empty()` in
   `fsdp2_load_full_state_dict`. `to_empty()` gives every parameter fresh
   storage, so a tied `lm_head` stops aliasing the embedding. Nothing fails
   when that happens — values are still correct because rank 0's state dict
   carries `lm_head.weight` as an alias — but the embedding then receives only
   the input-side half of its gradient, and the broadcast ranks quietly train
   untied. This is presumably why the guard existed.

**Relation to #5746.** That PR proposed change (1) alone, with `Test: N/A`,
and was self-closed by its author after 35 hours with no review; nothing has
touched these lines since. Its direction was right, but (1) without (2) would
have silently untied every model this path is meant to help. This PR is the
completed and tested version of that idea, not a competing one.

### Checklist Before Starting

- [x] Search for similar PRs:
  - [`is:pr tie_word_embeddings meta`](https://github.com/verl-project/verl/pulls?q=is%3Apr+tie_word_embeddings+meta) — only #5746 (closed, see above)
  - [`is:pr 7834 in:body`](https://github.com/verl-project/verl/pulls?q=is%3Apr+7834+in%3Abody) — none
  - `git log a9f29851..origin/main -- verl/workers/engine/fsdp/transformer_impl.py verl/utils/fsdp_utils.py` — empty; the guard is unchanged on current `main`.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

**CPU regression test** (runs under `cpu_unit_tests.yml` via the `_on_cpu.py` suffix):

```console
$ pytest tests/utils/test_fsdp2_tied_weights_on_cpu.py
4 passed
```

It pins both halves: that `to_empty()` drops the tie and `tie_weights()`
restores it, and that the embedding gradient matches the rank-0 module only
when re-tied. The un-retied case is asserted to *differ*, so the test cannot
pass vacuously — if `to_empty` ever stops dropping the tie, that assertion
fails and tells the reader the re-tie can go.

**GPU validation**, 2x H100 80GB (driver 580.126.09, CUDA 13.0), the repo's
own pins (`torch 2.11.0+cu130`, `transformers 5.9.0`), on `a9f29851` + this
patch, using `Qwen/Qwen2.5-0.5B` (`tie_word_embeddings: true`):

Structural claims, from a script that mirrors `_build_module`'s exact
sequence (`get_init_weight_context_manager` → `from_pretrained` →
`state_dict()` → `apply_fsdp2` → `fsdp2_load_full_state_dict`) and asserts
on every rank afterwards:

```
[rank1] built on meta device: True
[rank0] built on meta device: False
[rank1] lm_head.weight IS embed_tokens.weight -> True
[rank0] lm_head.weight IS embed_tokens.weight -> True
[rank1] lm_head values == embed values -> True
[rank0] lm_head values == embed values -> True
```

End to end, verl's own SFT smoke on the patched fsdp2 path:

```console
$ MODEL_PATH=Qwen/Qwen2.5-0.5B BACKEND=fsdp FSDP_STRATEGY=fsdp2 NUM_GPUS=2 \
    bash tests/special_e2e/sft/run_sft_engine.sh
step:1 - train/loss:0.912957489490509 - train/grad_norm:28.38
step:2 - val/loss:0.7424649596214294
```

Regression check on the untouched FSDP1 path, same model:

```console
$ MODEL_PATH=Qwen/Qwen2.5-0.5B BACKEND=fsdp FSDP_STRATEGY=fsdp NUM_GPUS=2 \
    bash tests/special_e2e/sft/run_sft_engine.sh
step:1 - train/loss:0.912957489490509
step:2 - val/loss:0.7466959953308105
```

The first-step loss on the patched fsdp2 path is **bit-identical** to the
FSDP1 path (`0.912957489490509` on both). FSDP1 never goes through meta init
for a tied model, so this is the strongest evidence I have that the tie
genuinely survives `fully_shard` + broadcast. The step-2 values differ in the
4th decimal, as expected from different reduction order.

**Validation on the checkpoint that surfaced this** — CohereLabs/North-Mini-Code-1.0
(30B/A3B, 61 GB bf16, `tie_word_embeddings: true`), 4x H100 80GB, 2 TB host RAM
(1006 GB container limit),
`torch 2.11.0+cu130` / `transformers 5.9.0`, `a9f29851` + this patch.

A script that mirrors `_build_module`'s exact sequence (`get_init_weight_context_manager`
→ `from_pretrained` → `state_dict()` → `apply_fsdp2` → `fsdp2_load_full_state_dict`),
load only, run once with the pre-patch value of `use_meta_tensor` and once with the
patched one, recording each rank's `VmHWM` and the host's `free` used-memory peak:

```
                       rank0      rank1     rank2     rank3    host "used" peak
use_meta_tensor=False  112.0 GB   112.0 GB  112.0 GB  112.0 GB   318 GB   (every rank materialises)
use_meta_tensor=True   112.0 GB    56.7 GB   56.7 GB   56.7 GB   143 GB   (rank 0 only; ranks 1-3 on meta)
tie held on every rank:  True in both runs
```

Two notes so the numbers are read correctly. The pre-patch figure is what verl on
`main` does today for this model; the fix does not change the pre-patch path, so
"tie held" there is expected — that path never goes through `to_empty()`. The
~57 GB `VmHWM` on the meta ranks is file-backed: `from_pretrained` still maps the
safetensors, and RSS counts touched file pages; the host-level `used` figure
(which excludes page cache) is the one that reflects anonymous memory, and it
drops from 318 GB to 143 GB. Per-rank cost on this box is ~112 GB rather than the
~180 GB I derived from the 8-rank OOM in #7834 — that derivation had folded in
the rest of the GRPO stack; the load itself is ~61 GB of weights plus ~50 GB of
expert-fusion buffers.
End-to-end training on the 30B is **not** demonstrated, and I want that to be
unambiguous. I made three 2-step SFT attempts on 4x H100 80GB (1006 GB container
memory limit), all with this patch: two with `engine.param_offload` /
`engine.optimizer_offload` stalled at the allocator ceiling (fp32 master weights
leave ~15 GB per GPU for activations and they never finished step 1), and one
with `engine.offload_policy=True` (fsdp2 `CPUOffloadPolicy`) loaded fine —
16-20 GB per GPU — and then sat with every rank in a futex wait and flat memory
for over five minutes.

To attribute that stall I then ran unpatched `a9f29851` (clean tree) under the
exact same `offload_policy=True` command on an identical pod (4x H100 SXM, same
1006 GB limit). It never reached the point where the patched run stalls:

```
                     from_pretrained          host RAM                         outcome
a9f29851 + patch     completes (rank 0 only)  fits                             fully_shard done, 16-20 GB/GPU, then stalls
a9f29851 unpatched   completes on all 4 ranks 1000 GB at +3m10s, then cgroup   rank 2 SIGKILL (exitcode -9) at +3m22s;
                                              memory.peak == memory.max        GPU never above 3.5 GB (CUDA context only)
                                              (1006 GB), oom_kill 1
```

verl forces fp32 master weights for training (`transformer_impl.py:257`), so
every rank materialises the 30B in fp32 plus its expert-fusion buffers; four
copies hit the container limit while `fully_shard` is being set up, before any
parameter shard reaches a GPU. That is #7834 reproduced through the actual
trainer on 4 GPUs, not only through the 8-GPU GRPO stack. It also means the
stall stays unattributed: on this hardware the unpatched code cannot get to
where the patched code stalls, and I do not have a box with more than 1 TB for
four ranks to try. I am not claiming the stall is or is not caused by this
patch.

The `tie_weights()` call sits inside `fsdp2_load_full_state_dict`, and under
`CPUOffloadPolicy` that function goes on to `model.to("cpu")` and moves buffers
back to the device, so re-tying an about-to-be-offloaded module is a
combination worth checking on its own. I ran the SFT smoke above
(`run_sft_engine.sh` arguments, `engine.strategy=fsdp2`, Qwen2.5-0.5B, tied)
three ways on one 2x H100 machine:

```
                                           step-1 train/loss   step-2 train/loss    step-2 val/loss
a9f29851 unpatched, offload_policy=True    0.912957489490509   0.8167611956596375   0.7426378726959229
a9f29851 + patch,   offload_policy=True    0.912957489490509   0.8166656494140625   0.7429283261299133
a9f29851 + patch,   no offload             0.912957489490509   0.8167972564697266   0.7430338263511658
```

All three exit 0. Step-1 loss is bit-identical across the three and to the
earlier runs; step-2 differences are in the 4th decimal, the same spread the
patched no-offload config shows between two different 2x H100 hosts
(0.7424649596214294 above vs 0.7430338263511658 here). So under
`CPUOffloadPolicy` the patched path trains a tied model within run-to-run
noise of the unpatched path, and the 30B stall does not reproduce at this
size. What remains open is the 30B stall itself, which I could not run
unpatched on any box I had (see above); if a maintainer has a >1 TB host for
four ranks I can post the exact command.

### API and Usage Example

No API change. A tied-embedding model on `actor.strategy=fsdp2` now loads the
same way an untied one does:

```bash
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.model.path=CohereLabs/North-Mini-Code-1.0 \
    actor_rollout_ref.actor.strategy=fsdp2 ...
# rank 0 materialises; ranks 1..N-1 build on meta and receive weights by
# broadcast; host RAM no longer scales with N.
```

### Design & Code Changes

- `verl/workers/engine/fsdp/transformer_impl.py` (+13/−3): `use_meta_tensor`
  is `True` when `strategy == "fsdp2"`, otherwise the existing
  `not tie_word_embeddings`. Comment explains why the fsdp2 case is safe and
  what it depends on.
- `verl/utils/fsdp_utils.py` (+8): after `set_model_state_dict` in
  `fsdp2_load_full_state_dict`, call `model.tie_weights()` when the config
  ties embeddings and the model exposes the method. Guarded so untied models
  and non-HF modules are untouched.
- `tests/utils/test_fsdp2_tied_weights_on_cpu.py` (+102): the regression
  test described above. Uses a tiny `LlamaConfig(tie_word_embeddings=True)`;
  buffers are copied from the reference module, mirroring the buffer
  broadcast `fsdp2_load_full_state_dict` already does, so the only variable
  under test is the tie.

Scope is deliberately small. If maintainers would rather keep the guard and
treat the memory behaviour as intended, change (2) stands on its own as a
correctness fix for anyone who lifts the guard later; I'm happy to split.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs) — no user-facing option changes.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) — `tests/utils/test_fsdp2_tied_weights_on_cpu.py` is picked up by `cpu_unit_tests.yml`.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel
- [ ] If your PR is related to the `recipe` submodule ... — not related.
