### PR TITLE
[megatron, model] fix: pad one-row VLM SP batches for fused forward

### DIFF
--- a/tests/models/test_build_vlm_attn_mask_thd_on_cpu.py
+++ b/tests/models/test_build_vlm_attn_mask_thd_on_cpu.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""One-row VLM + sequence-parallel must pack as B>1 before TP scatter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import verl.models.mcore.util as mcore_util
+from verl.models.mcore.model_forward_fused import fused_forward_model_engine
+from verl.models.mcore.util import build_vlm_attn_mask_thd
+
+
+class _FakeMpu:
+    def __init__(self, tp: int = 1, cp: int = 1, cp_rank: int = 0):
+        self._tp, self._cp, self._cp_rank = tp, cp, cp_rank
+
+    def get_tensor_model_parallel_world_size(self):
+        return self._tp
+
+    def get_context_parallel_world_size(self):
+        return self._cp
+
+    def get_context_parallel_rank(self):
+        return self._cp_rank
+
+
+@pytest.fixture
+def parallel_state(monkeypatch):
+    def _set(tp=1, cp=1):
+        monkeypatch.setattr(mcore_util, "mpu", _FakeMpu(tp=tp, cp=cp))
+
+    return _set
+
+
+def _nested(rows, dtype=torch.long):
+    return torch.nested.nested_tensor([torch.tensor(r, dtype=dtype) for r in rows], layout=torch.jagged)
+
+
+def test_a_one_row_vlm_sp_batch_forces_pack_then_scatter(parallel_state):
+    parallel_state(tp=4, cp=1)
+    input_ids = _nested([[1, 2, 3, 4, 5]])
+
+    bshd, attention_mask = build_vlm_attn_mask_thd(input_ids, pad_token_id=0, sequence_parallel=True)
+
+    assert bshd.shape == (2, 8)
+    assert attention_mask.shape == bshd.shape
+    assert attention_mask[0].tolist() == [True, True, True, True, True, False, False, False]
+    assert not attention_mask[1].any()
+    assert not bshd[1].any()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+def test_a_one_row_vlm_sp_batch_stays_on_cuda(parallel_state):
+    parallel_state(tp=4, cp=1)
+    row = torch.tensor([1, 2, 3, 4, 5], dtype=torch.long, device="cuda")
+    input_ids = torch.nested.nested_tensor([row], layout=torch.jagged)
+    bshd, attention_mask = build_vlm_attn_mask_thd(input_ids, pad_token_id=0, sequence_parallel=True)
+    assert bshd.device.type == "cuda"
+    assert attention_mask.device.type == "cuda"
+    assert bshd.shape == (2, 8)
+    assert not attention_mask[1].any()
+
+
+def test_a_one_row_vlm_batch_without_sp_stays_batch_one(parallel_state):
+    parallel_state(tp=4, cp=1)
+    input_ids = _nested([[1, 2, 3, 4, 5]])
+
+    bshd, attention_mask = build_vlm_attn_mask_thd(input_ids, pad_token_id=0, sequence_parallel=False)
+
+    assert bshd.shape == (1, 8)
+    assert attention_mask.shape == (1, 8)
+    assert attention_mask[0].sum().item() == 5
+
+
+@pytest.mark.parametrize(("sequence_parallel", "expected_shape"), [(True, (2, 8)), (False, (1, 8))])
+def test_fused_vlm_forward_uses_the_aligned_bshd_contract(parallel_state, sequence_parallel, expected_shape):
+    parallel_state(tp=4, cp=1)
+
+    class Model:
+        pre_process = True
+        post_process = False
+        config = SimpleNamespace(fp8=None, sequence_parallel=sequence_parallel)
+
+        def __call__(self, **kwargs):
+            input_ids = kwargs["input_ids"]
+            attention_mask = kwargs["attention_mask"]
+            assert input_ids.shape == expected_shape
+            assert attention_mask.shape == input_ids.shape
+            assert attention_mask[0].sum().item() == 5
+            if sequence_parallel:
+                assert not attention_mask[1].any()
+            return "model-output"
+
+    forward = fused_forward_model_engine(vision_model=True)
+    result = forward(
+        Model(),
+        input_ids=_nested([[1, 2, 3, 4, 5]]),
+        labels=_nested([[2, 3, 4, 5, 6]]),
+        multi_modal_inputs={},
+        temperature=1.0,
+        calculate_entropy=False,
+        pad_token_id=0,
+    )
+    assert result == "model-output"

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -305,7 +305,10 @@ def fused_forward_model_engine(vision_model: bool = False):
 
         attention_mask = None
         if vision_model:
-            input_ids_rmpad, attention_mask = build_vlm_attn_mask_thd(input_ids, pad_token_id)
+            sequence_parallel = bool(getattr(unwrap_model(model).config, "sequence_parallel", False))
+            input_ids_rmpad, attention_mask = build_vlm_attn_mask_thd(
+                input_ids, pad_token_id, sequence_parallel=sequence_parallel
+            )
 
         labels_rmpad, _, _ = preprocess_thd_engine(
             labels,

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -848,7 +848,7 @@ def postprocess_bshd_engine(
     return output_new_tensor
 
 
-def build_vlm_attn_mask_thd(input_ids: torch.Tensor, pad_token_id: int = None):
+def build_vlm_attn_mask_thd(input_ids: torch.Tensor, pad_token_id: int = None, sequence_parallel: bool = False):
     seqlens_in_batch = input_ids.offsets().diff()
 
     # Align to TP/CP so ``combined_embeddings`` is divisible by tp_size before
@@ -861,7 +861,17 @@ def build_vlm_attn_mask_thd(input_ids: torch.Tensor, pad_token_id: int = None):
         max_seqlen += (align_size - max_seqlen % align_size) % align_size
 
     batch_size = input_ids.shape[0]
-    input_ids_with_pad = input_ids.to_padded_tensor(pad_token_id, output_size=(batch_size, max_seqlen))
+    pad_id = 0 if pad_token_id is None else pad_token_id
+    input_ids_with_pad = input_ids.to_padded_tensor(pad_id, output_size=(batch_size, max_seqlen))
+    # Qwen3-VL packs-then-scatters only when B>1. A one-row SP batch would scatter dim0=1.
+    if sequence_parallel and batch_size == 1:
+        dummy = torch.full(
+            (1, max_seqlen),
+            pad_id,
+            dtype=input_ids_with_pad.dtype,
+            device=input_ids_with_pad.device,
+        )
+        input_ids_with_pad = torch.cat([input_ids_with_pad, dummy], dim=0)
     attention_mask = torch.zeros_like(input_ids_with_pad, dtype=torch.bool)
     for i, seqlen in enumerate(seqlens_in_batch):
         attention_mask[i, :seqlen] = True


### PR DESCRIPTION
### What does this PR do?

Qwen3-VL packs-then-scatters `combined_embeddings` only when `B>1`. A one-row sequence-parallel fused forward would scatter `dim0=1`. `build_vlm_attn_mask_thd` now appends a dummy pad row when `sequence_parallel=True` and `B==1`. `fused_forward_model_engine` reads `model.config.sequence_parallel` and passes it through.

The existing Megatron `output_processor` hook is unchanged.

This is the Megatron half of internal `88be5d463d`. The SGLang prompt-logprob visual-pad ID restore is a separate PR.

### Checklist Before Starting

- [x] Search: [build_vlm_attn_mask_thd](https://github.com/verl-project/verl/pulls?q=build_vlm_attn_mask_thd), [fused VLM](https://github.com/verl-project/verl/pulls?q=is%3Apr+fused+VLM), [sequence_parallel vision](https://github.com/verl-project/verl/pulls?q=is%3Apr+sequence_parallel+vision). No open overlap. Main already calls `build_vlm_attn_mask_thd` in the fused engine path (#6933-era output-processor); this adds the missing SP dummy row.
- [x] Title format.

### Test

```bash
PYTHONPATH=. python -m pytest -q tests/models/test_build_vlm_attn_mask_thd_on_cpu.py
# 4 passed + 1 skip on CPU; 5 passed on 1xH100 including the CUDA nested-tensor case
```

Existing `tests/models/test_model_forward_fused.py` still 8 passed.

### API and Usage Example

No config change. Fused VLM + sequence parallel one-row microbatches get a legal pack-then-scatter batch.

### Checklist Before Submitting

- [x] Contribute guide / per-file pre-commit on changed paths.
- [ ] GitHub CI — fork PRs need `ci-request`.
- [x] CPU + CUDA unit tests added.

### AI assistance disclosure

Grok assisted with porting, tests, and this description. The human submitter reviews every changed line before merge.