### PR TITLE
[worker, model] feat: add dense Qwen3 critic support to TorchTitan

### DIFF
--- a/docs/workers/torchtitan_workers.rst
+++ b/docs/workers/torchtitan_workers.rst
@@ -1,11 +1,11 @@
 TorchTitan Backend
 ==================
 
-Last updated: 07/08/2026.
+Last updated: 09/12/2026.
 
 We support the `TorchTitan <https://github.com/pytorch/torchtitan>`_ backend by
-implementing the ``TorchTitanEngine`` and ``TorchTitanEngineWithLMHead`` engine
-classes. The TorchTitan backend delegates model building, parallelization
+implementing the ``TorchTitanEngine``, ``TorchTitanEngineWithLMHead``, and
+``TorchTitanEngineWithValueHead`` engine classes. The TorchTitan backend delegates model building, parallelization
 (FSDP2 / TP / CP / EP), optimizer construction and sharding, LR scheduling,
 gradient clipping, and checkpointing to TorchTitan's infrastructure, while using
 verl's own training loop (``forward_backward_batch``), data pipeline, and loss
@@ -133,3 +133,52 @@ To mirror ``FSDP_SIZE=2 TP_SIZE=2`` on 4 GPUs:
 .. code:: shell
 
    NUM_GPUS=4 FSDP_SIZE=2 TP_SIZE=2 bash tests/special_e2e/run_ppo_trainer_torchtitan.sh
+
+PPO critic
+----------
+
+The TorchTitan backend also provides ``TorchTitanEngineWithValueHead`` for a
+dense Qwen3 critic. With ``model_engine=torchtitan``, choosing
+``algorithm.adv_estimator=gae`` selects the existing TorchTitan critic config.
+For example, using the GSM8K script above:
+
+.. code:: shell
+
+   NUM_GPUS=2 FSDP_SIZE=2 AC_MODE=none \
+     bash tests/special_e2e/run_ppo_trainer_torchtitan.sh \
+       algorithm.adv_estimator=gae \
+       actor_rollout_ref.rollout.n=1 \
+       critic.torchtitan.data_parallel_shard_size=2 \
+       critic.torchtitan.attn_type=flex \
+       critic.torchtitan.activation_checkpoint=none \
+       critic.torchtitan.use_torch_compile=False
+
+The critic retains the input embedding vocabulary and replaces the output
+projection with an independent scalar head before TorchTitan creates FSDP
+shards and optimizers. Its per-token values feed verl's existing clipped value
+loss. Both packed and right-padded execution return values in the input's
+jagged sequence layout. For ``attn_type=flex``, the critic uses the full
+FlexAttention kernel: the supported PyTorch dev20260625 nightly's short-query
+GQA decoding path can disagree with padded evaluation.
+
+``critic.model.path`` may point to a causal LM checkpoint or a Qwen3 checkpoint
+with a scalar ``score.weight`` and optional ``score.bias``. Missing head weights
+are initialized; a missing bias starts at zero. A vocabulary-sized
+``lm_head.weight`` is never used as the value head. Missing backbone weights and
+incompatible score shapes are errors. Native TorchTitan checkpoints retain
+the value head, optimizer, and LR scheduler for resuming training.
+
+The initial critic implementation supports dense Qwen3 on CUDA with FSDP2 data
+parallelism. TP, CP, PP, EP, and LoRA are rejected during engine construction.
+The actor's parallelism support is unchanged. Validation uses the Qwen3 debug
+model with FlexAttention and ``spmd_types``; a download-free distributed
+training and checkpoint regression test is available:
+
+.. code:: shell
+
+   torchrun --nproc_per_node=2 \
+     tests/special_distributed/test_torchtitan_critic.py \
+     --work-dir /tmp/verl-torchtitan-critic
+   torchrun --nproc_per_node=2 \
+     tests/special_distributed/test_torchtitan_critic.py \
+     --work-dir /tmp/verl-torchtitan-score --with-score

