### PR TITLE
[single_controller] feat: introduce backend-neutral Runtime and control contracts

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -58,9 +58,12 @@ on:
       # Entrypoints
       - ".github/workflows/vllm.yml"
       - "tests/special_e2e/generation"
+      - "tests/experimental/reward_loop/run_determinism_e2e_with_rm.py"
       - "tests/workers/rollout"
       - "verl/trainer/main_generation.py"
       - "verl/trainer/config/generation.yaml"
+      - "verl/trainer/main_ppo.py"
+      - "verl/trainer/config/ppo_trainer.yaml"
 
 # Cancel jobs on the same ref if a new one is triggered
 concurrency:
@@ -122,7 +125,7 @@ jobs:
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force
-          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
+          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k --local_dir ${HOME}/data/gsm8k
       - name: Test the latest vLLM Rollout async with agent loop
         run: |
           ROLLOUT_NAME=vllm pytest -svvv tests/experimental/agent_loop

--- a/docs/advance/determinism.md
+++ b/docs/advance/determinism.md
@@ -16,11 +16,15 @@ Useful for:
 
 ## Quick Start
 
+`full_determinism` is supported on all training engines (FSDP, Megatron, etc.) via each engine's config. The example below uses FSDP; for Megatron set `actor_rollout_ref.actor.megatron_config.full_determinism=true` (and similarly for the ref model).
+
 ```yaml
 actor_rollout_ref:
   rollout:
     full_determinism: true
     seed: 42
+    # If the policy model is not covered by vLLM batch invariance, set to 1.
+    # max_num_seqs: 1
   actor:
     fsdp_config:
       full_determinism: true
@@ -34,7 +38,17 @@ reward:
     rollout:
       full_determinism: true
       seed: 42
+      # If the RM model is not covered by vLLM batch invariance, set to 1.
+      # max_num_seqs: 1
+
+trainer:
+  # REQUIRED: use the V0 trainer backend. The default V1 backend collects rollout
+  # outputs in completion order (via a TransferQueue), which varies across runs and
+  # breaks bitwise reproducibility. V0 uses asyncio.gather (submission order).
+  use_v1: false
 ```
+
+Both actor rollout and generative RM (VLM scoring) rely on vLLM batch invariance for co-batching. If your model or hardware is not covered, set `max_num_seqs=1` to serialize. Discriminative RM (score-outputting, e.g. Skywork-Reward) is forced to `1` automatically (see Reward model routing).
 
 Or via Hydra overrides:
 
@@ -47,84 +61,69 @@ python -m verl.trainer.main_ppo \
   reward.reward_model.enable=true \
   reward.reward_model.rollout.full_determinism=true \
   reward.reward_model.rollout.seed=42 \
+  trainer.use_v1=false \
   [other config overrides...]
 ```
 
-> **Important:** `PYTHONHASHSEED` must be set **before the Python interpreter starts**. verl handles this automatically — it sets `PYTHONHASHSEED` from `rollout.seed` before `ray.init()` and propagates it to all Ray actors. Do NOT set it manually.
+If the policy or RM model is not covered by vLLM batch invariance, add `actor_rollout_ref.rollout.max_num_seqs=1` and/or `reward.reward_model.rollout.max_num_seqs=1` to serialize. Discriminative RM (score-outputting) is forced to 1 automatically.
 
 ## Configuration Reference
 
 | Parameter | Default | Scope | Description |
 |-----------|---------|-------|-------------|
 | `actor_rollout_ref.rollout.full_determinism` | `false` | Rollout | Enables deterministic rollout generation |
+| `actor_rollout_ref.rollout.max_num_seqs` | `1024` | Rollout | Set to `1` to serialize if the policy model is not covered by vLLM batch invariance |
 | `actor_rollout_ref.rollout.seed` | `42` | Rollout | Base seed; each replica uses `replica_rank + seed` |
 | `actor_rollout_ref.actor.fsdp_config.full_determinism` | `false` | Actor | Enables deterministic PyTorch ops for actor |
 | `actor_rollout_ref.ref.fsdp_config.full_determinism` | `false` | Ref model | Enables deterministic PyTorch ops for reference model |
-| `reward.reward_model.rollout.full_determinism` | `false` | Reward model | Enables deterministic RM inference (forces `max_num_seqs=1`) |
+| `reward.reward_model.rollout.full_determinism` | `false` | Reward model | Enables deterministic RM inference |
+| `reward.reward_model.rollout.max_num_seqs` | `1024` | Reward model | Discriminative RM forced to 1 under full_determinism; set to 1 for generative RM if not covered by batch invariance |
 | `reward.reward_model.rollout.seed` | `42` | Reward model | Base seed for RM vLLM server |
+| `trainer.use_v1` | `true` | Trainer | Must be `false` under `full_determinism`. V1 (AgentLoopManagerTQ) collects outputs in completion order, which varies across runs; V0 (AgentLoopManager) uses submission order. |
 
 ## How It Works
 
-Determinism is enforced at five layers. All must be enabled for full E2E reproducibility:
+`full_determinism=true` is enforced at five layers. The training entrypoint sets `PYTHONHASHSEED` (from `rollout.seed`), `VERL_FULL_DETERMINISM`, `VLLM_BATCH_INVARIANT`, and the NCCL/cuBLAS determinism env vars (`CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, `NCCL_DETERMINISTIC`, `NCCL_ALGO`) before `ray.init()` and forwards them to all Ray actors via `PPO_RAY_RUNTIME_ENV`. These must be set before torch/NCCL init, so the entrypoint exports them rather than `enable_full_determinism()` (which runs after the actor is already up). Do NOT set `PYTHONHASHSEED` manually — the entrypoint handles it.
 
-### PyTorch-level
+### Floating-point determinism
 
-`enable_full_determinism(seed)` sets `PYTHONHASHSEED`, `CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, seeds all RNGs, calls `torch.use_deterministic_algorithms(True, warn_only=True)`, and disables cuDNN benchmarking. Applied in all training engine implementations.
+`enable_full_determinism(seed)` sets `CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, `NCCL_DETERMINISTIC`, `NCCL_ALGO`, seeds all RNGs, calls `torch.use_deterministic_algorithms(True, warn_only=True)`, and disables cuDNN benchmarking. Applied in all training engine implementations (FSDP, Megatron, etc.). The flash-attn Triton cross-entropy kernel (used to compute log-probs) has a non-deterministic reduction not covered by the env vars above, so `VERL_DISABLE_FLASH_ATTN_CE=1` is set by default to force the pure-PyTorch `log_softmax`+gather path.
 
-### Environment propagation
+### Sampling seeds
 
-`main_ppo.run_ppo()` sets three env vars before `ray.init()`:
+- **Replica seed**: each replica uses `replica_rank + config.seed`, producing different but internally reproducible outputs across replicas. Two runs with the same config produce bitwise-aligned results.
+- **Per-request seed**: each `generate()` call injects `SamplingParams.seed = replica_rank + config.seed` to reset the sampler RNG per request, so the same prompt+seed yields the same tokens regardless of batch.
 
-- `PYTHONHASHSEED` — freezes Python hash() and dict ordering
-- `VERL_FULL_DETERMINISM` — signals subprocesses to apply determinism
-- `VLLM_BATCH_INVARIANT` — makes vLLM outputs independent of batch composition
+### Deterministic routing
 
-These are forwarded to all Ray actors via `PPO_RAY_RUNTIME_ENV`.
+- **Actor rollout**: `SingleTurnAgentLoop` uses `request_id=f"det-{priority}"` (priority from `non_tensor_batch["priority"]`), and `GlobalRequestLoadBalancer` (with `full_determinism=True`) routes with `hash(request_id) % len(servers)` — the same request always routes to the same vLLM server across runs. (`priority` is vLLM-only; `LLMServerClient.generate()` filters it for non-vLLM backends.) When `full_determinism=True`, `LLMServerClient._vllm_request_id()` forwards this stable `request_id` to vLLM itself.
+- **Reward**: `NaiveRouter` routes with `binascii.crc32(request body) % len(candidates)` among equally-loaded RM replicas, so the same reward request always routes to the same replica. This neutralizes replica-level floating-point differences that seed alone cannot equalize.
 
-### vLLM batch invariance + per-request seed
+### Trainer backend (V0 required)
 
-`VLLM_BATCH_INVARIANT=1` ensures vLLM outputs don't depend on which other requests are batched together. Each `generate()` call injects `SamplingParams.seed = replica_rank + config.seed` to reset RNG per request.
+Full determinism requires the **V0** trainer backend (`trainer.use_v1=false`, i.e. `AgentLoopManager`). The default V1 backend (`AgentLoopManagerTQ`) decouples rollout submission from collection via a fire-and-forget TransferQueue: outputs are collected **in completion order**, which depends on per-request latency and varies across runs, so the output concatenation order (and thus the training batch) differs run-to-run. V0 instead uses `asyncio.gather`, which returns outputs in **submission order** — stable across runs.
 
-### Priority scheduling + deterministic routing
+Set `trainer.use_v1=false` explicitly when enabling `full_determinism`.
 
-Without determinism, request order depends on arrival timing and server selection on dict iteration order. When `full_determinism=true`:
+### Batch invariance
 
