### PR TITLE
[rollout, trainer] feat: ship routed_experts as ragged per-token payload

### DIFF
--- a/tests/experimental/agent_loop/test_as_dict_routed_experts_sentinel_on_cpu.py
+++ b/tests/experimental/agent_loop/test_as_dict_routed_experts_sentinel_on_cpu.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""``AgentLoopOutput.as_dict`` keeps int16 routing and pads the tail with the sentinel."""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from verl.experimental.agent_loop.agent_loop import AgentLoopMetrics, AgentLoopOutput
+from verl.utils.routed_experts import ROUTER_REPLAY_UNRECORDED
+
+LAYERS, TOPK = 4, 2
+
+
+def _output(routed_experts, prompt_len=3, response_len=4):
+    return AgentLoopOutput(
+        prompt_ids=list(range(1, prompt_len + 1)),
+        response_ids=list(range(1, response_len + 1)),
+        response_mask=[1] * response_len,
+        metrics=AgentLoopMetrics(),
+        extra_fields={},
+        routed_experts=routed_experts,
+    )
+
+
+def test_as_dict_casts_to_int16_and_pads_unrecorded_tail():
+    n_real = 5
+    experts = np.arange(n_real * LAYERS * TOPK, dtype=np.int32).reshape(n_real, LAYERS, TOPK) % 16
+    routed = _output(experts).as_dict()["routed_experts"]
+
+    assert routed.dtype == torch.int16
+    assert routed.shape == (7, LAYERS, TOPK)
+    assert torch.equal(routed[:n_real], torch.as_tensor(experts, dtype=torch.int16))
+    assert bool((routed[n_real:] == ROUTER_REPLAY_UNRECORDED).all())
+
+
+def test_as_dict_accepts_readonly_frombuffer():
+    n_real = 4
+    payload = np.arange(n_real * LAYERS * TOPK, dtype=np.int32).tobytes()
+    experts = np.frombuffer(payload, dtype=np.int32).reshape(n_real, LAYERS, TOPK)
+    assert not experts.flags.writeable
+
+    routed = _output(experts).as_dict()["routed_experts"]
+    assert routed.dtype == torch.int16
+    routed[0, 0, 0] = 123
+    assert int(np.frombuffer(payload, dtype=np.int32)[0]) == 0
+
+
+def test_as_dict_truncates_overlong_capture():
+    prompt_len, response_len = 3, 4
+    n_real = prompt_len + response_len + 5
+    experts = np.arange(n_real * LAYERS * TOPK, dtype=np.int16).reshape(n_real, LAYERS, TOPK) % 16
+    routed = _output(experts, prompt_len, response_len).as_dict()["routed_experts"]
+    assert routed.shape == (prompt_len + response_len, LAYERS, TOPK)
+    assert torch.equal(routed, torch.as_tensor(experts[: prompt_len + response_len], dtype=torch.int16))

--- a/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
+++ b/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
@@ -15,6 +15,7 @@
 import math
 from types import SimpleNamespace
 
+import numpy as np
 import torch
 
 import verl.trainer.ppo.metric_utils as metric_utils
@@ -106,6 +107,40 @@ def test_rollout_moe_load_balance_metrics_survive_negative_filler():
     )
 
     assert metrics
+
+
+def test_rollout_moe_load_balance_metrics_ragged_matches_dense():
+    # Same two sequences as the dense per-sequence drop-last case, stored as
+    # attended-token rows: last token of each row is the unrecorded filler.
+    dense = torch.zeros(2, 4, 1, 1, dtype=torch.long)
+    dense[0, :, 0, 0] = torch.tensor([1, 2, 3, 0])
+    dense[1, :, 0, 0] = torch.tensor([2, 0, 0, 0])
+    response_mask = torch.tensor([[True, True, True, True], [True, True, False, False]])
+    dense_counts = metric_utils._compute_rollout_moe_load_counts(
+        routed_experts=dense, response_mask=response_mask, num_experts=4
+    )
+
+    ragged = np.empty(2, dtype=object)
+    ragged[0] = np.array([[[1]], [[2]], [[3]], [[0]]], dtype=np.int16)
+    ragged[1] = np.array([[[2]], [[0]]], dtype=np.int16)
+    ragged_counts = metric_utils._compute_rollout_moe_load_counts(
+        routed_experts=ragged, response_mask=response_mask, num_experts=4
+    )
+    assert torch.equal(dense_counts, ragged_counts)
+
+
+def test_compute_moe_lb_metrics_reads_non_tensor_routed_experts():
+    accumulator = RolloutMoELoadBalanceMetricsAccumulator(model_config={"num_experts": 2})
+    ragged = np.empty(1, dtype=object)
+    ragged[0] = np.array([[[0]], [[1]], [[0]]], dtype=np.int16)
+    batch = SimpleNamespace(
+        batch={"response_mask": torch.tensor([[True, True, True]], dtype=torch.bool)},
+        non_tensor_batch={"routed_experts": ragged},
+    )
+
+    metrics = compute_moe_lb_metrics(batch, moe_lb_metrics_interval=1, global_steps=1, accumulator=accumulator)
+    assert metrics["rollout/moe/routed_experts_found"] == 1.0
+    assert metrics["rollout/moe/routed_expert_assignments"] == 2
 
 
 def test_rollout_moe_load_balance_metrics_drop_last_valid_per_sequence():

--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -338,6 +338,34 @@ def test_response_to_nested():
         torch.testing.assert_close(tensor, expected)
 
 
+def test_left_right_2_no_padding_dense_routed_experts():
+    batch_size, seq_len, layers, topk = 2, 8, 2, 2
+    attention_mask = torch.tensor(
+        [[0, 0, 1, 1, 1, 1, 0, 0], [1, 1, 1, 0, 0, 0, 0, 0]],
+        dtype=torch.int64,
+    )
+    input_ids = torch.arange(batch_size * seq_len).reshape(batch_size, seq_len)
+    response_mask = torch.zeros(batch_size, 3, dtype=torch.int64)
+    position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
+    routed = torch.arange(batch_size * seq_len * layers * topk, dtype=torch.int16).reshape(
+        batch_size, seq_len, layers, topk
+    )
+    data = TensorDict(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+            "position_ids": position_ids,
+            "routed_experts": routed,
+        },
+        batch_size=[batch_size],
+    )
+    converted = left_right_2_no_padding(data)
+    assert converted["routed_experts"].is_nested
+    expected = torch.cat([routed[i, attention_mask[i].bool()] for i in range(batch_size)], dim=0)
+    torch.testing.assert_close(converted["routed_experts"].values(), expected)
+
+
 if __name__ == "__main__":
     test_padding_conversion_with_log_probs()
     test_padding_conversion_without_log_probs()
@@ -346,4 +374,5 @@ if __name__ == "__main__":
     test_embeds_padding_2_no_padding_varying_lengths()
     test_response_from_nested()
     test_response_to_nested()
+    test_left_right_2_no_padding_dense_routed_experts()
     print("All padding conversion tests passed!")

--- a/tests/utils/test_routed_experts_ragged.py
+++ b/tests/utils/test_routed_experts_ragged.py
@@ -80,9 +80,10 @@ def test_cuda_ragged_unpad_matches_dense_and_keeps_sentinel():
     assert dense_out["routed_experts"].is_nested
     assert ragged_out["routed_experts"].is_nested
     assert dense_out["routed_experts"].values().device.type == "cuda"
+    assert ragged_out["routed_experts"].values().device.type == "cuda"
     torch.testing.assert_close(
-        ragged_out["routed_experts"].values().cpu(),
-        dense_out["routed_experts"].values().cpu(),
+        ragged_out["routed_experts"].values(),
+        dense_out["routed_experts"].values(),
     )
     values = dense_out["routed_experts"].values()
     offsets = dense_out["routed_experts"].offsets()

--- a/tests/utils/test_routed_experts_ragged.py
+++ b/tests/utils/test_routed_experts_ragged.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CUDA unpad of ragged vs dense routed_experts must agree."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.utils.routed_experts import ROUTER_REPLAY_UNRECORDED, pack_padded_routed_experts
+from verl.workers.utils.padding import left_right_2_no_padding
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+
+LAYERS, TOPK = 2, 3
+SENTINEL = ROUTER_REPLAY_UNRECORDED
+
+
+def test_cuda_ragged_unpad_matches_dense_and_keeps_sentinel():
+    device = torch.device("cuda")
+    attention_mask = torch.tensor(
+        [[0, 0, 1, 1, 1, 0], [1, 1, 1, 0, 0, 0]],
+        dtype=torch.int64,
+        device=device,
+    )
+    batch_size, seq_len = attention_mask.shape
+    input_ids = torch.arange(batch_size * seq_len, dtype=torch.int64, device=device).reshape(batch_size, seq_len)
+    response_mask = torch.zeros(batch_size, 2, dtype=torch.int64, device=device)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+    dense = torch.arange(batch_size * seq_len * LAYERS * TOPK, dtype=torch.int16, device=device).reshape(
+        batch_size, seq_len, LAYERS, TOPK
+    )
+    # Last attended token of each row is unrecorded (the sampled token never re-entered MoE).
+    for i in range(batch_size):
+        attended_idx = attention_mask[i].nonzero(as_tuple=False).flatten()
+        dense[i, attended_idx[-1]] = SENTINEL
+
+    packed = pack_padded_routed_experts(list(dense.detach().cpu()), attention_mask.cpu())
+
+    dense_td = TensorDict(
+        {
+            "input_ids": input_ids.clone(),
+            "attention_mask": attention_mask.clone(),
+            "response_mask": response_mask.clone(),
+            "position_ids": position_ids.clone(),
+            "routed_experts": dense.clone(),
+        },
+        batch_size=[batch_size],
+    )
+    ragged_proto = DataProto(
+        batch=TensorDict(
+            {
+                "input_ids": input_ids.clone(),
+                "attention_mask": attention_mask.clone(),
+                "response_mask": response_mask.clone(),
+                "position_ids": position_ids.clone(),
+            },
+            batch_size=[batch_size],
+        ),
+        non_tensor_batch={"routed_experts": packed},
+    )
+
+    dense_out = left_right_2_no_padding(dense_td)
+    ragged_out = left_right_2_no_padding(ragged_proto.to_tensordict())
+
+    assert dense_out["routed_experts"].is_nested
+    assert ragged_out["routed_experts"].is_nested
+    assert dense_out["routed_experts"].values().device.type == "cuda"
+    torch.testing.assert_close(
+        ragged_out["routed_experts"].values().cpu(),
+        dense_out["routed_experts"].values().cpu(),
+    )
+    values = dense_out["routed_experts"].values()
+    offsets = dense_out["routed_experts"].offsets()
+    for i in range(batch_size):
+        last = values[int(offsets[i + 1].item()) - 1]
+        assert bool((last == SENTINEL).all())

--- a/tests/utils/test_routed_experts_ragged_on_cpu.py
+++ b/tests/utils/test_routed_experts_ragged_on_cpu.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ragged routed-experts wire format: pack, nested round-trip, dense adapter, DataProto ops."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.trainer.ppo.padding_utils import build_padding_routed_experts
+from verl.utils.attention_utils import unpad_input
+from verl.utils.routed_experts import (
+    ROUTER_REPLAY_UNRECORDED,
+    has_rollout_routed_experts,
+    pack_padded_routed_experts,
+    ragged_routed_experts_to_nested,
+    rollout_and_actor_routed_experts_conflict,
+    unrecorded_fill_value,
+)
+from verl.workers.utils.padding import left_right_2_no_padding
+
+LAYERS, TOPK = 2, 3
+SENTINEL = ROUTER_REPLAY_UNRECORDED
+
+
+def _padded_row(attended: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Scatter ``attended`` into a config-length row, filling pad with the sentinel."""
+    seq = int(mask.numel())
+    row = torch.full((seq, LAYERS, TOPK), SENTINEL, dtype=torch.int16)
+    row[mask.bool()] = attended
+    return row
+
+
+def test_unrecorded_fill_value_does_not_wrap_unsigned():
+    assert unrecorded_fill_value(torch.int16) == SENTINEL
+    assert unrecorded_fill_value(torch.uint8) == 0
+
+
+def test_pack_strips_padding_and_keeps_final_token_sentinel():
+    # Left-padded prompt + right-padded response. The last attended token is the
+    # sampled token that never re-entered MoE, so it stays the sentinel.
+    mask = torch.tensor(
+        [
+            [0, 0, 1, 1, 1, 1, 0],
+            [0, 1, 1, 1, 0, 0, 0],
+        ],
+        dtype=torch.int64,
+    )
+    row0 = torch.tensor(
+        [
+            [[0, 1, 2], [3, 4, 5]],
+            [[6, 7, 8], [9, 10, 11]],
+            [[12, 13, 14], [15, 16, 17]],
+            [[SENTINEL] * TOPK, [SENTINEL] * TOPK],
+        ],
+        dtype=torch.int16,
+    )
+    row1 = torch.tensor(
+        [
+            [[1, 1, 1], [2, 2, 2]],
+            [[3, 3, 3], [4, 4, 4]],
+            [[SENTINEL] * TOPK, [SENTINEL] * TOPK],
+        ],
+        dtype=torch.int16,
+    )
+    padded = [_padded_row(row0, mask[0]).unsqueeze(0), _padded_row(row1, mask[1])]
+    packed = pack_padded_routed_experts(padded, mask)
+
+    assert packed.dtype == object
+    assert packed.shape == (2,)
+    np.testing.assert_array_equal(packed[0], row0.numpy())
+    np.testing.assert_array_equal(packed[1], row1.numpy())
+    assert int(packed[0][-1, 0, 0]) == SENTINEL
+    assert int(packed[1][-1, 0, 0]) == SENTINEL
+
+
+def test_pack_rejects_partial_payload():
+    mask = torch.ones(2, 4, dtype=torch.int64)
+    row = torch.zeros(1, 4, LAYERS, TOPK, dtype=torch.int16)
+    with pytest.raises(ValueError, match="partial routing payload"):
+        pack_padded_routed_experts([row, None], mask)
+
+
+def test_pack_rejects_seq_mismatch():
+    mask = torch.ones(1, 5, dtype=torch.int64)
+    row = torch.zeros(1, 3, LAYERS, TOPK, dtype=torch.int16)
+    with pytest.raises(ValueError, match="expected"):
+        pack_padded_routed_experts([row], mask)
+
+
+def test_ragged_to_nested_matches_unpad_offsets():
+    mask = torch.tensor([[0, 1, 1, 1, 0], [1, 1, 0, 0, 0]], dtype=torch.int64)
+    input_ids = torch.arange(10, dtype=torch.int64).reshape(2, 5)
+    rows = [
+        torch.arange(3 * LAYERS * TOPK, dtype=torch.int16).reshape(3, LAYERS, TOPK).numpy(),
+        torch.arange(100, 100 + 2 * LAYERS * TOPK, dtype=torch.int16).reshape(2, LAYERS, TOPK).numpy(),
+    ]
+    packed = np.empty(2, dtype=object)
+    packed[:] = rows
+    _, _, cu_seqlens, *_ = unpad_input(input_ids.unsqueeze(-1), mask)
+    nested = ragged_routed_experts_to_nested(packed, cu_seqlens)
+
+    assert nested.is_nested
+    torch.testing.assert_close(nested.offsets(), cu_seqlens.to(dtype=nested.offsets().dtype))
+    torch.testing.assert_close(nested.values(), torch.from_numpy(np.concatenate(rows, axis=0)))
+
+
+def test_ragged_to_nested_rejects_row_count_drift():
+    mask = torch.ones(2, 3, dtype=torch.int64)
+    input_ids = torch.ones(2, 3, dtype=torch.int64)
+    packed = np.empty(2, dtype=object)
+    packed[0] = np.zeros((3, LAYERS, TOPK), dtype=np.int16)
+    packed[1] = np.zeros((2, LAYERS, TOPK), dtype=np.int16)
+    _, _, cu_seqlens, *_ = unpad_input(input_ids.unsqueeze(-1), mask)
+    with pytest.raises(ValueError, match="cu_seqlens"):
+        ragged_routed_experts_to_nested(packed, cu_seqlens)
+
+
+def test_dense_adapter_still_unpads():
+    batch_size, seq_len = 2, 6
+    attention_mask = torch.tensor(
+        [[0, 0, 1, 1, 1, 0], [1, 1, 1, 0, 0, 0]],
+        dtype=torch.int64,
+    )
+    input_ids = torch.arange(batch_size * seq_len, dtype=torch.int64).reshape(batch_size, seq_len)
+    response_mask = torch.zeros(batch_size, 2, dtype=torch.int64)
+    position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
+    routed = torch.arange(batch_size * seq_len * LAYERS * TOPK, dtype=torch.int16).reshape(
+        batch_size, seq_len, LAYERS, TOPK
+    )
+    data = TensorDict(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+            "position_ids": position_ids,
+            "routed_experts": routed,
+        },
+        batch_size=[batch_size],
+    )
+    converted = left_right_2_no_padding(data)
+    assert converted["routed_experts"].is_nested
+    expected = torch.cat([routed[0, attention_mask[0].bool()], routed[1, attention_mask[1].bool()]], dim=0)
+    torch.testing.assert_close(converted["routed_experts"].values(), expected)
+
+
+def test_ragged_adapter_round_trips_through_left_right_2_no_padding():
+    batch_size, seq_len = 2, 6
+    attention_mask = torch.tensor(
+        [[0, 0, 1, 1, 1, 0], [1, 1, 1, 0, 0, 0]],
+        dtype=torch.int64,
+    )
+    input_ids = torch.arange(batch_size * seq_len, dtype=torch.int64).reshape(batch_size, seq_len)
+    response_mask = torch.zeros(batch_size, 2, dtype=torch.int64)
+    position_ids = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
+    rows = [
+        torch.arange(3 * LAYERS * TOPK, dtype=torch.int16).reshape(3, LAYERS, TOPK).numpy(),
+        torch.arange(50, 50 + 3 * LAYERS * TOPK, dtype=torch.int16).reshape(3, LAYERS, TOPK).numpy(),
+    ]
+    packed = np.empty(batch_size, dtype=object)
+    packed[:] = rows
+    proto = DataProto(
+        batch=TensorDict(
+            {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "response_mask": response_mask,
+                "position_ids": position_ids,
+            },
+            batch_size=[batch_size],
+        ),
+        non_tensor_batch={"routed_experts": packed},
+    )
+    converted = left_right_2_no_padding(proto.to_tensordict())
+    assert converted["routed_experts"].is_nested
+    torch.testing.assert_close(
+        converted["routed_experts"].values(),
+        torch.from_numpy(np.concatenate(rows, axis=0)),
+    )
+
+
+def test_dataproto_concat_reorder_chunk_keep_per_row_blocks():
+    def _one(marker: int, n: int) -> DataProto:
+        row = np.full((n, LAYERS, TOPK), marker, dtype=np.int16)
+        packed = np.empty(1, dtype=object)
+        packed[0] = row
+        return DataProto(
+            batch=TensorDict({"input_ids": torch.zeros(1, 2, dtype=torch.int64)}, batch_size=[1]),
+            non_tensor_batch={"routed_experts": packed},
+        )
+
+    a, b, c = _one(1, 2), _one(2, 5), _one(3, 1)
+    cat = DataProto.concat([a, b, c])
+    assert cat.non_tensor_batch["routed_experts"].shape == (3,)
+    assert int(cat.non_tensor_batch["routed_experts"][1][0, 0, 0]) == 2
+    assert cat.non_tensor_batch["routed_experts"][1].shape[0] == 5
+
+    cat.reorder(torch.tensor([2, 0, 1]))
+    assert [int(row[0, 0, 0]) for row in cat.non_tensor_batch["routed_experts"]] == [3, 1, 2]
+
+    chunks = cat.chunk(chunks=3)
+    assert [int(c.non_tensor_batch["routed_experts"][0][0, 0, 0]) for c in chunks] == [3, 1, 2]
+
+
+def test_build_padding_routed_experts_mirrors_numpy_and_tensor():
+    src_np = np.zeros((4, LAYERS, TOPK), dtype=np.int16)
+    pad_np = build_padding_routed_experts(src_np, 7)
+    assert isinstance(pad_np, np.ndarray)
+    assert pad_np.shape == (7, LAYERS, TOPK)
+    assert bool((pad_np == SENTINEL).all())
+
+    src_t = torch.zeros(4, LAYERS, TOPK, dtype=torch.int16)
+    pad_t = build_padding_routed_experts(src_t, 7)
+    assert pad_t.shape == (7, LAYERS, TOPK)
+    assert bool((pad_t == SENTINEL).all())
+
+
+def test_r2_r3_conflict_sees_non_tensor_rollout_payload():
+    rollout = DataProto(
+        batch=TensorDict({"input_ids": torch.zeros(1, 2, dtype=torch.int64)}, batch_size=[1]),
+        non_tensor_batch={"routed_experts": np.empty(1, dtype=object)},
+    )
+    actor = DataProto(
+        batch=TensorDict({"routed_experts": torch.zeros(1, 2, 1, 1, dtype=torch.int16)}, batch_size=[1]),
+    )
+    assert has_rollout_routed_experts(rollout)
+    assert rollout_and_actor_routed_experts_conflict(rollout, actor)
+
+    empty = DataProto(batch=TensorDict({"input_ids": torch.zeros(1, 2, dtype=torch.int64)}, batch_size=[1]))
+    assert not rollout_and_actor_routed_experts_conflict(empty, actor)

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -58,6 +58,7 @@ from verl.utils.rollout_trace import (
     RolloutTraceConfig,
     rollout_trace_attr,
 )
