### PR TITLE
[sglang, rollout] fix: restore clipped multimodal prompt-logprob ids

### DIFF
--- a/tests/workers/rollout/test_sglang_prompt_logprob_mm_alias_on_cpu.py
+++ b/tests/workers/rollout/test_sglang_prompt_logprob_mm_alias_on_cpu.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SGLang prompt-logprob metadata may echo an internal visual pad id (or 0)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from verl.workers.rollout.sglang_rollout.async_sglang_server import (
+    _extract_prompt_logprobs_sglang,
+    _record_prompt_logprob_id_aliases,
+)
+
+IMAGE_PAD = 99
+HASH_PAD = 1_222_222
+
+
+class _FakeImageItem:
+    def __init__(self, offsets, pad_value=HASH_PAD):
+        self.offsets = offsets
+        self.pad_value = pad_value
+
+    def set_pad_value(self):
+        if self.pad_value is None:
+            self.pad_value = HASH_PAD
+
+
+def test_aliases_are_limited_to_concrete_multimodal_offsets():
+    request = SimpleNamespace()
+    mm_inputs = {
+        "input_ids": [10, IMAGE_PAD, 20],
+        "padded_input_ids": [1_111_111, HASH_PAD, 20],
+        "mm_items": [_FakeImageItem(offsets=[(1, 1)], pad_value=HASH_PAD)],
+    }
+
+    _record_prompt_logprob_id_aliases(mm_inputs, [10, IMAGE_PAD, 20], request, vocab_size=500)
+
+    assert request._verl_prompt_logprob_id_aliases == {1: {0, HASH_PAD}}
+
+
+def test_matching_padded_and_exact_ids_are_not_aliased():
+    request = SimpleNamespace()
+    mm_inputs = {
+        "input_ids": [10, IMAGE_PAD, 20],
+        "padded_input_ids": [10, IMAGE_PAD, 20],
+        "mm_items": [_FakeImageItem(offsets=[(1, 1)], pad_value=IMAGE_PAD)],
+    }
+
+    _record_prompt_logprob_id_aliases(mm_inputs, [10, IMAGE_PAD, 20], request, vocab_size=500)
+
+    assert request._verl_prompt_logprob_id_aliases == {}
+
+
+def test_text_tokens_next_to_a_span_are_not_aliased():
+    request = SimpleNamespace()
+    mm_inputs = {
+        "input_ids": [10, IMAGE_PAD, 20],
+        "padded_input_ids": [0, HASH_PAD, 0],
+        "mm_items": [_FakeImageItem(offsets=[(1, 1)])],
+    }
+
+    _record_prompt_logprob_id_aliases(mm_inputs, [10, IMAGE_PAD, 20], request, vocab_size=500)
+
+    assert request._verl_prompt_logprob_id_aliases == {1: {0, HASH_PAD}}
+
+
+def test_extract_restores_clipped_pad_id_and_keeps_logprobs():
+    request = SimpleNamespace()
+    sequence = [10, IMAGE_PAD, 20]
+    mm_inputs = {
+        "padded_input_ids": [10, HASH_PAD, 20],
+        "mm_items": [_FakeImageItem(offsets=[(1, 1)])],
+    }
+    _record_prompt_logprob_id_aliases(mm_inputs, sequence, request, vocab_size=500)
+
+    extra = {}
+    restored = _extract_prompt_logprobs_sglang(
+        meta_info={
+            "input_token_logprobs": [
+                (None, 10, None),
+                (-0.2, 0, None),
+                (-0.3, 20, None),
+            ]
+        },
+        num_prompt_logprobs=0,
+        sequence_ids=sequence,
+        result_dict=extra,
+        prompt_logprob_id_aliases=request._verl_prompt_logprob_id_aliases,
+    )
+
+    assert restored == 1
+    assert extra["prompt_ids"] == [[IMAGE_PAD], [20], [0]]
+    assert extra["prompt_logprobs"][0] == [pytest.approx(-0.2)]
+    assert extra["prompt_logprobs"][1] == [pytest.approx(-0.3)]
+
+
+def test_extract_fail_closes_on_an_unaliased_mismatch():
+    extra = {}
+    with pytest.raises(AssertionError, match="first_mismatch_index=1"):
+        _extract_prompt_logprobs_sglang(
+            meta_info={
+                "input_token_logprobs": [
+                    (None, 10, None),
+                    (-0.2, 0, None),
+                    (-0.3, 20, None),
+                ]
+            },
+            num_prompt_logprobs=0,
+            sequence_ids=[10, IMAGE_PAD, 20],
+            result_dict=extra,
+        )
+
+
+def test_extract_accepts_omitted_first_row():
+    extra = {}
+    restored = _extract_prompt_logprobs_sglang(
+        meta_info={
+            "input_token_logprobs": [
+                (-0.2, 11, None),
+                (-0.3, 12, None),
+            ]
+        },
+        num_prompt_logprobs=0,
+        sequence_ids=[10, 11, 12],
+        result_dict=extra,
+    )
+    assert restored == 0
+    assert extra["prompt_ids"] == [[11], [12], [0]]

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -70,37 +70,165 @@ logger.setLevel(logging.INFO)
 visible_devices_keyword = get_visible_devices_keyword()
 
 
