### PR TITLE
[sglang, rollout] fix: block sampled vision placeholders

### DIFF
--- a/tests/workers/rollout/test_sglang_vision_placeholder_ban_on_cpu.py
+++ b/tests/workers/rollout/test_sglang_vision_placeholder_ban_on_cpu.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SGLang follow-up to #7038: ban sampled vision placeholders via custom logits."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("sglang")
+
+from sglang.srt.sampling.custom_logit_processor import (
+    CustomLogitProcessor,
+    DisallowedTokensLogitsProcessor,
+)
+
+from verl.workers.rollout.sglang_rollout.async_sglang_server import (
+    _merge_banned_token_params,
+    _resolve_enable_custom_logit_processor,
+)
+
+IMAGE_PAD = 151655
+VIDEO_PAD = 151656
+
+
+class TestMergeBannedTokenParams:
+    def test_preserves_unrelated_custom_params(self):
+        params = {"custom_params": {"processor_mode": "strict"}}
+        _merge_banned_token_params(params, [7, 9])
+        assert params["custom_params"] == {"processor_mode": "strict", "token_ids": [7, 9]}
+
+    def test_accepts_identical_caller_token_ids(self):
+        params = {"custom_params": {"token_ids": [7, 9]}}
+        _merge_banned_token_params(params, [7, 9])
+        assert params["custom_params"]["token_ids"] == [7, 9]
+
+    def test_rejects_conflicting_caller_token_ids(self):
+        params = {"custom_params": {"token_ids": [3]}}
+        with pytest.raises(ValueError, match="conflicts with the vision placeholder ban"):
+            _merge_banned_token_params(params, [7, 9])
+
+    def test_rejects_non_mapping_custom_params(self):
+        with pytest.raises(TypeError, match="must be a mapping"):
+            _merge_banned_token_params({"custom_params": [1, 2]}, [7])
+
+
+class TestLaunchFlagAgreesWithRequest:
+    def test_bans_force_the_flag_on(self):
+        assert _resolve_enable_custom_logit_processor([IMAGE_PAD], {}) is True
+
+    def test_text_only_leaves_user_flag_on(self):
+        assert _resolve_enable_custom_logit_processor([], {"enable_custom_logit_processor": True}) is True
+
+    def test_text_only_without_user_flag_stays_off(self):
+        assert _resolve_enable_custom_logit_processor([], {}) is False
+
+    def test_explicit_false_conflicts_when_ids_are_banned(self):
+        with pytest.raises(ValueError, match="enable_custom_logit_processor=False"):
+            _resolve_enable_custom_logit_processor([IMAGE_PAD, VIDEO_PAD], {"enable_custom_logit_processor": False})
+
+
+class TestDisallowedTokensLogitsProcessor:
+    def _apply(self, logits, banned_token_ids):
+        processor = CustomLogitProcessor.from_str(DisallowedTokensLogitsProcessor.to_str())
+        custom_params = {"token_ids": banned_token_ids}
+        return processor(logits, [custom_params] * logits.shape[0])
+
+    def test_banned_columns_are_masked_and_the_rest_survive(self):
+        vocab_size = 151680
+        logits = torch.randn(4, vocab_size)
+        original = logits.clone()
+        masked = self._apply(logits, [IMAGE_PAD, VIDEO_PAD])
+        assert torch.isneginf(masked[:, IMAGE_PAD]).all()
+        assert torch.isneginf(masked[:, VIDEO_PAD]).all()
+        keep = torch.ones(vocab_size, dtype=torch.bool)
+        keep[[IMAGE_PAD, VIDEO_PAD]] = False
+        torch.testing.assert_close(masked[:, keep], original[:, keep])
+
+    def test_a_banned_id_can_never_win_the_argmax(self):
+        logits = torch.full((2, 32), -10.0)
+        logits[:, 7] = 100.0
+        logits[:, 3] = 1.0
+        masked = self._apply(logits, [7])
+        assert masked.argmax(dim=-1).tolist() == [3, 3]
+
+
+class TestGenerateReqInputCarriesProcessor:
+    def test_request_keeps_processor_string_and_token_ids(self):
+        from sglang.srt.managers.io_struct import GenerateReqInput
+
+        banned = [IMAGE_PAD, VIDEO_PAD]
+        sampling_params = {"max_new_tokens": 8, "custom_params": {"token_ids": banned}}
+        request = GenerateReqInput(
+            rid="req-0",
+            input_ids=[1, 2, 3],
+            sampling_params=sampling_params,
+            custom_logit_processor=DisallowedTokensLogitsProcessor.to_str(),
+        )
+        request.normalize_batch_and_arguments()
+        processor_str = request.custom_logit_processor
+        if isinstance(processor_str, list):
+            assert len(processor_str) == 1
+            processor_str = processor_str[0]
+        assert processor_str == DisallowedTokensLogitsProcessor.to_str()
+        assert request.sampling_params["custom_params"] == {"token_ids": banned}

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import secrets
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Optional
 