+from verl.utils.routed_experts import pack_padded_routed_experts, unrecorded_fill_value
 from verl.utils.skip import SkipManager
 from verl.utils.tokenizer import (
     build_multimodal_processor_inputs,
@@ -129,10 +130,11 @@ class AgentLoopOutput(BaseModel):
             # Router replay indexes this field by absolute token position, so it must
             # span the whole sequence. The rollout engine records fewer rows than that:
             # it only sees tokens fed through the model, and multi-turn loops stop
-            # recording at the last generation. Trailing rows stay zero; replay masks
-            # them out instead of consuming them.
+            # recording at the last generation. Trailing rows hold the unrecorded
+            # sentinel; replay masks them out instead of consuming them.
             total_length = output["prompts"].size(0) + output["responses"].size(0)
-            aligned = routed_experts.new_zeros((total_length, *routed_experts.shape[1:]))
+            fill = unrecorded_fill_value(routed_experts.dtype)
+            aligned = routed_experts.new_full((total_length, *routed_experts.shape[1:]), fill)
             num_rows = min(routed_experts.size(0), total_length)
             aligned[:num_rows] = routed_experts[:num_rows]
             output["routed_experts"] = aligned
@@ -764,7 +766,8 @@ class AgentLoopWorker:
             else:
                 raise TypeError(f"Unsupported type for routed_experts: {type(output.routed_experts)}")
             experts_tensor = experts_tensor.to(torch.int16)
-            routed_experts = torch.zeros(1, total_length, layer_num, topk_num, dtype=experts_tensor.dtype)
+            fill = unrecorded_fill_value(experts_tensor.dtype)
+            routed_experts = torch.full((1, total_length, layer_num, topk_num), fill, dtype=experts_tensor.dtype)
 
             # Calculate start position: left padding means original prompt starts at the end
             start_pos = prompt_output["input_ids"].shape[1] - len(output.prompt_ids)
@@ -1040,8 +1043,12 @@ class AgentLoopWorker:
         optional_outputs = {}
         if inputs[0].response_logprobs is not None:
             optional_outputs["rollout_log_probs"] = torch.cat([input.response_logprobs for input in inputs], dim=0)
+        routed_experts_ragged = None
         if inputs[0].routed_experts is not None:
-            optional_outputs["routed_experts"] = torch.cat([input.routed_experts for input in inputs], dim=0)
+            routed_experts_ragged = pack_padded_routed_experts(
+                [input.routed_experts for input in inputs],
+                attention_mask,
+            )
         if inputs[0].teacher_logprobs is not None and inputs[0].teacher_ids is not None:
             optional_outputs["teacher_logprobs"] = torch.cat([input.teacher_logprobs for input in inputs], dim=0)
             optional_outputs["teacher_ids"] = torch.cat([input.teacher_ids for input in inputs], dim=0)
@@ -1072,6 +1079,8 @@ class AgentLoopWorker:
         }
         if self.reward_loop_worker_handles is None and input_non_tensor_batch:
             non_tensor_batch.update(input_non_tensor_batch)