-- Each sample gets a globally unique priority injected into the batch (`non_tensor_batch["priority"]`), so each rollout request is scheduled with a stable, distinct priority
-- `SingleTurnAgentLoop` uses `request_id=f"det-{priority}"` instead of random UUID
-- `GlobalRequestLoadBalancer` tie-breaking uses `hash(request_id) % len(candidates)` — deterministic with frozen `PYTHONHASHSEED`
+`VLLM_BATCH_INVARIANT=1` makes vLLM outputs independent of batch composition. Coverage is model- and hardware-dependent — see the [vLLM batch invariance docs](https://docs.vllm.ai/en/latest/features/batch_invariance/) (and [tested models](https://docs.vllm.ai/en/latest/features/batch_invariance/#tested-models)). If not covered, set `max_num_seqs=1` to serialize.
 
-> **Note:** `priority` is a vLLM-only parameter. `LLMServerClient.generate()` automatically filters it for non-vLLM backends.
+For reward specifically:
+- **Discriminative RM** (score-outputting, e.g. Skywork-Reward; no custom reward fn): `max_num_seqs` is **forced to 1** — batch invariance is verified on generation models, not score-outputting RM architectures.
+- **Generative RM** (VLM that outputs text scores, via custom reward fn): `max_num_seqs` is **not forced** — user-managed; rely on batch invariance + per-request seed.
 
-### Reward model serialization
+## Side Effects
 
-vLLM's `/classify` endpoint (used by RM) does not support priority or batch invariance. When `full_determinism=true`, `RewardModelManager` forces `max_num_seqs=1`, serializing RM inference one request at a time.
+- **Performance**: deterministic PyTorch kernels are slower and cuDNN benchmarking is disabled. Discriminative RM is serialized (`max_num_seqs=1`) under full_determinism.
+- **Recommendation**: Only enable for debugging, regression testing, or research. Leave disabled for production training.
 
-## Side Effects and Limitations
+## Limitations
 
-**Performance**: deterministic PyTorch kernels are slower, cuDNN benchmarking is disabled, and RM `max_num_seqs=1` causes severe throughput loss. Typical E2E throughput drops 10–30% without RM; RM determinism can drop significantly more.
-
-**Recommendation**: Only enable for debugging, regression testing, or research. Leave disabled for production training.
-
-**Nondeterministic fallbacks**: Some GPU ops have no deterministic implementation. `torch.use_deterministic_algorithms(True, warn_only=True)` warns when these are encountered.
-
-**Backend support**:
-
-| Backend | Rollout | Reward model |
-|---------|---------|--------------|
-| vLLM | ✅ | ✅ (serialized) |
-| SGLang | ❌ | ❌ |
-| TensorRT-LLM | ❌ | ❌ |
-
-**PYTHONHASHSEED**: Must be set before process start. verl handles this automatically; manual Ray actor creation must propagate it via `runtime_env`.
-
-**Data parallelism**: Each replica uses `replica_rank + seed`, producing different but internally reproducible outputs. Two runs with the same config produce bitwise-aligned results.
-
-**Multi-turn agent not supported**: Full determinism only works for single-turn rollouts (`single_turn_agent_loop`). Multi-turn rollouts (`tool_agent_loop`) are **not** bitwise reproducible, for two reasons:
-
-- `tool_agent_loop` uses a random UUID per trajectory as `request_id` and does not pass `priority` to `server_manager.generate()`, so the deterministic routing and priority scheduling described above do not apply.
-- Even with those added, each turn is interleaved with external tool calls whose execution time varies across runs, so the order in which requests arrive at vLLM cannot be made deterministic. This is inherent to multi-turn agentic workloads.
-
-For bitwise-reproducible rollouts, use `single_turn_agent_loop`. (The per-request sampling seed is still applied to multi-turn requests inside the vLLM server, but this alone is not sufficient for end-to-end reproducibility.)
+- **Hardware**: vLLM batch invariance (and some deterministic GPU ops) requires specific hardware — see the [vLLM batch invariance docs](https://docs.vllm.ai/en/latest/features/batch_invariance/) for requirements. On unsupported hardware, set `max_num_seqs=1` to serialize. `torch.use_deterministic_algorithms(True, warn_only=True)` warns when a deterministic kernel is unavailable.
+- **Backend**: only vLLM is supported.
+- **Trainer backend**: the V0 trainer (`trainer.use_v1=false`) is required. The default V1 backend's TransferQueue collects outputs in completion order, which is nondeterministic (see [Trainer backend](#trainer-backend-v0-required) above).
+- **Multi-turn agent**: not supported. Full determinism only works for single-turn rollouts (`single_turn_agent_loop`). Multi-turn rollouts (`tool_agent_loop`) are **not** bitwise reproducible — `tool_agent_loop` uses a random UUID per trajectory as `request_id`, does not pass `priority`, and each turn is interleaved with external tool calls whose timing varies across runs. Use `single_turn_agent_loop` for bitwise-reproducible rollouts.
 
 ## Verifying Determinism
 
@@ -136,7 +135,7 @@ VLLM_DETERMINISM_N_GPUS=2 \
 pytest tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py -v -s
 ```
 
-E2E training (bitwise-aligned reward curves across two full PPO runs):
+E2E training (bitwise-aligned reward curves across two full PPO runs). Runs PPO twice with identical seeds, compares per-step reward curves in float32; exit code 0 = aligned, 1 = not aligned / error (usable as a CI gate):
 
 ```bash
 python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
@@ -144,5 +143,7 @@ python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
   --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \
   --train_files ~/data/gsm8k/train.parquet \
   --val_files ~/data/gsm8k/test.parquet \
-  --n_gpus 2 --n_steps 5
+  --n_gpus 2 --n_steps 2
 ```
+
+See the script's module docstring for the full argument reference (e.g. `--plot`, `--save_metrics`, multi-replica coverage, and why the RM `max_num_seqs` is forced to 1 for discriminative RMs but allowed `>1` for generative RMs).

--- a/docs/advance/enhanced_single_controller.md
+++ b/docs/advance/enhanced_single_controller.md
@@ -1,0 +1,380 @@
+# Enhanced single controller
+
+Last updated: 09/11/2026.
+
+The enhanced single controller provides a backend-neutral control plane for
+creating distributed workers, placing them on resources, invoking methods, and
+providing a process-global ObjectStore. Ray remains the default execution backend.
+Monarch and TorchStore provide an opt-in path for deployments that run inside a
+Monarch job.
+
+This page describes the design, configuration, runtime concepts, and
+integration guidance.
+
+## Design
+
+The control plane has five main concepts:
+
+- `Runtime` owns backend resources and worker groups for one process.
+- `ResourcePool` describes an ordered, sliceable placement of processes.
+- `WorkerGroup` owns a group of workers; `RemoteWorkerGroup` is a non-owning
+  invocation view over all or part of that group.
+- `RemoteCall` is an in-flight invocation with a deadline fixed at
+  submission time.
+- `ObjectStore` provides backend-neutral storage to every WorkerGroup.
+
+The execution backend handles resource allocation and transport. Ray uses
+placement groups and Ray actors. Monarch uses `HostMesh`, `ProcMesh`, and
+`ActorMesh`. Dispatch, collection, rank views, fused roles, topology
+compilation, and cleanup ordering stay in the shared control plane.
+
+```text
+Runtime
+├── Topology ──> ResourcePool
+├── ObjectStore
+└── WorkerGroup ──> Worker processes
+                    └── RemoteCall
+
+RuntimeBackend
+├── Ray: PlacementGroup + actors + Ray object store
+└── Monarch: HostMesh + ProcMesh + ActorMesh + TorchStore
+```
+
+The design follows four ownership rules:
+
+1. verl owns orchestration. It validates topology, compiles placement, creates
+   worker groups, dispatches calls, and determines shutdown order.
+2. The backend owns deterministic execution. It satisfies compiled placement
+   requests, starts processes, transports one invocation to one rank, and
+   releases backend resources.
+3. The root Runtime owns lifecycle. Attached worker processes may create nested
+   worker groups, but they do not start global ObjectStore resources or create
+   another root.
+4. `ObjectStore` is the only control-plane boundary used by storage-backed data
+   planes. Ray and TorchStore references do not enter the shared orchestration
+   contract.
+
+### Backend contract
+
+Built-in backends implement a private `RuntimeBackend` protocol. Its operations
+provide root resource pools, compile backend placement, select device ranges,
+derive imperative pools, create worker groups, construct child attach
+configuration, and close backend resources. Each backend also supplies one
+submission function that receives resolved per-rank calls and returns a
+`RemoteCall`.
+
+The backend contract does not decide which model uses a pool, how ranks are
+sliced, or how calls are dispatched and collected. Those decisions remain in
+the shared Runtime so Ray and Monarch follow the same control semantics.
+
+### Worker execution contract
+
+Each backend process hosts a `WorkerContainer`. The container constructs the
+`Worker`, resolves fused roles, and provides one execution contract:
+
+- asynchronous worker methods run on the actor event loop and may serve
+  concurrent requests;
+- synchronous methods run in a dedicated single-thread executor to preserve
+  SPMD call order;
+- dispatch and collection metadata is evaluated in the shared
+  `RemoteWorkerGroup`;
+- shutdown stops admission and drains pending invocations before releasing the
+  worker process.
+
+Ray realizes this contract with generated proxy actors. Monarch uses a
+`concurrent_endpoint` on its worker actor. This difference stays below the
+shared `WorkerGroup` API.
+
+## Choosing a backend
+
+### Ray
+
+Ray is the default. Existing recipes can continue to derive placement from
+`trainer.nnodes` and `trainer.n_gpus_per_node`:
+
+```yaml
+runtime:
+  backend: ray
+  ray: {}
+```
+
+```bash
+python -m verl.trainer.main_ppo \
+  trainer.nnodes=1 \
+  trainer.n_gpus_per_node=8
+```
+
+An empty topology is intentional. The Runtime uses declarative placement only
+when `topology.models` is non-empty; otherwise it preserves the trainer-derived
+Ray placement.
+
+### Monarch with TorchStore
+
+Install the pinned Monarch and TorchStore dependencies through the project
+extra:
+
+```bash
+pip install -e ".[monarch]"
+```
+
+Use the opt-in PPO configuration:
+
+```bash
+python -m verl.trainer.main_ppo \
+  --config-name=ppo_monarch_neoproto \
+  trainer.nnodes=2 \
+  trainer.n_gpus_per_node=8
+```
+
+The preset selects:
+
+```yaml
+runtime:
+  backend: monarch
+  monarch:
+    object_store:
+      store_name_prefix: verl_ppo
+      timeout_s: 300.0
+      strategy: host
+```
+
+The V0 trainer uses NeoProto-backed `verl.DataProto` on both backends and has no
+`trainer.data_plane` selector. Standalone `DataProto` construction
+uses inline references without starting a backend.
+
+The preset also composes `topology/monarch_neoproto.yaml`, which places the
+actor, rollout, and critic on one device pool. Monarch starts one global
+TorchStore and installs its client in the controller and every WorkerGroup.
+
+`runtime.monarch.job_mode` controls job ownership:
+
+- `current` loads the current job supplied by `monarch apply`. This is the
+  recipe default.
+- `process` creates and owns a local `ProcessJob`. It is intended for local and
+  portable end-to-end runs.
+
+## Declarative topology
+
+A topology maps clusters to device pools and models:
+
+```yaml
+topology:
+  clusters:
+    - name: default
+      nnodes: 2
+      n_gpus_per_node: 8
+
+  device_pools:
+    - name: train
+      cluster: default
+      nnodes: 2
+      n_gpus_per_node: 8
+
+  models:
+    - name: actor
+      worker: actor
+      config_key: actor_rollout_ref
+      resource_pool: train
+
+    - name: rollout
+      worker: rollout
+      config_key: actor_rollout_ref
+      resource_pool: train
+
+    - name: critic
+      worker: critic
+      config_key: critic
+      resource_pool: train
+
+```
+
+The Runtime validates the complete topology before allocating backend
+resources. Validation includes:
+
+- unique cluster, pool, and model names;
+- device-pool capacity within each cluster;
+- model references to existing pools;
+- valid, non-overlapping model `device_range` values.
+
+Models with the same pool and identical device range are colocated. Disjoint
+device ranges split a pool into non-owning views. Partial overlap is rejected.
+The topology log printed before worker creation shows the resolved model
+placement.
+
+### Extending the standard Monarch topology
+
+The standard preset covers the actor, rollout, and critic used by the default
+GAE PPO recipe. A configuration that enables a dedicated reference model,
+reward model, teacher model, or standalone rollout group must declare that
+model in a replacement topology. Each Runtime process starts its backend's
+ObjectStore client automatically.
+
+## Using the Runtime API
+
+`Runtime.from_config` creates the process root. Only one live Runtime may exist
+in a process. Use it as a context manager so worker groups, the global
+ObjectStore, and backend resources close in the correct order:
+
+```python
+from verl.runtime import ClassWithInitArgs, Runtime
+
+runtime_config = {
+    "backend": "ray",
+    "env_vars": {"MY_WORKER_SETTING": "1"},
+    "ray": {},
+}
+
+with Runtime.from_config(runtime_config) as runtime:
+    pool = runtime.create_resource_pool(
+        nnodes=1,
+        processes_per_node=8,
+        device_type="gpu",
+    )
+    actor = ClassWithInitArgs(ActorWorker, config)
+    actor_wg = runtime.create_worker_group(actor, on=pool)
+    output = actor_wg.update_actor(batch)
+```
+
+Root-level `runtime.env_vars` is the authoritative environment mapping for
+worker processes. Do not duplicate it under `runtime.ray` or
+`runtime.monarch`.
+
+When topology declares a model, callers can use its compiled pool:
+
+```python
+actor_pool = runtime.model_resource_pool("actor")
+actor_wg = runtime.create_worker_group(actor, on=actor_pool)
+```
+
+### Single actors and rank views
+
+A single actor is a one-process `WorkerGroup`:
+
+```python
+controller_pool = runtime.create_resource_pool(
+    nnodes=1,
+    processes_per_node=1,
+    device_type="cpu",
+    on="controller",
+)
+runner = runtime.create_worker_group(
+    ClassWithInitArgs(TaskRunner),
+    on=controller_pool,
+)
+runner.execute_rank_zero_sync("run", config)
+```
+
+Rank views do not allocate new resources:
+
+```python
+rank_zero = actor_wg.rank(0)
+second_tp_group = actor_wg.slice(start=8, size=8)
+```
+
+`WorkerGroup` owns the underlying processes. `RemoteWorkerGroup` and rank views
+only provide invocation handles; closing a view does not create a second
+lifecycle owner.
+
+Runtime tracks groups without keeping them alive. Local rank and fused-role
+views retain their parent group; remote projections do not. Garbage collection
+of the last local group or view releases the backend workers asynchronously.
+Ray actors explicitly created with detached lifetime remain independent of this
+collection. Explicit `Runtime.close()` closes live groups and drains pending
+backend termination before releasing its dependencies.
+
+### Non-blocking calls and deadlines
+
+Methods retain the dispatch and collection behavior defined by `@register`.
+Call `submit` with `blocking=False` to receive a `RemoteCall`:
+
+```python
+call = actor_wg.submit(
+    "update_actor",
+    args=(batch,),
+    timeout=300,
+    blocking=False,
+)
+result = call.result()
+```
+
+The timeout becomes an absolute deadline when the call is submitted. Delaying
+`result()` does not restart the timeout. `RemoteCall.gather(calls)` preserves
+input order. `RemoteCall.wait(calls, count=n)` returns another `RemoteCall`
+whose result contains the completed and pending calls.
+
+In asynchronous code, await the same object:
+
+```python
+result = await call
+```
+
+## ObjectStore
+
+Object storage is exposed through the module-level `verl.runtime.put`, `get`,
+`delete`, and batch functions. Ray implements them with native ObjectRefs;
+Monarch implements them with TorchStore. Backend implementation types are not
+part of the user API.
+
+The selected backend installs a process-global client in the controller and
+every WorkerGroup. WorkerGroup shutdown does not close that client. The root
+Runtime drains its controller client once after all WorkerGroups have stopped,
+then closes the backend-owned global store. Worker processes use process-exit
+cleanup after their attached Runtime has stopped.
+
+## Child runtimes and nested worker groups
+
+Backend-spawned workers receive an `AttachSpec` containing Runtime identity,
+backend configuration, compiled topology, resource pools, and ObjectStore
+client configuration. The child creates a process-local `RuntimeContext`,
+exposed through:
+
+```python
+from verl.runtime import current_runtime
+
+runtime = current_runtime()
+```
+
+This allows rollout replicas and other workers to create nested worker groups
+without starting a second root Runtime or acquiring ownership of global
+ObjectStore resources.
+
+## Compatibility and migration
+
+Existing Ray recipes remain the default. Legacy imports such as
+`RayWorkerGroup`, `RayClassWithInitArgs`, and `ResourcePoolManager` remain
+available during migration, but new integrations should use the neutral
+`Runtime`, `ResourcePool`, and `WorkerGroup` contracts.
+
+The backend registry is private and currently supports built-in backends only.
+Integrations should not register third-party Runtime backends against the
+internal protocol.
+
+## Testing backend lifecycles
+
+Run the complete controller selection with a fresh Python interpreter per case:
+
+```bash
+python -m tests.run_isolated_tests \
+  --output /tmp/runtime-tests \
+  tests/runtime tests/single_controller
+```
+
+The runner retains the collected case manifest, individual pytest logs, JUnit
+reports and exit codes. Each test executes its normal fixtures and teardown.
+This isolates Monarch's process-global client, which cannot restart after
+shutdown in the same interpreter. Live single-host tests use `LocalJob` with
+real worker processes. Backend unit fakes cover owned-job cleanup and rollback.
+This is a standalone validation entrypoint. The portable 1x8 E2E runner also
+creates a private LocalJob context for each Monarch case.
+
+## Current limitations
+
+- Remote work must run as a method on a long-lived `Worker`; there is no
+  stateless task API equivalent to decorating a function with `ray.remote`.
+- Resource pools are homogeneous rectangular grids. One pool cannot express
+  different process counts on different nodes.
+- Pool views must select contiguous processes within one node or complete
+  contiguous nodes. Ragged and strided selections are not supported.
+- `DevicePool.attributes` is preserved but is not enforced for placement.
+- Fine-grained NUMA and NIC affinity are outside the current topology model.
+- The TRT-LLM asynchronous server and Ray rendezvous remain Ray-specific.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,7 @@ verl is fast with:
    advance/skip_manager.rst
    advance/agent_loop
    advance/reward_loop
+   advance/enhanced_single_controller.md
    advance/grafana_prometheus.md
    advance/mtp.md
    advance/determinism.md

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,11 @@ with open(os.path.join(version_folder, "verl/version/version")) as f:
 
 install_requires = [
     "accelerate",
+    "cachetools",
     "codetiming",
     "datasets",
     "dill",
+    "exceptiongroup; python_version < '3.11'",
     "hydra-core",
     "numpy>=2.0.0",
     "pandas",
@@ -61,7 +63,6 @@ SGLANG_REQUIRES = [
 TRL_REQUIRES = ["trl<=0.9.6"]
 # Keep the legacy mbridge dependency available during its deprecation window.
 MCORE_REQUIRES = ["megatron-bridge", "mbridge"]
-
 extras_require = {
     "test": TEST_REQUIRES,
     "prime": PRIME_REQUIRES,

--- a/tests/experimental/agent_loop/test_basic_agent_loop.py
+++ b/tests/experimental/agent_loop/test_basic_agent_loop.py
@@ -427,12 +427,12 @@ class TestLoadBalancerRouting:
     """Least-loaded selection."""
 
     def test_distributes_across_servers(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         servers = [ray.get(lb.acquire_server.remote(request_id=f"r{i}"))[0] for i in range(3)]
         assert sorted(servers) == ["s0", "s1", "s2"]
 
     def test_new_requests_route_to_least_loaded(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         # Load s0 with 3 inflight requests
         ray.get(lb.acquire_server.remote(request_id="a"))[0]  # -> s0
         ray.get(lb.acquire_server.remote(request_id="a"))[0]  # sticky -> s0
@@ -444,7 +444,7 @@ class TestLoadBalancerRouting:
         assert s_new == "s2"
 
     def test_release_rebalances(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         s0 = ray.get(lb.acquire_server.remote(request_id="r0"))[0]
         s1 = ray.get(lb.acquire_server.remote(request_id="r1"))[0]
         assert s0 != s1
@@ -456,13 +456,13 @@ class TestLoadBalancerRouting:
 
     def test_release_invalid_server_silently_ignored(self, ray_for_lb):
         """Releasing a nonexistent server is silently ignored (hybrid-safe)."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         # Should not raise
         ray.get(lb.release_server.remote(server_id="nonexistent"))
 
     def test_release_without_inflight_silently_ignored(self, ray_for_lb):
         """Releasing a server with no inflight requests is silently ignored (hybrid-safe)."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         # Should not raise even though s1 has 0 inflight
         ray.get(lb.release_server.remote(server_id="s1"))
 
@@ -471,7 +471,7 @@ class TestLoadBalancerStickySession:
     """Request-level sticky session."""
 
     def test_same_request_id_same_server(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None, "s3": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None, "s3": None})
         s0 = ray.get(lb.acquire_server.remote(request_id="conv-abc"))[0]
         ray.get(lb.release_server.remote(server_id=s0))
         s1 = ray.get(lb.acquire_server.remote(request_id="conv-abc"))[0]
@@ -482,14 +482,14 @@ class TestLoadBalancerHybrid:
     """Dynamic server add/remove for hybrid scaling."""
 
     def test_add_server(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.add_servers.remote(servers={"s2": None}))
         status = ray.get(lb.get_status.remote())
         assert "s2" in status["servers"]
         assert status["servers"]["s2"] == 0
 
     def test_remove_server_purges_handle(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         # remove_server now purges from both _inflight_requests and _servers
         status = ray.get(lb.get_status.remote())
@@ -501,7 +501,7 @@ class TestLoadBalancerHybrid:
 
     def test_removed_server_invalidates_sticky_session(self, ray_for_lb):
         """When a sticky session points to a removed server, cache is invalidated."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         # Occupy s0 so that the sticky request is assigned to s1
         ray.get(lb.acquire_server.remote(request_id="occupy-s0"))[0]  # -> s0
         # Pin request to s1 (least-loaded now)
@@ -516,7 +516,7 @@ class TestLoadBalancerHybrid:
 
     def test_remove_server_also_purges_registry(self, ray_for_lb):
         """remove_servers atomically purges from both LB pool and handle registry."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         status = ray.get(lb.get_status.remote())
         # Both _inflight_requests and _servers are cleaned up (no separate cleanup step needed)
@@ -524,7 +524,7 @@ class TestLoadBalancerHybrid:
         assert "s1" not in status["registered_handles"]
 
     def test_get_all_servers_excludes_removed(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         all_servers = ray.get(lb.get_all_servers.remote())
         assert "s0" in all_servers
@@ -532,14 +532,14 @@ class TestLoadBalancerHybrid:
         assert "s1" not in all_servers
 
     def test_no_available_servers_raises(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s0", "s1"]))
         with pytest.raises(ray.exceptions.RayTaskError, match="No available servers"):
             ray.get(lb.acquire_server.remote(request_id="r1"))
 
     def test_add_server_readds_previously_removed(self, ray_for_lb):
         """Re-adding a previously removed server makes it routable again."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         # s1 is removed, only s0 is available
         assert ray.get(lb.acquire_server.remote(request_id="r1"))[0] == "s0"
@@ -550,13 +550,13 @@ class TestLoadBalancerHybrid:
         assert s in ("s0", "s1")
 
     def test_get_inflight_count(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         assert ray.get(lb.get_inflight_count.remote(server_id="s0")) == 0
         ray.get(lb.acquire_server.remote(request_id="r1"))[0]  # -> s0 (least loaded)
         assert ray.get(lb.get_inflight_count.remote(server_id="s0")) == 1
 
     def test_get_status_reports_active_correctly(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         status = ray.get(lb.get_status.remote())
         assert status["active_servers"] == 2  # s0 and s2

--- a/tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
+++ b/tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,38 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-E2E determinism verification: run PPO training twice, verify reward curves bitwise aligned.
+E2E determinism gate: run PPO twice with identical seeds, verify the per-step
+reward curves are bitwise aligned in float32.
 
-Uses colocate mode: RM shares the same GPU pool with actor/ref/rollout,
-so RM scoring goes through the ``_compute_reward_colocate`` path with
-sleep/wake GPU memory management.
+Reward curves are parsed from the training subprocess stdout (the ``console``
+logger prints ``step:N - key:V - ...`` per step), so no intermediate files are
+needed. ``--save_metrics`` also writes a per-run JSONL; ``--plot`` also saves a
+comparison PNG (needs matplotlib). Exit code is the verdict: 0 = aligned,
+1 = not aligned / a run crashed.
+
+Colocate mode (RM shares the actor/ref/rollout GPU pool). Replica count is
+``n_gpus // *_tp``, so the defaults launch 2 rollout + 2 RM replicas — this
+exercises both the deterministic load-balancer's hash routing (rollout) and
+``NaiveRouter`` crc32 routing (RM). Uses the V0 trainer backend (V1's TQ
+collects outputs in completion order, breaking bitwise reproducibility).
+
+RM ``max_num_seqs`` is pinned to 1 in the Hydra command: this script uses a
+discriminative RM (no custom reward fn), whose ``/classify`` pooling path is
+not covered by ``VLLM_BATCH_INVARIANT`` and would drift under co-batching.
+Generative RMs (custom reward fn) are not forced and may run ``>1``. See
+``RewardLoopManager`` for the runtime force-to-1 guard.
 
 Usage:
-  python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
-    --policy_model ~/models/Qwen/Qwen2.5-0.5B-Instruct \
-    --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \
-    --train_files ~/data/gsm8k/train.parquet \
-    --val_files ~/data/gsm8k/test.parquet \
-    --n_gpus 2 --n_steps 5
-
-Defaults to 2 GPUs: all shared by actor/ref/rollout/RM in colocate mode.
-
-After both runs complete, verifies bitwise alignment of reward curves and
-saves a comparison plot to output_dir/determinism_reward_curves.png.
+  python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \\
+    --policy_model ~/models/Qwen/Qwen2.5-0.5B-Instruct \\
+    --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \\
+    --train_files ~/data/gsm8k/train.parquet \\
+    --val_files ~/data/gsm8k/test.parquet \\
+    --n_gpus 2 --n_steps 2
 """
 
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 # Seed used for all determinism configs — same across both runs.
 SEED = 42
+
+# Matches a console-logger line of the form
+#   step:0 - critic/rewards/mean:0.123 - other/key:1.0
+# Captures the step index and the named metric value (as a string token).
+_STEP_LINE_RE = re.compile(r"(?<![\w:])step\s*:\s*(\d+)\s*-?\s*(.*)$")
 
 
 def run_training(
@@ -58,34 +73,32 @@ def run_training(
     rm_tp=1,
     train_files=None,
     val_files=None,
+    temperature=0.7,
+    max_num_seqs=4,
+    save_metrics=False,
 ):
     """Run one PPO training session via main_ppo using Hydra overrides.
 
-    Uses colocate mode (RM shares the same GPU pool with actor/ref/rollout)
-    so that RM scoring goes through the well-tested ``_compute_reward_colocate``
-    path with sleep/wake GPU memory management.
+    Captures stdout so the caller can parse the per-step reward curve. No JSONL
+    is written unless ``save_metrics`` is set.
 
-    Args:
-        n_gpus: Total GPUs visible to the trainer.  All are shared by
-            actor/ref/rollout/RM in colocate mode.
-        rollout_tp: Rollout TP per replica.
-        rm_tp: RM TP per replica.  In colocate mode, RM replicas share the
-            same GPUs as rollout; ``n_gpus // rollout_tp`` rollout replicas and
-            ``n_gpus // rm_tp`` RM replicas are created.
+    Colocate mode: RM shares the actor/ref/rollout GPU pool, so ``n_gpus // *_tp``
+    rollout and RM replicas are created.
     """
-    env = os.environ.copy()
-    jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
     env = os.environ.copy()
     env["VLLM_DISABLE_COMPILE_CACHE"] = "1"
     env["TOKENIZERS_PARALLELISM"] = "true"
     env["NCCL_DEBUG"] = "WARN"
     env["VLLM_LOGGING_LEVEL"] = "WARN"
-    env["VERL_FILE_LOGGER_PATH"] = jsonl_path
-    # PYTHONHASHSEED must be set before Python starts; this ensures deterministic
-    # hash() across all processes spawned by this training run (driver, Ray actors,
-    # NaiveRouter subprocess, etc.).
+    # PYTHONHASHSEED must be set before Python starts for deterministic hash().
     env["PYTHONHASHSEED"] = str(SEED)
-    env["VERL_DETERMINISM_DEBUG"] = "1"
+
+    # Default: console only. --save_metrics adds the file logger.
+    loggers = ["console"]
+    jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
+    if save_metrics:
+        loggers = ["console", "file"]
+        env["VERL_FILE_LOGGER_PATH"] = jsonl_path
 
     cmd = [
         sys.executable,
@@ -98,44 +111,41 @@ def run_training(
         f"actor_rollout_ref.rollout.seed={SEED}",
         "actor_rollout_ref.rollout.scheduling_policy=priority",
         "actor_rollout_ref.rollout.enforce_eager=true",
-        "actor_rollout_ref.rollout.temperature=0.7",
+        f"actor_rollout_ref.rollout.temperature={temperature}",
         "actor_rollout_ref.rollout.calculate_log_probs=true",
         "actor_rollout_ref.rollout.n=1",
         "actor_rollout_ref.rollout.prompt_length=64",
         "actor_rollout_ref.rollout.response_length=64",
         "actor_rollout_ref.rollout.max_model_len=128",
-        "actor_rollout_ref.rollout.max_num_seqs=4",
+        f"actor_rollout_ref.rollout.max_num_seqs={max_num_seqs}",
         f"actor_rollout_ref.rollout.tensor_model_parallel_size={rollout_tp}",
         "actor_rollout_ref.rollout.agent.num_workers=1",
         "actor_rollout_ref.rollout.disable_log_stats=true",
         # Actor
         "actor_rollout_ref.actor.fsdp_config.full_determinism=true",
         f"actor_rollout_ref.actor.fsdp_config.seed={SEED}",
-        "actor_rollout_ref.actor.fsdp_config.param_offload=true",
-        "actor_rollout_ref.actor.fsdp_config.optimizer_offload=true",
+        "actor_rollout_ref.actor.fsdp_config.param_offload=false",
+        "actor_rollout_ref.actor.fsdp_config.optimizer_offload=false",
         "actor_rollout_ref.actor.fsdp_config.fsdp_size=1",
         "actor_rollout_ref.actor.use_dynamic_bsz=true",
         "actor_rollout_ref.actor.ppo_mini_batch_size=4",
+        "actor_rollout_ref.actor.shuffle=false",
         # Ref
         "actor_rollout_ref.ref.fsdp_config.full_determinism=true",
         f"actor_rollout_ref.ref.fsdp_config.seed={SEED}",
         # Model
         f"actor_rollout_ref.model.path={policy_model}",
         "actor_rollout_ref.model.trust_remote_code=true",
-        # RM — colocate mode: shares GPU pool with actor/ref/rollout.
-        # RM scoring goes through _compute_reward_colocate path with
-        # sleep/wake GPU memory management (not agent-loop HTTP path).
+        # RM — colocate (shares GPU pool with actor/ref/rollout; _compute_reward_colocate path).
         "reward.reward_model.enable=true",
         f"reward.reward_model.model_path={rm_model}",
         "reward.reward_model.rollout.name=vllm",
         "reward.reward_model.rollout.full_determinism=true",
         f"reward.reward_model.rollout.seed={SEED}",
         "reward.reward_model.rollout.enforce_eager=true",
-        "reward.reward_model.rollout.gpu_memory_utilization=0.4",
+        "reward.reward_model.rollout.gpu_memory_utilization=0.3",
         f"reward.reward_model.rollout.tensor_model_parallel_size={rm_tp}",
         "reward.reward_model.rollout.max_model_len=512",
-        # Serialize RM inference for determinism: max_num_seqs=1 ensures
-        # each RM forward pass processes one request at a time.
         "reward.reward_model.rollout.max_num_seqs=1",
         "reward.reward_model.rollout.skip_tokenizer_init=false",
         "reward.reward_model.rollout.disable_log_stats=true",
@@ -146,11 +156,13 @@ def run_training(
         # Trainer
         f"trainer.n_gpus_per_node={n_gpus}",
         "trainer.nnodes=1",
+        # V0 backend (V1's TQ collects outputs in completion order → nondeterministic concat).
+        "trainer.use_v1=false",
         f"trainer.total_training_steps={n_steps}",
         "trainer.total_epochs=1",
         "data.train_batch_size=8",
         f"trainer.experiment_name={run_name}",
-        "trainer.logger=[console,file]",
+        f"trainer.logger={list(loggers)}".replace(" ", ""),  # e.g. ['console','file']
         # Data
         "data.shuffle=true",
         f"data.seed={SEED}",
@@ -167,18 +179,23 @@ def run_training(
         cmd.append(f"data.val_files={val_files}")
 
     print(f"\n{'=' * 60}")
-    print(f"Starting {run_name}")
+    print(f"Starting {run_name} (metrics: {', '.join(loggers)})")
     print(f"{'=' * 60}\n")
 
     subprocess.run(["ray", "stop"], env=env, capture_output=True)
     time.sleep(3)
 
-    result = subprocess.run(cmd, env=env)
-    if result.returncode != 0:
-        print(f"ERROR: {run_name} failed (return code {result.returncode})")
-        # Print the JSONL file if it exists — it may contain partial metrics useful for debugging.
-        jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
-        if os.path.exists(jsonl_path):
+    proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
+    stdout_lines = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        stdout_lines.append(line)
+        sys.stdout.write(line)
+        sys.stdout.flush()
+    returncode = proc.wait()
+    if returncode != 0:
+        print(f"ERROR: {run_name} failed (return code {returncode})")
+        if save_metrics and os.path.exists(jsonl_path):
             print(f"Partial metrics in {jsonl_path}:")
             with open(jsonl_path) as f:
                 for line in f:
@@ -186,10 +203,73 @@ def run_training(
         sys.exit(1)
 
     print(f"\n{run_name} completed.")
+    return "".join(stdout_lines)
+
+
+_NP_WRAP = re.compile(r"np\.(?:float|int|uint|bool)\d*\((.+)\)")
+_NUM_RE = re.compile(r"(?<![A-Za-z0-9._])[-+]?(?:\d+\.\d+|\d+\.|\.\d+|\d+)(?:[eE][-+]?\d+)?")
+
+
+def _parse_float(token: str) -> float:
+    """Parse a metric value to float (handles ``np.float64(x)``, ``np.int32(n)``, plain floats)."""
+    token = token.strip()
+    m = _NP_WRAP.match(token)
+    if m:
+        token = m.group(1).strip()
+    try:
+        return float(token)
+    except ValueError:
+        m = _NUM_RE.search(token)
+        return float(m.group(0)) if m else float("nan")
+
+
+def parse_reward_curve_from_stdout(stdout: str):
+    """Parse per-step reward metrics from training stdout.
+
+    Console logger lines look like ``step:1 - critic/rewards/mean:0.5 - ...``.
+    Returns ``(steps, rewards)`` using the reward key picked per step, or
+    ``(None, None)`` if no step line with a reward key was found.
+    """
+    metrics_by_step = {}
+    for line in stdout.splitlines():
+        m = _STEP_LINE_RE.search(line)
+        if not m:
+            continue
+        step = int(m.group(1))
+        rest = m.group(2)
+        data = {}
+        # Values may contain ':'; split on " - " first, then on the FIRST ':' only.
+        for chunk in rest.split(" - "):
+            chunk = chunk.strip()
+            if not chunk or ":" not in chunk:
+                continue
+            key, _, value = chunk.partition(":")
+            data[key.strip()] = value.strip()
+        if data:
+            metrics_by_step[step] = data
+
+    if not metrics_by_step:
+        return None, None
+
+    steps = sorted(metrics_by_step)
+    rewards = []
+    for s in steps:
+        key = _pick_reward_key(metrics_by_step[s])
+        if key is None:
+            print(f"ERROR: No reward key found in step {s}")
+            print(f"  Available keys: {list(metrics_by_step[s].keys())}")
+            return None, None
+        rewards.append(_parse_float(metrics_by_step[s][key]))
+
+    train_key = _pick_reward_key(metrics_by_step.get(1, {}))
+    val_key = _pick_reward_key(metrics_by_step.get(0, {}))
+    print(f"Using training reward key: {train_key}, validation reward key: {val_key}")
+
+    return steps, rewards
 
 
 def read_metrics_from_jsonl(output_dir, run_name):
-    """Read per-step metrics from FileLogger JSONL output."""
+    """Read per-step metrics from FileLogger JSONL output (opt-in path)."""
     filepath = os.path.join(output_dir, f"{run_name}.jsonl")
     if not os.path.exists(filepath):
         print(f"ERROR: Metrics file not found at {filepath}")
@@ -205,32 +285,21 @@ def read_metrics_from_jsonl(output_dir, run_name):
 
 
 def _pick_reward_key(data: dict) -> str | None:
-    """Pick the best reward key from a single step's data dict.
-
-    Training steps use ``critic/rewards/mean``; validation (step 0) uses
-    ``val-core/.../reward/mean@1``.  Returns None if nothing matches.
-    """
-    # Training-step keys (preferred order)
+    """Pick the reward key from a step's data dict (training or validation)."""
     for key in ["critic/rewards/mean", "reward/mean", "train/reward/mean"]:
         if key in data:
             return key
-    # Validation-step keys
     for key in ["val-core/unknown/reward/mean@1", "val-core/reward/mean"]:
         if key in data:
             return key
-    # Fallback: any key containing both "reward" and "mean"
-    for key in data:
+    for key in data:  # fallback: any key with "reward" and "mean"
         if "reward" in key.lower() and "mean" in key.lower():
             return key
     return None
 
 
 def extract_reward_curve(metrics_by_step):
-    """Extract mean reward per step from metrics dict.
-
-    Step 0 (validation) uses a different key namespace than training steps,
-    so we pick the best key for each step independently.
-    """
+    """Extract mean reward per step from a metrics dict (JSONL path)."""
     steps = sorted(metrics_by_step.keys())
     rewards = []
     for s in steps:
@@ -239,7 +308,7 @@ def extract_reward_curve(metrics_by_step):
             print(f"ERROR: No reward key found in step {s}")
             print(f"  Available keys: {list(metrics_by_step[s].keys())}")
             sys.exit(1)
-        rewards.append(metrics_by_step[s][key])
+        rewards.append(float(metrics_by_step[s][key]))
 
     train_key = _pick_reward_key(metrics_by_step.get(1, {}))
     val_key = _pick_reward_key(metrics_by_step.get(0, {}))
@@ -249,13 +318,20 @@ def extract_reward_curve(metrics_by_step):
 
 
 def verify_bitwise_alignment(rewards1, rewards2):
-    """Verify two reward curves are bitwise aligned (float32)."""
+    """Verify two reward curves are bitwise aligned (float32).
+
+    Returns ``(aligned, reason)`` so the caller surfaces a concrete failure cause.
+    """
     r1 = np.array(rewards1, dtype=np.float32)
     r2 = np.array(rewards2, dtype=np.float32)
 
-    assert len(r1) == len(r2), f"Length mismatch: {len(r1)} vs {len(r2)}"
+    if len(r1) != len(r2):
+        return (
+            False,
+            f"length mismatch: run1 has {len(r1)} steps, run2 has {len(r2)} steps",
+        )
 
-    aligned = np.all(r1 == r2)
+    aligned = bool(np.all(r1 == r2))
     max_diff = float(np.max(np.abs(r1 - r2))) if not aligned else 0.0
 
     print(f"\n{'=' * 60}")
@@ -268,14 +344,36 @@ def verify_bitwise_alignment(rewards1, rewards2):
     if not aligned:
         for i in range(len(r1)):
             if r1[i] != r2[i]:
-                print(f"  Step {i + 1} DIFF: {float(r1[i])} vs {float(r2[i])}, diff={abs(float(r1[i]) - float(r2[i]))}")
+                print(f"  Step {i} DIFF: {float(r1[i])} vs {float(r2[i])}, diff={abs(float(r1[i]) - float(r2[i]))}")
     print(f"{'=' * 60}")
 
-    return aligned
+    if aligned:
+        return True, "reward curves are bitwise aligned"
+    return False, f"reward curves differ (max_diff={max_diff:.3e})"
+
+
+def print_reward_table(steps, rewards1, rewards2, aligned):
+    """Print a compact side-by-side reward comparison to stdout."""
+    print(f"\n{'Step':>6} | {'Run 1':>16} | {'Run 2':>16} | {'Diff':>12} | {'Match':>5}")
+    print("-" * 64)
+    for i, s in enumerate(steps):
+        r1 = float(rewards1[i])
+        r2 = float(rewards2[i])
+        diff = abs(r1 - r2)
+        match = "✓" if r1 == r2 else "✗"
+        print(f"{s:>6} | {r1:>16.8f} | {r2:>16.8f} | {diff:>12.3e} | {match:>5}")
+    print("-" * 64)
+    status = "✓ BITWISE ALIGNED" if aligned else "✗ NOT ALIGNED"
+    print(f"Verdict: {status}\n")
 
 
 def plot_reward_curves(steps1, rewards1, rewards2, output_path):
     """Plot two reward curves overlaid for visual comparison."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
     r1 = [float(r) for r in rewards1]
     r2 = [float(r) for r in rewards2]
     steps = [s for s in steps1]
@@ -316,18 +414,40 @@ def plot_reward_curves(steps1, rewards1, rewards2, output_path):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="E2E determinism verification: run twice, compare reward curves")
-    parser.add_argument("--policy_model", default="~/models/Qwen/Qwen2.5-0.5B-Instruct")
-    parser.add_argument("--rm_model", default="~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B")
-    # All GPUs shared by actor/ref/rollout/RM in colocate mode.
-    parser.add_argument("--n_gpus", type=int, default=2)
-    parser.add_argument("--rollout_tp", type=int, default=1)
-    parser.add_argument("--rm_tp", type=int, default=1)
-    parser.add_argument("--n_steps", type=int, default=2)
-    parser.add_argument("--train_files", default=None, help="Path to training data parquet")
-    parser.add_argument("--val_files", default=None, help="Path to validation data parquet")
-    parser.add_argument("--output_dir", default="/tmp/determinism_e2e")
-    parser.add_argument("--project_name", default="determinism_e2e")
+    parser = argparse.ArgumentParser(
+        description="E2E determinism gate: run PPO twice, verify reward curves bitwise aligned.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--policy_model", default="~/models/Qwen/Qwen2.5-0.5B-Instruct", help="Policy (actor) model path."
+    )
+    parser.add_argument(
+        "--rm_model",
+        default="~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B",
+        help="Reward model path (discriminative → max_num_seqs forced to 1).",
+    )
+    parser.add_argument("--n_gpus", type=int, default=2, help="Total GPUs (single node); replicas = n_gpus // *_tp.")
+    parser.add_argument("--rollout_tp", type=int, default=1, help="Rollout tensor-parallel size per replica.")
+    parser.add_argument("--rm_tp", type=int, default=1, help="RM tensor-parallel size per replica.")
+    parser.add_argument("--n_steps", type=int, default=2, help="PPO steps per run (raise to 10 for a longer curve).")
+    parser.add_argument("--train_files", default=None, help="Training parquet (omitted → synthetic dataset).")
+    parser.add_argument("--val_files", default=None, help="Validation parquet (omitted → reuse train set).")
+    parser.add_argument(
+        "--output_dir", default="/tmp/determinism_e2e", help="Where tables / plots / optional JSONL go."
+    )
+    parser.add_argument(
+        "--temperature", type=float, default=0.7, help="Rollout temperature (0 = greedy, deterministic without a seed)."
+    )
+    parser.add_argument(
+        "--max_num_seqs",
+        type=int,
+        default=4,
+        help="Actor ROLLOUT max_num_seqs (the RM's is forced to 1). Lower to 1 to serialize if the policy "
+        "model is not batch-invariant.",
+    )
+    parser.add_argument("--project_name", default="determinism_e2e", help="Tracking project name.")
+    parser.add_argument("--save_metrics", action="store_true", help="Also write {output_dir}/{run_name}.jsonl per run.")
+    parser.add_argument("--plot", action="store_true", help="Also save a comparison PNG (needs matplotlib).")
     args = parser.parse_args()
 
     policy_model = os.path.expanduser(args.policy_model)
@@ -343,38 +463,62 @@ def main():
         output_dir=output_dir,
         rollout_tp=args.rollout_tp,
         rm_tp=args.rm_tp,
+        temperature=args.temperature,
+        max_num_seqs=args.max_num_seqs,
         train_files=args.train_files,
         val_files=args.val_files,
+        save_metrics=args.save_metrics,
     )
 
     # ── Run 1 ──
-    run_training(run_name="run1", **common_kwargs)
+    stdout1 = run_training(run_name="run1", **common_kwargs)
 
     # ── Run 2 ──
-    run_training(run_name="run2", **common_kwargs)
+    stdout2 = run_training(run_name="run2", **common_kwargs)
 
-    # ── Read metrics ──
-    metrics1 = read_metrics_from_jsonl(output_dir, "run1")
-    metrics2 = read_metrics_from_jsonl(output_dir, "run2")
-
-    steps1, rewards1 = extract_reward_curve(metrics1)
-    steps2, rewards2 = extract_reward_curve(metrics2)
+    # ── Extract reward curves ──
+    if args.save_metrics:
+        metrics1 = read_metrics_from_jsonl(output_dir, "run1")
+        metrics2 = read_metrics_from_jsonl(output_dir, "run2")
+        steps1, rewards1 = extract_reward_curve(metrics1)
+        steps2, rewards2 = extract_reward_curve(metrics2)
+    else:
+        steps1, rewards1 = parse_reward_curve_from_stdout(stdout1)
+        steps2, rewards2 = parse_reward_curve_from_stdout(stdout2)
+        if steps1 is None or steps2 is None:
+            print("\n❌ FAILURE: could not parse reward metrics from stdout.")
+            sys.exit(1)
 
     # ── Verify ──
-    aligned = verify_bitwise_alignment(rewards1, rewards2)
+    aligned, reason = verify_bitwise_alignment(rewards1, rewards2)
 
-    # ── Plot ──
-    plot_path = os.path.join(output_dir, "determinism_reward_curves.png")
-    plot_reward_curves(steps1, rewards1, rewards2, plot_path)
+    # ── Show results ──
+    if steps1 == steps2:
+        print_reward_table(steps1, rewards1, rewards2, aligned)
+    else:  # length mismatch already reported; dump both raw curves
+        print("\nRun 1 reward curve:")
+        for s, r in zip(steps1, rewards1, strict=False):
+            print(f"  step {s}: {float(r):.8f}")
+        print("Run 2 reward curve:")
+        for s, r in zip(steps2, rewards2, strict=False):
+            print(f"  step {s}: {float(r):.8f}")
 
+    # ── Plot (opt-in) ──
+    if args.plot:
+        try:
+            plot_path = os.path.join(output_dir, "determinism_reward_curves.png")
+            plot_steps = steps1 if steps1 == steps2 else list(range(min(len(rewards1), len(rewards2))))
+            plot_reward_curves(plot_steps, rewards1[: len(plot_steps)], rewards2[: len(plot_steps)], plot_path)
+        except ImportError:
+            print("matplotlib not installed; skipping plot.")
+
+    # ── Exit code is the verdict (CI gate) ──
     if aligned:
-        print("\n🎉 SUCCESS: E2E determinism verified — reward curves are bitwise aligned!")
+        print("\n🎉 SUCCESS: reward curves are bitwise aligned!")
+        sys.exit(0)
     else:
-        print("\n❌ FAILURE: Reward curves are NOT bitwise aligned.")
-        print(
-            "Check: actor/critic full_determinism, rollout seed + priority"
-            " + batch_invariant, RM full_determinism, data shuffle seed"
-        )
+        print(f"\n❌ FAILURE: {reason}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the public :mod:`verl.runtime` package."""

--- a/tests/single_controller/base/__init__.py
+++ b/tests/single_controller/base/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for backend-neutral single-controller primitives."""

--- a/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
@@ -23,9 +23,6 @@ Tests:
 2. Cross-instance vLLM: two separate server instances produce identical logprobs.
 3. Cross-instance AgentLoop: two full AgentLoopManager pipelines produce identical logprobs.
 
-Cross-instance RewardLoop determinism is verified by the separate E2E script:
-  tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
-
 Environment overrides:
   VLLM_DETERMINISM_DENSE_MODEL_PATH  - policy model (default Qwen2.5-0.5B-Instruct)
   VLLM_DETERMINISM_N_GPUS            - GPUs for AgentLoop tests (default 1)

--- a/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
@@ -52,8 +52,32 @@ class TestBuildCliArgsFromConfig:
         assert result == ["--enable-prefix-caching"]
 
     def test_bool_false(self):
-        """Bool False is skipped entirely."""
+        """Optional[bool] args emit '--no-key' for an explicit False."""
         config = {"enable-prefix-caching": False}
+        result = build_cli_args_from_config(config)
+        assert result == ["--no-enable-prefix-caching"]
+
+    def test_bool_false_plain_bool_omitted(self):
+        """Bool False on a plain-bool arg is skipped (parser default is False)."""
+        config = {"enforce_eager": False}
+        result = build_cli_args_from_config(config)
+        assert result == []
+
+    def test_bool_false_union_str_arg_omitted(self):
+        """Bool False on a `bool | str | None` arg is skipped (string flag, no --no- form)."""
+        config = {"hf_token": False}
+        result = build_cli_args_from_config(config)
+        assert result == []
+
+    def test_bool_false_underscore_key(self):
+        """Underscore keys emit the negative flag in the key's own spelling."""
+        config = {"enable_prefix_caching": False}
+        result = build_cli_args_from_config(config)
+        assert result == ["--no-enable_prefix_caching"]
+
+    def test_bool_false_non_engine_arg_omitted(self):
+        """Bool False on args unknown to AsyncEngineArgs is omitted."""
+        config = {"disable-log-requests": False}
         result = build_cli_args_from_config(config)
         assert result == []
 
@@ -132,6 +156,44 @@ class TestBuildCliArgsFromConfig:
         config = {"sizes": [42]}
         result = build_cli_args_from_config(config)
         assert result == ["--sizes", "42"]
+
+
+class TestCliArgsVllmParserRoundTrip:
+    """Serialized args must round-trip through vLLM's serve CLI parser."""
+
+    @staticmethod
+    def _build_parser():
+        import vllm.entrypoints.cli.serve as serve_mod
+        from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+        parser = FlexibleArgumentParser(description="test")
+        subparsers = parser.add_subparsers(required=False, dest="subparser")
+        for cmd in serve_mod.cmd_init():
+            cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
+        return parser
+
+    def test_explicit_false_survives_parsing(self):
+        """Explicit False survives parse_args and AsyncEngineArgs.from_cli_args."""
+        from vllm.engine.arg_utils import AsyncEngineArgs
+
+        parser = self._build_parser()
+        config = {
+            "skip_tokenizer_init": False,
+            "enable_chunked_prefill": True,
+            "enable_prefix_caching": False,
+            "enable_sleep_mode": True,
+            "enforce_eager": False,
+            "disable_log_stats": False,
+        }
+        argv = ["serve", "dummy-model"] + build_cli_args_from_config(config)
+        namespace = parser.parse_args(args=argv)
+        engine_args = AsyncEngineArgs.from_cli_args(namespace)
+        assert engine_args.enable_prefix_caching is False
+        assert engine_args.enable_chunked_prefill is True
+        assert engine_args.enable_sleep_mode is True
+        assert engine_args.skip_tokenizer_init is False
+        assert engine_args.enforce_eager is False
+        assert engine_args.disable_log_stats is False
 
 
 class TestVllmColocateZmqHandle:

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -280,6 +280,26 @@ class RewardLoopManager:
     def __init__(self, config: DictConfig, rm_resource_pool: RayResourcePool = None):
         self.config = config
         if self.config.reward.reward_model.enable:
+            rm_rollout = self.config.reward.reward_model.rollout
+            # The discriminative /classify (pooling) path is not covered by
+            # VLLM_BATCH_INVARIANT (vLLM batch invariance is verified on generation
+            # models, not pooling RM architectures). Serialize /classify with
+            # max_num_seqs=1 to keep it bitwise reproducible. The generative
+            # /v1/chat/completions path (custom reward fn) is user-managed and not
+            # forced here — rely on VLLM_BATCH_INVARIANT + per-request seed.
+            if (
+                rm_rollout.full_determinism
+                and self.config.reward.custom_reward_function.path is None
+                and rm_rollout.max_num_seqs != 1
+            ):
+                logger.warning(
+                    "[reward_model] full_determinism=True: forcing rollout.max_num_seqs "
+                    "from %s to 1 for the /classify pooling path (batch invariance not "
+                    "verified for pooling RM). See the determinism doc.",
+                    rm_rollout.max_num_seqs,
+                )
+                with open_dict(self.config):
+                    rm_rollout.max_num_seqs = 1
             self.reward_model_manager = RewardModelManager(config.reward.reward_model, rm_resource_pool)
             self.reward_router_address = self.reward_model_manager.get_router_address()
         else:

--- a/verl/experimental/reward_loop/reward_model.py
+++ b/verl/experimental/reward_loop/reward_model.py
@@ -42,20 +42,6 @@ class RewardModelManager:
         self.config = config
         self.resource_pool = resource_pool
 
-        # Determinism workaround: vLLM /classify (pooling path) does not honor
-        # `priority` and is not covered by VLLM_BATCH_INVARIANT, so co-batched RM
-        # forward passes break bitwise reproducibility. Force max_num_seqs=1 to
-        # serialize RM inference whenever full_determinism is enabled.
-        if self.config.rollout.full_determinism and self.config.rollout.max_num_seqs != 1:
-            logger.warning(
-                "[reward_model] full_determinism=True: forcing rollout.max_num_seqs "
-                "from %d to 1. vLLM pooling/classify does not support priority "
-                "scheduling or batch invariance; serializing RM inference is "
-                "currently the only way to keep RM scores bitwise reproducible.",
-                self.config.rollout.max_num_seqs,
-            )
-            self.config.rollout.max_num_seqs = 1
-
         self._initialize_llm_servers()
         self._initialize_router()
         assert self.config.rollout.skip_tokenizer_init is False, "Reward model should not skip tokenizer init."

--- a/verl/experimental/reward_loop/router/naive_router.py
+++ b/verl/experimental/reward_loop/router/naive_router.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import binascii
 import logging
 import multiprocessing
 import os
@@ -94,6 +95,7 @@ class NaiveRouter:
         self.app = FastAPI()
         self.worker_urls = worker_urls
         self.request_counts = {url: 0 for url in worker_urls}
+        self.full_determinism = os.getenv("VERL_FULL_DETERMINISM", "0") == "1"
 
         self.max_connections = max_connections
         self.timeout = timeout
@@ -137,15 +139,16 @@ class NaiveRouter:
         if not self.worker_urls:
             return JSONResponse(status_code=503, content={"error": "No available workers"})
 
-        worker_url = self._select_worker()
+        # Read the body first so it can seed deterministic routing under
+        # full_determinism (same body → same worker across runs).
+        body = await request.body()
+        headers = dict(request.headers)
+
+        worker_url = self._select_worker(body if self.full_determinism else None)
         target_url = f"{worker_url}/{endpoint}"
 
         if self.verbose:
             logger.debug(f"[router] Forwarding request → {target_url}")
-
-        # Copy request data
-        body = await request.body()
-        headers = dict(request.headers)
 
         try:
             for attempt in range(self.max_attempts):
@@ -177,9 +180,23 @@ class NaiveRouter:
             # worker's count leaks upward and skews load balancing permanently.
             self._release_worker(worker_url)
 
-    def _select_worker(self) -> str:
-        """Select the least-loaded worker (simple round-robin by request count)."""
-        url = min(self.request_counts, key=self.request_counts.get)
+    def _select_worker(self, request_id: bytes | None = None) -> str:
+        """Select the least-loaded worker.
+
+        Under ``full_determinism`` (signalled by a non-None ``request_id`` derived
+        from the request body), tie-break among equally-loaded workers with
+        ``binascii.crc32(request_id)`` so the same request always routes to the same
+        worker across runs — otherwise each replica may diverge in floating-point state.
+        crc32 is platform-independent and does not rely on PYTHONHASHSEED.
+        """
+        min_count = min(self.request_counts.values())
+        candidates = [url for url, c in self.request_counts.items() if c == min_count]
+        if len(candidates) == 1:
+            url = candidates[0]
+        elif request_id is not None:
+            url = candidates[binascii.crc32(request_id) % len(candidates)]
+        else:
+            url = candidates[0]
         self.request_counts[url] += 1
         return url
 

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -144,9 +144,11 @@ class TeacherModelManager:
                 )
 
     def _initialize_load_balancer_handle(self):
+        import ray
+
         from verl.workers.rollout.llm_server import GlobalRequestLoadBalancer
 
-        self.load_balancer_handle = GlobalRequestLoadBalancer.remote(
+        self.load_balancer_handle = ray.remote(GlobalRequestLoadBalancer).remote(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True))
         )
 

--- a/verl/runtime/__init__.py
+++ b/verl/runtime/__init__.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public backend-neutral Runtime and ObjectStore API."""
+
+from __future__ import annotations
+
+from verl.runtime.config import RuntimeConfig, parse_env_vars, select_backend
+from verl.runtime.core import Runtime, current_runtime
+from verl.runtime.object_store import delete, delete_many, get, get_many, put, put_many
+from verl.single_controller.base.actor import ClassWithInitArgs
+from verl.single_controller.base.decorator import Dispatch, Execute, make_nd_compute_dataproto_dispatch_fn, register
+from verl.single_controller.base.errors import (
+    ExceptionGroup,
+    PlacementUnavailableError,
+    RPCError,
+    RPCRemoteError,
+    RPCTimeoutError,
+    RPCTransportError,
+    RPCUnavailableError,
+)
+from verl.single_controller.base.remote_call import RemoteCall
+from verl.single_controller.base.remote_worker_group import RemoteWorkerGroup
+from verl.single_controller.base.resource_pool import ResourcePool, split_resource_pool
+from verl.single_controller.base.topology import Cluster, DevicePool, Model, Topology
+from verl.single_controller.base.worker import Worker
+from verl.single_controller.base.worker_group import WorkerGroup
+
+__all__ = [
+    "ClassWithInitArgs",
+    "Cluster",
+    "DevicePool",
+    "Dispatch",
+    "Execute",
+    "ExceptionGroup",
+    "Model",
+    "PlacementUnavailableError",
+    "RPCError",
+    "RPCRemoteError",
+    "RPCTimeoutError",
+    "RPCTransportError",
+    "RPCUnavailableError",
+    "RemoteCall",
+    "RemoteWorkerGroup",
+    "ResourcePool",
+    "Runtime",
+    "RuntimeConfig",
+    "Topology",
+    "Worker",
+    "WorkerGroup",
+    "current_runtime",
+    "delete",
+    "delete_many",
+    "get",
+    "get_many",
+    "make_nd_compute_dataproto_dispatch_fn",
+    "put",
+    "put_many",
+    "parse_env_vars",
+    "register",
+    "select_backend",
+    "split_resource_pool",
+]

--- a/verl/runtime/backend_registry.py
+++ b/verl/runtime/backend_registry.py
@@ -1,0 +1,114 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Private built-in backend factory registry for the concrete Runtime.
+
+Built-in Ray and Monarch adapters register lazy loaders here. This is not a
+third-party plugin seam; only built-in backends are accepted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal, Protocol, TypeVar
+
+from verl.single_controller.base.actor import ActorSpec
+from verl.single_controller.base.resource_pool import ResourcePool
+from verl.single_controller.base.topology import Topology
+from verl.single_controller.base.worker import Worker
+from verl.single_controller.base.worker_group import WorkerGroup
+
+WorkerT = TypeVar("WorkerT", bound=Worker)
+
+
+class RuntimeBackend(Protocol):
+    """Private backend handle owned by one concrete Runtime instance."""
+
+    def root_resource_pools(self) -> Mapping[str, ResourcePool]:
+        """Return backend-discovered named root resource domains."""
+        ...
+
+    def resolve_topology(self, topology: Topology) -> Mapping[str, ResourcePool]:
+        """Resolve declared DevicePools into backend ResourcePools."""
+        ...
+
+    def select_device_range(self, pool: ResourcePool, start: int, end: int) -> ResourcePool:
+        """Compile one per-node model device range into a non-owning pool view."""
+        ...
+
+    def derive_resource_pool(
+        self,
+        root: ResourcePool,
+        *,
+        nnodes: int,
+        processes_per_node: int,
+        device_type: Literal["gpu", "cpu"],
+    ) -> ResourcePool:
+        """Derive an imperative pool from one backend resource domain."""
+        ...
+
+    def create_worker_group(
+        self,
+        actor: ActorSpec[WorkerT],
+        *,
+        pool: ResourcePool,
+        topology: Topology,
+        resource_pools: Mapping[str, ResourcePool],
+    ) -> WorkerGroup[WorkerT]:
+        """Construct one owning WorkerGroup on ``pool``.
+
+        The backend delivers each spawned process the AttachSpec it needs to
+        build its Runtime node and start its process-global ObjectStore.
+        """
+        ...
+
+    def start_object_store(self, config: dict[str, object]) -> None:
+        """Start the root backend or an attached client."""
+        ...
+
+    def close(self) -> None:
+        """Close backend-owned resources when Runtime closes."""
+        ...
+
+    def child_attach_config(self) -> Mapping[str, object]:
+        """Return the serializable backend section copied into child RuntimeContext."""
+        ...
+
+
+def create_backend(name: str, section: Mapping[str, object] | None, topology: Topology) -> RuntimeBackend:
+    if name == "ray":
+        from verl.single_controller.ray.factory import create_backend as create_ray_backend
+
+        return create_ray_backend(section)
+    if name == "monarch":
+        from verl.single_controller.monarch.factory import create_backend as create_monarch_backend
+
+        return create_monarch_backend(section, topology)
+    raise ValueError(f"Unknown runtime backend: {name!r}")
+
+
+def attach_backend(
+    name: str,
+    section: Mapping[str, object] | None,
+    resource_pools: Mapping[str, ResourcePool],
+) -> RuntimeBackend:
+    if name == "ray":
+        from verl.single_controller.ray.factory import attach_backend as attach_ray_backend
+
+        return attach_ray_backend(section, resource_pools)
+    if name == "monarch":
+        from verl.single_controller.monarch.factory import attach_backend as attach_monarch_backend
+
+        return attach_monarch_backend(section, resource_pools)
+    raise ValueError(f"Unknown runtime backend: {name!r}")

--- a/verl/runtime/config.py
+++ b/verl/runtime/config.py
@@ -1,0 +1,100 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Root RuntimeConfig mapping and selected-backend section helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypeAlias
+
+RuntimeConfig: TypeAlias = Mapping[str, object]
+
+_ALLOWED_ROOT_KEYS = frozenset({"backend", "env_vars", "ray", "monarch", "topology"})
+_BUILTIN_BACKENDS = frozenset({"ray", "monarch"})
+
+
+def parse_env_vars(value: object | None) -> dict[str, str]:
+    """Parse root-level ``env_vars`` into a str-to-str mapping.
+
+    Args:
+        value: Root ``RuntimeConfig["env_vars"]`` value, or None when absent.
+
+    Returns:
+        Validated environment mapping (empty when ``value`` is None).
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f'RuntimeConfig["env_vars"] must be a mapping, got {type(value)!r}')
+    result: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise TypeError(f'RuntimeConfig["env_vars"] keys must be str, got {type(key)!r}')
+        if not isinstance(item, str):
+            raise TypeError(f'RuntimeConfig["env_vars"][{key!r}] must be a str, got {type(item)!r}')
+        result[key] = item
+    return result
+
+
+def select_backend(config: RuntimeConfig) -> str:
+    """Return the selected backend name after validating the root mapping.
+
+    Args:
+        config: Root composition mapping.
+
+    Returns:
+        Selected built-in backend name.
+
+    Raises:
+        TypeError: Root config is not a mapping or backend is not a string.
+        ValueError: Root keys are unknown or backend is unsupported/missing.
+    """
+    if not isinstance(config, Mapping):
+        raise TypeError(f"RuntimeConfig must be a mapping, got {type(config)!r}")
+    unknown = set(config) - _ALLOWED_ROOT_KEYS
+    if unknown:
+        unknown_list = ", ".join(sorted(repr(key) for key in unknown))
+        raise ValueError(f"unknown RuntimeConfig root key(s): {unknown_list}")
+    if "backend" not in config:
+        raise ValueError('RuntimeConfig missing required key "backend"')
+    backend = config["backend"]
+    if not isinstance(backend, str):
+        raise TypeError(f'RuntimeConfig "backend" must be a str, got {type(backend)!r}')
+    if backend not in _BUILTIN_BACKENDS:
+        raise ValueError(f"unsupported RuntimeConfig backend {backend!r}; expected one of {sorted(_BUILTIN_BACKENDS)}")
+    return backend
+
+
+def materialize_backend_section(config: RuntimeConfig, backend: str | None = None) -> dict[str, object]:
+    """Copy the selected backend section and inject root ``env_vars``.
+
+    ``env_vars`` is a root-level RuntimeConfig field applied to every backend.
+    Backend sections must not declare it; this helper injects the parsed root
+    value before private parsers run.
+    """
+    if not isinstance(config, Mapping):
+        raise TypeError(f"RuntimeConfig must be a mapping, got {type(config)!r}")
+    name = backend if backend is not None else select_backend(config)
+    raw = config.get(name)
+    if raw is None:
+        section: dict[str, object] = {}
+    else:
+        if not isinstance(raw, Mapping):
+            raise TypeError(f'RuntimeConfig["{name}"] must be a mapping, got {type(raw)!r}')
+        section = dict(raw)
+    if "env_vars" in section:
+        raise ValueError(f'env_vars belongs at RuntimeConfig root, not in RuntimeConfig["{name}"]')
+    section["env_vars"] = parse_env_vars(config.get("env_vars"))
+    return section

--- a/verl/runtime/core.py
+++ b/verl/runtime/core.py
@@ -1,0 +1,553 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Concrete Runtime construction and process-level lifecycle authority."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import uuid
+import weakref
+from collections.abc import Mapping
+from contextlib import suppress
+from types import TracebackType
+from typing import Literal, TypeVar, cast
+
+from verl.runtime.backend_registry import RuntimeBackend, attach_backend, create_backend
+from verl.runtime.config import RuntimeConfig, materialize_backend_section, select_backend
+from verl.runtime.executor import RuntimeThreadPoolExecutor, _drain_future, run_in_thread
+from verl.runtime.runtime_context import (
+    AttachSpec,
+    RuntimeContext,
+    clear_runtime_context,
+    install_runtime_context,
+    runtime_context,
+)
+from verl.single_controller.base.actor import ActorRoleMap, ActorSpec, ClassWithInitArgs
+from verl.single_controller.base.fused import create_fused_worker_groups, normalize_role_actors
+from verl.single_controller.base.lifecycle import close_owned
+from verl.single_controller.base.resource_pool import ResourcePool
+from verl.single_controller.base.topology import Topology, _format_topology
+from verl.single_controller.base.worker import Worker
+from verl.single_controller.base.worker_group import WorkerGroup
+
+WorkerT = TypeVar("WorkerT", bound=Worker)
+
+_RUNTIME: Runtime | None = None
+logger = logging.getLogger(__name__)
+
+
+class Runtime:
+    """Create WorkerGroups and own resources created through this Runtime.
+
+    There is at most one live Runtime per process. ``Runtime.from_config``
+    establishes a root; nested callers use :func:`verl.runtime.runtime`.
+    """
+
+    def __init__(self, handle: RuntimeBackend, *, root: bool) -> None:
+        self._backend = handle
+        self._root = root
+        self._closed = False
+        self._closing = False
+        self._worker_group_executor_joined = False
+        context = runtime_context()
+        self._runtime_id = context.runtime_id
+        self._node_path = context.node_path
+        self._backend_name = context.backend
+        self._groups: weakref.WeakValueDictionary[int, WorkerGroup[Worker]] = weakref.WeakValueDictionary()
+        self._cleanup_groups: list[WorkerGroup[Worker]] = []
+        self._groups_lock = threading.Lock()
+        self._worker_group_executor = RuntimeThreadPoolExecutor(
+            thread_name_prefix="verl-worker-group",
+        )
+        self._root_pools = dict(handle.root_resource_pools())
+        for name, pool in self._root_pools.items():
+            pool._bind_runtime_scope(self._runtime_id, name)
+        self._resource_pools = dict(self._root_pools)
+        self._model_resource_pools: dict[str, ResourcePool] = {}
+        self._topology = Topology()
+
+    @property
+    def topology(self) -> Topology:
+        """Return the validated topology configured on this Runtime."""
+        return self._topology
+
+    @property
+    def backend(self) -> str:
+        """Return the selected backend name."""
+        return self._backend_name
+
+    @property
+    def runtime_id(self) -> str:
+        """Return the process tree's Runtime identity."""
+        return self._runtime_id
+
+    @property
+    def node_path(self) -> tuple[str, ...]:
+        """Return this Runtime node's path within the process tree."""
+        return self._node_path
+
+    def model_resource_pool(self, name: str) -> ResourcePool:
+        """Return the model-level resource selection compiled from topology."""
+        self._ensure_open()
+        try:
+            return self._model_resource_pools[name]
+        except KeyError as exc:
+            raise KeyError(
+                f"unknown topology model {name!r}; available: {sorted(self._model_resource_pools)!r}"
+            ) from exc
+
+    def current_host_resource_pool(self, name: str = "parent") -> ResourcePool:
+        """Return the one-host ResourcePool view containing this Worker rank."""
+        self._ensure_open()
+        try:
+            pool = self._root_pools[name]
+        except KeyError as exc:
+            raise KeyError(
+                f"unknown current Runtime ResourcePool {name!r}; available: {sorted(self._root_pools)!r}"
+            ) from exc
+        try:
+            world_size = int(os.environ["WORLD_SIZE"])
+            rank = int(os.environ["RANK"])
+            local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+            local_rank = int(os.environ["LOCAL_RANK"])
+        except (KeyError, ValueError) as exc:
+            raise RuntimeError("current_host_resource_pool requires Worker SPMD rank environment") from exc
+        if world_size != pool.world_size:
+            raise RuntimeError(
+                f"Worker WORLD_SIZE does not match its parent ResourcePool: {world_size} != {pool.world_size}"
+            )
+        if local_world_size != pool.processes_per_node:
+            raise RuntimeError(
+                "Worker LOCAL_WORLD_SIZE does not match its parent ResourcePool: "
+                f"{local_world_size} != {pool.processes_per_node}"
+            )
+        if rank < 0 or rank >= world_size:
+            raise RuntimeError(f"Worker RANK={rank} is outside WORLD_SIZE={world_size}")
+        if local_rank < 0 or local_rank >= local_world_size:
+            raise RuntimeError(f"Worker LOCAL_RANK={local_rank} is outside LOCAL_WORLD_SIZE={local_world_size}")
+        expected_local_rank = rank % local_world_size
+        if local_rank != expected_local_rank:
+            raise RuntimeError(
+                f"Worker LOCAL_RANK does not match RANK modulo LOCAL_WORLD_SIZE: {local_rank} != {expected_local_rank}"
+            )
+        node_index = rank // local_world_size
+        start = node_index * pool.processes_per_node
+        return pool.slice(slice(start, start + pool.processes_per_node))
+
+    @classmethod
+    def from_config(cls, config: RuntimeConfig) -> Runtime:
+        """Create the root Runtime and publish it for process-local callers.
+
+        Args:
+            config: Mapping containing the backend selector and backend sections.
+
+        Returns:
+            The open process-level Runtime.
+
+        Raises:
+            RuntimeError: If a live Runtime already exists in this process.
+        """
+
+        global _RUNTIME
+        if _RUNTIME is not None and not _RUNTIME._closed:
+            raise RuntimeError("Runtime is already initialized in this process")
+        backend = select_backend(config)
+        section = materialize_backend_section(config, backend)
+        env_vars = cast(dict[str, str], section["env_vars"])
+        raw_topology = cast(Mapping[str, object], config).get("topology")
+        parsed_topology = Topology.from_mapping(raw_topology)
+        # ``models`` is the opt-in switch.  Clusters and DevicePools without a
+        # model declaration must not reserve resources or change legacy placement.
+        topology = parsed_topology if parsed_topology.models else Topology()
+        if topology.models:
+            logger.info("Runtime topology plan:\n%s", _format_topology(topology))
+        runtime_id = uuid.uuid4().hex
+        handle: RuntimeBackend | None = None
+        context: RuntimeContext | None = None
+        try:
+            handle = create_backend(backend, section, topology)
+            child_section = dict(handle.child_attach_config())
+            context_config: dict[str, object] = {
+                "backend": backend,
+                "env_vars": dict(env_vars),
+                backend: child_section,
+            }
+            object_store_config: dict[str, object] = {}
+            context = RuntimeContext(
+                runtime_id=runtime_id,
+                node_path=("runtime",),
+                config=context_config,
+                object_store_config=object_store_config,
+            )
+            install_runtime_context(context)
+            runtime = cls(handle=handle, root=True)
+            runtime._resolve_topology(topology)
+            handle.start_object_store(object_store_config)
+        except BaseException:
+            _abort_initialization(context, handle)
+            raise
+        _RUNTIME = runtime
+        return runtime
+
+    @classmethod
+    def _attach(cls, spec: AttachSpec) -> Runtime:
+        """Build this backend-spawned process's Runtime node from an AttachSpec.
+
+        The parent delivers one :class:`AttachSpec` bundling identity, the static
+        config needed to rebuild the backend, and the runtime state the root
+        already decided (topology, resource pools, and ObjectStore client
+        configuration). This process assembles its own RuntimeContext here
+        rather than receiving one pre-derived by the parent.
+        """
+        global _RUNTIME
+        object_store_config = dict(spec.object_store_config)
+        context = RuntimeContext(
+            runtime_id=spec.runtime_id,
+            node_path=spec.node_path,
+            config=spec.config,
+            object_store_config=object_store_config,
+        )
+        install_runtime_context(context)
+        if _RUNTIME is not None and not _RUNTIME._closed:
+            if _RUNTIME._runtime_id != spec.runtime_id:
+                raise RuntimeError(
+                    f"process already belongs to Runtime {_RUNTIME._runtime_id!r}; cannot attach {spec.runtime_id!r}"
+                )
+            return _RUNTIME
+        backend = context.backend
+        section = materialize_backend_section(spec.config, backend)
+        handle: RuntimeBackend | None = None
+        try:
+            handle = attach_backend(backend, section, spec.resource_pools)
+            runtime = cls(handle=handle, root=False)
+            runtime._topology = spec.topology
+            runtime._resource_pools = dict(spec.resource_pools)
+            runtime._compile_model_resource_pools()
+            handle.start_object_store(object_store_config)
+        except BaseException:
+            _abort_initialization(context, handle)
+            raise
+        _RUNTIME = runtime
+        return runtime
+
+    def _resolve_topology(self, topology: Topology) -> None:
+        resolved = dict(self._backend.resolve_topology(topology)) if topology.models else {}
+        overlap = set(resolved) & set(self._root_pools)
+        if overlap:
+            raise ValueError(f"DevicePool names conflict with Runtime root pools: {sorted(overlap)!r}")
+        self._topology = topology
+        for name, pool in resolved.items():
+            pool._bind_runtime_scope(self._runtime_id, name)
+        self._resource_pools = {**self._root_pools, **resolved}
+        self._compile_model_resource_pools()
+        if topology.models:
+            logger.info(
+                "Resolved Runtime topology:\n%s",
+                _format_topology(topology, self._model_resource_pools),
+            )
+
+    def _compile_model_resource_pools(self) -> None:
+        views: dict[tuple[str, tuple[int, int]], ResourcePool] = {}
+        device_pools = {pool.name: pool for pool in self._topology.device_pools}
+        for name, key in self._topology._model_placements().items():
+            pool_name, selected = key
+            spec = device_pools[pool_name]
+            pool = views.get(key)
+            if pool is None:
+                source = self._resource_pools[pool_name]
+                pool = (
+                    source
+                    if selected == (0, spec.n_gpus_per_node)
+                    else self._backend.select_device_range(source, *selected)
+                )
+                if pool is not source:
+                    source._inherit_runtime_scope(pool)
+                views[key] = pool
+            self._model_resource_pools[name] = pool
+
+    def create_resource_pool(
+        self,
+        *,
+        nnodes: int | None,
+        processes_per_node: int,
+        device_type: Literal["gpu", "cpu"] = "gpu",
+        on: ResourcePool | str | None = None,
+    ) -> ResourcePool:
+        """Derive an imperative ResourcePool from a selected host domain.
+
+        Args:
+            nnodes: Number of nodes to select. ``None`` selects every node in
+                the chosen root domain.
+            processes_per_node: Homogeneous process count per selected node.
+            device_type: Resource class claimed by each process.
+            on: Root pool or root name. Omit only when exactly one non-controller
+                root exists, or when the controller root is the only root.
+        Returns:
+            The ResourcePool created and tracked by this Runtime.
+        """
+        self._ensure_open()
+        root = self._resolve_root_pool(on)
+        selected_nnodes = root.nnodes if nnodes is None else nnodes
+        derived = self._backend.derive_resource_pool(
+            root,
+            nnodes=selected_nnodes,
+            processes_per_node=processes_per_node,
+            device_type=device_type,
+        )
+        root._inherit_runtime_scope(derived)
+        return derived
+
+    def _resolve_root_pool(self, on: ResourcePool | str | None) -> ResourcePool:
+        if isinstance(on, ResourcePool):
+            if on._runtime_owner() != self._runtime_id:
+                raise ValueError("ResourcePool does not belong to this Runtime")
+            return on
+        if isinstance(on, str):
+            try:
+                return self._root_pools[on]
+            except KeyError as exc:
+                raise KeyError(f"unknown root ResourcePool {on!r}; available: {sorted(self._root_pools)!r}") from exc
+        if on is not None:
+            raise TypeError(f"on must be ResourcePool, str, or None, got {type(on)!r}")
+        candidates = [pool for name, pool in self._root_pools.items() if name != "controller"]
+        if len(candidates) == 1:
+            return candidates[0]
+        if not candidates and "controller" in self._root_pools:
+            return self._root_pools["controller"]
+        raise ValueError(
+            "create_resource_pool requires on= when Runtime exposes multiple root pools; "
+            f"available: {sorted(self._root_pools)!r}"
+        )
+
+    def create_worker_group(
+        self,
+        actor: ActorSpec[WorkerT] | ActorRoleMap[WorkerT],
+        *,
+        on: ResourcePool,
+    ) -> WorkerGroup[WorkerT] | dict[str, WorkerGroup[WorkerT]]:
+        """Synchronously create one WorkerGroup or fused role views."""
+        self._ensure_open()
+        if self._worker_group_executor.owns_current_thread():
+            created, _owned = self._create_worker_group_with_owner(actor, on=on)
+            return created
+        creation = self._worker_group_executor.submit(
+            self._create_worker_group_with_owner,
+            actor,
+            on=on,
+        )
+        created, _owned = creation.result()
+        return created
+
+    async def create_worker_group_async(
+        self,
+        actor: ActorSpec[WorkerT] | ActorRoleMap[WorkerT],
+        *,
+        on: ResourcePool,
+    ) -> WorkerGroup[WorkerT] | dict[str, WorkerGroup[WorkerT]]:
+        """Create one WorkerGroup on this Runtime's bounded creation executor."""
+        creation = run_in_thread(
+            self._worker_group_executor,
+            lambda: self._create_worker_group_with_owner(actor, on=on),
+        )
+        try:
+            created, _owned = await asyncio.shield(creation)
+            return created
+        except asyncio.CancelledError as cancellation:
+            # Backend creation cannot be cancelled safely once submitted. Wait
+            # for its terminal outcome despite repeated cancellation so failures
+            # are not silently detached.
+            try:
+                _created, owned = await _drain_future(creation)
+            except Exception as creation_error:
+                raise cancellation from creation_error
+
+            cleanup: asyncio.Future[None] | None = None
+            with self._groups_lock:
+                if not self._closing:
+                    # Runtime.close() sets _closing under this same lock before
+                    # shutting down the executor. Therefore cleanup is either
+                    # submitted before that shutdown fence or owned by Runtime.
+                    cleanup = run_in_thread(
+                        self._worker_group_executor,
+                        lambda: self._abandon_worker_group(owned),
+                    )
+            if cleanup is not None:
+                try:
+                    await _drain_future(cleanup)
+                except Exception as cleanup_error:
+                    raise cancellation from cleanup_error
+            raise cancellation
+
+    def _create_worker_group_with_owner(
+        self,
+        actor: ActorSpec[WorkerT] | ActorRoleMap[WorkerT],
+        *,
+        on: ResourcePool,
+    ) -> tuple[WorkerGroup[WorkerT] | dict[str, WorkerGroup[WorkerT]], WorkerGroup[WorkerT]]:
+        """Create one WorkerGroup or fused role views.
+
+        Args:
+            actor: Worker class, deferred constructor, or role-to-actor mapping.
+            on: ResourcePool whose physical nodes form the scheduling domain.
+        Returns:
+            Created WorkerGroup or non-owning role-name views, plus the owned group.
+        """
+        self._ensure_open()
+        # Validate actor class identity before any allocation side effects.
+        normalized_actor: ActorSpec[WorkerT] | dict[str, ActorSpec[WorkerT]]
+        if isinstance(actor, Mapping):
+            if not actor:
+                raise ValueError("fused role mapping must be non-empty")
+            normalized_actor = normalize_role_actors(actor)
+        elif isinstance(actor, ClassWithInitArgs | type):
+            normalized_actor = actor
+        else:
+            raise TypeError(
+                f"actor must be a Worker class, ClassWithInitArgs, or role-name mapping; got {type(actor)!r}"
+            )
+        if not isinstance(on, ResourcePool):
+            raise TypeError(f"on must be ResourcePool, got {type(on)!r}")
+        pool = on
+        if pool._runtime_owner() != self._runtime_id:
+            raise ValueError("ResourcePool does not belong to this Runtime")
+        child_topology, child_resources = self._child_resource_scope(pool)
+
+        def spawn_root(actor: ActorSpec[WorkerT]) -> WorkerGroup[WorkerT]:
+            return self._backend.create_worker_group(
+                actor, pool=pool, topology=child_topology, resource_pools=child_resources
+            )
+
+        if isinstance(normalized_actor, Mapping):
+            created, owned = create_fused_worker_groups(normalized_actor, spawn_root=spawn_root)
+        else:
+            created = owned = spawn_root(normalized_actor)
+        with self._groups_lock:
+            self._groups[id(owned)] = owned
+        return created, owned
+
+    def _abandon_worker_group(self, owned: WorkerGroup[Worker]) -> None:
+        """Close a WorkerGroup whose caller cancelled before taking ownership."""
+        try:
+            owned.close()
+        except BaseException:
+            with self._groups_lock:
+                self._cleanup_groups.append(owned)
+            raise
+        with self._groups_lock:
+            self._groups.pop(id(owned), None)
+
+    def _child_resource_scope(self, pool: ResourcePool) -> tuple[Topology, dict[str, ResourcePool]]:
+        """Derive the child Runtime scope from topology and the selected pool."""
+        if pool._runtime_root() == "controller":
+            resources = {"controller": pool}
+            if self._topology.device_pools:
+                resources.update((item.name, self._resource_pools[item.name]) for item in self._topology.device_pools)
+                return self._topology, resources
+            cluster = self._resource_pools.get("cluster")
+            if cluster is not None:
+                resources["cluster"] = cluster
+            return Topology(), resources
+        return Topology(), {"parent": pool}
+
+    def close(self) -> None:
+        """Close the Runtime, clean up resources, and clear the process global.
+
+        The Runtime lifecycle owner must serialize calls to this method.
+        Concurrent ``close()`` calls are unsupported.
+        """
+        if self._closed:
+            return
+        with self._groups_lock:
+            # Stop admission before waiting for already-submitted creation and
+            # abandonment cleanup. A failed owner remains retryable, so
+            # _closing stays set until every dependency closes.
+            self._closing = True
+        if not self._worker_group_executor_joined:
+            self._worker_group_executor.shutdown(wait=True, cancel_futures=False)
+            self._worker_group_executor_joined = True
+
+        # Keep live owners stable during teardown; failed cleanup remains
+        # strongly owned for retry, without preventing normal caller-side GC.
+        groups = list(self._groups.values())
+        try:
+            close_owned(groups)
+        finally:
+            self._cleanup_groups = groups
+            self._groups = weakref.WeakValueDictionary((id(group), group) for group in groups)
+
+        if self._root:
+            from verl.runtime.object_store import _close_object_store
+
+            # WorkerGroup shutdown has completed. Drain the controller client
+            # once, immediately before the backend tears down global storage.
+            _close_object_store()
+        self._backend.close()
+
+        context = runtime_context()
+        self._closed = True
+        global _RUNTIME
+        if _RUNTIME is self:
+            _RUNTIME = None
+        clear_runtime_context(context)
+
+    def __enter__(self) -> Runtime:
+        """Return this open Runtime for context-managed use."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close the Runtime without replacing a context body's exception."""
+        try:
+            self.close()
+        except Exception:
+            if exc is None:
+                raise
+
+    def _ensure_open(self) -> None:
+        if self._closing or self._closed:
+            raise RuntimeError("Runtime is closed")
+
+
+def _abort_initialization(context: RuntimeContext | None, handle: RuntimeBackend | None) -> None:
+    """Roll back a failed root or attach while preserving its original error."""
+    with suppress(Exception):
+        from verl.runtime.object_store import _close_object_store
+
+        _close_object_store()
+    with suppress(Exception):
+        if handle is not None:
+            handle.close()
+    if context is not None:
+        clear_runtime_context(context)
+
+
+def current_runtime() -> Runtime:
+    """Return the Runtime belonging to the process-global RuntimeContext."""
+    if _RUNTIME is None or _RUNTIME._closed:
+        raise RuntimeError("Runtime is not initialized in this process")
+    return _RUNTIME
+
+
+def close_attached_runtime() -> None:
+    """Close the backend-attached Runtime node in the current worker process."""
+    if _RUNTIME is not None and not _RUNTIME._closed and not _RUNTIME._root:
+        _RUNTIME.close()

--- a/verl/runtime/executor.py
+++ b/verl/runtime/executor.py
@@ -1,0 +1,82 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context-inheriting executors owned by Runtime lifecycle objects."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextvars
+import threading
+from collections.abc import Callable
+from typing import TypeVar
+
+ResultT = TypeVar("ResultT")
+_EXECUTOR_THREAD = threading.local()
+
+
+def _install_context(
+    context_items: tuple[tuple[contextvars.ContextVar[object], object], ...],
+    owner_token: object,
+) -> None:
+    for variable, value in context_items:
+        variable.set(value)
+    _EXECUTOR_THREAD.owner_token = owner_token
+
+
+class RuntimeThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor):
+    """Give every owned worker thread the Runtime's construction context."""
+
+    def __init__(
+        self,
+        max_workers: int | None = None,
+        thread_name_prefix: str = "",
+    ) -> None:
+        # Runtime and backend routing contexts are stable for this executor's
+        # lifetime. Install them once per worker instead of copying them for
+        # every submitted call.
+        context_items = tuple(contextvars.copy_context().items())
+        self._owner_token = object()
+        super().__init__(
+            max_workers=max_workers,
+            thread_name_prefix=thread_name_prefix,
+            initializer=_install_context,
+            initargs=(context_items, self._owner_token),
+        )
+
+    def owns_current_thread(self) -> bool:
+        """Return whether the caller already runs on this executor."""
+        return getattr(_EXECUTOR_THREAD, "owner_token", None) is self._owner_token
+
+
+def run_in_thread(
+    executor: RuntimeThreadPoolExecutor,
+    function: Callable[[], ResultT],
+) -> asyncio.Future[ResultT]:
+    """Submit one blocking call to a Runtime-owned worker thread."""
+    return asyncio.get_running_loop().run_in_executor(executor, function)
+
+
+async def _drain_future(future: asyncio.Future[ResultT]) -> ResultT:
+    """Observe submitted work despite repeated cancellation of its caller."""
+    while not future.done():
+        try:
+            await asyncio.shield(future)
+        except asyncio.CancelledError:
+            continue
+    return future.result()
+
+
+__all__ = ["RuntimeThreadPoolExecutor", "run_in_thread"]

--- a/verl/runtime/object_store.py
+++ b/verl/runtime/object_store.py
@@ -1,0 +1,159 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral synchronous object-store capability."""
+
+from __future__ import annotations
+
+import atexit
+from typing import Any, Protocol, TypeVar, cast
+
+ReferenceT = TypeVar("ReferenceT")
+
+
+class ObjectStore(Protocol[ReferenceT]):
+    """Store explicitly keyed values behind backend-specific references."""
+
+    def put(self, key: str, value: Any, /) -> ReferenceT:
+        """Store one value and return its opaque reference.
+
+        Args:
+            key: Stable logical key chosen by the caller.
+            value: Value to store.
+
+        Returns:
+            A store-specific reference for the stored value.
+        """
+        ...
+
+    def get(self, reference: ReferenceT, /) -> Any:
+        """Resolve one opaque reference to its value.
+
+        Args:
+            reference: Store-specific reference returned by put().
+
+        Returns:
+            The value identified by the reference.
+        """
+        ...
+
+    def delete(self, reference: ReferenceT, /) -> None:
+        """Notify the store that the caller will stop using one reference.
+
+        Args:
+            reference: Store-specific reference the caller will stop using.
+        """
+        ...
+
+    def put_many(self, entries: list[tuple[str, Any]], /) -> list[ReferenceT]:
+        """Store values in input order using the single-value contract."""
+        self._validate_put_many_entries(entries)
+        return [self.put(key, value) for key, value in entries]
+
+    def get_many(self, references: list[ReferenceT], /) -> list[Any]:
+        """Resolve references in input order using the single-value contract."""
+        return [self.get(reference) for reference in references]
+
+    def delete_many(self, references: list[ReferenceT], /) -> None:
+        """Release references in input order using the single-value contract."""
+        for reference in references:
+            self.delete(reference)
+
+    def close(self) -> None:
+        """Drain pending cleanup and release process-local resources."""
+        return None
+
+    @staticmethod
+    def _validate_put_many_entries(entries: list[tuple[str, Any]]) -> None:
+        keys = []
+        for key, _value in entries:
+            if not isinstance(key, str) or not key:
+                raise ValueError(f"key must be a non-empty str, got {key!r}")
+            keys.append(key)
+        if len(keys) != len(set(keys)):
+            raise ValueError("put_many keys must be unique")
+
+
+_OBJECT_STORE: ObjectStore[Any] | None = None
+_ATEXIT_REGISTERED = False
+
+
+def _start_object_store(store: ObjectStore[Any]) -> None:
+    """Start the process-global object store.
+
+    Runtime construction is serialized per process. Replacing a live store
+    would lose its pending cleanup, so callers must close the owning Runtime
+    before installing another one.
+    """
+    global _ATEXIT_REGISTERED, _OBJECT_STORE
+    if _OBJECT_STORE is not None:
+        raise RuntimeError("ObjectStore is already started in this process")
+    _OBJECT_STORE = store
+    if not _ATEXIT_REGISTERED:
+        # Register lazily, after backend modules have initialized their own
+        # process-global resources. LIFO atexit ordering then closes the store
+        # before those lower-level resources.
+        atexit.register(_close_object_store)
+        _ATEXIT_REGISTERED = True
+
+
+def _close_object_store() -> None:
+    """Close and remove the process-global client.
+
+    A failed close keeps the store installed so the lifecycle owner can retry.
+    """
+    global _OBJECT_STORE
+    if _OBJECT_STORE is not None:
+        _OBJECT_STORE.close()
+        _OBJECT_STORE = None
+
+
+def _object_store() -> ObjectStore[Any]:
+    """Return the process-global backend implementation."""
+    if _OBJECT_STORE is None:
+        raise RuntimeError("No ObjectStore is started in this process")
+    return cast(ObjectStore[Any], _OBJECT_STORE)
+
+
+def put(key: str, value: Any, /) -> Any:
+    """Store one value and return its backend-specific opaque reference."""
+    return _object_store().put(key, value)
+
+
+def put_many(entries: list[tuple[str, Any]], /) -> list[Any]:
+    """Store values in input order."""
+    return _object_store().put_many(entries)
+
+
+def get(reference: Any, /) -> Any:
+    """Resolve one opaque ObjectStore reference."""
+    return _object_store().get(reference)
+
+
+def get_many(references: list[Any], /) -> list[Any]:
+    """Resolve references in input order."""
+    return _object_store().get_many(references)
+
+
+def delete(reference: Any, /) -> None:
+    """Release one ObjectStore reference."""
+    _object_store().delete(reference)
+
+
+def delete_many(references: list[Any], /) -> None:
+    """Release ObjectStore references."""
+    _object_store().delete_many(references)
+
+
+__all__ = ["ObjectStore", "delete", "delete_many", "get", "get_many", "put", "put_many"]

--- a/verl/runtime/runtime_context.py
+++ b/verl/runtime/runtime_context.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-injected identity for one process-local Runtime tree node."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from verl.runtime.config import RuntimeConfig, select_backend
+
+if TYPE_CHECKING:
+    from verl.single_controller.base.resource_pool import ResourcePool
+    from verl.single_controller.base.topology import Topology
+
+_RUNTIME_CONTEXT: RuntimeContext | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AttachSpec:
+    """Everything a backend-spawned process needs to build its Runtime node.
+
+    The parent assembles this once per WorkerGroup and the backend delivers it
+    as a single spawn payload: the child's identity (``runtime_id``,
+    ``node_path``), the static ``config`` used to rebuild the backend, and the
+    runtime state the root already decided (``topology``, ``resource_pools``).
+    ``object_store_config`` carries the root backend's client configuration so
+    every attached process starts the same process-global ObjectStore.
+    """
+
+    runtime_id: str
+    node_path: tuple[str, ...]
+    config: RuntimeConfig
+    topology: Topology
+    resource_pools: Mapping[str, ResourcePool]
+    object_store_config: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContext:
+    """Serializable identity for one Runtime tree node."""
+
+    runtime_id: str
+    node_path: tuple[str, ...]
+    config: RuntimeConfig
+    object_store_config: dict[str, object] = field(default_factory=dict, compare=False, hash=False)
+
+    def child_attach_spec(
+        self,
+        *,
+        node_path: tuple[str, ...],
+        topology: Topology,
+        resource_pools: Mapping[str, ResourcePool],
+    ) -> AttachSpec:
+        """Build the backend-serialized state for one child Runtime node."""
+        return AttachSpec(
+            runtime_id=self.runtime_id,
+            node_path=node_path,
+            config=self.config,
+            topology=topology,
+            resource_pools=resource_pools,
+            object_store_config=dict(self.object_store_config),
+        )
+
+    @property
+    def backend(self) -> str:
+        return select_backend(self.config)
+
+
+def runtime_context() -> RuntimeContext:
+    """Return the initialized process RuntimeContext."""
+    if _RUNTIME_CONTEXT is None:
+        raise RuntimeError("RuntimeContext is not initialized in this process")
+    return _RUNTIME_CONTEXT
+
+
+def install_runtime_context(context: RuntimeContext) -> RuntimeContext:
+    global _RUNTIME_CONTEXT
+    current = _RUNTIME_CONTEXT
+    if current is not None:
+        if current != context:
+            raise RuntimeError(
+                f"process already belongs to Runtime node {'/'.join(current.node_path)!r}; "
+                f"cannot attach {'/'.join(context.node_path)!r}"
+            )
+        return current
+    _RUNTIME_CONTEXT = context
+    return context
+
+
+def clear_runtime_context(expected: RuntimeContext) -> None:
+    global _RUNTIME_CONTEXT
+    if _RUNTIME_CONTEXT is not None and _RUNTIME_CONTEXT == expected:
+        _RUNTIME_CONTEXT = None
+
+
+__all__ = ["AttachSpec", "RuntimeContext", "runtime_context"]

--- a/verl/single_controller/base/actor.py
+++ b/verl/single_controller/base/actor.py
@@ -1,0 +1,342 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deferred actor construction descriptors."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Mapping
+from functools import partial
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeAlias, TypeVar, cast
+
+from verl.runtime.executor import RuntimeThreadPoolExecutor, run_in_thread
+from verl.single_controller.base.worker import Worker
+
+if TYPE_CHECKING:
+    from verl.single_controller.base.fused import FusedWorker
+
+ActorT = TypeVar("ActorT")
+
+
+class ClassWithInitArgs(Generic[ActorT]):
+    """Wrapper that stores constructor arguments for deferred instantiation.
+
+    This class is particularly useful for remote class instantiation where
+    the actual construction needs to happen at a different time or location.
+    """
+
+    def __init__(self, cls: type[ActorT], *args: Any, **kwargs: Any) -> None:
+        """Initialize the ClassWithInitArgs instance.
+
+        Args:
+            cls: The class to be instantiated later.
+            *args: Positional arguments for the class constructor.
+            **kwargs: Keyword arguments for the class constructor.
+        """
+        if not isinstance(cls, type):
+            raise TypeError(f"cls must be a type, got {type(cls)!r}")
+        self.cls = cls
+        self.args = args
+        self.kwargs = kwargs
+
+    @property
+    def actor_class(self) -> type[ActorT]:
+        """Return the stored actor class (alias of ``cls``)."""
+        return self.cls
+
+    @classmethod
+    def check_actor_class(cls, actor_class: type) -> None:
+        """Validate that a class can be reconstructed from an import manifest."""
+        module = getattr(actor_class, "__module__", None)
+        qualname = getattr(actor_class, "__qualname__", None)
+        if not isinstance(module, str) or not module:
+            raise ValueError(f"actor_class {actor_class!r} lacks a stable __module__")
+        if not isinstance(qualname, str) or not qualname or "<" in qualname:
+            raise ValueError(f"actor_class {actor_class!r} lacks a stable __qualname__")
+
+    def __call__(self) -> ActorT:
+        """Instantiate the stored class with the stored arguments."""
+        return self.cls(*self.args, **self.kwargs)
+
+
+class WorkerContainer:
+    """Own one Worker, its execution thread, calls, and retryable close."""
+
+    def __init__(
+        self,
+        actor: ClassWithInitArgs[Worker],
+        *,
+        thread_name_prefix: str,
+        owner_thread_setup: Callable[[], None] | None = None,
+    ) -> None:
+        self._thread_pool: RuntimeThreadPoolExecutor | None = None
+        self._worker: Worker | None = None
+        self._runs_on_actor_loop = False
+        self._active_calls = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
+        self._closing = False
+        self._closed = False
+
+        def setup_owner_thread() -> None:
+            if owner_thread_setup is not None:
+                owner_thread_setup()
+
+        try:
+            self._construct(
+                actor,
+                thread_name_prefix=thread_name_prefix,
+                setup_owner_thread=setup_owner_thread,
+            )
+        except BaseException:
+            self._abort_initialization()
+            raise
+
+    @property
+    def _owned_worker(self) -> Worker:
+        if self._worker is None:
+            raise RuntimeError("Worker construction did not complete")
+        return self._worker
+
+    @property
+    def _fused_worker(self) -> FusedWorker | None:
+        from verl.single_controller.base.fused import FusedWorker
+
+        return cast(FusedWorker, self._worker) if isinstance(self._worker, FusedWorker) else None
+
+    def _construct(
+        self,
+        actor: ClassWithInitArgs[Worker],
+        *,
+        thread_name_prefix: str,
+        setup_owner_thread: Callable[[], None],
+    ) -> None:
+        from verl.single_controller.base.fused import FusedWorker, _worker_class_is_async
+
+        if issubclass(actor.cls, FusedWorker):
+            actor_kwargs = dict(actor.kwargs)
+            actor_kwargs["defer_role_init"] = True
+            setup_owner_thread()
+            self._worker = actor.cls(*actor.args, **actor_kwargs)
+            self._initialize_fused_roles(async_capable=True)
+            fused = cast(FusedWorker, self._worker)
+            if any(not fused._fuw_role_is_async(name) for name in fused.cls_names):
+                self._thread_pool = RuntimeThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix=thread_name_prefix,
+                )
+
+                def initialize_sync_roles() -> None:
+                    setup_owner_thread()
+                    self._initialize_fused_roles(async_capable=False)
+
+                self._thread_pool.submit(initialize_sync_roles).result()
+            return
+
+        self._runs_on_actor_loop = _worker_class_is_async(actor.cls)
+        if self._runs_on_actor_loop:
+            setup_owner_thread()
+            self._worker = actor()
+            return
+
+        self._thread_pool = RuntimeThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=thread_name_prefix,
+        )
+
+        def initialize_sync_worker() -> None:
+            setup_owner_thread()
+            self._worker = actor()
+
+        self._thread_pool.submit(initialize_sync_worker).result()
+
+    def _abort_initialization(self) -> None:
+        fused = self._fused_worker
+        if fused is not None:
+            roles = [
+                name for name in fused.cls_names if name in fused.fused_worker_dict and fused._fuw_role_is_async(name)
+            ]
+            self._rollback_fused_roles(roles)
+        if self._thread_pool is not None:
+            self._thread_pool.shutdown(wait=True, cancel_futures=True)
+        from verl.runtime.core import close_attached_runtime
+
+        try:
+            close_attached_runtime()
+        except Exception:
+            pass
+
+    def _initialize_fused_roles(self, *, async_capable: bool) -> None:
+        fused = self._fused_worker
+        if fused is None:
+            raise RuntimeError("fused Worker construction did not complete")
+        existing = set(fused.fused_worker_dict)
+        try:
+            fused._initialize_roles(async_capable=async_capable)
+            for role_name in fused.cls_names:
+                if role_name in existing or fused._fuw_role_is_async(role_name) != async_capable:
+                    continue
+                fused.fused_worker_dict[role_name]._setup_visible_devices()
+        except BaseException:
+            created = [name for name in fused.cls_names if name not in existing and name in fused.fused_worker_dict]
+            self._rollback_fused_roles(created)
+            raise
+
+    def _rollback_fused_roles(self, role_names: list[str]) -> None:
+        fused = self._fused_worker
+        if fused is None:
+            return
+        for role_name in reversed(role_names):
+            role = fused.fused_worker_dict.get(role_name)
+            close = getattr(role, "close", None) if role is not None else None
+            try:
+                if callable(close):
+                    self._resolve(close)
+            except BaseException:
+                pass
+            finally:
+                fused.fused_worker_dict.pop(role_name, None)
+                if getattr(fused, role_name, None) is role:
+                    delattr(fused, role_name)
+
+    @staticmethod
+    def _resolve(function: Callable[[], Any]) -> Any:
+        result = function()
+        return asyncio.run(result) if inspect.isawaitable(result) else result
+
+    async def _call(self, function: Callable[[], Any], *, actor_loop: bool) -> Any:
+        if actor_loop:
+            result = function()
+            return await result if inspect.isawaitable(result) else result
+        if self._thread_pool is None:
+            raise RuntimeError("synchronous Worker thread is unavailable")
+        return await run_in_thread(self._thread_pool, lambda: self._resolve(function))
+
+    async def _close_fused_roles(self) -> None:
+        from verl.single_controller.base.errors import ExceptionGroup
+
+        fused = self._fused_worker
+        if fused is None:
+            raise RuntimeError("Worker is not fused")
+        errors: list[Exception] = []
+        for role_name in reversed(fused.cls_names):
+            role = fused.fused_worker_dict.get(role_name)
+            close = getattr(role, "close", None) if role is not None else None
+            if not callable(close):
+                continue
+            try:
+                await self._call(close, actor_loop=fused._fuw_role_is_async(role_name))
+            except Exception as exc:
+                errors.append(exc)
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise ExceptionGroup("runtime failures", errors)
+
+    async def _close_worker(self) -> None:
+        from verl.runtime.core import close_attached_runtime
+
+        worker = self._owned_worker
+        try:
+            if self._fused_worker is not None:
+                await self._close_fused_roles()
+            else:
+                await self._call(worker.close, actor_loop=self._runs_on_actor_loop)
+        finally:
+            # Attached backends may synchronously wait for RPC completion; keep
+            # that wait off the actor loop that delivers those completions.
+            await asyncio.to_thread(close_attached_runtime)
+
+    async def _release_worker(self) -> None:
+        def release() -> None:
+            self._worker = None
+
+        if self._thread_pool is None:
+            await asyncio.to_thread(release)
+        else:
+            await run_in_thread(self._thread_pool, release)
+
+    async def _shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closing = True
+        await self._idle.wait()
+        await self._close_worker()
+        await self._release_worker()
+        if self._thread_pool is not None:
+            self._thread_pool.shutdown(wait=True, cancel_futures=True)
+            self._thread_pool = None
+        self._closed = True
+
+    async def dispatch(
+        self,
+        method_name: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        """Invoke one Worker method and materialize its result before transport."""
+        if method_name == "_shutdown":
+            await self._shutdown()
+            return None
+        if self._closing:
+            raise RuntimeError("Worker actor is closing")
+
+        self._active_calls += 1
+        self._idle.clear()
+        try:
+            return await self._dispatch_open(method_name, args, kwargs)
+        finally:
+            self._active_calls -= 1
+            if self._active_calls == 0:
+                self._idle.set()
+
+    async def _dispatch_open(
+        self,
+        method_name: str,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Any:
+        worker = self._owned_worker
+        fused = self._fused_worker
+        if method_name == "_fuw_execute" and fused is not None:
+            role_name, role_method_name, *role_args = args
+            if fused._fuw_role_is_async(role_name):
+                return await fused._fuw_execute(
+                    role_name,
+                    role_method_name,
+                    *role_args,
+                    **kwargs,
+                )
+            return await self._call(
+                partial(
+                    fused._fuw_execute_sync,
+                    role_name,
+                    role_method_name,
+                    *role_args,
+                    **kwargs,
+                ),
+                actor_loop=False,
+            )
+
+        method = getattr(worker, method_name)
+        return await self._call(
+            partial(method, *args, **kwargs),
+            actor_loop=self._runs_on_actor_loop,
+        )
+
+
+ActorSpec: TypeAlias = type[ActorT] | ClassWithInitArgs[ActorT]
+ActorRoleMap: TypeAlias = Mapping[str, ActorSpec[ActorT]]

--- a/verl/single_controller/base/dependency.py
+++ b/verl/single_controller/base/dependency.py
@@ -1,0 +1,242 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resolve RemoteCall arguments for implicit submit-to-submit dependencies."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from typing import Any
+
+from verl.single_controller.base.errors import ExceptionGroup
+from verl.single_controller.base.remote_call import RemoteCall, _ActiveLoopWouldBlockError, remaining_deadline
+
+
+def walk_remote_call_dependencies(args: Sequence[Any], kwargs: Mapping[str, Any] | None = None) -> Iterator[Any]:
+    """Yield distinct RemoteCall values in stable depth-first order."""
+    seen_containers: set[int] = set()
+    emitted_calls: set[int] = set()
+
+    def walk(value: Any) -> Iterator[Any]:
+        if isinstance(value, RemoteCall):
+            identity = id(value)
+            if identity not in emitted_calls:
+                emitted_calls.add(identity)
+                yield value
+            return
+        if type(value) not in (list, tuple, dict):
+            return
+        container_id = id(value)
+        if container_id in seen_containers:
+            raise ValueError("cyclic container detected while resolving RemoteCall dependencies")
+        seen_containers.add(container_id)
+        try:
+            items = value.values() if type(value) is dict else value
+            for item in items:
+                yield from walk(item)
+        finally:
+            seen_containers.remove(container_id)
+
+    for arg in args:
+        yield from walk(arg)
+    if kwargs:
+        for value in kwargs.values():
+            yield from walk(value)
+
+
+def replace_remote_call_dependencies(
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any] | None,
+    resolved: Mapping[int, Any],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Replace RemoteCall values with their resolved outcomes."""
+
+    def rewrite(value: Any) -> Any:
+        if isinstance(value, RemoteCall):
+            return resolved[id(value)]
+        if type(value) is tuple:
+            return tuple(rewrite(item) for item in value)
+        if type(value) is list:
+            return [rewrite(item) for item in value]
+        if type(value) is dict:
+            return {key: rewrite(item) for key, item in value.items()}
+        return value
+
+    return (
+        tuple(rewrite(arg) for arg in args),
+        {key: rewrite(value) for key, value in (kwargs or {}).items()},
+    )
+
+
+def earliest_deadline(*deadlines: float | None) -> float | None:
+    finite = [deadline for deadline in deadlines if deadline is not None]
+    return min(finite) if finite else None
+
+
+def resolve_submit_dependencies(
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any] | None,
+    *,
+    downstream_deadline: float | None,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Resolve upstream submit results before dispatching the downstream call."""
+    dependencies = list(walk_remote_call_dependencies(args, kwargs))
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        in_event_loop = False
+    else:
+        in_event_loop = True
+
+    resolved: dict[int, Any] = {}
+    failures: list[Exception] = []
+    for dependency in dependencies:
+        identity = id(dependency)
+        observe_deadline = earliest_deadline(dependency._deadline, downstream_deadline)
+        remaining = remaining_deadline(observe_deadline)
+        try:
+            dependency._observe(0.0 if in_event_loop else remaining)
+            if in_event_loop and not dependency.done():
+                if remaining is not None and remaining <= 0:
+                    dependency._result_nowait()
+                raise _ActiveLoopWouldBlockError(
+                    "RemoteCall.result() cannot wait for submit dependencies in an active event loop; await it"
+                )
+            resolved[identity] = dependency._result_nowait()
+        except _ActiveLoopWouldBlockError:
+            raise
+        except Exception as exc:
+            failures.append(exc)
+
+    if len(failures) == 1:
+        raise failures[0]
+    if failures:
+        raise ExceptionGroup("runtime failures", failures)
+    return replace_remote_call_dependencies(args, kwargs, resolved)
+
+
+async def resolve_submit_dependencies_async(
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any] | None,
+    *,
+    downstream_deadline: float | None,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Resolve upstream submit results without blocking the caller event loop."""
+    dependencies = list(walk_remote_call_dependencies(args, kwargs))
+    resolved: dict[int, Any] = {}
+    failures: list[Exception] = []
+    for dependency in dependencies:
+        identity = id(dependency)
+        observe_deadline = earliest_deadline(dependency._deadline, downstream_deadline)
+        remaining = remaining_deadline(observe_deadline)
+        try:
+            if remaining is None:
+                resolved[identity] = await dependency
+            else:
+                try:
+                    resolved[identity] = await asyncio.wait_for(dependency, timeout=remaining)
+                except TimeoutError:
+                    dependency._observe(0.0)
+                    resolved[identity] = dependency._result_nowait()
+        except Exception as exc:
+            failures.append(exc)
+
+    if len(failures) == 1:
+        raise failures[0]
+    if failures:
+        raise ExceptionGroup("runtime failures", failures)
+    return replace_remote_call_dependencies(args, kwargs, resolved)
+
+
+class _DependencyRemoteCall(RemoteCall[Any]):
+    def __init__(
+        self,
+        args: Sequence[Any],
+        kwargs: Mapping[str, Any] | None,
+        *,
+        deadline: float | None,
+        submit_resolved: Callable[[tuple[Any, ...], dict[str, Any]], RemoteCall[Any]],
+    ) -> None:
+        super().__init__(deadline=deadline)
+        self._args = tuple(args)
+        self._kwargs = dict(kwargs or {})
+        self._submit_resolved = submit_resolved
+        self._target: RemoteCall[Any] | None = None
+
+    def _store_target_outcome(self) -> None:
+        if self._target is None or not self._target.done() or self.done():
+            return
+        try:
+            result = self._target._result_nowait()
+        except Exception as exc:
+            self._set_exception(exc)
+        else:
+            self._set_result(result)
+
+    def _observe(self, remaining: float | None) -> None:
+        if self.done():
+            return
+        if self._target is None:
+            try:
+                resolved = resolve_submit_dependencies(
+                    self._args,
+                    self._kwargs,
+                    downstream_deadline=self._deadline,
+                )
+                self._target = self._submit_resolved(*resolved)
+            except _ActiveLoopWouldBlockError:
+                raise
+            except Exception as exc:
+                self._set_exception(exc)
+                return
+        self._target._observe(remaining)
+        self._store_target_outcome()
+
+    async def _wait_async(self) -> None:
+        if self.done():
+            return
+        if self._target is None:
+            try:
+                resolved = await resolve_submit_dependencies_async(
+                    self._args,
+                    self._kwargs,
+                    downstream_deadline=self._deadline,
+                )
+                if self._target is None and not self.done():
+                    self._target = self._submit_resolved(*resolved)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._set_exception(exc)
+                return
+        if self._target is not None:
+            await RemoteCall._observe_async(self._target)
+            self._store_target_outcome()
+
+
+def dependency_remote_call(
+    args: Sequence[Any],
+    kwargs: Mapping[str, Any] | None,
+    *,
+    deadline: float | None,
+    submit_resolved: Callable[[tuple[Any, ...], dict[str, Any]], RemoteCall[Any]],
+) -> RemoteCall[Any]:
+    """Return one RemoteCall that submits only after its argument calls resolve."""
+    return _DependencyRemoteCall(
+        args,
+        kwargs,
+        deadline=deadline,
+        submit_resolved=submit_resolved,
+    )

--- a/verl/single_controller/base/errors.py
+++ b/verl/single_controller/base/errors.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RPC and placement errors for the common Runtime surface."""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from builtins import ExceptionGroup as ExceptionGroup
+else:
+    from exceptiongroup import ExceptionGroup as ExceptionGroup
+
+
+class RPCError(RuntimeError):
+    """Base class for RPC infrastructure failures."""
+
+
+class RPCTransportError(RPCError):
+    """Report that transport cannot determine the remote invocation outcome."""
+
+
+class RPCUnavailableError(RPCTransportError):
+    """Report that the backend confirmed the fixed remote target is unavailable."""
+
+
+class RPCTimeoutError(RPCTransportError, TimeoutError):
+    """Report that a submit deadline expired while the remote outcome is unknown."""
+
+
+class RPCRemoteError(RPCError):
+    """Fallback for an application exception that RPC cannot reconstruct."""
+
+
+class PlacementUnavailableError(RuntimeError):
+    """Report that the requested exact process topology cannot be allocated."""

--- a/verl/single_controller/base/fused.py
+++ b/verl/single_controller/base/fused.py
@@ -1,0 +1,229 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-independent fused Worker construction and invocation."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+from collections.abc import Mapping
+from contextlib import suppress
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
+
+from verl.single_controller.base.actor import ActorRoleMap, ClassWithInitArgs
+from verl.single_controller.base.worker import Worker
+from verl.utils.py_functional import temp_env_var
+
+if TYPE_CHECKING:
+    from verl.single_controller.base.worker_group import WorkerGroup
+
+GroupT = TypeVar("GroupT", bound="WorkerGroup[Worker]")
+
+
+def normalize_role_actors(roles: ActorRoleMap[Worker]) -> dict[str, ClassWithInitArgs[Worker]]:
+    """Normalize a role mapping into backend-independent constructors."""
+    normalized: dict[str, ClassWithInitArgs[Worker]] = {}
+    for role_name, actor in roles.items():
+        if not isinstance(role_name, str) or not role_name:
+            raise TypeError(f"fused role name must be a non-empty str, got {role_name!r}")
+        if isinstance(actor, ClassWithInitArgs):
+            normalized[role_name] = actor
+        elif isinstance(actor, type):
+            normalized[role_name] = ClassWithInitArgs(actor)
+        else:
+            raise TypeError(
+                f"actor must be a Worker class, ClassWithInitArgs, or role-name mapping; got {type(actor)!r}"
+            )
+    return normalized
+
+
+def role_manifests(roles: Mapping[str, ClassWithInitArgs[Worker]]) -> dict[str, dict[str, Any]]:
+    """Convert normalized constructors into transport-serializable manifests."""
+    manifests: dict[str, dict[str, Any]] = {}
+    for role_name, init in roles.items():
+        ClassWithInitArgs.check_actor_class(init.cls)
+        manifests[role_name] = {
+            "module": init.cls.__module__,
+            "qualname": init.cls.__qualname__,
+            "args": init.args,
+            "kwargs": dict(init.kwargs),
+        }
+    return manifests
+
+
+def create_fused_worker_groups(
+    roles: ActorRoleMap[Worker],
+    *,
+    spawn_root: Callable[[ClassWithInitArgs[Worker]], GroupT],
+) -> tuple[dict[str, GroupT], GroupT]:
+    """Create one fused root and non-owning role views with shared rollback."""
+    if not roles:
+        raise ValueError("fused actor mapping must be non-empty")
+    role_inits = normalize_role_actors(roles)
+    root = spawn_root(
+        ClassWithInitArgs(
+            FusedWorker,
+            role_manifests=role_manifests(role_inits),
+        )
+    )
+    try:
+        views = root._role_views(role_inits)
+        for view in views.values():
+            view._owned = False
+            view._parent_group = root
+    except BaseException:
+        with suppress(Exception):
+            root.close()
+        raise
+    return views, root
+
+
+def _load_class(module_name: str, qualname: str) -> type[Worker]:
+    obj: Any = importlib.import_module(module_name)
+    for part in qualname.split("."):
+        obj = getattr(obj, part)
+    if not isinstance(obj, type) or not issubclass(obj, Worker):
+        raise TypeError(f"{module_name}.{qualname} is not a Worker type")
+    return obj
+
+
+class FusedWorker(Worker):
+    """Own multiple role Workers in one process, independent of the transport."""
+
+    is_fused_worker = True
+
+    def __init__(
+        self,
+        role_manifests: Mapping[str, Mapping[str, Any]],
+        *,
+        defer_role_init: bool = False,
+    ) -> None:
+        super().__init__()
+        self.cls_names = list(role_manifests)
+        # Decode transport metadata once. Each owner thread constructs its
+        # roles later from these descriptors without interpreting manifests.
+        self._role_inits = {
+            name: ClassWithInitArgs(
+                _load_class(str(manifest["module"]), str(manifest["qualname"])),
+                *tuple(manifest.get("args") or ()),
+                **dict(manifest.get("kwargs") or {}),
+            )
+            for name, manifest in role_manifests.items()
+        }
+        self._role_async_capabilities = MappingProxyType(
+            {name: _worker_class_is_async(init.cls) for name, init in self._role_inits.items()}
+        )
+        self.fused_worker_dict: dict[str, Worker] = {}
+        if not defer_role_init:
+            self._initialize_roles(async_capable=None)
+
+    def _initialize_roles(self, *, async_capable: bool | None) -> None:
+        for role_name, init in self._role_inits.items():
+            if role_name in self.fused_worker_dict:
+                continue
+            if async_capable is not None and self._fuw_role_is_async(role_name) != async_capable:
+                continue
+            with temp_env_var("DISABLE_WORKER_INIT", "1"):
+                role = init()
+            role._configure_with_store(self.__dict__)
+            self.fused_worker_dict[role_name] = role
+            setattr(self, role_name, role)
+        # Inject the shared role map so siblings can look each other up.
+        for worker in self.fused_worker_dict.values():
+            setattr(worker, Worker.fused_worker_attr_name, self.fused_worker_dict)
+
+    def _fuw_method(self, role_name: str, method_name: str):
+        role = self.fused_worker_dict.get(role_name)
+        if role is None:
+            raise KeyError(f"unknown fused Worker role {role_name!r}")
+        return getattr(role, method_name)
+
+    def _fuw_role_is_async(self, role_name: str) -> bool:
+        """Return the immutable owner-thread capability for one fused role."""
+        try:
+            return self._role_async_capabilities[role_name]
+        except KeyError:
+            raise KeyError(f"unknown fused Worker role {role_name!r}") from None
+
+    def _fuw_execute_sync(self, role_name: str, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        method = self._fuw_method(role_name, method_name)
+        if inspect.iscoroutinefunction(method):
+            raise TypeError(f"fused Worker method {role_name}.{method_name} is async")
+        result = method(*args, **kwargs)
+        return asyncio.run(result) if inspect.isawaitable(result) else result
+
+    async def _fuw_execute(self, role_name: str, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Invoke one role method and materialize its result before transport."""
+        method = self._fuw_method(role_name, method_name)
+        # Role state and CUDA thread-local state belong to this actor thread.
+        result = method(*args, **kwargs)
+        return await result if inspect.isawaitable(result) else result
+
+    def close(self):
+        from verl.single_controller.base.errors import ExceptionGroup
+
+        async def _close_roles() -> None:
+            errors: list[Exception] = []
+            for role_name in reversed(self.cls_names):
+                role = self.fused_worker_dict.get(role_name)
+                close = getattr(role, "close", None) if role is not None else None
+                if not callable(close):
+                    continue
+                try:
+                    result = close()
+                    if inspect.isawaitable(result):
+                        await result
+                except Exception as exc:
+                    errors.append(exc)
+            if len(errors) == 1:
+                raise errors[0]
+            if errors:
+                raise ExceptionGroup("runtime failures", errors)
+
+        needs_async = any(
+            inspect.iscoroutinefunction(getattr(role, "close", None))
+            for role in (self.fused_worker_dict.get(name) for name in self.cls_names)
+            if role is not None
+        )
+        if needs_async:
+            return _close_roles()
+
+        errors: list[Exception] = []
+        for role_name in reversed(self.cls_names):
+            role = self.fused_worker_dict.get(role_name)
+            close = getattr(role, "close", None) if role is not None else None
+            if callable(close):
+                try:
+                    result = close()
+                    if inspect.isawaitable(result):
+                        asyncio.run(result)
+                except Exception as exc:
+                    errors.append(exc)
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise ExceptionGroup("runtime failures", errors)
+
+
+def _worker_class_is_async(role_cls: type[Worker]) -> bool:
+    """Whether user code on ``role_cls`` declares any coroutine method."""
+    for cls in role_cls.__mro__:
+        if cls is Worker:
+            break
+        if any(inspect.iscoroutinefunction(value) for value in cls.__dict__.values()):
+            return True
+    return False

--- a/verl/single_controller/base/lifecycle.py
+++ b/verl/single_controller/base/lifecycle.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared teardown for resources held in creation order."""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar
+
+from verl.single_controller.base.errors import ExceptionGroup
+
+
+class _Closable(Protocol):
+    def close(self) -> None: ...
+
+
+OwnerT = TypeVar("OwnerT", bound=_Closable)
+
+
+def close_owned(owners: list[OwnerT]) -> None:
+    """Close in reverse order, retaining only failed owners for a later retry.
+
+    The caller must serialize teardown and stop other writers first. A
+    BaseException interrupts the pass without changing the ownership list.
+    """
+    errors: list[Exception] = []
+    remaining: list[OwnerT] = []
+    for owner in reversed(owners):
+        try:
+            owner.close()
+        except Exception as exc:
+            errors.append(exc)
+            remaining.append(owner)
+    owners[:] = reversed(remaining)
+    if len(errors) == 1:
+        raise errors[0]
+    if errors:
+        raise ExceptionGroup("runtime failures", errors)

--- a/verl/single_controller/base/remote_call.py
+++ b/verl/single_controller/base/remote_call.py
@@ -1,0 +1,317 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collected remote completion with Future-shaped observation and submit-time deadlines."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Coroutine, Generator, Sequence
+from typing import Any, Generic, TypeVar, cast
+
+from verl.single_controller.base.errors import ExceptionGroup, RPCTimeoutError
+
+ResultT = TypeVar("ResultT")
+
+
+class _ObservationTimeout(Exception):
+    pass
+
+
+class _ActiveLoopWouldBlockError(RuntimeError):
+    pass
+
+
+async def _observe_with_timeout(operation: Coroutine[Any, Any, ResultT], remaining: float | None) -> ResultT:
+    """Bound one observation without mistaking a task's TimeoutError for ours."""
+    if remaining is None:
+        return await operation
+    task = asyncio.create_task(operation)
+    done, _pending = await asyncio.wait((task,), timeout=remaining)
+    if done:
+        return task.result()
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    raise _ObservationTimeout
+
+
+def create_deadline(timeout: float | None) -> float | None:
+    """Create an absolute monotonic deadline from a submit-time timeout.
+
+    Args:
+        timeout: ``None`` for no deadline, or a finite non-negative duration.
+
+    Returns:
+        Absolute ``time.monotonic()`` deadline, or None.
+    """
+    if timeout is None:
+        return None
+    if isinstance(timeout, bool) or not isinstance(timeout, int | float):
+        raise TypeError(f"timeout must be None or a finite non-negative number, got {type(timeout)!r}")
+    if timeout < 0 or timeout != timeout or timeout == float("inf"):
+        raise ValueError(f"timeout must be a finite non-negative number, got {timeout!r}")
+    return time.monotonic() + float(timeout)
+
+
+def remaining_deadline(deadline: float | None, *, now: float | None = None) -> float | None:
+    """Return remaining seconds until deadline, or None when unbounded."""
+    if deadline is None:
+        return None
+    current = time.monotonic() if now is None else now
+    return max(0.0, deadline - current)
+
+
+class RemoteCall(Awaitable[ResultT], ABC, Generic[ResultT]):
+    """Represent one collected remote completion with a submit-time deadline.
+
+    A call is observed through ``result()``, ``done()``, or ``await``.
+    ``timeout`` exists only on submit; observation uses the stored deadline.
+    """
+
+    def __init__(self, *, deadline: float | None) -> None:
+        self._deadline = deadline
+        self._result: ResultT | None = None
+        self._exception: BaseException | None = None
+        self._done = False
+
+    def __await__(self) -> Generator[Any, None, ResultT]:
+        """Await the same value or exception as result()."""
+        return self._await_result().__await__()
+
+    async def _await_result(self) -> ResultT:
+        remaining = remaining_deadline(self._deadline)
+        try:
+            if remaining is None:
+                await self._wait_async()
+            else:
+                await asyncio.wait_for(self._wait_async(), timeout=remaining)
+        except TimeoutError:
+            self._observe(0.0)
+        return self._result_nowait()
+
+    def result(self) -> ResultT:
+        """Return the result, using the absolute deadline created by submit()."""
+        self._observe(remaining_deadline(self._deadline))
+        return self._result_nowait()
+
+    @staticmethod
+    def wait(
+        calls: Sequence[RemoteCall[Any]],
+        *,
+        count: int = 1,
+    ) -> RemoteCall[tuple[list[RemoteCall[Any]], list[RemoteCall[Any]]]]:
+        """Return one awaitable call that completes after ``count`` inputs."""
+        if not isinstance(calls, Sequence) or isinstance(calls, str | bytes):
+            raise TypeError(f"calls must be a sequence of RemoteCall, got {type(calls)!r}")
+        if not calls:
+            raise ValueError("calls must be non-empty")
+        identities: set[int] = set()
+        for call in calls:
+            if not isinstance(call, RemoteCall):
+                raise TypeError(f"calls must contain RemoteCall instances, got {type(call)!r}")
+            call_id = id(call)
+            if call_id in identities:
+                raise ValueError("calls must have unique ids")
+            identities.add(call_id)
+        if isinstance(count, bool) or not isinstance(count, int):
+            raise TypeError(f"count must be a non-bool int, got {type(count)!r}")
+        if count < 1 or count > len(calls):
+            raise ValueError(f"count must satisfy 1 <= count <= len(calls); got count={count}, len={len(calls)}")
+        return cast(RemoteCall[_WaitResult], _AggregateRemoteCall(calls, count=count))
+
+    @staticmethod
+    def gather(calls: Sequence[RemoteCall[ResultT]]) -> RemoteCall[list[ResultT]]:
+        """Return one awaitable call that collects all inputs in order."""
+        if not isinstance(calls, Sequence) or isinstance(calls, str | bytes):
+            raise TypeError(f"calls must be a sequence of RemoteCall, got {type(calls)!r}")
+        for call in calls:
+            if not isinstance(call, RemoteCall):
+                raise TypeError(f"calls must contain RemoteCall instances, got {type(call)!r}")
+        return cast(RemoteCall[list[ResultT]], _AggregateRemoteCall(calls))
+
+    @staticmethod
+    def _has_running_loop() -> bool:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        return True
+
+    @staticmethod
+    async def _observe_async(call: RemoteCall[Any]) -> RemoteCall[Any]:
+        try:
+            await call
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            pass
+        return call
+
+    @staticmethod
+    async def _wait_async_many(
+        calls: Sequence[RemoteCall[Any]],
+        count: int,
+    ) -> tuple[list[RemoteCall[Any]], list[RemoteCall[Any]]]:
+        tasks = {asyncio.create_task(RemoteCall._observe_async(call)) for call in calls}
+        done_ids: set[int] = set()
+        try:
+            while tasks and len(done_ids) < count:
+                completed, tasks = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                for task in completed:
+                    call = task.result()
+                    if call.done():
+                        done_ids.add(id(call))
+        finally:
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+        if len(done_ids) < count:
+            raise RPCTimeoutError(f"only {len(done_ids)} of {count} requested remote calls completed")
+        done = [call for call in calls if id(call) in done_ids][:count]
+        selected = {id(call) for call in done}
+        not_done = [call for call in calls if id(call) not in selected]
+        return done, not_done
+
+    @staticmethod
+    async def _gather_async_many(calls: Sequence[RemoteCall[ResultT]]) -> list[ResultT]:
+        await asyncio.gather(*(RemoteCall._observe_async(call) for call in calls))
+        values: list[ResultT] = []
+        errors: list[Exception] = []
+        for call in calls:
+            try:
+                values.append(call._result_nowait())
+            except Exception as exc:  # noqa: BLE001 - aggregate completed failures
+                errors.append(exc)
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise ExceptionGroup("runtime failures", errors)
+        return values
+
+    def done(self) -> bool:
+        """Return whether this call has a terminal local outcome."""
+        return self._done
+
+    def _result_nowait(self) -> ResultT:
+        """Return the cached result or raise its cached exception without observing."""
+        if not self.done():
+            raise RPCTimeoutError("remote call deadline expired while outcome remained unknown")
+        if self._exception is not None:
+            raise self._exception
+        return cast(ResultT, self._result)
+
+    def _set_result(self, result: ResultT) -> None:
+        """Publish the first successful terminal outcome."""
+        if self._done:
+            return
+        self._result = result
+        self._done = True
+
+    def _set_exception(self, exception: BaseException) -> None:
+        """Publish the first failed terminal outcome."""
+        if self._done:
+            return
+        self._exception = exception
+        self._done = True
+
+    @abstractmethod
+    def _observe(self, remaining: float | None) -> None:
+        """Poll backend completion using remaining deadline budget.
+
+        ``remaining`` of ``0`` is a zero-time poll. ``None`` waits without a
+        common-layer deadline budget.
+        """
+
+    @abstractmethod
+    async def _wait_async(self) -> None:
+        """Observe backend completion without blocking the caller event loop."""
+
+
+_WaitResult = tuple[list[RemoteCall[Any]], list[RemoteCall[Any]]]
+
+
+class _AggregateRemoteCall(RemoteCall[list[ResultT] | _WaitResult], Generic[ResultT]):
+    """Shared aggregation state; count selects wait versus gather collection."""
+
+    def __init__(self, calls: Sequence[RemoteCall[ResultT]], *, count: int | None = None) -> None:
+        super().__init__(deadline=None)
+        self._calls = tuple(calls)
+        self._count = count
+        if count is None and not calls:
+            self._set_result([])
+
+    def _observe(self, remaining: float | None) -> None:
+        if self.done():
+            return
+        if self._has_running_loop():
+            if self._count is not None:
+                raise RuntimeError("RemoteCall.wait(...).result() cannot run in an active event loop; await it")
+            self._observe_gather_in_loop(remaining)
+            return
+        try:
+            result = asyncio.run(_observe_with_timeout(self._collect(), remaining))
+        except _ObservationTimeout:
+            pass
+        except Exception as exc:
+            self._set_exception(exc)
+        else:
+            self._set_result(result)
+
+    async def _collect(self) -> list[ResultT] | _WaitResult:
+        if self._count is None:
+            return await self._gather_async_many(self._calls)
+        return await self._wait_async_many(self._calls, self._count)
+
+    async def _wait_async(self) -> None:
+        if self.done():
+            return
+        try:
+            result = await self._collect()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._set_exception(exc)
+        else:
+            self._set_result(result)
+
+    def _observe_gather_in_loop(self, remaining: float | None) -> None:
+        common_deadline = None if remaining is None else time.monotonic() + remaining
+        values: list[ResultT] = []
+        errors: list[Exception] = []
+        for call in self._calls:
+            deadlines = [deadline for deadline in (call._deadline, common_deadline) if deadline is not None]
+            try:
+                call._observe(remaining_deadline(min(deadlines) if deadlines else None))
+                values.append(call._result_nowait())
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+        if errors and all(isinstance(error, RPCTimeoutError | _ActiveLoopWouldBlockError) for error in errors):
+            would_block = next(
+                (error for error in errors if isinstance(error, _ActiveLoopWouldBlockError)),
+                None,
+            )
+            if would_block is not None:
+                raise would_block
+            return
+        if errors:
+            material = [error for error in errors if not isinstance(error, _ActiveLoopWouldBlockError)]
+            if len(material) == 1:
+                self._set_exception(material[0])
+            else:
+                self._set_exception(ExceptionGroup("runtime failures", material))
+        else:
+            self._set_result(values)

--- a/verl/single_controller/base/remote_worker_group.py
+++ b/verl/single_controller/base/remote_worker_group.py
@@ -1,0 +1,411 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral WorkerGroup invocation over backend handles."""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from abc import ABC
+from collections.abc import Callable, Mapping, Sequence
+from copy import copy
+from functools import partial
+from typing import Any, Generic, TypeVar
+
+from verl.single_controller.base.decorator import (
+    MAGIC_ATTR,
+    Dispatch,
+    Execute,
+    _materialize_futures,
+    collect_lazy_compute_data_proto,
+    get_predefined_dispatch_fn,
+    get_predefined_execute_fn,
+)
+from verl.single_controller.base.dependency import (
+    dependency_remote_call,
+    resolve_submit_dependencies,
+    walk_remote_call_dependencies,
+)
+from verl.single_controller.base.remote_call import RemoteCall, create_deadline
+from verl.single_controller.base.worker import Worker
+
+WorkerT = TypeVar("WorkerT", covariant=True)
+
+
+def registered_methods(worker_cls: type[Any]) -> dict[str, dict[str, Any]]:
+    """Build the Actor method manifest, preserving explicit distributed metadata."""
+    registered: dict[str, dict[str, Any]] = {}
+    for method_name in dir(worker_cls):
+        try:
+            method = getattr(worker_cls, method_name)
+        except Exception:  # noqa: BLE001 - class properties may reject access
+            continue
+        if not callable(method):
+            continue
+        metadata = getattr(method, MAGIC_ATTR, None)
+        if metadata is None:
+            for base in worker_cls.__mro__[1:]:
+                base_method = base.__dict__.get(method_name)
+                if base_method is not None and hasattr(base_method, MAGIC_ATTR):
+                    metadata = getattr(base_method, MAGIC_ATTR)
+                    break
+        if metadata is None:
+            continue
+        if not isinstance(metadata, dict):
+            raise TypeError(f"register metadata on {method_name} must be a dict, got {type(metadata)!r}")
+        if "dispatch_mode" not in metadata:
+            raise ValueError(f"register metadata on {method_name} missing dispatch_mode")
+        registered[method_name] = dict(metadata)
+
+    for base in worker_cls.__mro__:
+        if base is Worker:
+            break
+        for method_name, descriptor in base.__dict__.items():
+            if method_name in registered or method_name.startswith("_") or method_name == "close":
+                continue
+            if isinstance(descriptor, staticmethod | classmethod):
+                descriptor = descriptor.__func__
+            if not callable(descriptor):
+                continue
+            method = getattr(worker_cls, method_name)
+            registered[method_name] = {
+                "dispatch_mode": Dispatch.ONE_TO_ALL,
+                "execute_mode": Execute.ALL,
+                "blocking": not inspect.iscoroutinefunction(method),
+                "collect_single": True,
+            }
+    return registered
+
+
+def _dispatch_and_collect(metadata: Mapping[str, Any]) -> tuple[Callable[..., Any], Callable[..., Any]]:
+    dispatch_mode = metadata["dispatch_mode"]
+    if isinstance(dispatch_mode, Dispatch):
+        functions = get_predefined_dispatch_fn(dispatch_mode=dispatch_mode)
+        dispatch, collect = functions["dispatch_fn"], functions["collect_fn"]
+        if metadata.get("collect_single"):
+            base_collect = collect
+
+            def collect(worker_group, values):
+                result = base_collect(worker_group, values)
+                if worker_group.world_size != 1:
+                    return result
+                if not isinstance(result, list) or len(result) != 1:
+                    raise RuntimeError("single-Actor collection must contain exactly one result")
+                return result[0]
+
+        return dispatch, collect
+    if not isinstance(dispatch_mode, dict) or "dispatch_fn" not in dispatch_mode or "collect_fn" not in dispatch_mode:
+        raise TypeError("dispatch_mode must be a Dispatch or a dict containing dispatch_fn and collect_fn")
+    return dispatch_mode["dispatch_fn"], dispatch_mode["collect_fn"]
+
+
+def _returns_data_proto_future(metadata: Mapping[str, Any]) -> bool:
+    dispatch_mode = metadata["dispatch_mode"]
+    if dispatch_mode in (Dispatch.DP_COMPUTE_PROTO, Dispatch.DP_COMPUTE_PROTO_WITH_FUNC):
+        return True
+    if not isinstance(dispatch_mode, dict):
+        return False
+    collect = dispatch_mode["collect_fn"]
+    while isinstance(collect, partial):
+        collect = collect.func
+    return collect is collect_lazy_compute_data_proto
+
+
+def _rank_inputs(
+    dispatched_args: Any,
+    dispatched_kwargs: Any,
+    *,
+    rank: int,
+    world_size: int,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    args = dispatched_args if isinstance(dispatched_args, tuple | list) else (dispatched_args,)
+    kwargs = dict(dispatched_kwargs) if isinstance(dispatched_kwargs, Mapping) else {}
+    if not all(isinstance(value, list | tuple) and len(value) == world_size for value in args):
+        return tuple(args), kwargs
+    if not all(isinstance(value, list | tuple) and len(value) == world_size for value in kwargs.values()):
+        return tuple(args), kwargs
+    return tuple(value[rank] for value in args), {key: value[rank] for key, value in kwargs.items()}
+
+
+def _remove_padding(output: Any, count: int) -> Any:
+    if count > 0:
+        if hasattr(output, "select_idxs"):
+            return output.select_idxs(list(range(len(output)))[:-count])
+        if isinstance(output, list):
+            return output[:-count]
+    return output
+
+
+def _collect_data_future(output: Any, padding_count: int) -> Any:
+    from verl.protocol import DataProtoFuture
+
+    if not isinstance(output, DataProtoFuture):
+        raise TypeError("DataProto dispatch collect must return DataProtoFuture")
+    if padding_count > 0:
+        previous_dispatch = output.dispatch_fn
+
+        def remove_padding(value):
+            if previous_dispatch is not None:
+                value = previous_dispatch(value)
+            return value.select_idxs(list(range(len(value)))[:-padding_count])
+
+        output.dispatch_fn = remove_padding
+    return output
+
+
+class RemoteWorkerGroup(ABC, Generic[WorkerT]):
+    """A non-owning WorkerGroup facade backed by remote handles.
+
+    Dispatch, collection, rank selection, and the execute family are shared by
+    every backend. A concrete backend only turns rank calls into its RPC
+    handle. Resource placement and lifecycle ownership belong to
+    ``WorkerGroup`` and are intentionally absent here.
+    """
+
+    fused_worker_execute_fn_name = "_fuw_execute"
+    _backend_submit: Callable[..., RemoteCall[Any]]
+
+    def __init__(
+        self,
+        *,
+        method_metadata: Mapping[str, Mapping[str, Any]],
+        ranks: Sequence[int],
+        role_name: str | None = None,
+    ) -> None:
+        self._method_metadata = {name: dict(metadata) for name, metadata in method_metadata.items()}
+        self._ranks = tuple(ranks)
+        self._role_name = role_name
+        self._dispatch_info: dict[str, Any] = {}
+        self._collect_info: dict[str, Any] = {}
+
+    def __getattribute__(self, method_name: str) -> Any:
+        if not method_name.startswith("__"):
+            state = object.__getattribute__(self, "__dict__")
+            metadata = state.get("_method_metadata", {})
+            if method_name in metadata:
+                descriptor = inspect.getattr_static(type(self), method_name, None)
+                if descriptor is None or callable(descriptor):
+                    return RemoteWorkerGroup._bind_worker_method(self, method_name)
+        return object.__getattribute__(self, method_name)
+
+    def __getattr__(self, method_name: str) -> Any:
+        metadata = self.__dict__.get("_method_metadata", {})
+        if method_name not in metadata:
+            raise AttributeError(f"{type(self).__name__!s} has no attribute {method_name!r}")
+        return RemoteWorkerGroup._bind_worker_method(self, method_name)
+
+    def _bind_worker_method(self, method_name: str) -> Callable[..., Any]:
+        def bound(*args: Any, timeout: float | None = None, **kwargs: Any) -> Any:
+            return RemoteWorkerGroup.submit(self, method_name, args=args, kwargs=kwargs, timeout=timeout)
+
+        bound.__name__ = method_name
+        bound.__qualname__ = method_name
+        return bound
+
+    @property
+    def world_size(self) -> int:
+        return len(self._ranks)
+
+    def rank(self, index: int) -> RemoteWorkerGroup[WorkerT]:
+        if isinstance(index, bool) or not isinstance(index, int):
+            raise TypeError(f"index must be a non-bool int, got {type(index)!r}")
+        if index < 0 or index >= self.world_size:
+            raise IndexError(f"rank index {index} out of range for world_size={self.world_size}")
+        return self._view(index, index + 1)
+
+    def slice(self, start: int, size: int) -> RemoteWorkerGroup[WorkerT]:
+        if isinstance(start, bool) or not isinstance(start, int):
+            raise TypeError(f"start must be a non-bool int, got {type(start)!r}")
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise TypeError(f"size must be a non-bool int, got {type(size)!r}")
+        if start < 0:
+            raise IndexError(f"start must be >= 0, got {start}")
+        if size <= 0:
+            raise ValueError(f"size must be a positive int, got {size}")
+        stop = start + size
+        if stop > self.world_size:
+            raise IndexError(f"slice [{start}, {stop}) out of range for world_size={self.world_size}")
+        return self._view(start, stop)
+
+    def _view(self, start: int, stop: int) -> RemoteWorkerGroup[WorkerT]:
+        view = copy(self)
+        view._ranks = self._ranks[start:stop]
+        view._dispatch_info = {}
+        view._collect_info = {}
+        return view
+
+    def submit(
+        self,
+        method_name: str,
+        args: tuple[Any, ...] = (),
+        kwargs: Mapping[str, Any] | None = None,
+        *,
+        timeout: float | None = None,
+        blocking: bool | None = None,
+    ) -> Any:
+        """Dispatch and collect one Worker method.
+
+        ``blocking`` can synthesize unregistered method metadata or
+        override a registered method with an explicit warning.
+        """
+        if not self._ranks:
+            raise RuntimeError("WorkerGroup view has no target ranks")
+        if blocking is not None and not isinstance(blocking, bool):
+            raise TypeError(f"blocking must be bool or None, got {type(blocking)!r}")
+        lookup_name = method_name.split(".", 1)[-1]
+        metadata = self._method_metadata.get(lookup_name)
+        if metadata is None:
+            synthesized_blocking = True if blocking is None else blocking
+            warnings.warn(
+                f"submitting unregistered method {lookup_name!r}; "
+                "synthesizing Dispatch.ALL_TO_ALL / Execute.ALL / "
+                f"blocking={synthesized_blocking}",
+                stacklevel=2,
+            )
+            metadata = {
+                "dispatch_mode": Dispatch.ALL_TO_ALL,
+                "execute_mode": Execute.ALL,
+                "blocking": synthesized_blocking,
+            }
+        elif blocking is not None and blocking != metadata["blocking"]:
+            warnings.warn(
+                f"overriding registered blocking={metadata['blocking']} with blocking={blocking} "
+                f"for method {lookup_name!r}",
+                stacklevel=2,
+            )
+
+        should_block = metadata["blocking"] if blocking is None else blocking
+        deadline = create_deadline(timeout)
+
+        if not should_block and next(walk_remote_call_dependencies(args, kwargs), None) is not None:
+            call = dependency_remote_call(
+                args,
+                kwargs,
+                deadline=deadline,
+                submit_resolved=lambda resolved_args, resolved_kwargs: RemoteWorkerGroup._dispatch_call(
+                    self, lookup_name, metadata, (resolved_args, resolved_kwargs), deadline, preserve_data_future=False
+                ),
+            )
+            if _returns_data_proto_future(metadata):
+                from verl.protocol import DataProtoFuture
+
+                return DataProtoFuture.concat([call])
+            return call
+        resolved_args, resolved_kwargs = resolve_submit_dependencies(
+            args,
+            kwargs,
+            downstream_deadline=deadline,
+        )
+        call = RemoteWorkerGroup._dispatch_call(
+            self,
+            lookup_name,
+            metadata,
+            (resolved_args, resolved_kwargs),
+            deadline,
+            preserve_data_future=not should_block,
+        )
+        if not should_block:
+            return call
+        return call.result()
+
+    def _dispatch_call(
+        self,
+        method_name: str,
+        metadata: Mapping[str, Any],
+        resolved: tuple[tuple[Any, ...], dict[str, Any]],
+        deadline: float | None,
+        *,
+        preserve_data_future: bool,
+    ) -> Any:
+        """Lower resolved inputs to rank calls, then apply the registered collector."""
+        from verl.protocol import _padding_size_key
+
+        dispatch, collect = _dispatch_and_collect(metadata)
+        args, kwargs = resolved
+        dispatched_args, dispatched_kwargs = dispatch(self, *args, **kwargs)
+        padding_count = int(dispatched_kwargs.pop(_padding_size_key, 0)) if isinstance(dispatched_kwargs, dict) else 0
+        execute_name = get_predefined_execute_fn(execute_mode=metadata["execute_mode"])["execute_fn_name"]
+        rank_zero = execute_name == "execute_rank_zero"
+        ranks = self._ranks[:1] if rank_zero else self._ranks
+        calls = []
+        for relative_rank, backend_rank in enumerate(ranks):
+            rank_args, rank_kwargs = _rank_inputs(
+                dispatched_args, dispatched_kwargs, rank=relative_rank, world_size=self.world_size
+            )
+            rank_args, rank_kwargs = _materialize_futures(*rank_args, **rank_kwargs)
+            calls.append((backend_rank, rank_args, rank_kwargs))
+
+        # Materialize all rank inputs before routing, as custom dispatchers may
+        # return lazy values with side effects.
+        backend_calls = []
+        backend_method = method_name
+        for rank, rank_args, rank_kwargs in calls:
+            backend_method, backend_args = self._route_invocation(method_name, rank_args)
+            backend_calls.append((rank, backend_args, rank_kwargs))
+
+        def collect_result(values: list[Any]) -> Any:
+            output = collect(self, values[0] if rank_zero else values)
+            return _remove_padding(output, padding_count)
+
+        if preserve_data_future and _returns_data_proto_future(metadata):
+            rank_calls = [
+                self._backend_submit(
+                    method_name=backend_method,
+                    calls=[backend_call],
+                    collect=lambda values: values[0],
+                    deadline=deadline,
+                )
+                for backend_call in backend_calls
+            ]
+            return _collect_data_future(collect(self, rank_calls), padding_count)
+        return self._backend_submit(
+            method_name=backend_method, calls=backend_calls, collect=collect_result, deadline=deadline
+        )
+
+    def execute_rank_zero_sync(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        return self.execute_rank_zero_async(method_name, *args, **kwargs).result()
+
+    def execute_rank_zero_async(self, method_name: str, *args: Any, **kwargs: Any) -> RemoteCall[Any]:
+        if not self._ranks:
+            raise RuntimeError("WorkerGroup view has no target ranks")
+        backend_method, backend_args = self._route_invocation(method_name.split(".", 1)[-1], args)
+        return self._backend_submit(
+            method_name=backend_method,
+            calls=[(self._ranks[0], backend_args, dict(kwargs))],
+            collect=lambda values: values[0],
+            deadline=None,
+        )
+
+    def execute_all_sync(self, method_name: str, *args: Any, **kwargs: Any) -> list[Any]:
+        return RemoteCall.gather(self.execute_all_async(method_name, *args, **kwargs)).result()
+
+    def execute_all_async(self, method_name: str, *args: Any, **kwargs: Any) -> list[RemoteCall[Any]]:
+        if not self._ranks:
+            raise RuntimeError("WorkerGroup view has no target ranks")
+        execute_name, backend_args = self._route_invocation(method_name.split(".", 1)[-1], args)
+        return [
+            self._backend_submit(
+                method_name=execute_name,
+                calls=[(rank, backend_args, dict(kwargs))],
+                collect=lambda values: values[0],
+                deadline=None,
+            )
+            for rank in self._ranks
+        ]
+
+    def _route_invocation(self, method_name: str, args: tuple[Any, ...]) -> tuple[str, tuple[Any, ...]]:
+        if self._role_name is None:
+            return method_name, args
+        return self.fused_worker_execute_fn_name, (self._role_name, method_name, *args)

--- a/verl/single_controller/base/resource_pool.py
+++ b/verl/single_controller/base/resource_pool.py
@@ -1,0 +1,150 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ordered reusable rank placement."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Literal
+
+
+def normalize_pool_ranks(ranks: int | slice, world_size: int) -> tuple[int, int]:
+    """Normalize an int or contiguous slice selection against world_size.
+
+    Args:
+        ranks: Zero-based rank or contiguous Python slice.
+        world_size: Size of the pool or view being indexed.
+
+    Returns:
+        Inclusive-exclusive ``(start, stop)`` range in rank order.
+
+    Raises:
+        TypeError: Selection type is invalid.
+        ValueError: Slice step is invalid or the normalized range is empty.
+        IndexError: Integer rank is out of range.
+    """
+    if isinstance(ranks, bool) or not isinstance(ranks, int | slice):
+        raise TypeError(f"ranks must be an int or slice, got {type(ranks)!r}")
+    if isinstance(ranks, int):
+        if ranks < 0 or ranks >= world_size:
+            raise IndexError(f"rank {ranks} out of range for world_size={world_size}")
+        return ranks, ranks + 1
+    if ranks.step not in (None, 1):
+        raise ValueError(f"ResourcePool.slice only supports step=1, got {ranks.step!r}")
+    start, stop, _step = ranks.indices(world_size)
+    if stop <= start:
+        raise ValueError(f"ResourcePool.slice produced an empty range for {ranks!r} with world_size={world_size}")
+    return start, stop
+
+
+def rectangular_pool_view(
+    ranks: int | slice,
+    *,
+    nnodes: int,
+    processes_per_node: int,
+) -> tuple[int, int, int, int]:
+    """Resolve a contiguous rank selection into a rectangular node-local view.
+
+    Returns ``(node_start, node_count, process_start, process_count)``. A view
+    may select any contiguous processes on one node, or complete contiguous
+    nodes. A range that cuts across node boundaries is rejected because it
+    would give the selected nodes different local process counts.
+    """
+    start, stop = normalize_pool_ranks(ranks, nnodes * processes_per_node)
+    first_node, process_start = divmod(start, processes_per_node)
+    last_node, last_process = divmod(stop - 1, processes_per_node)
+    if first_node == last_node:
+        return first_node, 1, process_start, stop - start
+    if process_start != 0 or last_process != processes_per_node - 1:
+        raise ValueError(
+            "ResourcePool.slice must preserve a homogeneous process count on every selected node; "
+            f"range [{start}, {stop}) cuts across node boundaries"
+        )
+    return first_node, last_node - first_node + 1, 0, processes_per_node
+
+
+class ResourcePool(ABC):
+    """Represent an ordered reusable placement of process ranks."""
+
+    def _bind_runtime_scope(self, runtime_id: str, root_name: str) -> None:
+        owner = getattr(self, "_runtime_owner_id", None)
+        if owner is not None and owner != runtime_id:
+            raise ValueError("ResourcePool already belongs to another Runtime")
+        self._runtime_owner_id = runtime_id
+        self._runtime_root_name = root_name
+
+    def _runtime_owner(self) -> str | None:
+        return getattr(self, "_runtime_owner_id", None)
+
+    def _runtime_root(self) -> str:
+        return getattr(self, "_runtime_root_name", "parent")
+
+    def _inherit_runtime_scope(self, view: ResourcePool) -> ResourcePool:
+        owner = self._runtime_owner()
+        if owner is not None:
+            view._bind_runtime_scope(owner, self._runtime_root())
+        return view
+
+    @property
+    @abstractmethod
+    def nnodes(self) -> int:
+        """Return the number of physical nodes in this pool or view."""
+
+    @property
+    @abstractmethod
+    def world_size(self) -> int:
+        """Return the number of ranks selected by this pool or view."""
+
+    @property
+    @abstractmethod
+    def processes_per_node(self) -> int:
+        """Return the identical process count selected on every node."""
+
+    @property
+    @abstractmethod
+    def device_type(self) -> Literal["gpu", "cpu"]:
+        """Return the logical device class shared by every selected rank."""
+
+    @abstractmethod
+    def slice(self, ranks: int | slice) -> ResourcePool:
+        """Return a non-owning view over one rank or a contiguous rank range.
+
+        Args:
+            ranks: A zero-based rank or a contiguous Python slice to select.
+
+        Returns:
+            A rank-ordered ResourcePool view backed by the same allocation.
+        """
+
+
+def split_resource_pool(resource_pool: ResourcePool, split_size: int | list[int]) -> list[ResourcePool]:
+    """Split an ordered pool into contiguous backend-neutral views."""
+    if isinstance(split_size, int):
+        if split_size <= 0 or resource_pool.world_size % split_size != 0:
+            raise ValueError("split_size must be positive and divide world_size")
+        sizes = [split_size] * (resource_pool.world_size // split_size)
+    else:
+        sizes = list(split_size)
+        if any(size <= 0 for size in sizes):
+            raise ValueError("split sizes must be positive")
+    if sum(sizes) != resource_pool.world_size:
+        raise ValueError("split sizes must sum to world_size")
+
+    views: list[ResourcePool] = []
+    start = 0
+    for size in sizes:
+        views.append(resource_pool.slice(slice(start, start + size)))
+        start += size
+    return views

--- a/verl/single_controller/base/topology.py
+++ b/verl/single_controller/base/topology.py
@@ -1,0 +1,296 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declarative model placement from https://github.com/verl-project/verl/issues/7269."""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from itertools import combinations
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from verl.single_controller.base.resource_pool import ResourcePool
+
+
+def _validate_name(name: str, value: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"{name} must be a non-empty str, got {value!r}")
+
+
+def _validate_capacity(name: str, value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a non-bool int, got {type(value)!r}")
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+
+
+@dataclass(frozen=True, slots=True)
+class Cluster:
+    """One gpu type and its available capacity."""
+
+    name: str
+    nnodes: int
+    n_gpus_per_node: int
+
+    def __post_init__(self) -> None:
+        _validate_name("cluster.name", self.name)
+        _validate_capacity("cluster.nnodes", self.nnodes)
+        _validate_capacity("cluster.n_gpus_per_node", self.n_gpus_per_node)
+
+
+@dataclass(frozen=True, slots=True)
+class DevicePool:
+    """A named group of gpus selected from one cluster."""
+
+    name: str
+    cluster: str
+    nnodes: int
+    n_gpus_per_node: int
+    attributes: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_name("device_pool.name", self.name)
+        _validate_name("device_pool.cluster", self.cluster)
+        _validate_capacity("device_pool.nnodes", self.nnodes)
+        _validate_capacity("device_pool.n_gpus_per_node", self.n_gpus_per_node)
+        if not isinstance(self.attributes, Mapping):
+            raise TypeError(f"device_pool.attributes must be a mapping, got {type(self.attributes)!r}")
+        attributes = dict(self.attributes)
+        object.__setattr__(self, "attributes", MappingProxyType(attributes))
+        if attributes:
+            warnings.warn(
+                f"device pool {self.name!r} attributes are preserved but not enforced: {sorted(attributes)!r}",
+                stacklevel=2,
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Model:
+    """One model instance assigned to a resource pool."""
+
+    name: str
+    worker: str
+    config_key: str
+    resource_pool: str
+    device_range: tuple[int, int] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_name("model.name", self.name)
+        _validate_name("model.worker", self.worker)
+        _validate_name("model.config_key", self.config_key)
+        _validate_name("model.resource_pool", self.resource_pool)
+        if self.device_range is not None:
+            if len(self.device_range) != 2:
+                raise ValueError("device_range must contain exactly two integers")
+            start, end = self.device_range
+            if any(isinstance(value, bool) or not isinstance(value, int) for value in (start, end)):
+                raise TypeError("device_range values must be non-bool integers")
+            if start < 0 or end <= start:
+                raise ValueError("device_range must satisfy 0 <= start < end")
+
+
+@dataclass(frozen=True, slots=True)
+class Topology:
+    """The cluster -> device_pool -> model declaration."""
+
+    clusters: tuple[Cluster, ...] = ()
+    device_pools: tuple[DevicePool, ...] = ()
+    models: tuple[Model, ...] = ()
+
+    def __post_init__(self) -> None:
+        for kind, entries in (
+            ("cluster", self.clusters),
+            ("device pool", self.device_pools),
+            ("model", self.models),
+        ):
+            if len({entry.name for entry in entries}) != len(entries):
+                raise ValueError(f"{kind} names must be unique")
+        self._validate_pool_capacity()
+        self._validate_models()
+        self._validate_model_overlap()
+
+    def _validate_pool_capacity(self) -> None:
+        clusters = {cluster.name: cluster for cluster in self.clusters}
+        selected_nodes = {name: 0 for name in clusters}
+        for device_pool in self.device_pools:
+            if device_pool.cluster not in clusters:
+                raise ValueError(f"device pool {device_pool.name!r} references unknown cluster {device_pool.cluster!r}")
+            cluster = clusters[device_pool.cluster]
+            if device_pool.n_gpus_per_node > cluster.n_gpus_per_node:
+                raise ValueError(f"device pool {device_pool.name!r} exceeds cluster {cluster.name!r} gpu capacity")
+            selected_nodes[device_pool.cluster] += device_pool.nnodes
+        for cluster_name, nnodes in selected_nodes.items():
+            if nnodes > clusters[cluster_name].nnodes:
+                raise ValueError(f"device pools exceed cluster {cluster_name!r} node capacity")
+
+    def _validate_models(self) -> None:
+        device_pools = {pool.name: pool for pool in self.device_pools}
+        for model in self.models:
+            if model.resource_pool not in device_pools:
+                raise ValueError(f"model {model.name!r} references unknown resource_pool {model.resource_pool!r}")
+            if (
+                model.device_range is not None
+                and model.device_range[1] > device_pools[model.resource_pool].n_gpus_per_node
+            ):
+                raise ValueError(f"model {model.name!r}.device_range exceeds its device pool")
+
+    def _model_placements(self) -> dict[str, tuple[str, tuple[int, int]]]:
+        """Return declared pool/range identities in model declaration order."""
+        device_pools = {pool.name: pool for pool in self.device_pools}
+        return {
+            model.name: (
+                model.resource_pool,
+                model.device_range or (0, device_pools[model.resource_pool].n_gpus_per_node),
+            )
+            for model in self.models
+        }
+
+    def _validate_model_overlap(self) -> None:
+        models_by_pool: dict[str, list[tuple[str, tuple[int, int]]]] = {}
+        for name, (pool_name, selected) in self._model_placements().items():
+            models_by_pool.setdefault(pool_name, []).append((name, selected))
+        for pool_name, placements in models_by_pool.items():
+            for (left_model, left), (right_model, right) in combinations(placements, 2):
+                if left == right or left[1] <= right[0] or right[1] <= left[0]:
+                    continue
+                raise ValueError(
+                    f"models {left_model!r} and {right_model!r} have overlapping "
+                    f"device ranges {left!r} and {right!r} on resource pool {pool_name!r}"
+                )
+
+    @classmethod
+    def from_mapping(cls, value: object | None) -> Topology:
+        if value is None:
+            return cls()
+        if not isinstance(value, Mapping):
+            raise TypeError(f"topology must be a mapping, got {type(value)!r}")
+        unknown = set(value) - {"clusters", "device_pools", "models"}
+        if unknown:
+            raise ValueError(f"unknown topology fields: {sorted(unknown)!r}")
+
+        raw_clusters = value.get("clusters", ())
+        raw_device_pools = value.get("device_pools", ())
+        raw_models = value.get("models", ())
+        for name, entries in (
+            ("clusters", raw_clusters),
+            ("device_pools", raw_device_pools),
+            ("models", raw_models),
+        ):
+            if isinstance(entries, str) or not isinstance(entries, Sequence):
+                raise TypeError(f"topology.{name} must be a sequence")
+            for index, entry in enumerate(entries):
+                if not isinstance(entry, Mapping):
+                    raise TypeError(f"topology.{name}[{index}] must be a mapping")
+
+        clusters = tuple(Cluster(**dict(entry)) for entry in raw_clusters)
+        device_pools = tuple(DevicePool(**dict(entry)) for entry in raw_device_pools)
+        models = []
+        for entry in raw_models:
+            payload = dict(entry)
+            device_range = payload.get("device_range")
+            if device_range is not None:
+                if isinstance(device_range, str | bytes) or not isinstance(device_range, Sequence):
+                    raise TypeError("model.device_range must be a two-item sequence")
+                payload["device_range"] = tuple(device_range)
+            models.append(Model(**payload))
+        return cls(clusters=clusters, device_pools=device_pools, models=tuple(models))
+
+
+def _format_topology(
+    topology: Topology,
+    model_resource_pools: Mapping[str, ResourcePool] | None = None,
+) -> str:
+    """Format the declared or compiled model placement report."""
+    pool_specs = {pool.name: pool for pool in topology.device_pools}
+    declared_placements = topology._model_placements()
+    declared_counts: dict[tuple[str, tuple[int, int]], int] = {}
+    actual_pools: dict[str, ResourcePool] = {}
+    actual_counts: dict[int, int] = {}
+    if model_resource_pools is None:
+        for placement in declared_placements.values():
+            declared_counts[placement] = declared_counts.get(placement, 0) + 1
+    else:
+        actual_pools = {model.name: model_resource_pools[model.name] for model in topology.models}
+        for pool in actual_pools.values():
+            actual_counts[id(pool)] = actual_counts.get(id(pool), 0) + 1
+    actor_model = next((model for model in topology.models if model.worker == "actor"), None)
+
+    rows = [("CLUSTER", "POOL", "GPUS", "MODEL", "WORKER", "PROCESS", "MODE")]
+    for model in topology.models:
+        pool_spec = pool_specs[model.resource_pool]
+        if model_resource_pools is None:
+            placement = declared_placements[model.name]
+            process = "colocated" if declared_counts[placement] > 1 else "dedicated"
+            with_actor = actor_model is not None and placement == declared_placements[actor_model.name]
+            pool = None
+        else:
+            pool = actual_pools[model.name]
+            process = "colocated" if actual_counts[id(pool)] > 1 else "dedicated"
+            with_actor = actor_model is not None and pool is actual_pools[actor_model.name]
+        mode = "-"
+        if model.worker == "rollout":
+            mode = "HYBRID" if with_actor else "STANDALONE"
+        elif model.worker in {"rm", "teacher"}:
+            mode = "COLOCATED" if with_actor else "DEDICATED"
+        rows.append(
+            (
+                pool_spec.cluster,
+                model.resource_pool,
+                _format_model_gpus(model, pool_spec, pool),
+                model.name,
+                model.worker,
+                process,
+                mode,
+            )
+        )
+    return _format_table(rows)
+
+
+def _format_table(rows: Sequence[tuple[str, ...]]) -> str:
+    widths = [max(len(row[index]) for row in rows) for index in range(len(rows[0]))]
+    return "\n".join("  ".join(value.ljust(widths[index]) for index, value in enumerate(row)).rstrip() for row in rows)
+
+
+def _format_model_gpus(
+    model: Model,
+    pool_spec: DevicePool,
+    pool: ResourcePool | None,
+) -> str:
+    start, end = model.device_range or (0, pool_spec.n_gpus_per_node)
+    if pool is not None and pool.processes_per_node != end - start:
+        raise RuntimeError(
+            f"compiled pool for model {model.name!r} has {pool.processes_per_node} processes per node; "
+            f"expected {end - start} from device_range"
+        )
+    nnodes = pool_spec.nnodes if pool is None else pool.nnodes
+    ranges = [
+        (node * pool_spec.n_gpus_per_node + start, node * pool_spec.n_gpus_per_node + end) for node in range(nnodes)
+    ]
+    merged: list[tuple[int, int]] = []
+    for current_start, current_end in ranges:
+        if merged and merged[-1][1] == current_start:
+            merged[-1] = (merged[-1][0], current_end)
+        else:
+            merged.append((current_start, current_end))
+    return ",".join(
+        str(range_start) if range_end - range_start == 1 else f"{range_start}-{range_end - 1}"
+        for range_start, range_end in merged
+    )
+
+
+__all__ = ["Cluster", "DevicePool", "Model", "Topology"]

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -102,6 +102,17 @@ def get_ppo_ray_runtime_env(config=None):
         if os.environ.get(key) is not None:
             runtime_env["env_vars"].pop(key, None)
     # Always forward these at call-time, not import-time.
-    for key in ("PYTHONHASHSEED", "VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT"):
+    for key in ("VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT", "VERL_RL_INSIGHT_ENABLE"):
         runtime_env["env_vars"][key] = os.environ.get(key, "0")
+    # Forward only when set: empty string breaks vLLM ParallelConfig int parsing.
+    for key in (
+        "PYTHONHASHSEED",
+        "CUBLAS_WORKSPACE_CONFIG",
+        "FLASH_ATTENTION_DETERMINISTIC",
+        "NCCL_DETERMINISTIC",
+        "NCCL_ALGO",
+    ):
+        val = os.environ.get(key)
+        if val is not None:
+            runtime_env["env_vars"][key] = val
     return runtime_env

--- a/verl/utils/net_utils.py
+++ b/verl/utils/net_utils.py
@@ -28,6 +28,25 @@ import ipaddress
 import socket
 
 
+def get_local_ip_address() -> str:
+    """Return the local address selected by the host routing table."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            # UDP connect selects a route without sending a packet.
+            sock.connect(("8.8.8.8", 53))
+            return str(sock.getsockname()[0])
+    except OSError as route_error:
+        try:
+            addresses = socket.getaddrinfo(socket.gethostname(), None, type=socket.SOCK_DGRAM)
+        except OSError as resolve_error:
+            raise RuntimeError("could not resolve a local IP address") from resolve_error
+        for _, _, _, _, sockaddr in addresses:
+            address = str(sockaddr[0])
+            if not ipaddress.ip_address(address).is_loopback:
+                return address
+        raise RuntimeError("could not resolve a non-loopback local IP address") from route_error
+
+
 def is_ipv4(ip_str: str) -> bool:
     """
     Check if the given string is an IPv4 address

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -16,6 +16,7 @@ Contain small torch utilities
 """
 
 import math
+import os
 from contextlib import contextmanager
 from typing import Optional
 
@@ -86,7 +87,13 @@ def logprobs_from_logits(logits, labels, inplace_backward=True):
     Returns:
         Tensor: Log-probabilities of the target labels, shape logits.shape[:-1].
     """
-    if FLAH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE:
+    # The flash-attn Triton cross-entropy kernel's reduction may be non-deterministic
+    # and is NOT controlled by FLASH_ATTENTION_DETERMINISTIC (that only governs the
+    # attention kernels) nor by torch.use_deterministic_algorithms (Triton custom ops
+    # don't trigger warn_only). Set VERL_DISABLE_FLASH_ATTN_CE=1 to force the pure
+    # PyTorch log_softmax+gather path for bitwise-reproducible log_probs.
+    _use_flash_ce = FLAH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE and os.environ.get("VERL_DISABLE_FLASH_ATTN_CE", "0") != "1"
+    if _use_flash_ce:
         batch_dim = logits.shape[:-1]
         last_dim = logits.shape[-1]
         logits = logits.reshape(-1, last_dim)

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -37,6 +37,15 @@ def enable_full_determinism(seed: int):
     os.environ["PYTHONHASHSEED"] = str(seed)
     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
     os.environ["FLASH_ATTENTION_DETERMINISTIC"] = "1"
+    os.environ["NCCL_DETERMINISTIC"] = "1"
+    os.environ["NCCL_ALGO"] = "Ring"
+    os.environ["NCCL_PROTO"] = "Simple"
+    # flash-attn's Triton cross-entropy kernel (used by logprobs_from_logits to
+    # compute log_probs) has a non-deterministic reduction that is NOT covered by
+    # FLASH_ATTENTION_DETERMINISTIC (only governs attention kernels' backward) nor
+    # by torch.use_deterministic_algorithms (Triton custom ops don't trigger
+    # warn_only). Force the pure-PyTorch log_softmax+gather path instead.
+    os.environ.setdefault("VERL_DISABLE_FLASH_ATTN_CE", "1")
     if is_npu_available:
         # The environment variable required to enable deterministic mode on Ascend NPUs.
         os.environ["HCCL_DETERMINISTIC"] = "true"

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -42,12 +42,15 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 DEFAULT_ROUTING_CACHE_SIZE = 10000
 
 
-@ray.remote
 class GlobalRequestLoadBalancer:
     """Global sticky-session + in-flight load balancer shared by all AgentLoopWorkers.
 
     When a sticky session points to a removed server, the cache entry is
     automatically invalidated and a new server is selected.
+
+    This is a plain Python class (not a Ray actor). It is wrapped with
+    ``ray.remote(...)`` at instantiation time so callers can subclass it and
+    override :meth:`acquire_server` before registering the subclass as an actor.
 
     Key features:
     - **Atomic acquire**: ``acquire_server()`` returns ``(server_id, handle)``
@@ -55,9 +58,9 @@ class GlobalRequestLoadBalancer:
       multi-turn conversations route to the same server.
     - **Least-loaded Selection**: When no sticky session exists, selects the
       server with the fewest in-flight requests.
-    - **Deterministic Routing**: When ``full_determinism=True``, tie-breaking
-      among equally-loaded servers uses ``hash(request_id)`` so the same
-      request always routes to the same server across runs.
+    - **Deterministic Routing**: When ``full_determinism=True``, routes every
+      request by ``hash(request_id) % len(servers)`` over the full pool so the
+      same request always routes to the same replica across runs.
     - **Dynamic Server Management**: Supports add/remove servers at runtime
       for hybrid scaling.
     """
@@ -96,14 +99,14 @@ class GlobalRequestLoadBalancer:
         if not self._inflight_requests:
             raise RuntimeError("No available servers in load balancer")
 
-        min_count = min(self._inflight_requests.values())
-        candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]
-        if len(candidates) == 1:
-            server_id = candidates[0]
-        elif self._full_determinism:
-            # Deterministic tie-breaking: same request_id → same server across runs
-            server_id = candidates[hash(request_id) % len(candidates)]
+        if self._full_determinism:
+            # Full-hash routing: same request_id always lands on the same replica
+            # across runs. Least-loaded selection depends on async arrival timing,
+            # which varies run-to-run, so it is bypassed entirely here.
+            server_id = list(self._servers)[hash(request_id) % len(self._servers)]
         else:
+            min_count = min(self._inflight_requests.values())
+            candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]
             server_id = candidates[0]
         self._request_id_to_server[request_id] = server_id
         self._inflight_requests[server_id] += 1
@@ -196,6 +199,14 @@ class LLMServerClient:
         # Awaiting here risks blocking the finally clause if the LB actor is unresponsive.
         self._load_balancer.release_server.remote(server_id=server_id)
 
+    def _vllm_request_id(self, request_id: str) -> str:
+        # request_id passed to vLLM. Default: a fresh uuid per turn so each turn
+        # is an independent vLLM request. Under full_determinism the caller's
+        # request_id is passed straight through so vLLM sees a stable id across runs.
+        if getattr(self.config.actor_rollout_ref.rollout, "full_determinism", False):
+            return request_id
+        return uuid4().hex
+
     @rollout_trace_op
     async def generate(
         self,
@@ -232,7 +243,7 @@ class LLMServerClient:
                 {"priority": priority} if priority != 0 and self.config.actor_rollout_ref.rollout.name == "vllm" else {}
             )
             output: TokenOutput = await server.generate.remote(
-                request_id=uuid4().hex,  # use new request_id for each turn
+                request_id=self._vllm_request_id(request_id),  # use new request_id for each turn
                 prompt_ids=prompt_ids,
                 sampling_params=sampling_params,
                 image_data=image_data,
@@ -370,6 +381,12 @@ class LLMServerManager:
             else init standalone server with a new resource pool.
         rollout_resource_pool (RayResourcePool): Resource pool for the server replicas, only needed for TensorRT-LLM.
         start_rank (int): First ``replica_rank`` to assign.  Defaults to 0.
+        load_balancer_cls: Optional subclass of
+            :class:`GlobalRequestLoadBalancer` to use as the routing actor
+            (wrapped with ``ray.remote`` at instantiation). Defaults to
+            :class:`GlobalRequestLoadBalancer`, whose routing honors the
+            ``full_determinism`` flag. Pass a subclass that overrides
+            :meth:`acquire_server` to take full control of routing.
     """
 
     def __init__(
@@ -378,6 +395,7 @@ class LLMServerManager:
         worker_group: RayWorkerGroup = None,
         rollout_resource_pool: RayResourcePool = None,
         start_rank: int = 0,
+        load_balancer_cls: type | None = None,
     ):
         self.config = config
         self.rollout_config = config.actor_rollout_ref.rollout
@@ -385,6 +403,7 @@ class LLMServerManager:
         self.worker_group = worker_group
         self.rollout_resource_pool = rollout_resource_pool
         self.start_rank = start_rank
+        self._load_balancer_cls = load_balancer_cls or GlobalRequestLoadBalancer
 
         assert worker_group is not None or self.rollout_config.nnodes > 0, "nnodes must be > 0 in standalone mode"
 
@@ -476,20 +495,30 @@ class LLMServerManager:
             update_prometheus_config(self.rollout_config.prometheus, self.server_addresses, self.rollout_config.name)
 
     async def _init_global_load_balancer(self) -> None:
-        self.global_load_balancer = GlobalRequestLoadBalancer.remote(
+        load_balancer_cls = self._load_balancer_cls
+        kwargs = dict(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
             max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
-            full_determinism=getattr(self.rollout_config, "full_determinism", False),
         )
+        # The default GlobalRequestLoadBalancer honors the full_determinism flag
+        # in acquire_server. A custom subclass overrides acquire_server and takes
+        # full control of routing, so the flag is not forwarded to it.
+        if load_balancer_cls is GlobalRequestLoadBalancer:
+            kwargs["full_determinism"] = getattr(self.rollout_config, "full_determinism", False)
+        self.global_load_balancer = ray.remote(load_balancer_cls).remote(**kwargs)
 
-    def get_client(self, client_cls=LLMServerClient, **kwargs) -> LLMServerClient:
+    def get_client(self, client_cls: type[LLMServerClient] | None = None, **kwargs) -> LLMServerClient:
         """Get the LLMServerClient to request LLM server replicas.
 
         Args:
-            client_cls: The client class to instantiate (default: ``LLMServerClient``).
-                Pass ``FullyAsyncLLMServerClient`` for abort-resume support.
+            client_cls: The client class to instantiate. Defaults to
+                :class:`LLMServerClient`. Pass a subclass to customize
+                request-id handling (e.g. a deterministic client that forwards
+                the caller's ``request_id`` straight to vLLM), or
+                :class:`FullyAsyncLLMServerClient` for abort-resume support.
             **kwargs: Forwarded to the client constructor.
         """
+        client_cls = client_cls or LLMServerClient
         return client_cls(
             config=self.config,
             load_balancer_handle=self.global_load_balancer,

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ctypes
+import dataclasses
+import functools
 import json
 import logging
 import os
@@ -390,6 +392,20 @@ class SuppressSignalInThread:
         signal.signal = self.original_signal
 
 
+@functools.lru_cache(maxsize=1)
+def _optional_bool_vllm_args() -> set[str]:
+    """Return the names of vLLM `AsyncEngineArgs` fields typed exactly `bool | None`.
+
+    For such fields an omitted flag leaves the None default, which vLLM can
+    resolve to True at engine-config time (e.g. `enable_prefix_caching`), so
+    an explicit False must be serialized as `--no-<flag>` instead of being
+    dropped.
+    """
+    from vllm.engine.arg_utils import AsyncEngineArgs
+
+    return {f.name for f in dataclasses.fields(AsyncEngineArgs) if set(get_args(f.type)) == {bool, type(None)}}
+
+
 def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
     """
     Convert a config dictionary to CLI arguments for vLLM server.
@@ -397,7 +413,8 @@ def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
     Handles different value types appropriately:
     - None: skipped
     - bool True: adds '--key'
-    - bool False: skipped
+    - bool False: adds '--no-key' for Optional[bool] engine args (whose None
+      default resolves to True), otherwise skipped
     - list: expands to '--key item1 item2 ...'
     - empty list: skipped (vLLM uses nargs="+" which requires at least one value)
     - dict: JSON serialized
@@ -416,6 +433,9 @@ def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
         if isinstance(v, bool):
             if v:
                 cli_args.append(f"--{k}")
+            elif k.replace("-", "_") in _optional_bool_vllm_args():
+                # Absent flag resolves to True at engine-config time.
+                cli_args.append(f"--no-{k}")
         elif isinstance(v, list):
             if not v:
                 # Skip empty lists - vLLM uses nargs="+" which requires at least one value


### PR DESCRIPTION
### What does this PR do?

Introduce `verl.runtime` as the public control-plane API and define backend-neutral worker, resource, RPC, topology, object-store, and lifecycle contracts under `verl.single_controller.base`. Runtime owns process context, group creation, and cleanup; concrete scheduling and transport belong to the backend adapters.

The public interfaces live in `verl.runtime`; their initial implementation lives in `verl.single_controller.base`. Existing `verl.single_controller` imports, Ray base classes, dispatch behavior, and protocol futures remain compatible. The existing Worker, WorkerGroup, decorator, and base exports retain their original definitions. Their replacement accompanies the Ray adapter and caller migration in the following PR.

This PR also adds the architecture guide and documentation index entry for the complete design. Backend implementations follow in the subsequent PRs.

Related design: [RFC](https://github.com/verl-project/verl/issues/7839).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+single_controller+Monarch - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22backend-neutral%22+Runtime - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+7269

Related work covers TransferQueue ([#7000](https://github.com/verl-project/verl/pull/7000)), NeoProto ([#7350](https://github.com/verl-project/verl/pull/7350)), and the V0 data path ([#7557](https://github.com/verl-project/verl/pull/7557)). The topology ([#7269](https://github.com/verl-project/verl/issues/7269)) and external-backend ([#6537](https://github.com/verl-project/verl/issues/6537)) RFCs complement the Runtime contracts, adapters, and storage integration here.

### Test

#### CPU CI

`vllm023.dev1`, Python 3.12.3 and Torch 2.11.0+cu130.

```bash
pytest -s -o python_files='*_on_cpu.py' --asyncio-mode=auto tests/ \
  --ignore=tests/trainer/ppo/v1 \
  --ignore=tests/trainer/test_multi_trajectories_advantage_on_cpu.py # 711 PASS, 27 SKIPPED
```

#### GPU CI

`sgl0512.dev2`, Python 3.12.3 and Torch 2.11.0+cu130.

```bash
pytest -s --ignore-glob="*on_npu.py" --ignore-glob="*test_special_*.py" \
  --ignore-glob='*on_cpu.py' --ignore-glob="*test_vllm*" \
  --ignore-glob="*_sglang*" --ignore-glob="*_hf_rollout*" \
  --ignore-glob="tests/models/" --ignore-glob='tests/special*' \
  --ignore-glob="tests/experimental" --ignore-glob="tests/workers/reward_model" \
  --ignore-glob="*test_shared_memory*" \
  --ignore-glob="tests/workers/rollout/rollout_trtllm" \
  --ignore-glob="*test_bucketed_weight_transfer*" tests/ # 243 PASS, 19 FAILED (pre-existing), 6 SKIPPED
```

```bash
LOW_MEMORY=True torchrun --standalone --nnodes=1 --nproc-per-node=8 \
  tests/utils/test_special_linear_cross_entropy_tp.py # PASS (exit 0)

torchrun --standalone --nnodes=1 --nproc-per-node=2 \
  tests/utils/test_special_megatron_kl_loss_tp.py # 4 PASS (exit 0)

python -m pre_commit run --all-files # PASS
```

#### Standalone PPO correctness

The validation baseline cherry-picks two commits from `main`, [#7027](https://github.com/verl-project/verl/pull/7027) and [#7508](https://github.com/verl-project/verl/pull/7508), to enable full determinism for correctness validation in this and the following PRs.

Two complete 1x8 training steps pass against the deterministic baseline, including training teardown. Metric tolerances are `rtol=1e-5`, `atol=1e-6`; checkpoint tensors use zero tolerance.

| Step | Semantic metrics | Decoded rollouts | Checkpoint values | Result |
| --- | ---: | ---: | --- | --- |
| 1 | 77 | 64 | Not saved | PASS |
| 2 | 77 | 64 | 19,233 | PASS |

### API and Usage Example

```python
from verl.runtime import ClassWithInitArgs, RemoteCall, Runtime, Topology, Worker
from verl.runtime.executor import RuntimeThreadPoolExecutor
```

The public contracts are importable independently of backend adapter creation. New callers import Workers, groups, and decorators through `verl.runtime`. Existing callers continue to use the original single-controller modules.

### Design & Code Changes

#### Compatibility with existing callers

The existing Ray constructors, worker groups, dispatch helpers, protocol futures, and import paths remain available. Neutral contracts are exposed separately through `verl.runtime` until the coordinated migration in the following PR.

#### Runtime: the process-level owner

`Runtime` is the public entry point for configuration, resource-pool selection, worker-group construction, and cleanup. A process has at most one live Runtime. The root owns backend resources and tracks the groups it creates; a worker attaches to that Runtime tree through an `AttachSpec` carrying its identity, backend configuration, topology, resource views, and object-store client configuration. `current_runtime()` lets nested callers reuse this context.

Runtime tracking does not keep a group alive. Local rank and fused-role views retain their parent group; releasing the last local reference allows backend workers to be reclaimed. Remote projections are non-owning. `Runtime.close()` closes groups that remain alive, and retains failed cleanup for retry.

Role mappings are validated through the shared `normalize_role_actors` helper before allocation, so Runtime and fused construction share one validation path.

The private `RuntimeBackend` protocol supplies resource discovery, placement resolution, group construction, object-store startup, and backend cleanup. The shared Runtime determines which operation to perform and who owns it; the backend supplies the concrete scheduling and execution mechanism.

#### Worker and invocation contracts

- `Worker` is the user implementation that runs in one process. `register` describes how a method dispatches arguments, selects ranks, and collects results; this metadata is independent of the execution backend.
- `ClassWithInitArgs` describes a Worker constructor without creating it in the controller. `WorkerContainer` constructs the Worker in its execution context, dispatches calls, and owns its close operation.
- `WorkerGroup` is the owning handle for a set of ranked workers. A single actor is the same abstraction with `world_size=1`. Rank selections and `RemoteWorkerGroup` projections expose invocation without transferring ownership of the underlying processes.
- `RemoteCall` represents an asynchronous result with a submit-time deadline. `result()`, `await`, `wait()`, and `gather()` observe the same operation. Observation timeout does not mean the remote operation was cancelled; later observation can still retrieve its completed result.
- Fused groups place multiple named Worker roles in each process. Role views preserve their method contracts while the owning root closes the shared processes once. Dependency handling resolves upstream calls before the downstream dispatch and preserves the caller's deadline.

#### Placement and object storage

`ResourcePool` describes an ordered, reusable placement of ranks: node count, processes per node, and device type. Slicing creates a non-owning view and preserves the placement coordinates and Runtime scope. `Topology` expresses `Cluster -> DevicePool -> Model`; Runtime compiles model selections into pools that backends can allocate.

`ObjectStore` is the data boundary: `put`, `get`, `delete`, their batch forms, and `close`. References are opaque to the neutral layer. Runtime coordinates client and backend lifetimes, while the selected backend implements storage and reference transport.

Existing protocol futures continue to accept Ray ObjectRefs in this PR. Their `RemoteCall` migration accompanies the Ray caller changes in the following PR.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [x] Add / Update the documentation. Runtime API documentation, `docs/advance/enhanced_single_controller.md`, and the documentation index.
- [ ] Add unit or end-to-end test(s) to the CI workflow. Existing tests remain unchanged.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] Not related to the `recipe` submodule.

AI assistance was used for this change and for its description.