@@ -41,6 +42,7 @@ from sglang.srt.managers.io_struct import (
     ResumeMemoryOccupationReqInput,
 )
 from sglang.srt.managers.tokenizer_manager import ServerStatus
+from sglang.srt.sampling.custom_logit_processor import DisallowedTokensLogitsProcessor
 
 from verl.plugin.platform import get_platform
 from verl.utils.config import omega_conf_to_dataclass
@@ -62,12 +64,48 @@ from verl.workers.rollout.sglang_rollout.utils import (
     lora_served_as_adapter,
     sglang_lora_target_modules,
 )
-from verl.workers.rollout.utils import get_max_position_embeddings, run_uvicorn
+from verl.workers.rollout.utils import (
+    get_max_position_embeddings,
+    get_vision_placeholder_token_ids,
+    run_uvicorn,
+)
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
 
 visible_devices_keyword = get_visible_devices_keyword()
+
+
+def _merge_banned_token_params(sampling_params: dict[str, Any], banned_token_ids: list[int]) -> None:
+    """Attach banned token ids without dropping caller-defined custom_params."""
+    current = sampling_params.get("custom_params")
+    if current is None:
+        custom_params: dict[str, Any] = {}
+    elif not isinstance(current, Mapping):
+        raise TypeError("sampling_params.custom_params must be a mapping when banned token ids are enabled")
+    else:
+        custom_params = dict(current)
+
+    configured_ids = custom_params.get("token_ids")
+    if configured_ids is not None and list(configured_ids) != list(banned_token_ids):
+        raise ValueError(
+            "sampling_params.custom_params.token_ids conflicts with the vision placeholder ban; "
+            "remove the custom value or make the lists identical"
+        )
+    custom_params["token_ids"] = list(banned_token_ids)
+    sampling_params["custom_params"] = custom_params
+
+
+def _resolve_enable_custom_logit_processor(banned_token_ids: list[int], engine_kwargs: dict[str, Any]) -> bool:
+    """Launch flag and per-request processor must agree, or SGLang rejects every request."""
+    if banned_token_ids and engine_kwargs.get("enable_custom_logit_processor") is False:
+        raise ValueError(
+            "engine_kwargs.sglang.enable_custom_logit_processor=False conflicts with "
+            f"{len(banned_token_ids)} banned vision placeholder id(s) {sorted(banned_token_ids)}. "
+            "SGLang would reject every request that carries the logits processor. "
+            "Drop that engine_kwargs override."
+        )
+    return bool(banned_token_ids) or bool(engine_kwargs.get("enable_custom_logit_processor"))
 
 
 def _extract_prompt_logprobs_sglang(
@@ -172,6 +210,10 @@ class SGLangHttpServer:
                     f"max_model_len ({self.config.max_model_len}) should be less than or equal to "
                     f"max_position_embeddings ({max_position_embeddings})"
                 )
+        self._banned_token_ids = get_vision_placeholder_token_ids(self.model_config.processor)
+        self._banned_logit_processor_str = DisallowedTokensLogitsProcessor.to_str() if self._banned_token_ids else None
+        if self._banned_token_ids:
+            logger.info(f"SGLang rollout: banning token ids {self._banned_token_ids} from being sampled")
         self.rollout_mode = rollout_mode
         self.workers = workers
 
@@ -337,8 +379,12 @@ class SGLangHttpServer:
             if quantization == "fp8"
             else json.dumps({}),
             "custom_weight_loader": custom_weight_loader or None,