+        if routed_experts_ragged is not None:
+            non_tensor_batch["routed_experts"] = routed_experts_ragged
 
         # add reward_extra_info to non_tensor_batch
         reward_extra_infos = [input.extra_fields.get("reward_extra_info", {}) for input in inputs]

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -534,7 +534,9 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                 }
                 metrics.update(old_log_prob_metrics)
                 old_log_prob.batch.pop("entropys")
-                if "routed_experts" in batch.batch and "routed_experts" in old_log_prob.batch:
+                from verl.utils.routed_experts import rollout_and_actor_routed_experts_conflict
+
+                if rollout_and_actor_routed_experts_conflict(batch, old_log_prob):
                     actor_cfg = self.config.actor_rollout_ref.actor
                     if getattr(actor_cfg, "strategy", None) == "megatron":
                         engine_cfg = getattr(actor_cfg, "megatron", None)
@@ -544,7 +546,9 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                         engine_cfg = None
                     router_mode = getattr(getattr(engine_cfg, "router_replay", None), "mode", "disabled")
                     if router_mode == "R2":
-                        batch.batch.pop("routed_experts")
+                        if batch.batch is not None:
+                            batch.batch.pop("routed_experts", None)
+                        batch.non_tensor_batch.pop("routed_experts", None)
                     else:
                         old_log_prob.batch.pop("routed_experts")
                 batch = batch.union(old_log_prob)

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -30,6 +30,7 @@ from verl import DataProto
 from verl.utils.fs import copy_to_local
 from verl.utils.import_utils import deprecated
 from verl.utils.model import update_model_config