+def _get_multimodal_processor_field(mm_inputs: Any, name: str, default: Any = None) -> Any:
+    if isinstance(mm_inputs, dict):
+        return mm_inputs.get(name, default)
+    return getattr(mm_inputs, name, default)
+
+
+def _as_token_id_list(input_ids: Any) -> Optional[list[int]]:
+    if input_ids is None:
+        return None
+    if isinstance(input_ids, torch.Tensor):
+        input_ids = input_ids.flatten().tolist()
+    else:
+        input_ids = list(input_ids)
+    return [int(token_id) for token_id in input_ids]
+
+
+def _record_prompt_logprob_id_aliases(
+    mm_inputs: Any,
+    exact_input_ids: list[int],
+    request_obj: Any,
+    vocab_size: Optional[int],
+    *,
+    materialize_pad_values: bool = False,
+) -> None:
+    """Record positions where SGLang substituted an internal multimodal pad id.
+
+    SGLang keeps hash pads in ``padded_input_ids`` for radix-cache identity, then
+    0.5.14 clips those out-of-vocabulary ids to 0 in prompt-logprob metadata.
+    Logprob values stay positional. Restore only ids recorded at concrete visual
+    offsets; a real vocabulary-tail token is left fail-closed.
+    """
+    aliases: dict[int, set[int]] = {}
+    mm_items = _get_multimodal_processor_field(mm_inputs, "mm_items") or []
+    if materialize_pad_values:
+        for item in mm_items:
+            if getattr(item, "pad_value", None) is None:
+                set_pad_value = getattr(item, "set_pad_value", None)
+                if callable(set_pad_value):
+                    set_pad_value()
+    multimodal_positions = {
+        position
+        for item in mm_items
+        for start, end in (item.offsets or [])
+        for position in range(int(start), int(end) + 1)
+    }
+    padded_input_ids = _as_token_id_list(_get_multimodal_processor_field(mm_inputs, "padded_input_ids"))
+    exact_input_ids = _as_token_id_list(exact_input_ids)
+    if exact_input_ids is not None and (padded_input_ids is None or len(padded_input_ids) != len(exact_input_ids)):
+        if mm_items and all(getattr(item, "pad_value", None) is not None for item in mm_items):
+            padded_input_ids = list(exact_input_ids)
+            for item in mm_items:
+                for start, end in item.offsets or []:
+                    start, end = int(start), int(end)
+                    padded_input_ids[start : end + 1] = [int(item.pad_value)] * (end - start + 1)
+    if padded_input_ids is not None and exact_input_ids is not None and len(padded_input_ids) == len(exact_input_ids):
+        for position, (exact_id, padded_id) in enumerate(zip(exact_input_ids, padded_input_ids, strict=True)):
+            if position not in multimodal_positions or padded_id == exact_id:
+                continue
+            accepted = {padded_id}
+            if vocab_size is not None and padded_id >= vocab_size - 1:
+                accepted.add(0)
+            aliases[position] = accepted
+    request_obj._verl_prompt_logprob_id_aliases = aliases
+
+
+def _install_prompt_logprob_id_alias_recording(tokenizer_manager: Any, vocab_size: Optional[int]) -> bool:
+    """Record pad-id aliases after SGLang tokenizes a multimodal prompt-logprob request."""
+    original = getattr(tokenizer_manager, "_tokenize_one_request", None)
+    if not callable(original) or getattr(tokenizer_manager, "_verl_prompt_logprob_id_aliases", False):
+        return False
+
+    async def tokenize_one_request_with_aliases(request_obj):
+        exact_input_ids = _as_token_id_list(getattr(request_obj, "input_ids", None))
+        tokenized_request = await original(request_obj)
+        mm_inputs = getattr(tokenized_request, "mm_inputs", None)
+        if mm_inputs is None:
+            mm_inputs = getattr(tokenized_request, "image_inputs", None)
+        if exact_input_ids is not None and mm_inputs is not None:
+            _record_prompt_logprob_id_aliases(
+                mm_inputs,
+                exact_input_ids,
+                request_obj,
+                vocab_size,
+                materialize_pad_values=True,
+            )
+        return tokenized_request
+
+    tokenizer_manager._tokenize_one_request = tokenize_one_request_with_aliases
+    tokenizer_manager._verl_prompt_logprob_id_aliases = True
+    return True
+
+
 def _extract_prompt_logprobs_sglang(
     meta_info: dict,
     num_prompt_logprobs: int,
-    sequence_length: int,
+    sequence_ids: Any,
     result_dict: dict[str, list],
-) -> None:
+    prompt_logprob_id_aliases: Optional[dict[int, set[int]]] = None,
+) -> int:
     """Shape SGLang input-logprobs into the vLLM ``extract_prompt_logprobs`` contract.
-    Populates ``result_dict`` with two ``[sequence_length, max(num_prompt_logprobs, 1)]``
-    lists — ``prompt_ids`` and ``prompt_logprobs`` — so the distillation teacher
-    consumer in ``teacher_manager.AsyncTeacherLLMServerManager`` can treat vLLM and
-    SGLang teachers interchangeably.
-    SGLang returns input logprobs with length ``S == len(input_ids)`` whose first
-    entry has ``logprob=None`` (no predicting context). That matches the vLLM
-    convention, so we skip entry 0 and append a trailing dummy row to keep the
-    total length equal to the consumer's ``len(sequence_ids)`` assertion.
+
+    SGLang may echo an internal multimodal pad id (or 0 after 0.5.14 clips it).
+    Restore only aliases recorded at concrete visual offsets for this request.
     """