+            "enable_custom_logit_processor": bool(self._banned_token_ids),
             **engine_kwargs,
         }
+        args["enable_custom_logit_processor"] = _resolve_enable_custom_logit_processor(
+            self._banned_token_ids, engine_kwargs
+        )
 
         # update lora-related args
         if self.lora_as_adapter:
@@ -612,6 +658,8 @@ class SGLangHttpServer:
             f"max_new_tokens {max_new_tokens} exceeds available context space {max_possible_tokens}"
         )
         sampling_params["max_new_tokens"] = max_new_tokens
+        if self._banned_token_ids:
+            _merge_banned_token_params(sampling_params, self._banned_token_ids)
         return_logprob = sampling_params.pop("logprobs", False)
 
         # vLLM-style "prompt_logprobs=K" from the distillation teacher: request
@@ -630,6 +678,8 @@ class SGLangHttpServer:
             # TODO: support video input for sglang
             # video_data=video_data,
         }
+        if self._banned_logit_processor_str:
+            request["custom_logit_processor"] = self._banned_logit_processor_str
 
         if prompt_logprobs is not None:
             request["logprob_start_len"] = 0


### PR DESCRIPTION
### What does this PR do?

Stops SGLang rollout from sampling `<|image_pad|>` / `<|video_pad|>` when no image or video backs them.

#7038 already does this for **vLLM**. That PR's description says the ban is installed in the vLLM engine and that SGLang still needs follow-up. This is that follow-up:

- Resolve the same ids with `get_vision_placeholder_token_ids` (processor only; empty for text-only).
- Serialize SGLang's built-in `DisallowedTokensLogitsProcessor` once per VL server.
- Pass it on `GenerateReqInput.custom_logit_processor` and the ids on `sampling_params.custom_params.token_ids`.
- Force `enable_custom_logit_processor` on when ids are banned, and reject an explicit `False` (SGLang's tokenizer_manager would otherwise reject every request).
- Merge existing `custom_params` rather than overwriting them.

Prompt placeholders are unchanged: a real image in the prompt still means what it always meant.

Related: #7038 (landed, vLLM-only). Closed #7515 attempted this; the first revision was an AgentLoop `get_rope_index` fallback and was closed. The author later reworked the fork to the sampling-layer ban but could not reopen. This PR is the sampling-layer approach, independently ported onto current `main`.

### Checklist Before Starting

- [x] Search for similar PRs: [get_vision_placeholder_token_ids](https://github.com/verl-project/verl/pulls?q=get_vision_placeholder_token_ids), [SGLang DisallowedTokens](https://github.com/verl-project/verl/pulls?q=is%3Apr+DisallowedTokens), [banned vision SGLang](https://github.com/verl-project/verl/pulls?q=is%3Apr+sglang+vision+placeholder). Open: none. Closed overlap: #7515. Merged: #7038 (vLLM).
- [x] Title follows `[{modules}] {type}: {description}`.

### Test

```bash
PYTHONPATH=. python -m pytest -q tests/workers/rollout/test_sglang_vision_placeholder_ban_on_cpu.py
# 11 passed (devbox CPU, and again on 1xH100 with sglang 0.5.14)
```

- merge of `custom_params` / conflict on `token_ids`
- launch-flag agreement (`False` vs banned ids)
- serialized `DisallowedTokensLogitsProcessor` masks only the banned columns
- greedy argmax cannot pick a banned id
- `GenerateReqInput` keeps the processor string after normalize

No full SGLang generate / VL training run in this PR.

### API and Usage Example

No new config keys. VL processors that already expose image/video token ids are banned automatically, matching #7038. Text-only processors stay untouched.

### Design & Code Changes

Only `async_sglang_server.py` plus CPU tests. vLLM path is unchanged.

### Checklist Before Submitting

- [x] Contribute guide.
- [x] Per-file pre-commit (ruff, mypy, license, compileall, …) passed on the changed paths.
- [ ] Repository-wide GitHub CI — fork PRs need `ci-request`.
- [ ] Docs — no public API/config change.
- [x] CPU tests added (`*_on_cpu.py`, collected by `cpu_unit_tests.yml`).
- [x] Recipe submodule — not applicable.

### AI assistance disclosure

Grok assisted with porting, tests, and this description. The human submitter reviews every changed line before merge.