+from verl.utils.routed_experts import get_routed_experts_from_data_proto
 
 logger = logging.getLogger(__name__)
 
@@ -202,18 +203,41 @@ def _compute_rollout_moe_load_balance_metrics_from_counts(
     return metrics
 
 
-def _compute_rollout_moe_load_counts(
-    routed_experts: torch.Tensor | None,
-    response_mask: torch.Tensor | None,
-    num_experts: int | None,
+def _select_response_routed_experts(
+    routed_experts: torch.Tensor | np.ndarray,
+    response_mask: torch.Tensor,
 ) -> torch.Tensor | None:
-    """Count routed experts in response tokens as [num_layers, num_experts].
+    """Gather response-token routing, dropping each sequence's last valid token."""
+    if isinstance(routed_experts, np.ndarray) and routed_experts.dtype == object:
+        if response_mask.dim() != 2 or response_mask.shape[0] != len(routed_experts):
+            logger.warning(
+                "Response mask shape %s is incompatible with ragged routed_experts len %s",
+                response_mask.shape,
+                len(routed_experts),
+            )
+            return None
+        parts = []
+        response_mask_cpu = response_mask.detach().to(device="cpu")
+        for i, row in enumerate(routed_experts):
+            n_resp = int(response_mask_cpu[i].sum())
+            if n_resp <= 1:
+                continue
+            arr = np.asarray(row)
+            if arr.shape[0] < n_resp:
+                logger.warning(
+                    "ragged routed_experts sample %s has %s tokens, shorter than response length %s",
+                    i,
+                    arr.shape[0],
+                    n_resp,
+                )
+                return None
+            parts.append(arr[-n_resp:-1])
+        if not parts:
+            return None
+        return torch.as_tensor(np.concatenate(parts, axis=0), dtype=torch.long)
 
-    Each sequence's last valid response position is excluded: that token is
-    sampled but never fed back through the model, so it carries no routing
-    record (its slot is filler, not data).
-    """
-    if routed_experts is None or response_mask is None or num_experts is None or num_experts <= 0:
+    if not isinstance(routed_experts, torch.Tensor):
+        logger.warning("Expected routed_experts tensor or ragged object array, got %s", type(routed_experts))
         return None
     if routed_experts.dim() != 4:
         logger.warning("Expected routed_experts with shape [bsz, seqlen, layers, topk], got %s", routed_experts.shape)
@@ -238,19 +262,35 @@ def _compute_rollout_moe_load_counts(
     response_routed_experts = routed_experts[:, -response_len:]
     response_mask = response_mask.to(device=response_routed_experts.device, dtype=torch.bool)
     # The final response token is sampled but never fed back through the model,
-    # so it has no routing record; its slot holds filler from batch assembly
-    # (zeros, see AgentLoopWorker._postprocess). Counting it would credit
-    # expert 0 with num_layers * topk phantom assignments per sequence, so drop
-    # each sequence's last valid position. This is the metrics counterpart of
-    # build_r3_replay_mask, which skips the same row on the replay side.
+    # so it has no routing record; its slot holds the unrecorded sentinel.
+    # Counting it would credit a phantom expert, so drop each sequence's last
+    # valid position. This is the metrics counterpart of build_r3_replay_mask.
     positions = torch.arange(response_len, device=response_mask.device)
     last_valid = torch.where(response_mask, positions, positions.new_full((), -1)).amax(dim=-1)
     has_valid = last_valid >= 0
     is_last_valid = (positions.unsqueeze(0) == last_valid.unsqueeze(1)) & has_valid.unsqueeze(1)
     response_mask = response_mask & ~is_last_valid
     selected = response_routed_experts[response_mask]
-    selected = selected.detach().to(device="cpu", dtype=torch.long)
     if selected.numel() == 0:
+        return None
+    return selected.detach().to(device="cpu", dtype=torch.long)
+
+
+def _compute_rollout_moe_load_counts(
+    routed_experts: torch.Tensor | np.ndarray | None,
+    response_mask: torch.Tensor | None,
+    num_experts: int | None,
+) -> torch.Tensor | None:
+    """Count routed experts in response tokens as [num_layers, num_experts].
+
+    Each sequence's last valid response position is excluded: that token is
+    sampled but never fed back through the model, so it carries no routing
+    record (its slot is filler, not data).
+    """
+    if routed_experts is None or response_mask is None or num_experts is None or num_experts <= 0:
+        return None
+    selected = _select_response_routed_experts(routed_experts, response_mask)
+    if selected is None or selected.numel() == 0:
         return None
     if selected.min() < 0 or selected.max() >= num_experts:
         logger.warning(
@@ -319,8 +359,8 @@ def compute_moe_lb_metrics(
         return {}
 
     updated_moe_lb_metrics = accumulator.update(
-        routed_experts=metrics_batch.batch.get("routed_experts", None),
-        response_mask=metrics_batch.batch.get("response_mask", None),
+        routed_experts=get_routed_experts_from_data_proto(metrics_batch),
+        response_mask=metrics_batch.batch.get("response_mask", None) if metrics_batch.batch is not None else None,
     )
     if global_steps % moe_lb_metrics_interval != 0:
         return {}

--- a/verl/trainer/ppo/padding_utils.py
+++ b/verl/trainer/ppo/padding_utils.py
@@ -26,6 +26,7 @@ import logging
 import uuid
 from typing import Any
 
+import numpy as np
 import torch
 
 try:
@@ -35,6 +36,7 @@ except ImportError:
     from verl.utils.transferqueue_utils import KVBatchMeta, tq
 
 from verl.utils.model import compute_position_id_with_mask
+from verl.utils.routed_experts import ROUTER_REPLAY_UNRECORDED, unrecorded_fill_value
 from verl.utils.tensordict_utils import list_of_dict_to_tensordict
 
 logger = logging.getLogger(__name__)
@@ -56,14 +58,24 @@ def build_padding_position_ids(source_position_ids: Any, attention_mask: torch.T
     return position_ids.reshape(view_shape).expand(*source_position_ids.shape[:-1], -1).clone()
 
 
-def build_padding_routed_experts(source_routed_experts: Any, seq_len: int) -> torch.Tensor | None:
-    """Build a zero routed-experts tensor matching the source per-token expert shape."""
+def build_padding_routed_experts(source_routed_experts: Any, seq_len: int) -> Any:
+    """Build an all-unrecorded routed-experts block matching the source representation."""
+    if isinstance(source_routed_experts, np.ndarray) and source_routed_experts.dtype != object:
+        info = np.iinfo(source_routed_experts.dtype)
+        fill = ROUTER_REPLAY_UNRECORDED if info.min < 0 else 0
+        return np.full(
+            (seq_len, *source_routed_experts.shape[1:]),
+            fill,
+            dtype=source_routed_experts.dtype,
+        )
     if not isinstance(source_routed_experts, torch.Tensor):
         return None
+    fill = unrecorded_fill_value(source_routed_experts.dtype)
     if source_routed_experts.dim() == 0:
-        return torch.zeros_like(source_routed_experts)
-    return torch.zeros(
+        return torch.full_like(source_routed_experts, fill)
+    return torch.full(
         (seq_len, *source_routed_experts.shape[1:]),
+        fill,
         dtype=source_routed_experts.dtype,
         device=source_routed_experts.device,
     )

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1599,7 +1599,9 @@ class RayPPOTrainer:
                             }
                             metrics.update(old_log_prob_metrics)
                             old_log_prob.batch.pop("entropys")
-                            if "routed_experts" in batch.batch and "routed_experts" in old_log_prob.batch:
+                            from verl.utils.routed_experts import rollout_and_actor_routed_experts_conflict
+
+                            if rollout_and_actor_routed_experts_conflict(batch, old_log_prob):
                                 raise ValueError(
                                     "Detected conflicting router replay configuration: "
                                     "router_replay.mode='R2' and enable_rollout_routing_replay=True "

--- a/verl/utils/routed_experts.py
+++ b/verl/utils/routed_experts.py
@@ -84,7 +84,7 @@ def _as_row_list(value: Any) -> list[Any] | None:
     """Per-sequence rows from a ragged container, or None if this is not one."""
     if isinstance(value, np.ndarray) and value.dtype == object:
         return list(value)
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, list | tuple):
         return list(value)
     return None
 

--- a/verl/utils/routed_experts.py
+++ b/verl/utils/routed_experts.py
@@ -134,7 +134,9 @@ def ragged_routed_experts_to_nested(routed_experts: Any, cu_seqlens: torch.Tenso
     values = np.concatenate([np.asarray(row) for row in rows], axis=0)
     if not values.flags.writeable:
         values = values.copy()
-    return torch.nested.nested_tensor_from_jagged(torch.from_numpy(values), offsets=cu_seqlens)
+    # Driver rows are host numpy; unpad offsets inherit input_ids.device.
+    values_t = torch.from_numpy(values).to(device=cu_seqlens.device)
+    return torch.nested.nested_tensor_from_jagged(values_t, offsets=cu_seqlens)
 
 
 def has_rollout_routed_experts(batch: Any) -> bool:

--- a/verl/utils/routed_experts.py
+++ b/verl/utils/routed_experts.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wire format for rollout ``routed_experts``.
+
+Driver batches cannot store a jagged NestedTensor in the TensorDict: ``cat``,
+``reorder`` and ``chunk`` all require a regular dim-0. Per-sequence numpy
+blocks in ``non_tensor_batch`` support those ops and only carry attended
+tokens. Consumers that still expect a tensor go through
+:func:`ragged_routed_experts_to_nested` (or the dense unpad adapter) at the
+worker boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+ROUTER_REPLAY_UNRECORDED = -1
+
+
+def unrecorded_fill_value(dtype: torch.dtype) -> int:
+    """Sentinel for a token the rollout never ran through MoE.
+
+    Unsigned dtypes cannot hold ``-1``; 0 is the only value that does not wrap
+    into a legal expert id.
+    """
+    if dtype.is_floating_point:
+        return ROUTER_REPLAY_UNRECORDED
+    return ROUTER_REPLAY_UNRECORDED if torch.iinfo(dtype).min < 0 else 0
+
+
+def pack_padded_routed_experts(rows: list[Any], attention_mask: torch.Tensor) -> np.ndarray:
+    """Strip config padding from per-sample routed-experts tensors.
+
+    Each input row is ``[1, seq, layers, topk]`` or ``[seq, layers, topk]`` with
+    ``seq == attention_mask.shape[1]``. The result is an object array of
+    ``[attended_i, layers, topk]`` numpy blocks, one per sample.
+    """
+    if any(row is None for row in rows):
+        raise ValueError(
+            "routed_experts is present on some samples of this chunk but not all; "
+            "a partial routing payload cannot be replayed consistently."
+        )
+    seq_len = int(attention_mask.shape[1])
+    packed = np.empty(len(rows), dtype=object)
+    for i, row in enumerate(rows):
+        row_tensor = torch.as_tensor(row)
+        if row_tensor.ndim == 4 and row_tensor.shape[0] == 1:
+            row_tensor = row_tensor[0]
+        if row_tensor.ndim != 3 or row_tensor.shape[0] != seq_len:
+            raise ValueError(
+                f"routed_experts sample {i} has shape {tuple(row_tensor.shape)}; expected "
+                f"(1, {seq_len}, layers, topk) or ({seq_len}, layers, topk)."
+            )
+        packed[i] = row_tensor[attention_mask[i].bool()].cpu().numpy()
+
+    attended = attention_mask.sum(dim=1).tolist()
+    mismatched = [
+        (i, int(packed[i].shape[0]), int(n)) for i, n in enumerate(attended) if int(packed[i].shape[0]) != int(n)
+    ]
+    if mismatched:
+        raise AssertionError(
+            "ragged routed_experts row count != attended tokens for "
+            f"{len(mismatched)} of {len(attended)} sequences "
+            f"(first offenders, as (index, rows, attended): {mismatched[:5]})."
+        )
+    return packed
+
+
+def _as_row_list(value: Any) -> list[Any] | None:
+    """Per-sequence rows from a ragged container, or None if this is not one."""
+    if isinstance(value, np.ndarray) and value.dtype == object:
+        return list(value)
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return None
+
+
+def ragged_routed_experts_to_nested(routed_experts: Any, cu_seqlens: torch.Tensor) -> Any:
+    """Rebuild ragged ``routed_experts`` into a jagged nested tensor.
+
+    Dense tensors (including already-nested ones) are returned unchanged so the
+    caller can keep the historical unpad path. ``cu_seqlens`` must match the
+    ``unpad_input`` offsets for ``input_ids``; a row-count mismatch would replay
+    every later token against the wrong experts.
+    """
+    if routed_experts is None or isinstance(routed_experts, torch.Tensor):
+        return routed_experts
+
+    try:
+        from tensordict.tensorclass import NonTensorData, NonTensorStack
+    except ImportError:  # pragma: no cover
+        NonTensorData = ()  # type: ignore[assignment]
+        NonTensorStack = ()  # type: ignore[assignment]
+
+    if isinstance(routed_experts, NonTensorStack):
+        rows = routed_experts.tolist()
+    elif isinstance(routed_experts, NonTensorData):
+        rows = _as_row_list(routed_experts.data)
+    else:
+        rows = _as_row_list(routed_experts)
+    if rows is None:
+        raise TypeError(f"unsupported routed_experts type: {type(routed_experts)}")
+    if not rows:
+        return routed_experts
+
+    expected = cu_seqlens.diff().tolist()
+    if len(rows) != len(expected):
+        raise ValueError(
+            f"ragged routed_experts has {len(rows)} sequences but cu_seqlens describes "
+            f"{len(expected)}; the rollout payload does not match this batch."
+        )
+    actual = [int(np.asarray(row).shape[0]) for row in rows]
+    if actual != [int(n) for n in expected]:
+        bad = [(i, a, int(e)) for i, (a, e) in enumerate(zip(actual, expected, strict=True)) if a != int(e)]
+        raise ValueError(
+            f"ragged routed_experts row counts disagree with cu_seqlens for {len(bad)} of "
+            f"{len(rows)} sequences (first offenders, as (index, rows, expected): {bad[:5]})."
+        )
+
+    values = np.concatenate([np.asarray(row) for row in rows], axis=0)
+    if not values.flags.writeable:
+        values = values.copy()
+    return torch.nested.nested_tensor_from_jagged(torch.from_numpy(values), offsets=cu_seqlens)
+
+
+def has_rollout_routed_experts(batch: Any) -> bool:
+    """True when the batch carries rollout routing, in either representation."""
+    tensor_batch = getattr(batch, "batch", None)
+    if tensor_batch is not None and "routed_experts" in tensor_batch.keys():
+        return True
+    non_tensor = getattr(batch, "non_tensor_batch", None) or {}
+    return "routed_experts" in non_tensor
+
+
+def rollout_and_actor_routed_experts_conflict(batch: Any, old_log_prob: Any) -> bool:
+    """R2 (actor-recorded) and R3 (rollout-recorded) routing present together."""
+    actor_batch = getattr(old_log_prob, "batch", None)
+    actor_has = actor_batch is not None and "routed_experts" in actor_batch.keys()
+    return has_rollout_routed_experts(batch) and actor_has
+
+
+def get_routed_experts_from_data_proto(data: Any) -> Any:
+    """Prefer the TensorDict copy, then the ragged ``non_tensor_batch`` copy."""
+    tensor_batch = getattr(data, "batch", None)
+    if tensor_batch is not None and "routed_experts" in tensor_batch.keys():
+        return tensor_batch.get("routed_experts")
+    non_tensor = getattr(data, "non_tensor_batch", None) or {}
+    return non_tensor.get("routed_experts", None)

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -18,6 +18,7 @@ from tensordict import TensorDict
 
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
+from verl.utils.routed_experts import ragged_routed_experts_to_nested
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
@@ -70,13 +71,14 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
     data["position_ids"] = position_ids_nested
     data["loss_mask"] = data["response_mask"]
 
-    routed_experts = data.get("routed_experts", None)
-    if routed_experts is not None and not routed_experts.is_nested:
+    routed_experts = ragged_routed_experts_to_nested(data.get("routed_experts", None), cu_seqlens)
+    if routed_experts is not None and isinstance(routed_experts, torch.Tensor) and routed_experts.is_nested:
+        data["routed_experts"] = routed_experts
+    elif routed_experts is not None and isinstance(routed_experts, torch.Tensor):
         routed_experts_rmpad = index_first_axis(routed_experts.unsqueeze(-1).flatten(0, 1), indices)
-        routed_experts_nested = torch.nested.nested_tensor_from_jagged(
+        data["routed_experts"] = torch.nested.nested_tensor_from_jagged(
             routed_experts_rmpad.squeeze(-1), offsets=cu_seqlens
         )
-        data["routed_experts"] = routed_experts_nested
 
     # (bsz, seqlen, topk)
     teacher_logprobs = data.get("teacher_logprobs", None)


### PR DESCRIPTION
### What does this PR do?

Ship rollout `routed_experts` on the driver as one numpy block per sequence in `non_tensor_batch`, sized to **attended tokens**, instead of a dense TensorDict tensor padded to the configured `prompt_length + response_length`. Worker unpad still accepts the previous dense tensor and rebuilds the same jagged NestedTensor. Positions the rollout never ran through MoE use a signed sentinel (`-1`) instead of expert 0.

This does **not** reintroduce int16 (`#7407`) or NestedTensor unpad (`#5240`); both are already on main. The leftover is the driver/wire representation: `_postprocess` still did `torch.cat` of ceiling-sized `[1, prompt+response, layers, topk]` tensors. Jagged NestedTensor cannot live in that TensorDict because `DataProto.concat` / `reorder` / `chunk` need a regular dim-0.

Related: `#5240`, `#7407`, `#6211` (transfer cost of padded routing), `#7158` / `#5519` (dtype/writability of the same payload).

### Checklist Before Starting

- [x] Search for similar PRs. Queries: [routed_experts](https://github.com/verl-project/verl/pulls?q=is%3Apr+routed_experts), [open routed_experts](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+routed_experts), [ragged routed](https://github.com/verl-project/verl/pulls?q=is%3Apr+ragged+routed_experts). Open hits (`#4517`, `#5506`) are AgentData / VL pad-size issues, not this transport. `#5240` already landed NestedTensor unpad; `#7407` already landed int16.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
PYTHONPATH=. python -m pytest -q \
  tests/utils/test_routed_experts_ragged_on_cpu.py \
  tests/utils/test_padding_on_cpu.py \
  tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py \
  tests/experimental/agent_loop/test_as_dict_routed_experts_sentinel_on_cpu.py
# 40 passed
```

Covered contracts:

- pack strips config padding and keeps the final-token unrecorded sentinel
- partial payloads and seq-length mismatches fail closed
- ragged → nested matches `unpad_input` offsets; row-count drift is rejected
- dense TensorDict path still unpads (adapter)
- `DataProto.concat` / `reorder` / `chunk` keep per-row blocks
- R2 (actor-recorded) vs R3 (rollout-recorded) conflict still fires when rollout routing lives in `non_tensor_batch`
- MoE load-balance metrics on ragged rows match the dense drop-last counts
- `AgentLoopOutput.as_dict` stays int16 and pads the tail with the sentinel, including read-only `np.frombuffer` input

No GPU/training run in this PR. The CPU tests exercise the actual pack/unpad helpers and DataProto ops, not mocked doubles of those helpers.

### API and Usage Example

No config or CLI change. Rollout routing replay (`enable_rollout_routing_replay=True`) keeps working; the payload is just smaller on the driver. Engine `prepare_model_inputs` still sees a jagged NestedTensor after `left_right_2_no_padding`.

Callers that read `batch.batch["routed_experts"]` on the driver should also look at `batch.non_tensor_batch["routed_experts"]`. `get_routed_experts_from_data_proto` does that.

### Design & Code Changes

- `AgentLoopWorker._postprocess` writes ragged rows into `non_tensor_batch` instead of `torch.cat` into the TensorDict.
- `_run_agent_loop` / `as_dict` fill unrecorded slots with `-1` (int16), not expert 0.
- `left_right_2_no_padding` converts ragged rows with the same `cu_seqlens` as `input_ids`; dense tensors keep the existing unpad path.
- Synthetic TransferQueue padding samples mirror the source representation (numpy row or tensor) and use the sentinel.
- R2/R3 exclusivity and MoE load-balance metrics see both representations.

Omega workspace sizing and Abbie-specific engine changes are intentionally out of this PR.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Per-file Ruff lint/format on the changed paths passed.
- [ ] Repository-wide pre-commit / CI — not run locally (no project venv in this worktree).
- [ ] Documentation — no public API/configuration change; behavior is internal to the routing payload.
- [x] CPU unit tests added; they are collected by the existing `cpu_unit_tests.yml` `test_*_on_cpu.py` glob.
- [ ] `ci-request` message — will send after CI is enabled on this PR.
- [x] Recipe submodule — not applicable.

### AI assistance disclosure

Grok assisted with porting, tests, and this description. The human submitter reviews every changed line before merge; agent review is not represented as human review.