+    sequence_ids = _as_token_id_list(sequence_ids)
+    assert sequence_ids is not None and sequence_ids, "Prompt-logprob extraction requires a non-empty sequence."
+    sequence_length = len(sequence_ids)
     input_token_logprobs = meta_info.get("input_token_logprobs") or []
     if num_prompt_logprobs > 0:
         input_top_logprobs = meta_info.get("input_top_logprobs") or []
+        assert len(input_top_logprobs) == len(input_token_logprobs), (
+            f"SGLang input_top_logprobs length ({len(input_top_logprobs)}) does not match "
+            f"input_token_logprobs length ({len(input_token_logprobs)})."
+        )
+
+    restored_aliases = 0
+
+    def align_returned_ids(returned_ids: list[int], expected_ids: list[int], offset: int) -> list[int]:
+        nonlocal restored_aliases
+        normalized_ids: list[int] = []
+        for local_index, (expected_id, returned_id) in enumerate(zip(expected_ids, returned_ids, strict=True)):
+            absolute_index = local_index + offset
+            if returned_id == expected_id:
+                normalized_ids.append(returned_id)
+            elif returned_id in (prompt_logprob_id_aliases or {}).get(absolute_index, set()):
+                normalized_ids.append(expected_id)
+                restored_aliases += 1
+            else:
+                raise AssertionError(
+                    "SGLang prompt-logprob token IDs do not match the request: "
+                    f"first_mismatch_index={absolute_index}, expected_id={expected_id}, "
+                    f"returned_id={returned_id}."
+                )
+        return normalized_ids
+
+    if len(input_token_logprobs) == sequence_length:
+        returned_ids = [int(entry[1]) for entry in input_token_logprobs]
+        normalized_returned_ids = align_returned_ids(returned_ids, sequence_ids, offset=0)
+        scored_positions = range(1, sequence_length)
+    elif len(input_token_logprobs) == sequence_length - 1:
+        returned_ids = [int(entry[1]) for entry in input_token_logprobs]
+        normalized_returned_ids = align_returned_ids(returned_ids, sequence_ids[1:], offset=1)
+        scored_positions = range(sequence_length - 1)
+    else:
+        raise AssertionError(
+            f"SGLang input_token_logprobs length ({len(input_token_logprobs)}) does not match sequence length "
+            f"({sequence_length}) or aligned omitted-first length ({sequence_length - 1})."
+        )
+
     prompt_ids_ls: list[list[int]] = []
     prompt_logprobs_ls: list[list[float]] = []
-    # Entry 0 has logprob=None (no predicting context); skip it, matching vLLM.
-    for position in range(1, len(input_token_logprobs)):
+    for position in scored_positions:
+        meta_index = position if len(input_token_logprobs) == sequence_length else position
         if num_prompt_logprobs == 0:
-            logprob, token_id, _ = input_token_logprobs[position]
-            prompt_ids_ls.append([int(token_id)])
+            logprob, _, _ = input_token_logprobs[meta_index]
+            prompt_ids_ls.append([normalized_returned_ids[meta_index]])
             prompt_logprobs_ls.append([float(logprob)])
         else:
-            top_entries = input_top_logprobs[position]
-            # SGLang returns ranked best-first; we preserve that ordering so rank
-            # 0 is the top-1 token, matching the vLLM extractor's rank-1 slot.
+            top_entries = input_top_logprobs[meta_index]
             ids = [int(tok_id) for _, tok_id, _ in top_entries]
             logprobs = [float(logprob) for logprob, _, _ in top_entries]
             assert len(ids) == num_prompt_logprobs, (
@@ -108,7 +236,6 @@ def _extract_prompt_logprobs_sglang(
             )
             prompt_ids_ls.append(ids)
             prompt_logprobs_ls.append(logprobs)
-    # Trailing dummy row so total length == len(sequence_ids), matching vLLM.
     pad_width = max(num_prompt_logprobs, 1)
     prompt_ids_ls.append([0] * pad_width)
     prompt_logprobs_ls.append([0.0] * pad_width)
@@ -118,6 +245,7 @@ def _extract_prompt_logprobs_sglang(
     )
     result_dict["prompt_ids"] = prompt_ids_ls
     result_dict["prompt_logprobs"] = prompt_logprobs_ls
+    return restored_aliases
 
 
 class SGLangHttpServer:
@@ -476,6 +604,12 @@ class SGLangHttpServer:
 
         self._server_port, self._server_task = await run_uvicorn(app, server_args, self._server_address)
         self.tokenizer_manager.server_status = ServerStatus.Up
+        tokenizer = getattr(self.model_config, "tokenizer", None)
+        try:
+            vocab_size = len(tokenizer) if tokenizer is not None else None
+        except TypeError:
+            vocab_size = None
+        _install_prompt_logprob_id_alias_recording(self.tokenizer_manager, vocab_size)
 
     async def wake_up(self):
         if self.node_rank != 0:
@@ -701,8 +835,9 @@ class SGLangHttpServer:
             _extract_prompt_logprobs_sglang(
                 meta_info=meta_info,
                 num_prompt_logprobs=prompt_logprobs,
-                sequence_length=len(prompt_ids),
+                sequence_ids=prompt_ids,
                 result_dict=extra_fields,
+                prompt_logprob_id_aliases=getattr(generate_request, "_verl_prompt_logprob_id_aliases", None),
             )
 
         # Re-key backend spec-decoding stats to the rollout-common names.


### PR DESCRIPTION
### What does this PR do?

SGLang keeps multimodal hash pads in `padded_input_ids` for radix-cache identity. On 0.5.14 those out-of-vocabulary ids are clipped to 0 in prompt-logprob metadata, so distillation sees the wrong token at visual positions even though the logprob values stay positional.

Record the concrete visual offsets on the request after tokenization, then restore the canonical ids at extract time. Positions whose padded and exact ids already agree are not aliased, so a real vocabulary-tail token stays fail-closed.

This is the SGLang half of internal `88be5d463d`. The Megatron fused VLM SP-pad alignment is a separate PR.

### Checklist Before Starting

- [x] Search: [prompt logprob multimodal](https://github.com/verl-project/verl/pulls?q=prompt+logprob+multimodal), [padded_input_ids](https://github.com/verl-project/verl/pulls?q=padded_input_ids), [vision pad logprob](https://github.com/verl-project/verl/pulls?q=is%3Apr+vision+pad+logprob). No open overlap.
- [x] Title format.

### Test

```bash
PYTHONPATH=. python -m pytest -q tests/workers/rollout/test_sglang_prompt_logprob_mm_alias_on_cpu.py
# 6 passed on CPU and on 1xH100 (sglang 0.5.14 + CUDA)
```

No full VL generate in this PR.

### API and Usage Example

No config change. Prompt-logprob distillation on SGLang VL teachers gets canonical image/video placeholder ids back.

### Checklist Before Submitting

- [x] Contribute guide / per-file pre-commit on changed paths.
- [ ] GitHub CI — fork PRs need `ci-request`.
- [x] CPU tests added.

### AI assistance disclosure

Grok assisted with porting, tests, and this description. The human submitter reviews every changed line before merge.