--- a/tests/special_distributed/test_torchtitan_critic.py
+++ b/tests/special_distributed/test_torchtitan_critic.py
@@ -1,0 +1,276 @@
+# Copyright 2026 Individual Contributor: Zupeng Wang
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run with torchrun --nproc_per_node=2 test_torchtitan_critic.py --work-dir /tmp/critic.
+
+Uses a randomly initialized Qwen3 debug model and a local tokenizer; no model
+download or rollout server is needed. Add --with-score to load an HF critic.
+"""
+
+import argparse
+import json
+import os
+from functools import partial
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from safetensors.torch import load_file
+from tensordict import TensorDict
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from torch.distributed.tensor import DTensor
+from transformers import PreTrainedTokenizerFast, Qwen3Config, Qwen3ForCausalLM, Qwen3ForTokenClassification, Qwen3Model
+
+from verl.trainer.config import CheckpointConfig
+from verl.utils import tensordict_utils as tu
+from verl.workers.config import CriticConfig, HFModelConfig, TorchtitanEngineConfig, TorchtitanOptimizerConfig
+from verl.workers.engine.torchtitan import TorchTitanEngineWithValueHead
+from verl.workers.utils.losses import value_loss
+
+
+def make_checkpoint(path, with_score):
+    torch.manual_seed(42)
+    config = Qwen3Config(
+        vocab_size=2048,
+        hidden_size=256,
+        intermediate_size=3072,
+        num_hidden_layers=8,
+        num_attention_heads=16,
+        num_key_value_heads=8,
+        head_dim=128,
+        tie_word_embeddings=True,
+        max_position_embeddings=4096,
+        rope_theta=1000000.0,
+        bos_token_id=1,
+        eos_token_id=2,
+        pad_token_id=0,
+        num_labels=1,
+        classifier_dropout=0.0,
+    )
+    cls = Qwen3ForTokenClassification if with_score else Qwen3ForCausalLM
+    model = cls(config).to(torch.bfloat16)
+    if with_score:
+        with torch.no_grad():
+            model.score.bias.fill_(0.125)
+    model.save_pretrained(path)
+    vocab = {"<pad>": 0, "<bos>": 1, "<eos>": 2, "<unk>": 3}
+    vocab.update({f"token{i}": i for i in range(4, config.vocab_size)})
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=Tokenizer(WordLevel(vocab, unk_token="<unk>")),
+        unk_token="<unk>",
+        bos_token="<bos>",
+        eos_token="<eos>",
+        pad_token="<pad>",
+    )
+    tokenizer.save_pretrained(path)
+
+
+def make_batch():
+    rank = dist.get_rank()
+    sequences = [torch.arange(11, 27, device="cuda") + rank, torch.arange(21, 33, device="cuda") + rank]
+    prompt_lengths = [8, 6]
+
+    def nested(values):
+        return torch.nested.as_nested_tensor(values, layout=torch.jagged)
+
+    data = TensorDict(
+        {
+            "input_ids": nested(sequences),
+            "position_ids": nested([torch.arange(len(seq), device="cuda") for seq in sequences]),
+            "prompts": nested([seq[:n] for seq, n in zip(sequences, prompt_lengths, strict=True)]),
+            "responses": nested([seq[n:] for seq, n in zip(sequences, prompt_lengths, strict=True)]),
+            "loss_mask": nested(
+                [
+                    torch.cat([torch.zeros(n, device="cuda"), torch.ones(len(seq) - n, device="cuda")])
+                    for seq, n in zip(sequences, prompt_lengths, strict=True)
+                ]
+            ),
+            "response_mask": nested(
+                [torch.ones(len(seq) - n, device="cuda") for seq, n in zip(sequences, prompt_lengths, strict=True)]
+            ),
+            "values": nested(
+                [torch.zeros(len(seq) - n, device="cuda") for seq, n in zip(sequences, prompt_lengths, strict=True)]
+            ),
+            "returns": nested(
+                [
+                    torch.linspace(-0.4, 0.7, len(seq) - n, device="cuda")
+                    for seq, n in zip(sequences, prompt_lengths, strict=True)
+                ]
+            ),
+        },
+        batch_size=[2],
+    )
+    tu.assign_non_tensor(
+        data,
+        use_remove_padding=True,
+        use_dynamic_bsz=False,
+        micro_batch_size_per_gpu=1,
+        global_batch_size=2 * dist.get_world_size(),
+    )
+    return data
+
+
+def clone_state(value):
+    if isinstance(value, DTensor):
+        value = value.full_tensor()
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().clone()
+    if isinstance(value, dict):
+        return {k: clone_state(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [clone_state(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(clone_state(v) for v in value)
+    return value
+
+
+def snapshot(engine):
+    with engine.trainer.train_context():
+        return clone_state(
+            {
+                "model": engine.module[0].state_dict(),
+                "optimizer": engine.optimizer.state_dict(),
+                "scheduler": engine.lr_scheduler.state_dict(),
+            }
+        )
+
+
+def infer(engine, data, packed):
+    tu.assign_non_tensor(data, use_remove_padding=packed)
+    with engine.eval_mode(), engine.trainer.train_context(), torch.no_grad():
+        _, output = engine.forward_step(data, loss_function=None, forward_only=True)
+    return output["model_output"]["values"].values().float()
+
+
+def train_step(engine, data):
+    tu.assign_non_tensor(data, use_remove_padding=True)
+    config = CriticConfig(strategy="torchtitan", ppo_micro_batch_size_per_gpu=1)
+    with engine.train_mode():
+        engine.optimizer_zero_grad()
+        output = engine.forward_backward_batch(data, loss_function=partial(value_loss, config), forward_only=False)
+        grad_norm = engine.optimizer_step()
+        engine.lr_scheduler_step()
+    assert torch.isfinite(torch.tensor(grad_norm)) and grad_norm > 0
+    assert "critic/vf_loss" in output["metrics"]
+    return grad_norm
+
+
+def run(args):
+    device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl", device_id=device)
+    engine = None
+    try:
+        work = Path(args.work_dir).resolve()
+        assets = work / ("hf-critic" if args.with_score else "hf-lm")
+        if dist.get_rank() == 0:
+            work.mkdir(parents=True, exist_ok=True)
+            make_checkpoint(assets, args.with_score)
+        dist.barrier()
+        os.chdir(work)
+        engine = TorchTitanEngineWithValueHead(
+            model_config=HFModelConfig(path=str(assets), use_remove_padding=True, model_type="value_model"),
+            engine_config=TorchtitanEngineConfig(
+                data_parallel_shard_size=dist.get_world_size(),
+                attn_type="flex",
+                activation_checkpoint="none",
+                use_torch_compile=False,
+                spmd_backend="spmd_types",
+                max_seq_len=64,
+                param_offload=False,
+                optimizer_offload=False,
+            ),
+            optimizer_config=TorchtitanOptimizerConfig(lr=1e-4, total_training_steps=4),
+            checkpoint_config=CheckpointConfig(),
+        )
+        engine.initialize()
+        initial = snapshot(engine)
+        state = initial["model"]
+        assert state["lm_head.weight"].shape == (1, 256)
+        assert state["tok_embeddings.weight"].shape == (2048, 256)
+        source = load_file(assets / "model.safetensors")
+        torch.testing.assert_close(
+            state["tok_embeddings.weight"], source["model.embed_tokens.weight"].float(), rtol=0, atol=0
+        )
+        if args.with_score:
+            torch.testing.assert_close(state["lm_head.weight"], source["score.weight"].float(), rtol=0, atol=0)
+            torch.testing.assert_close(state["lm_head.bias"], source["score.bias"].float(), rtol=0, atol=0)
+        else:
+            assert torch.count_nonzero(state["lm_head.bias"]) == 0
+
+        data = make_batch()
+        packed = infer(engine, data, True)
+        padded = infer(engine, data, False)
+        torch.testing.assert_close(packed, padded, rtol=0.05, atol=0.03)
+        reference = (
+            Qwen3Model.from_pretrained(assets, dtype=torch.bfloat16, attn_implementation="sdpa").to(device).eval()
+        )
+        head = state["lm_head.weight"].to(device, dtype=torch.bfloat16)
+        bias = state["lm_head.bias"].to(device, dtype=torch.bfloat16)
+        with torch.no_grad():
+            expected = torch.cat(
+                [
+                    torch.nn.functional.linear(reference(seq.unsqueeze(0)).last_hidden_state, head, bias).flatten()
+                    for seq in data["input_ids"].unbind()
+                ]
+            ).float()
+        max_error = (packed - expected).abs().max().item()
+        torch.testing.assert_close(packed, expected, rtol=0.05, atol=0.03)
+        del reference, source, initial
+
+        grad_norm = train_step(engine, data)
+        after_one = snapshot(engine)
+        assert not torch.equal(after_one["model"]["lm_head.weight"], state["lm_head.weight"])
+        assert not torch.equal(after_one["model"]["tok_embeddings.weight"], state["tok_embeddings.weight"])
+        del state
+        # Exercise the engine's public checkpoint API at TorchTitan's save interval.
+        checkpoint_step = engine.checkpointer.interval
+        checkpoint = work / "resume" / f"global_step_{checkpoint_step}"
+        engine.save_checkpoint(str(checkpoint), global_step=checkpoint_step)
+        assert (checkpoint.parent / f"step-{checkpoint_step}" / ".metadata").exists()
+        train_step(engine, data)
+        after_two = snapshot(engine)
+        engine.load_checkpoint(str(checkpoint))
+        restored = snapshot(engine)
+        torch.testing.assert_close(restored, after_one, rtol=0, atol=0)
+        train_step(engine, data)
+        resumed_two = snapshot(engine)
+        torch.testing.assert_close(resumed_two, after_two, rtol=0, atol=0)
+        print(
+            json.dumps(
+                {
+                    "result": "PASS",
+                    "rank": dist.get_rank(),
+                    "world_size": dist.get_world_size(),
+                    "with_score": args.with_score,
+                    "hf_max_abs_error": max_error,
+                    "grad_norm": grad_norm,
+                    "checkpoint_model_optimizer_scheduler": "exact",
+                    "next_update_after_resume": "exact",
+                }
+            ),
+            flush=True,
+        )
+    finally:
+        if engine is not None:
+            engine.trainer.close()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--work-dir", required=True)
+    parser.add_argument("--with-score", action="store_true")
+    run(parser.parse_args())

--- a/tests/special_sanity/check_license.py
+++ b/tests/special_sanity/check_license.py
@@ -22,6 +22,7 @@ license_head_bytedance_26 = "Copyright 2026 Bytedance Ltd. and/or its affiliates
 # Add custom license headers below
 license_head_prime = "Copyright 2024 PRIME team and/or its affiliates"
 license_head_individual = "Copyright 2025 Individual Contributor:"
+license_head_individual_26 = "Copyright 2026 Individual Contributor:"
 license_head_sglang = "Copyright 2023-2024 SGLang Team"
 license_head_modelbest = "Copyright 2025 ModelBest Inc. and/or its affiliates"
 license_head_amazon = "Copyright 2025 Amazon.com Inc and/or its affiliates"
@@ -39,6 +40,7 @@ license_headers = [
     license_head_bytedance_26,
     license_head_prime,
     license_head_individual,
+    license_head_individual_26,
     license_head_sglang,
     license_head_modelbest,
     license_head_amazon,

--- a/tests/workers/test_torchtitan_value_model_on_cpu.py
+++ b/tests/workers/test_torchtitan_value_model_on_cpu.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Individual Contributor: Zupeng Wang
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from tensordict import TensorDict
+
+pytest.importorskip("torchtitan")
+
+from torchtitan.models.qwen3 import model_registry
+
+from verl.utils import tensordict_utils as tu
+from verl.workers.config import TorchtitanEngineConfig
+from verl.workers.engine.base import EngineRegistry
+from verl.workers.engine.torchtitan import TorchTitanEngineWithLMHead, TorchTitanEngineWithValueHead
+from verl.workers.engine.torchtitan.value_model import Qwen3ValueStateDictAdapter
+from verl.workers.utils.padding import no_padding_2_padding
+
+
+@pytest.fixture
+def critic():
+    engine = object.__new__(TorchTitanEngineWithValueHead)
+    engine.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(model_type="qwen3", initializer_range=0.02),
+        lora_rank=0,
+        lora={},
+        lora_adapter_path=None,
+    )
+    engine.engine_config = TorchtitanEngineConfig()
+    return engine
+
+
+def test_registration_and_scalar_head_before_model_construction(critic, monkeypatch):
+    monkeypatch.setenv("VERL_ENGINE_DEVICE", "cuda")
+    assert EngineRegistry.get_engine_cls("value_model", "torchtitan") is TorchTitanEngineWithValueHead
+    assert EngineRegistry.get_engine_cls("language_model", "torchtitan") is TorchTitanEngineWithLMHead
+    actor = model_registry("debugmodel", attn_backend="flex")
+    value = critic._configure_model_spec(actor)
+    assert actor.model.enable_weight_tying
+    assert actor.model.lm_head.out_features == 2048
+    assert not actor.model.layers[0].attention.inner_attention.kernel_options
+    assert not value.model.enable_weight_tying
+    assert value.model.vocab_size == actor.model.vocab_size
+    with torch.device("meta"):
+        model = value.model.build()
+    assert model.lm_head.weight.shape == (1, 256)
+    assert model.lm_head.bias.shape == (1,)
+    assert model.tok_embeddings.weight.shape == (2048, 256)
+    assert model.lm_head.weight is not model.tok_embeddings.weight
+    assert dict(model.named_parameters())["lm_head.weight"] is model.lm_head.weight
+
+
+@pytest.mark.parametrize(
+    "field", ["tensor_parallel_size", "context_parallel_size", "pipeline_parallel_size", "expert_parallel_size"]
+)
+def test_reject_unsupported_parallelism_before_trainer(critic, field):
+    critic.engine_config = TorchtitanEngineConfig(**{field: 2})
+    with pytest.raises(NotImplementedError, match=field):
+        critic._configure_model_spec(model_registry("debugmodel", attn_backend="flex"))
+
+
+@pytest.mark.parametrize("model_type,lora_rank", [("qwen3_moe", 0), ("llama", 0), ("qwen3", 8)])
+def test_reject_unsupported_model(critic, model_type, lora_rank):
+    critic.model_config.hf_config.model_type = model_type
+    critic.model_config.lora_rank = lora_rank
+    with pytest.raises(NotImplementedError):
+        critic._configure_model_spec(model_registry("debugmodel", attn_backend="flex"))
+
+
+@pytest.mark.parametrize("options", [{"lora": {"rank": 8}}, {"lora_adapter_path": "/unused-adapter"}])
+def test_reject_nested_lora_and_pretrained_adapter(critic, options):
+    for key, value in options.items():
+        setattr(critic.model_config, key, value)
+    with pytest.raises(NotImplementedError, match="LoRA"):
+        critic._configure_model_spec(model_registry("debugmodel", attn_backend="flex"))
+
+
+def make_adapter(critic, path=None):
+    spec = critic._configure_model_spec(model_registry("debugmodel", attn_backend="flex"))
+    return Qwen3ValueStateDictAdapter(spec.model, str(path) if path else None)
+
+
+def test_hf_roundtrip_preserves_score_and_never_uses_lm_head(critic):
+    adapter = make_adapter(critic)
+    embedding = torch.randn(2048, 256)
+    score = torch.randn(1, 256)
+    bias = torch.randn(1)
+    hf = {
+        "model.embed_tokens.weight": embedding,
+        "score.weight": score,
+        "score.bias": bias,
+        "lm_head.weight": torch.randn(2048, 256),
+    }
+    native = adapter.from_hf(hf)
+    assert native["lm_head.weight"] is score
+    assert native["lm_head.bias"] is bias
+    assert native["tok_embeddings.weight"] is embedding
+    exported = adapter.to_hf(native)
+    assert set(exported) == {"model.embed_tokens.weight", "score.weight", "score.bias"}
+    assert exported["score.weight"] is score
+    assert "lm_head.weight" in hf  # conversion must not mutate the caller's checkpoint
+
+
+@pytest.mark.parametrize("with_score", [False, True])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_initial_hf_load_and_export(critic, tmp_path, with_score, with_bias):
+    import torch.distributed.checkpoint as dcp
+
+    embedding = torch.randn(2048, 256)
+    saved = {"model.embed_tokens.weight": embedding}
+    if with_score:
+        saved["score.weight"] = torch.randn(1, 256)
+    if with_bias:
+        saved["score.bias"] = torch.randn(1)
+    save_file(saved, tmp_path / "model.safetensors")
+    adapter = make_adapter(critic, tmp_path)
+    initialized_head = torch.randn(1, 256)
+    native = {
+        "tok_embeddings.weight": torch.empty_like(embedding),
+        "lm_head.weight": initialized_head.clone(),
+        "lm_head.bias": torch.zeros(1),
+    }
+    with adapter.initial_hf_load(str(tmp_path)):
+        requested = adapter.to_hf(native)
+        dcp.load(requested, storage_reader=adapter.get_hf_storage_reader(str(tmp_path)))
+        loaded = adapter.from_hf(requested)
+    native.update(loaded)
+    torch.testing.assert_close(native["tok_embeddings.weight"], embedding)
+    torch.testing.assert_close(native["lm_head.weight"], saved.get("score.weight", initialized_head))
+    torch.testing.assert_close(native["lm_head.bias"], saved.get("score.bias", torch.zeros(1)))
+    assert "score.weight" in adapter.to_hf(native)
+
+
+def test_missing_backbone_is_not_silently_ignored(critic, tmp_path):
+    import torch.distributed.checkpoint as dcp
+    from torch.distributed.checkpoint.api import CheckpointException
+
+    save_file({"model.embed_tokens.weight": torch.ones(2048, 256)}, tmp_path / "model.safetensors")
+    adapter = make_adapter(critic, tmp_path)
+    with pytest.raises(CheckpointException, match="Missing key"):
+        with adapter.initial_hf_load(str(tmp_path)):
+            requested = adapter.to_hf({"norm.weight": torch.empty(256), "lm_head.weight": torch.empty(1, 256)})
+            dcp.load(requested, storage_reader=adapter.get_hf_storage_reader(str(tmp_path)))
+    assert "score.weight" in adapter.to_hf({"lm_head.weight": torch.empty(1, 256)})
+
+
+def test_reject_non_scalar_hf_score(critic, tmp_path):
+    save_file({"score.weight": torch.ones(2, 256)}, tmp_path / "model.safetensors")
+    adapter = make_adapter(critic, tmp_path)
+    with pytest.raises(ValueError, match="Expected score.weight shape"):
+        with adapter.initial_hf_load(str(tmp_path)):
+            pytest.fail("Invalid value head must be rejected before loading.")
+
+
+@pytest.mark.parametrize("packed", [True, False])
+@pytest.mark.parametrize("lengths", [[5, 3], [1], [1, 3]])
+def test_token_values_layout_and_gradient(critic, packed, lengths):
+    ids = torch.nested.as_nested_tensor([torch.arange(n) for n in lengths], layout=torch.jagged)
+    data = TensorDict({"input_ids": ids}, batch_size=[len(lengths)])
+    tu.assign_non_tensor(data, use_remove_padding=packed)
+    shape = (1, sum(lengths), 1) if packed else (len(lengths), max(lengths), 1)
+    logits = torch.arange(torch.tensor(shape).prod().item(), dtype=torch.float32).reshape(shape).requires_grad_()
+    result = critic.prepare_model_outputs(logits, {}, data)
+    assert set(result) == {"values"}
+    values = result["values"]
+    assert torch.equal(values.offsets(), ids.offsets())
+    expected = logits[0, :, 0] if packed else torch.cat([logits[i, :n, 0] for i, n in enumerate(lengths)])
+    torch.testing.assert_close(values.values(), expected)
+    values.values().sum().backward()
+    expected_grad = torch.ones_like(logits)
+    if not packed:
+        for i, n in enumerate(lengths):
+            expected_grad[i, n:] = 0
+    torch.testing.assert_close(logits.grad, expected_grad)
+
+
+def test_response_value_alignment(critic):
+    ids = torch.nested.as_nested_tensor([torch.arange(5), torch.arange(3)], layout=torch.jagged)
+    data = TensorDict(
+        {
+            "input_ids": ids,
+            "prompts": torch.nested.as_nested_tensor([torch.arange(3), torch.arange(1)], layout=torch.jagged),
+            "responses": torch.nested.as_nested_tensor([torch.arange(2), torch.arange(2)], layout=torch.jagged),
+        },
+        batch_size=[2],
+    )
+    logits = torch.arange(8, dtype=torch.float32).reshape(1, 8, 1)
+    result = critic.prepare_model_outputs(logits, {}, data)
+    torch.testing.assert_close(no_padding_2_padding(result["values"], data), torch.tensor([[2.0, 3.0], [5.0, 6.0]]))

--- a/verl/workers/engine/__init__.py
+++ b/verl/workers/engine/__init__.py
@@ -25,13 +25,14 @@ __all__ = [
 ]
 
 try:
-    from .torchtitan import TorchTitanEngine, TorchTitanEngineWithLMHead
+    from .torchtitan import TorchTitanEngine, TorchTitanEngineWithLMHead, TorchTitanEngineWithValueHead
 
-    __all__ += ["TorchTitanEngine", "TorchTitanEngineWithLMHead"]
+    __all__ += ["TorchTitanEngine", "TorchTitanEngineWithLMHead", "TorchTitanEngineWithValueHead"]
 except ImportError as e:
     warnings.warn(f"torchtitan engine is not available: {e!r}", stacklevel=1)
     TorchTitanEngine = None
     TorchTitanEngineWithLMHead = None
+    TorchTitanEngineWithValueHead = None
 
 try:
     from .veomni import VeOmniEngine, VeOmniEngineWithLMHead

--- a/verl/workers/engine/torchtitan/__init__.py
+++ b/verl/workers/engine/torchtitan/__init__.py
@@ -11,6 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .transformer_impl import TorchTitanEngine, TorchTitanEngineWithLMHead
+from .transformer_impl import TorchTitanEngine, TorchTitanEngineWithLMHead, TorchTitanEngineWithValueHead
 
-__all__ = ["TorchTitanEngine", "TorchTitanEngineWithLMHead"]
+__all__ = ["TorchTitanEngine", "TorchTitanEngineWithLMHead", "TorchTitanEngineWithValueHead"]

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -15,12 +15,14 @@
 The concrete Engine implementation using PyTorch TorchTitan parallelism (FSDP2 + TP + PP)
 """
 
+import copy
 import gc
 import importlib
 import logging
 import os
 import re
 from contextlib import nullcontext
+from functools import partial
 from typing import Any, Callable, Optional
 
 import torch
@@ -62,6 +64,7 @@ from verl.workers.engine.torchtitan.utils import (
 
 from ..base import BaseEngine, BaseEngineCtx, EngineRegistry
 from ..utils import enable_full_determinism, postprocess_batch_func, prepare_micro_batches
+from .value_model import Qwen3ValueStateDictAdapter, parallelize_qwen3_value_model
 
 
 def _hf_entry_row_slots(name, spec, place, lidx, lval):
@@ -133,6 +136,7 @@ class TorchTitanEngine(BaseEngine):
         # Get ModelSpec from model registry
         model_module = importlib.import_module(f"torchtitan.models.{torchtitan_name}")
         model_spec = model_module.model_registry(torchtitan_flavor, attn_backend=self.engine_config.attn_type)
+        model_spec = self._configure_model_spec(model_spec)
 
         optimizer = OptimizersContainer.Config(
             param_groups=[
@@ -269,6 +273,13 @@ class TorchTitanEngine(BaseEngine):
             is_collect = is_collect and (cp_mesh.get_local_rank() == 0)
         return is_collect
 
+    def _configure_model_spec(self, model_spec):
+        """Customize the model before TorchTitan creates parameters and optimizers."""
+        return model_spec
+
+    def _load_initial_weights(self):
+        self.checkpointer.load()
+
     def initialize(self):
         """
         Build the model, optimizer, and learning rate scheduler with TorchTitan parallelism.
@@ -279,7 +290,7 @@ class TorchTitanEngine(BaseEngine):
         self.module = self.trainer.model_parts
         self.checkpointer = self.trainer.checkpointer
         # load initial HF weights
-        self.checkpointer.load()
+        self._load_initial_weights()
 
         if not self.engine_config.forward_only:
             self.optimizer = self.trainer.optimizers
@@ -883,3 +894,79 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
             }
 
             return loss, output
+
+
+@EngineRegistry.register(model_type="value_model", backend=["torchtitan"], device=["cuda"])
+class TorchTitanEngineWithValueHead(TorchTitanEngineWithLMHead):
+    """Dense Qwen3 critic with FSDP2 data parallelism."""
+
+    def _configure_model_spec(self, model_spec):
+        if self.model_config.hf_config.model_type != "qwen3":
+            raise NotImplementedError("The TorchTitan critic currently supports dense Qwen3 models only.")
+        for field in (
+            "tensor_parallel_size",
+            "context_parallel_size",
+            "pipeline_parallel_size",
+            "expert_parallel_size",
+        ):
+            if getattr(self.engine_config, field) != 1:
+                raise NotImplementedError(f"The TorchTitan critic requires {field}=1; use FSDP2 data parallelism.")
+        if (
+            self.model_config.lora_rank > 0
+            or self.model_config.lora.get("rank", 0) > 0
+            or self.model_config.lora_adapter_path
+        ):
+            raise NotImplementedError("The TorchTitan critic does not support LoRA.")
+
+        model_spec = copy.deepcopy(model_spec)
+        # Do this before Trainer constructs/shards the model and its optimizer.
+        # Preserve the full input vocabulary and untie only the scalar head.
+        model_spec.model.enable_weight_tying = False
+        model_spec.model.lm_head.out_features = 1
+        model_spec.model.lm_head.bias = True
+        model_spec.model.lm_head.param_init = {
+            "weight": partial(torch.nn.init.normal_, std=self.model_config.hf_config.initializer_range),
+            "bias": torch.nn.init.zeros_,
+        }
+        model_spec.state_dict_adapter = Qwen3ValueStateDictAdapter
+        model_spec.parallelize_fn = parallelize_qwen3_value_model
+        if self.engine_config.attn_type == "flex":
+            # Critics evaluate full sequences. On the supported dev20260625
+            # nightly, the short-query GQA decoding kernel disagrees with the
+            # full attention path; this also affects short critic micro-batches.
+            for layer in model_spec.model.layers:
+                layer.attention.inner_attention.kernel_options["FORCE_USE_FLEX_ATTENTION"] = True
+        return model_spec
+
+    def _load_initial_weights(self):
+        with self.checkpointer.sd_adapter.initial_hf_load(self.model_config.path):
+            super()._load_initial_weights()
+
+    def _to_hf_named_params(self, params):
+        return self.checkpointer.sd_adapter.to_hf(params)
+
+    def prepare_model_inputs(self, micro_batch: TensorDict):
+        """Prepare token inputs and TorchTitan attention metadata for either layout."""
+        inputs, extra_inputs, extra_kwargs, output_args = super().prepare_model_inputs(micro_batch)
+        if not tu.get_non_tensor_data(micro_batch, "use_remove_padding", default=True):
+            # TorchTitan attention consumes BlockMask/VarlenMetadata, not a HF
+            # binary padding mask. Right padding cannot affect preceding tokens.
+            extra_kwargs["attention_masks"] = get_attention_masks(
+                inputs, extra_inputs["positions"], self.engine_config.attn_type
+            )
+        return inputs, extra_inputs, extra_kwargs, output_args
+
+    def prepare_model_outputs(self, logits, output_args, micro_batch: TensorDict):
+        """Return differentiable token values in the original jagged sequence layout."""
+        pad_mode = tu.get_non_tensor_data(micro_batch, "pad_mode", default=DatasetPadMode.NO_PADDING)
+        if pad_mode != DatasetPadMode.NO_PADDING:
+            raise NotImplementedError(f"pad_mode {pad_mode} not supported")
+        offsets = micro_batch["input_ids"].offsets()
+        values = logits.squeeze(-1)
+        if tu.get_non_tensor_data(micro_batch, "use_remove_padding", default=True):
+            values = values.squeeze(0)
+        else:
+            lengths = offsets.diff()
+            values = torch.nested.narrow(values, 1, torch.zeros_like(lengths), lengths, layout=torch.jagged)
+            values = torch.cat(values.unbind())
+        return {"values": torch.nested.nested_tensor_from_jagged(values, offsets)}

--- a/verl/workers/engine/torchtitan/value_model.py
+++ b/verl/workers/engine/torchtitan/value_model.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Individual Contributor: Zupeng Wang
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from contextlib import contextmanager
+
+from torchtitan.models.qwen3.parallelize import parallelize_qwen3
+from torchtitan.models.qwen3.state_dict_adapter import Qwen3StateDictAdapter
+
+
+class Qwen3ValueStateDictAdapter(Qwen3StateDictAdapter):
+    """Keep TorchTitan's decoder head in DCP and use HF's scalar score head."""
+
+    def __init__(self, model_config, hf_assets_path):
+        super().__init__(model_config, hf_assets_path)
+        self.from_hf_map.pop("lm_head.weight")
+        self.from_hf_map["score.weight"] = "lm_head.weight"
+        self.from_hf_map["score.bias"] = "lm_head.bias"
+        self._missing_initial_head = set()
+        if self.fqn_to_index_mapping is not None:
+            self.fqn_to_index_mapping.pop("lm_head.weight", None)
+            self.fqn_to_index_mapping.setdefault("score.weight", 1)
+            self.fqn_to_index_mapping.setdefault("score.bias", 1)
+
+    @contextmanager
+    def initial_hf_load(self, path):
+        """Allow newly initialized head parameters while strictly loading the backbone."""
+        # A causal LM checkpoint has no scalar head. Omit only that requested
+        # tensor; DCP must still reject a missing backbone parameter.
+        metadata = self.get_hf_storage_reader(path).read_metadata().state_dict_metadata
+        head_shapes = {"score.weight": (1, self.model_config.dim), "score.bias": (1,)}
+        for name, shape in head_shapes.items():
+            if name in metadata and tuple(metadata[name].size) != shape:
+                raise ValueError(f"Expected {name} shape {shape}, got {tuple(metadata[name].size)}")
+        previous = self._missing_initial_head
+        self._missing_initial_head = head_shapes.keys() - metadata.keys()
+        try:
+            yield
+        finally:
+            self._missing_initial_head = previous
+
+    def to_hf(self, state_dict):
+        """Export the scalar score head, omitting only absent initial HF parameters."""
+        result = super().to_hf(state_dict)
+        for name in self._missing_initial_head:
+            result.pop(name, None)
+        return result
+
+    def from_hf(self, hf_state_dict):
+        """Convert HF backbone and score parameters to TorchTitan names."""
+        # Vocabulary logits are unrelated to token values, even when the source
+        # checkpoint has an untied language-model head.
+        return super().from_hf({key: value for key, value in hf_state_dict.items() if key != "lm_head.weight"})
+
+
+def parallelize_qwen3_value_model(model, **kwargs):
+    """Declare the scalar bias layout before TorchTitan applies parallelism."""
+    shardings = model.config.lm_head.sharding_config.state_shardings
+    shardings["bias"] = copy.deepcopy(shardings["weight"])
+    return parallelize_qwen3(model, **kwargs)


### PR DESCRIPTION
### What does this PR do?

Adds a dense Qwen3 critic to the TorchTitan engine so PPO/GAE can use the existing `value_model` worker and clipped value loss. Currently, selecting that combination fails with `Unknown backend: torchtitan`.

This implements the critic sub-item of [#5306](https://github.com/verl-project/verl/issues/5306), not the entire roadmap. A scalar head is created before model sharding and optimizer construction. HF backbone weights and optional `score.weight/score.bias` load through a dedicated adapter; native DCP retains the head, optimizer and scheduler.

### Checklist Before Starting

- [x] Checked issue #5306, its comments/timeline, and open/closed PRs. No matching critic implementation was found. Queries: [issue references](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+5306+in%3Abody), [TorchTitan critic](https://github.com/verl-project/verl/pulls?q=is%3Apr+torchtitan+critic).
- [x] Proposed title: `[worker, model] feat: add dense Qwen3 critic support to TorchTitan`.

### Test

Remote host: 2 × RTX 3090; Python 3.12.13; torch 2.14.0.dev20260625+cu130; torchtitan 0.1.0.dev20260701+cu130; transformers 5.9.0.

```bash
pytest -q tests/workers/test_torchtitan_value_model_on_cpu.py
torchrun --nproc_per_node=2 tests/special_distributed/test_torchtitan_critic.py --work-dir /tmp/critic-base
torchrun --nproc_per_node=2 tests/special_distributed/test_torchtitan_critic.py --work-dir /tmp/critic-score --with-score
pre-commit run --all-files --show-diff-on-failure
```

- 24 CPU tests passed.
- Both two-GPU cases passed, using a locally generated Qwen3 debug model and tokenizer.
- HF comparison maximum absolute error: 0.0087890625 from an LM checkpoint; 0.0068359375 from a checkpoint with a scalar score head.
- Both the head and backbone update with the existing clipped value loss.
- Model, optimizer and scheduler restore exactly. The next update after resume matches uninterrupted execution exactly.
- Existing actor forward regression matches the unmodified baseline.
- PPO/GAE Hydra config resolves to TorchTitanCriticConfig and TorchtitanEngineConfig.
- All 14 repository pre-commit hooks passed, and the commit hook passed again.

These tests cover the engine and existing PPO value loss. A complete rollout-backed PPO run, convergence and throughput are not claimed.

### API and Usage Example

`model_engine=torchtitan algorithm.adv_estimator=gae` uses the existing critic config. The documentation includes a complete set of overrides for the existing GSM8K script.

The initial implementation supports dense Qwen3 on CUDA with FSDP2 data parallelism. TP, CP, PP, EP and LoRA are explicitly rejected.

### Design & Code Changes

- Preserve vocabulary embeddings; use an untied scalar head initialized from HF `initializer_range`.
- Declare the bias sharding before TorchTitan parallelization.
- Omit only absent initial head parameters during HF loading; retain strict missing-backbone checks.
- Return differentiable token values in the original jagged layout for packed and padded execution.
- Select full FlexAttention for the critic. The supported dev20260625 nightly's short-query GQA decoding kernel failed the HF/packed-vs-padded parity check; switching only the attention kernel resolved the discrepancy.
- Reuse existing optimizer, value loss, and DCP lifecycle.
- Recognize the 2026 individual-contributor license header in the existing license checker.

### Checklist Before Submitting

- [x] Read AGENTS.md and CONTRIBUTING.md.
- [x] Human submitter reviewed the final change and authorized publication.
- [x] Relevant tests were executed on the remote GPU host; commands and results are listed above.
- [x] Add documentation and unit/distributed regression tests.
- [ ] Request upstream GPU CI after human review and publication. The existing TorchTitan workflow is currently under `.github/workflows/.stash/`; this patch does not activate it. CPU tests skip when TorchTitan is unavailable, and the distributed tests have been run manually on the remote host.
- [x] This PR contains only the reviewed commit `3f40ac0dda3404013f33edce0661c3f559c3c8f8`.

AI assistance: implementation, tests and this description were prepared with OpenAI Codex. The human submitter reviewed the final change and authorized publication. Upstream CI has not yet been requested.
