### PR TITLE
[fsdp, megatron, rollout, model] feat: support Kimi K3 training on Ascend NPUs

### DIFF
--- a/examples/ascend_extras/grpo_trainer/run_kimi_k3_fsdpturbo.sh
+++ b/examples/ascend_extras/grpo_trainer/run_kimi_k3_fsdpturbo.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$SCRIPT_DIR/kimi_k3_runtime.sh"
+PROJECT_ROOT=$BACKEND_ROOT
+run_mode="${KIMI_RUN_MODE:-single}"
+start_time="${VERL_RUN_TIMESTAMP:-$(date +%Y%m%d_%H%M%S)}"
+project_name="${VERL_PROJECT_NAME:-GRPO-Kimi-K3-A3B}"
+
+model_path=${MODEL_PATH:-/mnt/share/w00848461/weights/K3-top16-pruned_bf16_countbench_128_n4}
+
+case "$run_mode" in
+    single)
+        nnodes=1
+        npus_per_node=${NPUS_PER_NODE:-8}
+        ;;
+    multinode)
+        nnodes=${NNODES:?set by ray_start_multi_nodes.sh}
+        ((nnodes >= 2)) || { echo "multinode mode requires at least two nodes" >&2; exit 2; }
+        npus_per_node=${NPUS_PER_NODE:-16}
+        ;;
+    *) echo "Unsupported KIMI_RUN_MODE: $run_mode" >&2; exit 2 ;;
+esac
+
+turbo_fsdp_size=$((nnodes * npus_per_node))
+turbo_ep_size=${TURBO_EP_SIZE:-$npus_per_node}
+rollout_tp_size=${ROLLOUT_TP:-$npus_per_node}
+if ((turbo_ep_size <= 0 || rollout_tp_size <= 0 || turbo_fsdp_size % turbo_ep_size != 0 || turbo_fsdp_size % rollout_tp_size != 0 || turbo_ep_size != rollout_tp_size)); then
+    echo "FSDP requires actor EP = rollout TP > 0, dividing the actor world size" >&2
+    exit 2
+fi
+turbo_efsdp_size=$((turbo_fsdp_size / turbo_ep_size))
+rollout_ep_size=$rollout_tp_size
+visible_devices_default=$(seq -s, 0 $((npus_per_node - 1)))
+max_response_length=${VERL_MAX_RESPONSE_LENGTH:-512}
+rollout_max_num_seqs=${VERL_VLLM_MAX_NUM_SEQS:-32}
+rollout_max_num_batched_tokens=${VERL_VLLM_MAX_NUM_BATCHED_TOKENS:-4096}
+train_batch_size=${TRAIN_BATCH_SIZE:-16}
+rollout_n=${ROLLOUT_N:-4}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-16}
+exp_name=${VERL_EXPERIMENT_NAME:-kimi_k3_fsdpturbo_${nnodes}nodes_${start_time}}
+total_training_steps=${VERL_TOTAL_TRAINING_STEPS:-5}
+save_freq_default=-1
+profiler_log_level_default=WARN
+
+save_freq="${VERL_SAVE_FREQ:-${save_freq_default}}"
+rollout_enforce_eager="${VERL_VLLM_ENFORCE_EAGER:-False}"
+max_actor_ckpt_to_keep="${VERL_MAX_ACTOR_CKPT_TO_KEEP:-2}"
+resume_mode="${VERL_RESUME_MODE:-disable}"
+resume_from_path="${VERL_RESUME_FROM_PATH:-}"
+train_file="${TRAIN_FILE:-/mnt/share/w00848461/datasets/countbenchqa_lite/train_448.parquet}"
+test_file="${TEST_FILE:-/mnt/share/w00848461/datasets/countbenchqa_lite/train.parquet}"
+
+verl_path="${PROJECT_ROOT}/verl"
+fsdp_turbo_path="${PROJECT_ROOT}/FSDPTurbo"
+vllm_path="${PROJECT_ROOT}/vllm"
+vllm_ascend_path="${PROJECT_ROOT}/vllm-ascend"
+runtime_site="${PROJECT_ROOT}/.runtime-site"
+cann_python_site=/usr/local/Ascend/cann-9.0.1/python/site-packages
+
+# The checkpoint's Python files are executable remote code. Keep actor and
+# rollout on the reviewed FSDP-Turbo implementation for every launch.
+model_source=$model_path
+model_path="$PROJECT_ROOT/models/fsdpturbo-$(basename "$model_source")"
+python3 "$SCRIPT_DIR/prepare_kimi_k3_model.py" "$model_source" "$model_path" --code "$fsdp_turbo_path/fsdp_turbo/models/kimi"
+
+export PYTHONPATH="${PROJECT_ROOT}/.python_deps/modelopt-0.46.0:${runtime_site}:${verl_path}:${vllm_path}:${vllm_ascend_path}:${fsdp_turbo_path}:${fsdp_turbo_path}/examples:${cann_python_site}"
+export FSDP_TURBO_ROOT="${fsdp_turbo_path}"
+export VLLM_ASCEND_PATH="${vllm_ascend_path}"
+export ASCEND_RT_VISIBLE_DEVICES="${ASCEND_RT_VISIBLE_DEVICES:-${visible_devices_default}}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+export NON_MEGATRON="${NON_MEGATRON:-true}"
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV="${RAY_ENABLE_UV_RUN_RUNTIME_ENV:-0}"
+export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+export TOKENIZERS_PARALLELISM="${TOKENIZERS_PARALLELISM:-true}"
+export VLLM_LOGGING_LEVEL="${VLLM_LOGGING_LEVEL:-${profiler_log_level_default}}"
+export VERL_LOGGING_LEVEL="${VERL_LOGGING_LEVEL:-${profiler_log_level_default}}"
+export VLLM_DISABLE_COMPILE_CACHE="${VLLM_DISABLE_COMPILE_CACHE:-1}"
+export VLLM_BATCH_INVARIANT="${VLLM_BATCH_INVARIANT:-0}"
+export VLLM_ALLOW_RUNTIME_LORA_UPDATING="${VLLM_ALLOW_RUNTIME_LORA_UPDATING:-true}"
+export VLLM_USE_V1="${VLLM_USE_V1:-1}"
+export VLLM_ASCEND_ENABLE_FLASHCOMM="${VLLM_ASCEND_ENABLE_FLASHCOMM:-1}"
+export VLLM_ASCEND_ENABLE_NZ="${VLLM_ASCEND_ENABLE_NZ:-0}"
+export CUDA_DEVICE_MAX_CONNECTIONS="${CUDA_DEVICE_MAX_CONNECTIONS:-1}"
+export MULTI_STREAM_MEMORY_REUSE="${MULTI_STREAM_MEMORY_REUSE:-1}"
+export CPU_AFFINITY_CONF="${CPU_AFFINITY_CONF:-1}"
+export HCCL_OP_EXPANSION_MODE="${HCCL_OP_EXPANSION_MODE:-AIV}"
+export HCCL_SOCKET_IFNAME="${HCCL_SOCKET_IFNAME:-enp48s3u1u1}"
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-${HCCL_SOCKET_IFNAME}}"
+export HCCL_HOST_SOCKET_PORT_RANGE="${HCCL_HOST_SOCKET_PORT_RANGE:-auto}"
+export HCCL_NPU_SOCKET_PORT_RANGE="${HCCL_NPU_SOCKET_PORT_RANGE:-auto}"
+export HCCL_IF_BASE_PORT="${HCCL_IF_BASE_PORT:-50000}"
+export HCCL_EXEC_TIMEOUT="${HCCL_EXEC_TIMEOUT:-17340}"
+export HCCL_CONNECT_TIMEOUT="${HCCL_CONNECT_TIMEOUT:-7200}"
+export HCCL_ASYNC_ERROR_HANDLING="${HCCL_ASYNC_ERROR_HANDLING:-0}"
+export HCCL_BUFFSIZE="${HCCL_BUFFSIZE:-256}"
+export P2P_HCCL_BUFFSIZE="${P2P_HCCL_BUFFSIZE:-20}"
+export VLLM_VERSION="${VLLM_VERSION:-0.26.0}"
+export VERL_KIMI_MLP_CHUNK_TOKENS="${VERL_KIMI_MLP_CHUNK_TOKENS:-128}"
+
+export NPUS_PER_NODE=$npus_per_node
+KIMI_RAY_ARGS=()
+if [[ "$run_mode" == single ]]; then
+    kimi_single_ray_args
+else
+    : "${RAY_ADDRESS:?multinode mode must be started by ray_start_multi_nodes.sh}"
+fi
+
+rollout_data_dir="${VERL_ROLLOUT_DATA_DIR:-${PROJECT_ROOT}/rollout_dump/${start_time}}"
+training_log_dir="${PROJECT_ROOT}/verl/logs"
+mkdir -p "${rollout_data_dir}" "${training_log_dir}"
+training_log="${training_log_dir}/${exp_name}.log"
+
+max_prompt_length=1024
+rollout_multimodal_token_margin="${VERL_VLLM_MULTIMODAL_TOKEN_MARGIN:-16384}"
+rollout_max_model_len="${VERL_VLLM_MAX_MODEL_LEN:-$((max_prompt_length + max_response_length + rollout_multimodal_token_margin))}"
+ppo_max_token_len=$(((max_prompt_length + max_response_length) / 2))
+
+RAY_CONFIG=()
+while IFS= read -r name; do
+    case "$name" in
+        PYTHON*|NON_MEGATRON|FSDP_TURBO*|VLLM*|VERL*|ASCEND*|HCCL*|GLOO*|KIMI*|OMP*|TOKENIZERS*|TMPDIR|XDG_CACHE_HOME|HF_HOME|HF_MODULES_CACHE|TRITON_CACHE_DIR|TORCHINDUCTOR_CACHE_DIR)
+            RAY_CONFIG+=("++ray_kwargs.ray_init.runtime_env.env_vars.$name=\"${!name}\"") ;;
+    esac
+done < <(compgen -e)
+
+DATA_CONFIG=(
+    data.train_files="${train_file}"
+    data.val_files="${test_file}"
+    "data.train_batch_size=${train_batch_size}"
+    "data.max_prompt_length=${max_prompt_length}"
+    "data.max_response_length=${max_response_length}"
+    data.filter_overlong_prompts=True
+    data.filter_overlong_prompts_workers=null
+    data.truncation=error
+    data.image_key=images
+    data.shuffle=False
+    data.validation_shuffle=False
+    data.trust_remote_code=True
+)
+
+TRAINER_CONFIG=(
+    trainer.critic_warmup=0
+    'trainer.logger=["console"]'
+    trainer.project_name="${project_name}"
+    trainer.experiment_name="${exp_name}"
+    "trainer.n_gpus_per_node=${npus_per_node}"
+    "trainer.nnodes=${nnodes}"
+    trainer.balance_batch=True
+    trainer.resume_from_path="${resume_from_path}"
+    "trainer.resume_mode=${resume_mode}"
+    "trainer.save_freq=${save_freq}"
+    trainer.default_local_dir="${PROJECT_ROOT}/checkpoints/${project_name}/${exp_name}"
+    "trainer.max_actor_ckpt_to_keep=${max_actor_ckpt_to_keep}"
+    trainer.test_freq=-1
+    trainer.val_before_train=False
+    trainer.total_epochs=10
+    "trainer.total_training_steps=${total_training_steps}"
+    trainer.rollout_data_dir="${rollout_data_dir}"
+)
+
+MODEL_CONFIG=(
+    "actor_rollout_ref.model.path=${model_path}"
+    actor_rollout_ref.model.trust_remote_code=True
+    actor_rollout_ref.model.use_remove_padding=False
+    actor_rollout_ref.model.enable_gradient_checkpointing=False
+)
+
+ACTOR_CONFIG=(
+    actor_rollout_ref.actor.checkpoint.save_contents="['model','optimizer','extra']"
+    actor_rollout_ref.actor.checkpoint.load_contents="['model','optimizer','extra']"
+    actor_rollout_ref.actor.optim.lr=1e-6
+    actor_rollout_ref.actor.optim.lr_scheduler_type=constant
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.0
+    actor_rollout_ref.actor.optim.weight_decay=0.01
+    actor_rollout_ref.actor.optim.clip_grad=1.0
+    actor_rollout_ref.actor.optim.optimizer=AdamW
+    "actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}"
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.entropy_coeff=0
+    actor_rollout_ref.actor.kl_loss_coef=0.01
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    "actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len}"
+)
+
+ROLLOUT_CONFIG=(
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.kimi_training_backend=fsdpturbo
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.kimi_training_causal_conv1d=True
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.kimi_kda_oproj_fp32_reduce=True
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1
+    "actor_rollout_ref.rollout.tensor_model_parallel_size=${rollout_tp_size}"
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.mm_encoder_tp_mode=data
+    "actor_rollout_ref.rollout.expert_parallel_size=${rollout_ep_size}"
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.ignore_eos=False
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6
+    actor_rollout_ref.rollout.enable_rollout_routing_replay=True
+    "actor_rollout_ref.rollout.max_model_len=${rollout_max_model_len}"
+    "actor_rollout_ref.rollout.max_num_seqs=${rollout_max_num_seqs}"
+    "actor_rollout_ref.rollout.n=${rollout_n}"
+    actor_rollout_ref.rollout.enable_chunked_prefill=True
+    "actor_rollout_ref.rollout.max_num_batched_tokens=${rollout_max_num_batched_tokens}"
+    actor_rollout_ref.rollout.free_cache_engine=True
+    "actor_rollout_ref.rollout.enforce_eager=${rollout_enforce_eager}"
+    actor_rollout_ref.rollout.enable_prefix_caching=False
+    actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=256
+    actor_rollout_ref.rollout.load_format=dummy
+    actor_rollout_ref.rollout.logprobs_mode=processed_logprobs
+    actor_rollout_ref.rollout.calculate_log_probs=True
+    actor_rollout_ref.rollout.temperature=1.0
+    actor_rollout_ref.rollout.top_p=1.0
+    actor_rollout_ref.rollout.top_k=-1
+)
+
+# Kimi MoE reload keeps the graph-captured runtime storage address stable, so
+# graph mode can survive weight updates without recapture. Eager remains an
+# explicit diagnostic fallback.
+case "${rollout_enforce_eager,,}" in
+    false|0|no|off)
+        ROLLOUT_CONFIG+=(
+            +actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.cudagraph_mode=FULL_DECODE_ONLY
+            '+actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.cudagraph_capture_sizes=[1,2,4,8,16]'
+            +actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.max_cudagraph_capture_size=16
+            +actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.enable_sleep_mode_extra_cleanup=False
+        )
+        ;;
+esac
+
+# The actor and reference use the same model and sharding topology.
+fsdp_modules='{vision_tower.encoder.blocks.\{*\}:{},mm_projector:{},language_model.model.embed_tokens:{},language_model.model.layers.\{*\}.self_attn:{},language_model.model.layers.\{*\}.mlp:{},language_model.model.layers.\{*\}.block_sparse_moe:{},language_model.lm_head:{}}'
+FSDP_CONFIG=()
+for role in actor ref; do
+    prefix="actor_rollout_ref.$role"
+    FSDP_CONFIG+=(
+        "$prefix.strategy=fsdp_turbo"
+        "$prefix.fsdp_config.model_dtype=bfloat16"
+        "$prefix.fsdp_config.dtype=bfloat16"
+        "+$prefix.fsdp_config.turbo_config.model.attn_implementation=eager"
+        "+$prefix.fsdp_config.turbo_config.distributed.fsdp_plan.ignored_modules=[]"
+        "++$prefix.fsdp_config.turbo_config.distributed.fsdp_plan.apply_modules=$fsdp_modules"
+        "$prefix.fsdp_config.turbo_config.distributed.fsdp_plan.reduce_dtype=bf16"
+        "$prefix.fsdp_config.turbo_config.distributed.fsdp_plan.fsdp_implementation=native"
+        "$prefix.fsdp_config.turbo_config.distributed.fully_shard_parallel_size=$turbo_fsdp_size"
+        "$prefix.fsdp_config.turbo_config.distributed.ulysses_parallel_size=1"
+        "$prefix.fsdp_config.turbo_config.distributed.expert_parallel_size=$turbo_ep_size"
+        "+$prefix.fsdp_config.turbo_config.distributed.ep_plan.apply_modules=['language_model.model.layers.{*}.block_sparse_moe.experts']"
+        "+$prefix.fsdp_config.turbo_config.distributed.ep_plan.dispatcher=custom_ep_forward_fused"
+        "$prefix.fsdp_config.turbo_config.distributed.expert_fully_shard_parallel_size=$turbo_efsdp_size"
+        "+$prefix.fsdp_config.turbo_config.distributed.ep_plan.apply_efsdp_modules=['language_model.model.layers.{*}.block_sparse_moe.experts']"
+        "$prefix.fsdp_config.reshard_after_forward=True"
+        "$prefix.fsdp_config.offload_policy=False"
+        "$prefix.fsdp_config.param_offload=False"
+        "$prefix.entropy_from_logits_with_chunking=True"
+        "$prefix.use_torch_compile=False"
+    )
+done
+FSDP_CONFIG+=(
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False
+    actor_rollout_ref.actor.fsdp_config.turbo_config.distributed.fsdp_plan.num_to_forward_prefetch=1
+    actor_rollout_ref.actor.fsdp_config.turbo_config.distributed.fsdp_plan.num_to_backward_prefetch=1
+    +actor_rollout_ref.actor.fsdp_config.turbo_config.distributed.ep_plan.fixed_router=False
+    +actor_rollout_ref.actor.fsdp_config.turbo_config.memory.recompute=True
+    '+actor_rollout_ref.actor.fsdp_config.turbo_config.memory.recompute_plan=["language_model.model.layers.{*}","vision_tower.encoder.blocks.{*}"]'
+    actor_rollout_ref.ref.fsdp_config.wrap_policy.min_num_params=0
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1
+    "actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=$ppo_max_token_len"
+)
+
+echo "Kimi run: mode=${run_mode} experiment=${exp_name} model=${model_path} steps=${total_training_steps}"
+echo "Kimi offload: actor_policy=False actor_param=False actor_optimizer=False ref_config_policy=False ref_forward_only_runtime_policy=True"
+echo "Kimi topology: nodes=${nnodes} NPU/node=${npus_per_node} FSDP=${turbo_fsdp_size} EP=${turbo_ep_size} eFSDP=${turbo_efsdp_size} rollout_TP=${rollout_tp_size}"
+echo "Kimi sequence: prompt=${max_prompt_length} response=${max_response_length} multimodal_margin=${rollout_multimodal_token_margin} model_len=${rollout_max_model_len} actor_ref_tokens_per_gpu=${ppo_max_token_len}"
+echo "Kimi batches: train=${train_batch_size} rollout_n=${rollout_n} effective=$((train_batch_size * rollout_n)) ppo_mini=${ppo_mini_batch_size} micro_per_gpu=1 max_num_seqs=${rollout_max_num_seqs} max_batched_tokens=${rollout_max_num_batched_tokens}"
+echo "Kimi training log: ${training_log}"
+
+cd "${verl_path}"
+python3 -m verl.trainer.main_ppo \
+    --config-path=config \
+    --config-name=ppo_trainer.yaml \
+    model_engine=dp \
+    algorithm.adv_estimator=grpo \
+    algorithm.use_kl_in_reward=False \
+    algorithm.rollout_correction.bypass_mode=False \
+    "${DATA_CONFIG[@]}" \
+    "${MODEL_CONFIG[@]}" \
+    "${ACTOR_CONFIG[@]}" \
+    "${ROLLOUT_CONFIG[@]}" \
+    "${FSDP_CONFIG[@]}" \
+    "${TRAINER_CONFIG[@]}" \
+    "${RAY_CONFIG[@]}" \
+    "${KIMI_RAY_ARGS[@]}" \
+    "$@" 2>&1 | tee "${training_log}"

--- a/examples/ascend_extras/grpo_trainer/run_kimi_k3_megatron.sh
+++ b/examples/ascend_extras/grpo_trainer/run_kimi_k3_megatron.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+# Kimi-K3 CountBench GRPO: vLLM-Ascend rollout + Megatron/MindSpeed actor/ref.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+BACKEND_ROOT=${BACKEND_ROOT:-$(cd -- "$SCRIPT_DIR/../../.." && pwd -P)}
+source "$SCRIPT_DIR/kimi_k3_runtime.sh"
+RUN_MODE=${KIMI_RUN_MODE:-single}
+RUN_TIMESTAMP=${VERL_RUN_TIMESTAMP:-$(date +%Y%m%d_%H%M%S)}
+MODEL_PATH=${MODEL_PATH:-/mnt/share/w00848461/weights/K3-top16-pruned_bf16_countbench_128_n4}
+NUM_HIDDEN_LAYERS=$(python3 - "$MODEL_PATH/config.json" <<'PYCONFIG'
+import json
+import sys
+with open(sys.argv[1]) as stream:
+    config = json.load(stream)
+print(config.get("text_config", config)["num_hidden_layers"])
+PYCONFIG
+)
+TRAIN_FILE=${TRAIN_FILE:-/mnt/share/w00848461/datasets/countbenchqa_lite/train_448.parquet}
+VAL_FILE=${VAL_FILE:-$TRAIN_FILE}
+TRANSFORMERS_SITE=${TRANSFORMERS_SITE:-${BACKEND_ROOT}/.python_deps/transformers-5.10.4}
+MODELOPT_SITE=${MODELOPT_SITE:-${BACKEND_ROOT}/.python_deps/modelopt-0.46.0}
+VLLM_METADATA_SITE=${VLLM_METADATA_SITE:-${BACKEND_ROOT}/.python_deps/vllm-0.26.0}
+VLLM_SOURCE=${VLLM_SOURCE:-${BACKEND_ROOT}/vllm}
+VLLM_ASCEND_SOURCE=${VLLM_ASCEND_SOURCE:-${BACKEND_ROOT}/vllm-ascend}
+CANN_HOME=${ASCEND_HOME_PATH:-/usr/local/Ascend/ascend-toolkit/latest}
+CANN_PYTHON_SITE=${CANN_PYTHON_SITE:-${CANN_HOME}/python/site-packages}
+CANN_TBE_SITE=${CANN_TBE_SITE:-${CANN_HOME}/opp/built-in/op_impl/ai_core/tbe}
+
+ACTOR_GRAD_OFFLOAD=${ACTOR_GRAD_OFFLOAD:-True}
+SAVE_FREQ=${SAVE_FREQ:--1}
+OPTIMIZER_CPU_OFFLOAD=${OPTIMIZER_CPU_OFFLOAD:-True}
+OPTIMIZER_STORE_PARAM_REMAINDERS=${OPTIMIZER_STORE_PARAM_REMAINDERS:-True}
+REF_PARAM_OFFLOAD=${REF_PARAM_OFFLOAD:-True}
+ACTOR_RECOMPUTE=${ACTOR_RECOMPUTE:-True}
+
+case "$RUN_MODE" in
+    single)
+        NNODES=1
+        NPUS_PER_NODE=${NPUS_PER_NODE:-8}
+        ACTOR_TP=${ACTOR_TP:-4}
+        ACTOR_PP=${ACTOR_PP:-1}
+        ACTOR_CP=${ACTOR_CP:-1}
+        ACTOR_EP=${ACTOR_EP:-2}
+        ACTOR_ETP=${ACTOR_ETP:-1}
+        ROLLOUT_TP=${ROLLOUT_TP:-8}
+        ROLLOUT_EP=${ROLLOUT_EP:-8}
+        VISIBLE_DEVICES_DEFAULT=0,1,2,3,4,5,6,7
+        EXPERIMENT_NAME=${EXPERIMENT_NAME:-kimi_k3_megatron_1node_${RUN_TIMESTAMP}}
+        ;;
+    multinode)
+        : "${NNODES:?NNODES must be set by the multi-node Ray entry}"
+        if ((NNODES < 2)); then
+            echo "multinode mode requires NNODES >= 2, got $NNODES" >&2
+            exit 2
+        fi
+        NPUS_PER_NODE=${NPUS_PER_NODE:-16}
+        # TP4 x PP4 leaves four dense data-parallel replicas on four 16-NPU
+        # nodes. EP8 x ETP2 x PP4 still shards routed-expert parameters across
+        # the complete 64-rank world (expert data parallel size 1).
+        ACTOR_TP=${ACTOR_TP:-4}
+        # PP2 leaves too little physical HBM for the multimodal vLLM profile.
+        # PP4 reduces actor/ref parameter residency per rank and is retained
+        # for the no-offload fused-KDA fast path.
+        ACTOR_PP=${ACTOR_PP:-4}
+        ACTOR_CP=${ACTOR_CP:-1}
+        # Split each routed expert across two tensor-parallel ranks. EP8/ETP2
+        # preserves the 16-rank expert-parallel product while avoiding the
+        # TE-NPU one-group GroupedLinear edge case of EP16/ETP1.
+        ACTOR_EP=${ACTOR_EP:-8}
+        ACTOR_ETP=${ACTOR_ETP:-2}
+        # Keep actor parameters resident, but release Megatron's disposable
+        # FP32 grad flat-buffer storage between train phases. This creates the
+        # headroom required by Megatron-Bridge TP gathers during weight sync.
+        ROLLOUT_TP=${ROLLOUT_TP:-16}
+        ROLLOUT_EP=${ROLLOUT_EP:-16}
+        VISIBLE_DEVICES_DEFAULT=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+        EXPERIMENT_NAME=${EXPERIMENT_NAME:-kimi_k3_megatron_${NNODES}nodes_${RUN_TIMESTAMP}}
+        ;;
+    *)
+        echo "unsupported KIMI_RUN_MODE: $RUN_MODE (expected single or multinode)" >&2
+        exit 2
+        ;;
+esac
+
+# Multi-node mode defaults to the requested fast path.  Single-node mode keeps
+# its memory-saving defaults so invoking this script directly remains useful.
+# Every switch is independently overridable for staged OOM fallback tests.
+if [[ "$RUN_MODE" == single ]]; then
+    ACTOR_MICRO_BATCH_SIZE_PER_GPU=${ACTOR_MICRO_BATCH_SIZE_PER_GPU:-1}
+    LOG_PROB_MICRO_BATCH_SIZE_PER_GPU=${LOG_PROB_MICRO_BATCH_SIZE_PER_GPU:-1}
+    KIMI_KDA_DISABLE_INTERNAL_RECOMPUTE=${KIMI_KDA_DISABLE_INTERNAL_RECOMPUTE:-False}
+    KIMI_MEGATRON_DYNAMIC_MULTIMODAL_LENGTH=${KIMI_MEGATRON_DYNAMIC_MULTIMODAL_LENGTH:-False}
+    ACTOR_PARAM_OFFLOAD=${ACTOR_PARAM_OFFLOAD:-True}
+    ACTOR_OPTIMIZER_OFFLOAD=${ACTOR_OPTIMIZER_OFFLOAD:-True}
+    ROLLOUT_ENFORCE_EAGER=${ROLLOUT_ENFORCE_EAGER:-True}
+    ROLLOUT_GPU_MEMORY_UTILIZATION=${ROLLOUT_GPU_MEMORY_UTILIZATION:-0.6}
+    TQ_STORAGE_UNITS=${TQ_STORAGE_UNITS:-8}
+else
+    # Dynamic multimodal padding removes the fixed 4096-token tail. mbs=4
+    # reaches the 64-GiB HBM ceiling during grad-norm reduction; mbs=2 keeps
+    # enough collective workspace while retaining useful PP4 occupancy.
+    ACTOR_MICRO_BATCH_SIZE_PER_GPU=${ACTOR_MICRO_BATCH_SIZE_PER_GPU:-2}
+    LOG_PROB_MICRO_BATCH_SIZE_PER_GPU=${LOG_PROB_MICRO_BATCH_SIZE_PER_GPU:-4}
+    KIMI_KDA_DISABLE_INTERNAL_RECOMPUTE=${KIMI_KDA_DISABLE_INTERNAL_RECOMPUTE:-True}
+    KIMI_MEGATRON_DYNAMIC_MULTIMODAL_LENGTH=${KIMI_MEGATRON_DYNAMIC_MULTIMODAL_LENGTH:-True}
+    # FusedAdam materializes FP32 views of its low-precision moments during
+    # step(); with this model those transient buffers exceed 64-GiB HBM even
+    # at micro-batch 1. Offload optimizer state/updates, release actor gradient
+    # storage between phases, and stage the frozen reference model on CPU.
+    ACTOR_PARAM_OFFLOAD=${ACTOR_PARAM_OFFLOAD:-False}
+    ACTOR_OPTIMIZER_OFFLOAD=${ACTOR_OPTIMIZER_OFFLOAD:-False}
+    ROLLOUT_ENFORCE_EAGER=${ROLLOUT_ENFORCE_EAGER:-False}
+    # PP4 plus reference/gradient staging leaves enough HBM for a 0.50 vLLM
+    # budget while keeping actor parameters resident.
+    if ((ACTOR_PP >= 4)); then
+        ROLLOUT_GPU_MEMORY_UTILIZATION=${ROLLOUT_GPU_MEMORY_UTILIZATION:-0.50}
+    else
+        ROLLOUT_GPU_MEMORY_UTILIZATION=${ROLLOUT_GPU_MEMORY_UTILIZATION:-0.38}
+    fi
+    # SimpleStorage has one request worker per unit; use eight units per node
+    # so the simultaneous 64-rank GETs do not serialize behind one queue.
+    TQ_STORAGE_UNITS=${TQ_STORAGE_UNITS:-$((NNODES * 8))}
+fi
+TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT=${TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT:-600}
+TQ_NUM_THREADS=${TQ_NUM_THREADS:-8}
+KIMI_MEGATRON_MULTIMODAL_LENGTH_ALIGNMENT=${KIMI_MEGATRON_MULTIMODAL_LENGTH_ALIGNMENT:-256}
+# Ascend's colocated vLLM refit is most stable with one reusable IPC buffer
+# large enough for every full HF tensor. Kimi K3's 163840 x 7168 BF16 token
+# embedding/lm-head tensor is 2240 MiB; smaller buckets fall back to creating
+# short-lived direct NPU IPC handles for those tensors on every update. 4096
+# MiB also matches the upstream Ascend recipes added for the process-separated
+# checkpoint-engine weight transfer path.
+ROLLOUT_UPDATE_WEIGHTS_BUCKET_MEGABYTES=${ROLLOUT_UPDATE_WEIGHTS_BUCKET_MEGABYTES:-4096}
+for positive_integer in ACTOR_MICRO_BATCH_SIZE_PER_GPU LOG_PROB_MICRO_BATCH_SIZE_PER_GPU TQ_STORAGE_UNITS TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT TQ_NUM_THREADS KIMI_MEGATRON_MULTIMODAL_LENGTH_ALIGNMENT ROLLOUT_UPDATE_WEIGHTS_BUCKET_MEGABYTES; do
+    if [[ ! "${!positive_integer}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "$positive_integer must be a positive integer, got ${!positive_integer}" >&2
+        exit 2
+    fi
+done
+if [[ "${OPTIMIZER_CPU_OFFLOAD,,}" != true && "${OPTIMIZER_STORE_PARAM_REMAINDERS,,}" == true ]]; then
+    echo "NPU FusedAdam requires OPTIMIZER_STORE_PARAM_REMAINDERS=False" >&2
+    exit 2
+fi
+if [[ "${OPTIMIZER_CPU_OFFLOAD,,}" == true ]]; then
+    OPTIMIZER_OFFLOAD_FRACTION=${OPTIMIZER_OFFLOAD_FRACTION:-1.0}
+else
+    OPTIMIZER_OFFLOAD_FRACTION=${OPTIMIZER_OFFLOAD_FRACTION:-0.0}
+fi
+ROLLOUT_CUDAGRAPH_MODE=${ROLLOUT_CUDAGRAPH_MODE:-FULL_DECODE_ONLY}
+ROLLOUT_CUDAGRAPH_CAPTURE_SIZES=${ROLLOUT_CUDAGRAPH_CAPTURE_SIZES:-'[1,2,4,8,16]'}
+ROLLOUT_MAX_CUDAGRAPH_CAPTURE_SIZE=${ROLLOUT_MAX_CUDAGRAPH_CAPTURE_SIZE:-16}
+ROLLOUT_SLEEP_EXTRA_CLEANUP=${ROLLOUT_SLEEP_EXTRA_CLEANUP:-False}
+if ((ACTOR_PP > 1)); then
+    pipeline_base_layers=$((NUM_HIDDEN_LAYERS / ACTOR_PP))
+    PIPELINE_FIRST_LAYERS=${PIPELINE_FIRST_LAYERS:-$pipeline_base_layers}
+    PIPELINE_LAST_LAYERS=${PIPELINE_LAST_LAYERS:-$((
+        NUM_HIDDEN_LAYERS - pipeline_base_layers * (ACTOR_PP - 1)
+    ))}
+fi
+
+ROLLOUT_N=${ROLLOUT_N:-4}
+TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-16}
+PPO_MINI_BATCH_SIZE=${PPO_MINI_BATCH_SIZE:-16}
+MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-1024}
+MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-512}
+MAX_VISUAL_TOKENS=${MAX_VISUAL_TOKENS:-1024}
+MAX_MODEL_LENGTH=${MAX_MODEL_LENGTH:-4096}
+
+PROJECT_NAME=${PROJECT_NAME:-verl_kimi_k3}
+OUTPUT_ROOT=${OUTPUT_ROOT:-${BACKEND_ROOT}/verl/outputs/${PROJECT_NAME}/${EXPERIMENT_NAME}}
+LOG_DIR=${LOG_DIR:-${BACKEND_ROOT}/verl/logs}
+
+TOTAL_EPOCHS=${TOTAL_EPOCHS:-10}
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-5}
+
+required_mm_length=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH - 1 + MAX_VISUAL_TOKENS))
+if ((MAX_MODEL_LENGTH < required_mm_length)); then
+    echo "MAX_MODEL_LENGTH=$MAX_MODEL_LENGTH is smaller than the multimodal budget $required_mm_length" >&2
+    exit 2
+fi
+
+world_size=$((NNODES * NPUS_PER_NODE))
+dense_parallel_size=$((ACTOR_TP * ACTOR_PP * ACTOR_CP))
+expert_parallel_size=$((ACTOR_ETP * ACTOR_EP * ACTOR_PP))
+if ((world_size % dense_parallel_size != 0 || world_size % expert_parallel_size != 0)); then
+    echo "invalid Megatron topology: world=$world_size dense=$dense_parallel_size expert=$expert_parallel_size" >&2
+    exit 2
+fi
+if ((ROLLOUT_EP % ROLLOUT_TP != 0)); then
+    echo "rollout EP=$ROLLOUT_EP must be divisible by TP=$ROLLOUT_TP" >&2
+    exit 2
+fi
+ROLLOUT_DP=${ROLLOUT_DP:-$((ROLLOUT_EP / ROLLOUT_TP))}
+rollout_world_size=$((ROLLOUT_TP * ROLLOUT_DP))
+if ((ROLLOUT_EP != rollout_world_size || world_size % rollout_world_size != 0)); then
+    echo "invalid rollout topology: world=$world_size TP=$ROLLOUT_TP DP=$ROLLOUT_DP EP=$ROLLOUT_EP" >&2
+    exit 2
+fi
+if ((ACTOR_PP > 1)); then
+    middle_pipeline_stages=$((ACTOR_PP - 2))
+    middle_pipeline_layers=$((NUM_HIDDEN_LAYERS - PIPELINE_FIRST_LAYERS - PIPELINE_LAST_LAYERS))
+    if ((middle_pipeline_layers < 0)); then
+        echo "pipeline first/last layers exceed $NUM_HIDDEN_LAYERS" >&2
+        exit 2
+    fi
+    if ((middle_pipeline_stages == 0)); then
+        if ((middle_pipeline_layers != 0)); then
+            echo "PP=2 pipeline layers must add up to $NUM_HIDDEN_LAYERS" >&2
+            exit 2
+        fi
+    elif ((middle_pipeline_layers % middle_pipeline_stages != 0)); then
+        echo "the $middle_pipeline_layers middle layers cannot be divided across $middle_pipeline_stages pipeline stages" >&2
+        exit 2
+    fi
+fi
+dense_dp=$((world_size / dense_parallel_size))
+if ((TRAIN_BATCH_SIZE % dense_dp != 0 || PPO_MINI_BATCH_SIZE % dense_dp != 0)); then
+    echo "batch sizes must be divisible by dense DP=$dense_dp" >&2
+    exit 2
+fi
+
+export ASCEND_RT_VISIBLE_DEVICES=${ASCEND_RT_VISIBLE_DEVICES:-$VISIBLE_DEVICES_DEFAULT}
+unset NON_MEGATRON || true
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
+export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
+export TOKENIZERS_PARALLELISM=${TOKENIZERS_PARALLELISM:-true}
+export TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT
+export TQ_NUM_THREADS
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=${RAY_ENABLE_UV_RUN_RUNTIME_ENV:-0}
+export RAY_DEDUP_LOGS=${RAY_DEDUP_LOGS:-0}
+export RAY_memory_usage_threshold=${RAY_memory_usage_threshold:-0.99}
+export MINDSPEED_BRIDGE_AUTOREG_MODE=${MINDSPEED_BRIDGE_AUTOREG_MODE:-off}
+export VERL_USE_MEGATRON_ADAPTOR=enabled
+export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+export HCCL_SOCKET_IFNAME=${HCCL_SOCKET_IFNAME:-enp48s3u1u1}
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-enp48s3u1u1}
+export HCCL_HOST_SOCKET_PORT_RANGE=${HCCL_HOST_SOCKET_PORT_RANGE:-auto}
+export HCCL_NPU_SOCKET_PORT_RANGE=${HCCL_NPU_SOCKET_PORT_RANGE:-auto}
+export HCCL_CONNECT_TIMEOUT=${HCCL_CONNECT_TIMEOUT:-7200}
+export HCCL_EXEC_TIMEOUT=${HCCL_EXEC_TIMEOUT:-17340}
+export VLLM_USE_V1=${VLLM_USE_V1:-1}
+export VLLM_VERSION=${VLLM_VERSION:-0.26.0}
+export VLLM_ASCEND_ENABLE_FLASHCOMM=${VLLM_ASCEND_ENABLE_FLASHCOMM:-1}
+export VLLM_ASCEND_ENABLE_NZ=${VLLM_ASCEND_ENABLE_NZ:-0}
+export VLLM_DISABLE_COMPILE_CACHE=${VLLM_DISABLE_COMPILE_CACHE:-1}
+KIMI_USE_FUSED_KDA=${KIMI_USE_FUSED_KDA:-True}
+KIMI_VLLM_USE_TRAINING_CAUSAL_CONV1D=${KIMI_VLLM_USE_TRAINING_CAUSAL_CONV1D:-True}
+KIMI_KDA_OPROJ_FP32_REDUCE=${KIMI_KDA_OPROJ_FP32_REDUCE:-True}
+export KIMI_RUN_TOKEN=${KIMI_RUN_TOKEN:-$(cat /proc/sys/kernel/random/uuid)}
+
+source_roots=(
+    "$TRANSFORMERS_SITE"
+    "$MODELOPT_SITE"
+    "$VLLM_METADATA_SITE"
+    "$VLLM_SOURCE"
+    "$VLLM_ASCEND_SOURCE"
+    "$BACKEND_ROOT/verl"
+    "$BACKEND_ROOT/MS-Bridge-KIMI-K3"
+    "$BACKEND_ROOT/Megatron-Bridge/src"
+    "$BACKEND_ROOT/Megatron-LM-KIMI-K3"
+    "$BACKEND_ROOT/MegatronAdaptor"
+    "$BACKEND_ROOT/TransformerEngineNPU"
+    "$BACKEND_ROOT/MindSpeed-Ops"
+    "$BACKEND_ROOT/.runtime-site"
+    "$CANN_PYTHON_SITE"
+    "$CANN_TBE_SITE"
+)
+joined_pythonpath=$(IFS=:; echo "${source_roots[*]}")
+export PYTHONPATH="$joined_pythonpath"
+
+pipeline_summary=""
+if ((ACTOR_PP > 1)); then
+    if ((middle_pipeline_stages == 0)); then
+        pipeline_summary=" pipeline_layers=${PIPELINE_FIRST_LAYERS}+${PIPELINE_LAST_LAYERS}"
+    else
+        pipeline_layers_per_middle_stage=$((middle_pipeline_layers / middle_pipeline_stages))
+        pipeline_summary=" pipeline_layers=${PIPELINE_FIRST_LAYERS}+${pipeline_layers_per_middle_stage}x${middle_pipeline_stages}+${PIPELINE_LAST_LAYERS}"
+    fi
+fi
+echo "run=$RUN_MODE model=$MODEL_PATH world=$world_size TP=$ACTOR_TP PP=$ACTOR_PP EP=$ACTOR_EP ETP=$ACTOR_ETP rollout_TP=$ROLLOUT_TP rollout_DP=$ROLLOUT_DP rollout_EP=$ROLLOUT_EP${pipeline_summary} steps=$TOTAL_TRAINING_STEPS"
+echo "optimizer_cpu_offload=$OPTIMIZER_CPU_OFFLOAD optimizer_offload_fraction=$OPTIMIZER_OFFLOAD_FRACTION store_param_remainders=$OPTIMIZER_STORE_PARAM_REMAINDERS actor_param_offload=$ACTOR_PARAM_OFFLOAD actor_optimizer_offload=$ACTOR_OPTIMIZER_OFFLOAD actor_grad_offload=$ACTOR_GRAD_OFFLOAD ref_param_offload=$REF_PARAM_OFFLOAD recompute=$ACTOR_RECOMPUTE enforce_eager=$ROLLOUT_ENFORCE_EAGER rollout_gpu_memory_utilization=$ROLLOUT_GPU_MEMORY_UTILIZATION update_weights_bucket_mb=$ROLLOUT_UPDATE_WEIGHTS_BUCKET_MEGABYTES cudagraph_mode=$ROLLOUT_CUDAGRAPH_MODE cudagraph_sizes=$ROLLOUT_CUDAGRAPH_CAPTURE_SIZES cudagraph_max=$ROLLOUT_MAX_CUDAGRAPH_CAPTURE_SIZE sleep_extra_cleanup=$ROLLOUT_SLEEP_EXTRA_CLEANUP"
+echo "micro_batch_actor=$ACTOR_MICRO_BATCH_SIZE_PER_GPU micro_batch_log_prob=$LOG_PROB_MICRO_BATCH_SIZE_PER_GPU"
+echo "training_kda=fused:$KIMI_USE_FUSED_KDA internal_recompute_disabled=$KIMI_KDA_DISABLE_INTERNAL_RECOMPUTE dynamic_multimodal_length=$KIMI_MEGATRON_DYNAMIC_MULTIMODAL_LENGTH multimodal_length_alignment=$KIMI_MEGATRON_MULTIMODAL_LENGTH_ALIGNMENT dist_checkpoint=${ACTOR_USE_DIST_CHECKPOINTING:-True} resume_mode=${RESUME_MODE:-disable}"
+echo "transfer_queue_storage_units=$TQ_STORAGE_UNITS transfer_queue_timeout_s=$TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT transfer_queue_threads_per_unit=$TQ_NUM_THREADS"
+DATA=(
+    data.train_files="$TRAIN_FILE"
+    data.val_files="$VAL_FILE"
+    data.image_key=images
+    "data.train_batch_size=$TRAIN_BATCH_SIZE"
+    "data.max_prompt_length=$MAX_PROMPT_LENGTH"
+    "data.max_response_length=$MAX_RESPONSE_LENGTH"
+    data.filter_overlong_prompts=True
+    # Kimi-K3's remote-code tokenizer retains an SSLContext, so even
+    # datasets' one-worker pool cannot pickle it.
+    # A null num_proc keeps this lightweight filter in the Ray actor process.
+    data.filter_overlong_prompts_workers=null
+    data.truncation=error
+    data.shuffle=False
+    data.validation_shuffle=False
+    data.trust_remote_code=True
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.model.trust_remote_code=True
+    actor_rollout_ref.model.use_remove_padding=False
+    actor_rollout_ref.model.use_fused_kernels=False
+)
+
+ACTOR=(
+    "actor_rollout_ref.actor.optim.lr=${ACTOR_LR:-1e-6}"
+    actor_rollout_ref.actor.optim.lr_decay_style=constant
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.0
+    actor_rollout_ref.actor.optim.weight_decay=0.01
+    actor_rollout_ref.actor.optim.clip_grad=1.0
+    actor_rollout_ref.actor.optim.use_precision_aware_optimizer=True
+    actor_rollout_ref.actor.optim.main_grads_dtype=bf16
+    actor_rollout_ref.actor.optim.exp_avg_dtype=bf16
+    actor_rollout_ref.actor.optim.exp_avg_sq_dtype=bf16
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_cpu_offload=$OPTIMIZER_CPU_OFFLOAD"
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_offload_fraction=$OPTIMIZER_OFFLOAD_FRACTION"
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.store_param_remainders=$OPTIMIZER_STORE_PARAM_REMAINDERS"
+    "actor_rollout_ref.actor.ppo_mini_batch_size=$PPO_MINI_BATCH_SIZE"
+    "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$ACTOR_MICRO_BATCH_SIZE_PER_GPU"
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))
+    actor_rollout_ref.actor.use_dynamic_bsz=False
+    actor_rollout_ref.actor.use_torch_compile=False
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.kl_loss_coef=0.01
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.entropy_coeff=0
+    actor_rollout_ref.actor.calculate_entropy=False
+    actor_rollout_ref.actor.entropy_from_logits_with_chunking=True
+    actor_rollout_ref.actor.megatron.router_replay.mode=R3
+    "actor_rollout_ref.actor.megatron.use_dist_checkpointing=${ACTOR_USE_DIST_CHECKPOINTING:-True}"
+    "actor_rollout_ref.actor.megatron.param_offload=$ACTOR_PARAM_OFFLOAD"
+    "actor_rollout_ref.actor.megatron.optimizer_offload=$ACTOR_OPTIMIZER_OFFLOAD"
+    "actor_rollout_ref.actor.megatron.grad_offload=$ACTOR_GRAD_OFFLOAD"
+    # Use the same MindSpeed Triton short convolution as rollout. The native
+    # grouped conv1d path differs by BF16 rounding before KDA recurrence.
+)
+
+if [[ "${ACTOR_RECOMPUTE,,}" == true ]]; then
+    ACTOR+=(
+        actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full
+        actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform
+        actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1
+    )
+fi
+
+REF=(
+    "actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=$LOG_PROB_MICRO_BATCH_SIZE_PER_GPU"
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=False
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))
+    actor_rollout_ref.ref.use_torch_compile=False
+    "actor_rollout_ref.ref.megatron.param_offload=$REF_PARAM_OFFLOAD"
+)
+
+if ((ACTOR_PP > 1)); then
+    ACTOR+=(
+        "+actor_rollout_ref.actor.megatron.override_transformer_config.num_layers_in_first_pipeline_stage=$PIPELINE_FIRST_LAYERS"
+        "+actor_rollout_ref.actor.megatron.override_transformer_config.num_layers_in_last_pipeline_stage=$PIPELINE_LAST_LAYERS"
+    )
+    REF+=(
+        "++actor_rollout_ref.ref.megatron.override_transformer_config.num_layers_in_first_pipeline_stage=$PIPELINE_FIRST_LAYERS"
+        "++actor_rollout_ref.ref.megatron.override_transformer_config.num_layers_in_last_pipeline_stage=$PIPELINE_LAST_LAYERS"
+    )
+fi
+
+BRIDGE=()
+for role in actor ref; do
+    BRIDGE+=(
+        "actor_rollout_ref.$role.megatron.use_mbridge=True"
+        "actor_rollout_ref.$role.megatron.vanilla_mbridge=False"
+        "actor_rollout_ref.$role.megatron.use_remove_padding=False"
+        "actor_rollout_ref.$role.megatron.tensor_model_parallel_size=$ACTOR_TP"
+        "actor_rollout_ref.$role.megatron.pipeline_model_parallel_size=$ACTOR_PP"
+        "actor_rollout_ref.$role.megatron.context_parallel_size=$ACTOR_CP"
+        "actor_rollout_ref.$role.megatron.expert_model_parallel_size=$ACTOR_EP"
+        "actor_rollout_ref.$role.megatron.expert_tensor_parallel_size=$ACTOR_ETP"
+        "actor_rollout_ref.$role.megatron.sequence_parallel=True"
+        "++actor_rollout_ref.$role.megatron.override_transformer_config.seq_length=$MAX_MODEL_LENGTH"
+        "++actor_rollout_ref.$role.megatron.override_transformer_config.kimi_use_fused_kda=$KIMI_USE_FUSED_KDA"
+        "++actor_rollout_ref.$role.megatron.override_transformer_config.kimi_kda_disable_internal_recompute=$KIMI_KDA_DISABLE_INTERNAL_RECOMPUTE"
+        "++actor_rollout_ref.$role.megatron.override_transformer_config.kimi_kda_oproj_fp32_reduce=$KIMI_KDA_OPROJ_FP32_REDUCE"
+        "++actor_rollout_ref.$role.megatron.override_transformer_config.kimi_dynamic_multimodal_length=$KIMI_MEGATRON_DYNAMIC_MULTIMODAL_LENGTH"
+        "++actor_rollout_ref.$role.megatron.override_transformer_config.kimi_multimodal_length_alignment=$KIMI_MEGATRON_MULTIMODAL_LENGTH_ALIGNMENT"
+        "++actor_rollout_ref.$role.megatron.override_transformer_config.kimi_use_fused_short_conv=True"
+    )
+done
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=vllm
+    "actor_rollout_ref.rollout.tensor_model_parallel_size=$ROLLOUT_TP"
+    "actor_rollout_ref.rollout.data_parallel_size=$ROLLOUT_DP"
+    "actor_rollout_ref.rollout.expert_parallel_size=$ROLLOUT_EP"
+    "actor_rollout_ref.rollout.n=$ROLLOUT_N"
+    actor_rollout_ref.rollout.temperature=1.0
+    actor_rollout_ref.rollout.top_p=1.0
+    actor_rollout_ref.rollout.top_k=-1
+    "actor_rollout_ref.rollout.gpu_memory_utilization=$ROLLOUT_GPU_MEMORY_UTILIZATION"
+    "actor_rollout_ref.rollout.max_model_len=$MAX_MODEL_LENGTH"
+    "actor_rollout_ref.rollout.max_num_seqs=${ROLLOUT_MAX_NUM_SEQS:-16}"
+    "actor_rollout_ref.rollout.max_num_batched_tokens=${ROLLOUT_MAX_BATCHED_TOKENS:-2048}"
+    actor_rollout_ref.rollout.enable_chunked_prefill=True
+    actor_rollout_ref.rollout.enable_prefix_caching=False
+    "actor_rollout_ref.rollout.enforce_eager=$ROLLOUT_ENFORCE_EAGER"
+    actor_rollout_ref.rollout.free_cache_engine=True
+    actor_rollout_ref.rollout.load_format=dummy
+    actor_rollout_ref.rollout.calculate_log_probs=True
+    actor_rollout_ref.rollout.enable_rollout_routing_replay=True
+    "actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=$LOG_PROB_MICRO_BATCH_SIZE_PER_GPU"
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=False
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))
+    "actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=$ROLLOUT_UPDATE_WEIGHTS_BUCKET_MEGABYTES"
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.mm_encoder_tp_mode=data
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.cudagraph_mode="$ROLLOUT_CUDAGRAPH_MODE"
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.cudagraph_capture_sizes="$ROLLOUT_CUDAGRAPH_CAPTURE_SIZES"
+    "+actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.max_cudagraph_capture_size=$ROLLOUT_MAX_CUDAGRAPH_CAPTURE_SIZE"
+    "+actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.enable_sleep_mode_extra_cleanup=$ROLLOUT_SLEEP_EXTRA_CLEANUP"
+    "+actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.kimi_training_causal_conv1d=$KIMI_VLLM_USE_TRAINING_CAUSAL_CONV1D"
+    "+actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.kimi_kda_oproj_fp32_reduce=$KIMI_KDA_OPROJ_FP32_REDUCE"
+)
+
+TRAINER=(
+    trainer.logger='["console"]'
+    trainer.project_name="$PROJECT_NAME"
+    trainer.experiment_name="$EXPERIMENT_NAME"
+    "trainer.nnodes=$NNODES"
+    "trainer.n_gpus_per_node=$NPUS_PER_NODE"
+    trainer.balance_batch=False
+    trainer.val_before_train=False
+    "trainer.resume_mode=${RESUME_MODE:-disable}"
+    "trainer.save_freq=$SAVE_FREQ"
+    # max_ckpt_to_keep=1 is failure-safe in verl: the previous checkpoint is
+    # removed only after the new checkpoint has been saved successfully.
+    "trainer.max_actor_ckpt_to_keep=${MAX_ACTOR_CKPT_TO_KEEP:-1}"
+    "trainer.max_critic_ckpt_to_keep=${MAX_CRITIC_CKPT_TO_KEEP:-1}"
+    "trainer.test_freq=${TEST_FREQ:--1}"
+    "trainer.total_epochs=$TOTAL_EPOCHS"
+    "trainer.total_training_steps=$TOTAL_TRAINING_STEPS"
+    trainer.default_local_dir="$OUTPUT_ROOT"
+)
+if [[ -n "${RESUME_FROM_PATH:-}" ]]; then
+    TRAINER+=(trainer.resume_from_path="$RESUME_FROM_PATH")
+fi
+
+TRANSFER_QUEUE=(
+    "transfer_queue.backend.SimpleStorage.num_data_storage_units=$TQ_STORAGE_UNITS"
+)
+
+RAY=()
+ray_env_vars=(
+    TMPDIR XDG_CACHE_HOME HF_HOME HF_MODULES_CACHE TRITON_CACHE_DIR TORCHINDUCTOR_CACHE_DIR PYTHONDONTWRITEBYTECODE
+    ASCEND_RT_VISIBLE_DEVICES PYTHONPATH OMP_NUM_THREADS PYTHONHASHSEED
+    TOKENIZERS_PARALLELISM TQ_SIMPLE_STORAGE_SEND_RECV_TIMEOUT TQ_NUM_THREADS
+    MINDSPEED_BRIDGE_AUTOREG_MODE VERL_USE_MEGATRON_ADAPTOR
+    VLLM_USE_V1 VLLM_VERSION VLLM_ASCEND_ENABLE_FLASHCOMM
+    VLLM_ASCEND_ENABLE_NZ VLLM_DISABLE_COMPILE_CACHE
+    CUDA_DEVICE_MAX_CONNECTIONS KIMI_RUN_TOKEN
+    HCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME HCCL_HOST_SOCKET_PORT_RANGE
+    HCCL_NPU_SOCKET_PORT_RANGE HCCL_CONNECT_TIMEOUT HCCL_EXEC_TIMEOUT
+)
+for name in "${ray_env_vars[@]}"; do
+    RAY+=("++ray_kwargs.ray_init.runtime_env.env_vars.${name}=\"${!name}\"")
+done
+
+KIMI_RAY_ARGS=()
+if [[ "$RUN_MODE" == single ]]; then
+    kimi_single_ray_args
+else
+    : "${RAY_ADDRESS:?multinode mode must be started by ray_start_multi_nodes.sh}"
+fi
+
+mkdir -p "$OUTPUT_ROOT" "$LOG_DIR"
+log_file="$LOG_DIR/${EXPERIMENT_NAME}.log"
+echo "log=$log_file output=$OUTPUT_ROOT"
+cd "$BACKEND_ROOT/verl"
+
+python3 -m verl.trainer.main_ppo \
+    --config-path=config \
+    --config-name=ppo_trainer.yaml \
+    model_engine=megatron \
+    algorithm.adv_estimator=grpo \
+    algorithm.use_kl_in_reward=False \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${REF[@]}" \
+    "${BRIDGE[@]}" \
+    "${ROLLOUT[@]}" \
+    "${TRAINER[@]}" \
+    "${TRANSFER_QUEUE[@]}" \
+    "${RAY[@]}" \
+    "${KIMI_RAY_ARGS[@]}" \
+    "$@" 2>&1 | tee "$log_file"

--- a/examples/data_preprocess/prepare_countbenchqa_lite_parquet.py
+++ b/examples/data_preprocess/prepare_countbenchqa_lite_parquet.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Convert a raw CountBenchQA-lite parquet shard to verl RL parquet.
+
+The raw shard contains ``image``, ``text``, ``question`` and ``number``.
+verl's RLHFDataset expects a chat-style ``prompt`` column and multimodal
+images in an ``images`` column, plus the ground-truth answer in
+``reward_model``.
+
+This script deliberately does not copy ``text`` into the output prompt:
+CountBenchQA captions can contain the answer and would leak the label.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import datasets
+
+INSTRUCTION = (
+    " You FIRST think about the reasoning process as an internal monologue and then provide the final answer."
+    " The reasoning process MUST BE enclosed within <think> </think> tags."
+    " The final answer MUST BE put in \\boxed{}."
+)
+
+
+def convert(input_path: str, output_path: str, split: str = "test") -> None:
+    dataset = datasets.load_dataset("parquet", data_files={"data": input_path})["data"]
+    required = {"image", "question", "number"}
+    missing = required.difference(dataset.column_names)
+    if missing:
+        raise ValueError(f"Raw CountBenchQA parquet is missing columns {sorted(missing)}; found {dataset.column_names}")
+
+    def make_example(example: dict, index: int) -> dict:
+        question = str(example["question"])
+        answer = str(example["number"])
+        return {
+            "data_source": "countbenchqa_lite",
+            "prompt": [
+                {
+                    "role": "user",
+                    "content": f"<image>\n{question}{INSTRUCTION}",
+                }
+            ],
+            "images": [example["image"]],
+            "ability": "math",
+            "reward_model": {"style": "rule", "ground_truth": answer},
+            "extra_info": {
+                "split": split,
+                "index": index,
+                "answer": answer,
+                "question": question,
+            },
+        }
+
+    converted = dataset.map(
+        make_example,
+        with_indices=True,
+        remove_columns=dataset.column_names,
+        desc="Converting CountBenchQA-lite to verl format",
+    )
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    converted.to_parquet(output_path)
+
+    print(f"wrote {len(converted)} rows to {output_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="raw CountBenchQA parquet shard")
+    parser.add_argument("--output", required=True, help="verl-format parquet output")
+    parser.add_argument("--split", default="test")
+    args = parser.parse_args()
+    convert(args.input, args.output, args.split)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import warnings
 from contextlib import nullcontext
+from types import SimpleNamespace
 from typing import Any, Optional
 
 import numpy as np
@@ -33,6 +34,7 @@ from verl.experimental.agent_loop.agent_loop import (
 )
 from verl.experimental.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
 from verl.utils.dataset.rl_dataset import RLHFDataset
+from verl.workers.rollout.r3_utils import KIMI_FULL_MODEL_ROUTE_SEMANTICS
 from verl.workers.rollout.replica import TokenOutput
 
 
@@ -189,6 +191,7 @@ async def test_agent_loop_worker_passes_only_hf_model_type_through_hydra(monkeyp
     worker.llm_client = object()
     worker.tokenizer = _FakeTokenizer()
     worker.processor = None
+    worker.model_config = object()
     worker.hf_model_type = "qwen2_5_vl"
     worker.dataset_cls = RLHFDataset
     worker.tools = []
@@ -350,7 +353,8 @@ async def test_agent_loop_extra_fields_schema_stable_for_training_concat_on_cpu(
 
 
 @pytest.mark.asyncio
-async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
+@pytest.mark.parametrize("full_r3", [False, True])
+async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu(full_r3):
     class _DummyWorker:
         _compute_multi_modal_inputs = AgentLoopWorker._compute_multi_modal_inputs
         _compute_position_ids = AgentLoopWorker._compute_position_ids
@@ -367,6 +371,10 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
             self.mm_processor_kwargs = {}
             self.reward_loop_worker_handles = None
 
+    worker = _DummyWorker()
+    worker.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(model_type="kimi_k3", num_hidden_layers=2, num_experts=8, num_experts_per_token=1)
+    )
     routed_experts = np.arange(8, dtype=np.int64).reshape(4, 2, 1)
     routed_experts.setflags(write=False)
     assert not routed_experts.flags.writeable
@@ -376,6 +384,8 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
         response_ids=[11, 12],
         response_mask=[1, 1],
         routed_experts=routed_experts,
+        routed_expert_weights=np.ones((4, 2, 1), dtype=np.float32) if full_r3 else None,
+        routed_experts_source_semantics=KIMI_FULL_MODEL_ROUTE_SEMANTICS if full_r3 else None,
         metrics=AgentLoopMetrics(),
         extra_fields={},
     )
@@ -387,17 +397,23 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
             category=UserWarning,
         )
         internal = await AgentLoopWorker._agent_loop_postprocess(
-            _DummyWorker(),
+            worker,
             output,
             validate=False,
             raw_prompt=[{"role": "user", "content": "hi"}],
         )
 
-    # Rollout is where routed_experts gets its int16 storage dtype, whatever dtype
-    # the backend handed over.
-    expected = torch.tensor(routed_experts.copy()).to(torch.int16).unsqueeze(0)
+    if full_r3:
+        assert internal.routed_experts.is_nested
+        torch.testing.assert_close(
+            internal.routed_experts.values(), torch.tensor(routed_experts.copy()).to(torch.uint8)
+        )
+        torch.testing.assert_close(internal.routed_expert_weights.values(), torch.ones(4, 2, 1))
+        return
+
+    expected = torch.tensor(routed_experts.copy()).unsqueeze(0)
     assert internal.routed_experts is not None
-    assert internal.routed_experts.dtype == torch.int16
+    assert internal.routed_experts.dtype == expected.dtype
     assert internal.routed_experts.shape == (1, 8, 2, 1)
     torch.testing.assert_close(internal.routed_experts[:, 2:6], expected)
     assert torch.count_nonzero(internal.routed_experts[:, :2]) == 0

--- a/tests/special_distributed/test_bucketed_weight_transfer_ipc_on_cpu.py
+++ b/tests/special_distributed/test_bucketed_weight_transfer_ipc_on_cpu.py
@@ -1,0 +1,31 @@
+"""CPU-only regression tests for vLLM weight-transfer IPC dispatch."""
+
+import torch
+from torch.multiprocessing.reductions import reduce_tensor
+
+from verl.workers.rollout.vllm_rollout import bucketed_weight_transfer as transfer
+
+
+def test_rebuild_cpu_handle_does_not_inject_accelerator_device(monkeypatch):
+    source = torch.arange(4, dtype=torch.float32)
+    handle = reduce_tensor(source)
+    assert len(handle[1]) < 7
+
+    monkeypatch.setattr(transfer, "get_device_name", lambda: "cpu")
+    rebuilt = transfer.rebuild_ipc(handle, device_id=0)
+
+    assert rebuilt.device.type == "cpu"
+    torch.testing.assert_close(rebuilt, source)
+
+
+def test_rebuild_accelerator_handle_uses_named_rebuilder(monkeypatch):
+    captured = {}
+
+    def rebuild_npu_tensor(*args):
+        captured["args"] = args
+        return torch.ones(1)
+
+    monkeypatch.setattr(transfer, "get_device_name", lambda: "cpu")
+    transfer.rebuild_ipc((rebuild_npu_tensor, (0, 1, 2, 3, 4, 5, 6)), device_id=9)
+
+    assert captured["args"][6] == 9

--- a/tests/trainer/test_constants_ppo_on_cpu.py
+++ b/tests/trainer/test_constants_ppo_on_cpu.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import os
+import subprocess
+import sys
 from unittest.mock import patch
 
+import pytest
 from omegaconf import OmegaConf
 
 from verl.trainer.constants_ppo import NVTX_INJECTION_ENV, get_ppo_ray_runtime_env
@@ -49,3 +52,20 @@ def test_nvtx_injection_override_can_be_opted_out():
         env_vars = get_ppo_ray_runtime_env(_config("torch"))["env_vars"]
 
     assert NVTX_INJECTION_ENV not in env_vars
+
+
+def test_standalone_transfer_queue_worker_initializes_optional_import_guard(monkeypatch):
+    pytest.importorskip("transfer_queue")
+    monkeypatch.delenv("VERL_TRANSFER_QUEUE_ENABLE_MOONCAKE", raising=False)
+    hook = get_ppo_ray_runtime_env()["worker_process_setup_hook"]
+    code = f"""
+from ray._private.runtime_env.setup_hook import load_and_execute_setup_hook
+error = load_and_execute_setup_hook({hook!r})
+assert error is None, error
+import transfer_queue
+import sys
+assert sys.modules["mooncake.store"] is None
+assert sys.modules["mooncake.engine"] is None
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/utils/debug/test_metrics.py
+++ b/tests/utils/debug/test_metrics.py
@@ -43,6 +43,18 @@ class TestMetrics(unittest.TestCase):
         print(metrics)
         assert metrics["training/rollout_probs_diff_valid"] == 1
 
+    def test_log_prob_diff_mean_is_absolute(self):
+        data = DataProto.from_dict(
+            {
+                "rollout_log_probs": torch.tensor([[-1.0, -2.0, -3.0]]),
+                "old_log_probs": torch.tensor([[-1.5, -1.0, -3.5]]),
+                "response_mask": torch.tensor([[1, 1, 0]]),
+                "responses": torch.zeros((1, 3)),
+            }
+        )
+        metrics = calculate_debug_metrics(data)
+        self.assertAlmostEqual(metrics["training/rollout_log_probs_diff_mean"], 0.75)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/megatron/test_dist_checkpointing_on_cpu.py
+++ b/tests/utils/megatron/test_dist_checkpointing_on_cpu.py
@@ -1,0 +1,45 @@
+from functools import partial
+from unittest.mock import patch
+
+import torch
+
+from verl.utils.megatron.dist_checkpointing import (
+    _MemoryEfficientSyncSaveStrategy,
+    _preload_tensors_for_sync_save,
+)
+
+
+def test_sync_preloader_reuses_cpu_tensor():
+    tensor = torch.ones(4)
+    buckets = [("part", "key", (b"metadata", [("tensor", tensor)]))]
+
+    staged = _preload_tensors_for_sync_save(buckets, non_blocking=False)
+
+    assert staged[0][2][1][0][1] is tensor
+
+
+def test_sync_strategy_replaces_only_its_request_preloader(tmp_path):
+    tensor = torch.ones(4)
+    buckets = [("part", "key", (b"metadata", [("tensor", tensor)]))]
+
+    def upstream_preloader(write_buckets, non_blocking=True):
+        return write_buckets, non_blocking
+
+    class Request:
+        def __init__(self):
+            self.preload_fn = partial(upstream_preloader, buckets, False)
+            self.executed = None
+
+        def _replace(self, **changes):
+            self.preload_fn = changes["preload_fn"]
+            return self
+
+        def execute_sync(self):
+            self.executed = self.preload_fn()
+
+    request = Request()
+    strategy = _MemoryEfficientSyncSaveStrategy()
+    with patch.object(strategy, "async_save", return_value=request):
+        strategy.save({}, tmp_path)
+
+    assert request.executed[0][2][1][0][1] is tensor

--- a/tests/utils/megatron/test_optimizer_offload_and_load.py
+++ b/tests/utils/megatron/test_optimizer_offload_and_load.py
@@ -25,7 +25,12 @@ from megatron.core.optimizer.optimizer import ChainedOptimizer
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_config import TransformerConfig
 
-from verl.utils.megatron_utils import load_megatron_optimizer, offload_megatron_optimizer
+from verl.utils.megatron_utils import (
+    load_megatron_grad_to_gpu,
+    load_megatron_optimizer,
+    offload_megatron_grad_to_cpu,
+    offload_megatron_optimizer,
+)
 
 # ==== Helper functions ==== #
 
@@ -130,6 +135,22 @@ def test_precision_aware_optimizer_offload_and_load(tmp_path):
         optimizer.zero_grad(set_to_none=False)
         update_successful, _, _ = optimizer.step()
         assert update_successful
+
+        # Grad-only offload releases and recreates the flat DDP buffers without
+        # moving model parameters.
+        grad_buffers = [
+            buffer
+            for model_chunk in model_chunks
+            for buffers in (model_chunk.buffers, model_chunk.expert_parallel_buffers)
+            for buffer in buffers
+        ]
+        expected_sizes = [buffer.grad_data.storage().size() for buffer in grad_buffers]
+        assert all(size > 0 for size in expected_sizes)
+        offload_megatron_grad_to_cpu(model_chunks)
+        assert all(buffer.grad_data.storage().size() == 0 for buffer in grad_buffers)
+        load_megatron_grad_to_gpu(model_chunks)
+        assert [buffer.grad_data.storage().size() for buffer in grad_buffers] == expected_sizes
+        assert all(torch.count_nonzero(buffer.grad_data) == 0 for buffer in grad_buffers)
 
         # Offload optimizer state.
         offload_megatron_optimizer(optimizer)

--- a/tests/utils/reward_score/test_countbenchqa.py
+++ b/tests/utils/reward_score/test_countbenchqa.py
@@ -1,0 +1,73 @@
+from verl.utils.reward_score import countbenchqa
+
+
+def _output(think: str, response: str, suffix: str = "") -> str:
+    return f"{think}<|close|> think <|sep|><|open|> response <|sep|>{response}<|close|> response <|sep|>{suffix}"
+
+
+def _result(think: str, response: str, ground_truth: str = "4") -> dict:
+    return countbenchqa.compute_score(_output(think, response), ground_truth)
+
+
+def test_correct_strict_response_gets_full_reward():
+    result = _result("guess 9", "There are four. \\boxed{4}")
+    assert result["score"] == 1.0
+    assert result["predicted"] == "4"
+    assert result["expected"] == "4"
+
+
+def test_correct_relaxed_box_gets_accuracy_without_format_reward():
+    assert _result("", "\\boxed(4)")["score"] == 0.9
+    assert _result("", "\\boxed4")["score"] == 0.9
+
+
+def test_answer_in_think_channel_is_never_rewarded():
+    assert _result("I think \\boxed{4}", "\\boxed{5}")["score"] == 0.1
+    assert countbenchqa.compute_score("I think \\boxed{4}", "4")["score"] == 0.0
+
+
+def test_first_response_is_authoritative_over_trailing_generated_xtml():
+    output = _output("", "\\boxed{5}", suffix="noise <|close|> think <|sep|>\\boxed{4}")
+    assert countbenchqa.compute_score(output, "4")["score"] == 0.1
+
+
+def test_invalid_ground_truth_is_not_rewarded():
+    assert countbenchqa.compute_score(_output("", "\\boxed{4}"), "four")["score"] == 0.0
+
+
+def test_integer_text_is_compared_canonically():
+    result = _result("", "\\boxed{+0004}", ground_truth="0004")
+    assert result["score"] == 1.0
+    assert result["predicted"] == "4"
+    assert result["expected"] == "4"
+
+
+def test_arbitrary_precision_prediction_is_transfer_queue_serializable():
+    from transfer_queue.utils.serial_utils import encode
+
+    huge_integer = "9" * 5000
+    result = _result("", f"\\boxed{{{huge_integer}}}")
+
+    assert result["score"] == 0.1
+    assert result["predicted"] == huge_integer
+    # This is the exact encoder that raised in the 33-step long run.
+    assert list(encode({"extra_fields": {"reward_extra_info": result}}))
+
+
+def test_kimi_stop_conditions_preserve_existing_values():
+    from verl.utils.model_adapters import add_kimi_k3_stop_conditions
+
+    params = {"stop": ["existing"], "stop_token_ids": [7]}
+    add_kimi_k3_stop_conditions(params, "kimi_k3", 163586)
+    assert params == {
+        "stop": ["existing", "<|close|> response <|sep|>"],
+        "stop_token_ids": [7, 163586],
+    }
+
+
+def test_stop_conditions_ignore_other_models():
+    from verl.utils.model_adapters import add_kimi_k3_stop_conditions
+
+    params = {}
+    add_kimi_k3_stop_conditions(params, "qwen3", None)
+    assert params == {}

--- a/tests/utils/test_kimi_k3_mcore_forward_on_cpu.py
+++ b/tests/utils/test_kimi_k3_mcore_forward_on_cpu.py
@@ -1,0 +1,125 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from verl.models.mcore.model_forward import _kimi_k3_dynamic_multimodal_length
+
+
+def _config(**overrides):
+    values = {
+        "seq_length": 4096,
+        "sequence_parallel": True,
+        "tensor_model_parallel_size": 4,
+        "kimi_multimodal_length_alignment": 256,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_dynamic_multimodal_length_uses_bounded_aligned_bucket():
+    indices = torch.tensor([[0, 1025]])
+
+    assert _kimi_k3_dynamic_multimodal_length(indices, _config()) == 1280
+
+
+def test_dynamic_multimodal_length_rejects_invalid_bucket():
+    with pytest.raises(ValueError, match="must be positive"):
+        _kimi_k3_dynamic_multimodal_length(
+            torch.tensor([[0]]),
+            _config(kimi_multimodal_length_alignment=0),
+        )
+
+    with pytest.raises(ValueError, match="exceeds the configured limit"):
+        _kimi_k3_dynamic_multimodal_length(
+            torch.tensor([[4095]]),
+            _config(kimi_multimodal_length_alignment=257),
+        )
+
+
+def test_kimi_forward_accepts_current_engine_options_and_preserves_jagged_rows():
+    from verl.models.mcore.model_forward import kimi_k3_forward_model_engine
+
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.post_process = True
+            self.config = _config(
+                model_type="kimi_k3",
+                media_placeholder_token_id=99,
+                context_parallel_size=1,
+                sequence_parallel=False,
+            )
+
+        def forward(self, *, input_ids, attention_mask, position_ids, layout_padding_mask):
+            assert attention_mask is None and position_ids is None
+            torch.testing.assert_close(layout_padding_mask, torch.tensor([[True, True, False], [True, True, True]]))
+            return input_ids.float().unsqueeze(-1).expand(-1, -1, 2)
+
+    ids = torch.nested.as_nested_tensor([torch.tensor([2, 3]), torch.tensor([4, 5, 6])], layout=torch.jagged)
+    temperatures = torch.nested.as_nested_tensor([torch.ones(2), torch.ones(3)], layout=torch.jagged)
+    output = kimi_k3_forward_model_engine(
+        Model(),
+        ids,
+        {},
+        pad_token_id=0,
+        data_format="bshd",
+        logits_processor=lambda logits, **kwargs: {"log_probs": logits[..., 0]},
+        logits_processor_args={"label": ids, "temperature": temperatures},
+        router_padding_mask=None,
+        mtp_loss_normalization_factor=None,
+        pad_to_length_bucket=None,
+        local_cp_size=None,
+        forced_max_seqlen=None,
+    )
+    torch.testing.assert_close(output["log_probs"].values(), ids.values().float())
+    torch.testing.assert_close(output["log_probs"].offsets(), ids.offsets())
+
+
+@pytest.mark.parametrize("option", ["router_padding_mask", "mtp_loss_normalization_factor", "pad_to_length_bucket"])
+def test_kimi_forward_rejects_unsupported_engine_modes(option):
+    from verl.models.mcore.model_forward import kimi_k3_forward_model_engine
+
+    with pytest.raises(NotImplementedError):
+        kimi_k3_forward_model_engine(None, None, {}, **{option: 1})
+
+
+def test_kimi_dynamic_image_forward_restores_raw_positions_and_prepares_replay():
+    from unittest.mock import Mock
+
+    from verl.models.mcore.model_forward import kimi_k3_forward_model_engine
+
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.post_process = True
+            self.config = _config(
+                model_type="kimi_k3",
+                media_placeholder_token_id=99,
+                context_parallel_size=1,
+                sequence_parallel=False,
+                seq_length=16,
+                kimi_dynamic_multimodal_length=True,
+                kimi_multimodal_length_alignment=8,
+                vision_config=SimpleNamespace(merge_type="sd2_tpool", merge_kernel_size=[2, 2]),
+            )
+
+        def forward(self, *, input_ids, multimodal_sequence_length, grid_thws, **kwargs):
+            assert multimodal_sequence_length == 8
+            torch.testing.assert_close(grid_thws, torch.tensor([[1, 4, 4]]))
+            return torch.arange(8, dtype=torch.float32).reshape(1, 8, 1)
+
+    ids = torch.nested.as_nested_tensor([torch.tensor([10, 99, 11])], layout=torch.jagged)
+    temperatures = torch.nested.as_nested_tensor([torch.ones(3)], layout=torch.jagged)
+    replay = Mock()
+    output = kimi_k3_forward_model_engine(
+        Model(),
+        ids,
+        {"grid_thws": torch.tensor([[1, 4, 4]]), "pixel_values": torch.zeros(16, 3)},
+        pad_token_id=0,
+        router_replay_prepare=replay,
+        logits_processor=lambda logits, **kwargs: {"log_probs": logits[..., 0]},
+        logits_processor_args={"label": ids, "temperature": temperatures},
+    )
+    replay.assert_called_once_with(max_model_rows=8)
+    torch.testing.assert_close(output["log_probs"].values(), torch.tensor([0.0, 4.0, 5.0]))

--- a/tests/utils/test_kimi_multimodal_adapter_on_cpu.py
+++ b/tests/utils/test_kimi_multimodal_adapter_on_cpu.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Huawei Technologies Co., Ltd.
+# Licensed under the Apache License, Version 2.0.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+from verl.utils.model_adapters import get_vllm_adapter
+
+
+def test_kimi_images_use_typed_vision_chunks():
+    image = Image.new("RGB", (14, 14))
+    wrapped = {"type": "image", "image": image}
+    adapter = get_vllm_adapter("kimi_k3")
+    payload = adapter.build_vllm_multimodal_data([image, wrapped])
+    assert set(payload) == {"vision_chunk"}
+    assert payload["vision_chunk"] == [wrapped, wrapped]
+    assert payload["vision_chunk"][1] is wrapped
+    assert adapter.build_vllm_multimodal_data() == {}
+    with pytest.raises(ValueError, match="only supports image"):
+        adapter.build_vllm_multimodal_data(video_data=[object()])
+
+
+def test_kimi_prompt_normalization_matches_vllm_image_replacement_target():
+    adapter = get_vllm_adapter("kimi_k3")
+    tokenizer = SimpleNamespace(
+        decode=Mock(
+            return_value="before <|media_begin|>image 448x448<|media_content|><|media_pad|><|media_end|> after"
+        ),
+        encode=Mock(return_value=[101, 102]),
+    )
+    assert adapter.prepare_vllm_prompt_ids([1, 2], tokenizer, [object()]) == [101, 102]
+    tokenizer.encode.assert_called_once_with(
+        "before <|media_begin|>image<|media_content|><|media_pad|><|media_end|> after"
+    )

--- a/tests/workers/engine/test_kimi_checkpoint_loading_on_cpu.py
+++ b/tests/workers/engine/test_kimi_checkpoint_loading_on_cpu.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import defaultdict
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from safetensors import safe_open
+from safetensors.torch import save_file
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Shard, distribute_tensor
+
+from verl.workers.engine.fsdp.streaming_loader import (
+    _add_kimi_packed_tasks,
+    _copy_task,
+    _TensorSpec,
+    load_kimi_k3_checkpoint_to_local_shards,
+)
+
+
+@pytest.mark.parametrize("projection", ["gate_up_proj", "down_proj"])
+def test_packed_local_slice_matches_external_experts(tmp_path, projection):
+    raw = {}
+    for expert in range(4):
+        for index, (name, shape) in enumerate((("w1", (4, 6)), ("w2", (6, 4)), ("w3", (4, 6)))):
+            raw[f"experts.{expert}.{name}.weight"] = (
+                torch.arange(24).reshape(shape).float() + 100 * expert + 1000 * index
+            )
+    packed_gate = torch.stack(
+        [torch.cat((raw[f"experts.{e}.w1.weight"].T, raw[f"experts.{e}.w3.weight"].T), dim=1) for e in range(4)]
+    )
+    packed_down = torch.stack([raw[f"experts.{e}.w2.weight"].T for e in range(4)])
+    packed = packed_gate if projection == "gate_up_proj" else packed_down
+    # Cross the gate/up boundary and retain only part of the eFSDP matrix.
+    offset = (1, 1, 3)
+    shape = (2, 2, 3)
+    destination = torch.full(shape, float("nan"))
+    spec = _TensorSpec(f"experts.{projection}", tuple(packed.shape), shape, offset, destination)
+    shard = tmp_path / "experts.safetensors"
+    save_file(raw, shard)
+    tasks = defaultdict(list)
+    _add_kimi_packed_tasks(spec, {name: shard.name for name in raw}, tasks)
+    with safe_open(shard, framework="pt", device="cpu") as handle:
+        for task in tasks[shard.name]:
+            _copy_task(task, handle.get_slice(task.source_key))
+    torch.testing.assert_close(destination, packed[1:3, 1:3, 3:6], rtol=0, atol=0)
+
+
+def test_streaming_load_preserves_buffers_and_rejects_incomplete_weights(tmp_path):
+    model = torch.nn.Linear(3, 2, bias=False, device="meta")
+    model.register_buffer("rotary", torch.arange(3).float(), persistent=False)
+    weight = torch.arange(6).reshape(2, 3).float()
+    save_file({"weight": weight}, tmp_path / "model.safetensors")
+    load_kimi_k3_checkpoint_to_local_shards(model, str(tmp_path), materialize_device="cpu")
+    torch.testing.assert_close(model.weight, weight, rtol=0, atol=0)
+    torch.testing.assert_close(model.rotary, torch.arange(3).float(), rtol=0, atol=0)
+    save_file({"unrelated": weight}, tmp_path / "model.safetensors")
+    with pytest.raises(RuntimeError, match="missing target parameters"):
+        load_kimi_k3_checkpoint_to_local_shards(model, str(tmp_path), materialize_device="cpu")
+
+
+@pytest.mark.parametrize("padding", ["zero", "nonzero", "too_short"])
+def test_streaming_load_validates_kda_head_padding(tmp_path, padding):
+    model = torch.nn.Module()
+    model.layer = torch.nn.Module()
+    model.layer.self_attn = torch.nn.Module()
+    model.layer.self_attn.A_log = torch.nn.Parameter(torch.empty(96, device="meta"))
+    weight = torch.cat((torch.arange(96).float(), torch.zeros(32)))
+    if padding == "nonzero":
+        weight[-1] = 1
+    elif padding == "too_short":
+        weight = weight[:95].clone()
+    save_file({"layer.self_attn.A_log": weight}, tmp_path / "model.safetensors")
+    if padding == "zero":
+        load_kimi_k3_checkpoint_to_local_shards(model, str(tmp_path), materialize_device="cpu")
+        torch.testing.assert_close(model.layer.self_attn.A_log, weight[:96], rtol=0, atol=0)
+    else:
+        error = ValueError if padding == "nonzero" else RuntimeError
+        match = "Nonzero inactive" if padding == "nonzero" else "shape mismatch"
+        with pytest.raises(error, match=match):
+            load_kimi_k3_checkpoint_to_local_shards(model, str(tmp_path), materialize_device="cpu")
+
+
+def _check_sharded_meta_load(rank, directory):
+    dist.init_process_group("gloo", init_method=f"file://{directory}/rendezvous", rank=rank, world_size=2)
+    try:
+        mesh = DeviceMesh("cpu", [0, 1])
+        model = torch.nn.Linear(6, 4, bias=False, device="meta")
+        model.weight = torch.nn.Parameter(distribute_tensor(model.weight, mesh, [Shard(0)]))
+        model.register_buffer("rotary", torch.arange(3).float(), persistent=False)
+        load_kimi_k3_checkpoint_to_local_shards(model, directory, materialize_device="cpu")
+        assert model.weight.placements == (Shard(0),)
+        assert model.weight.device_mesh == mesh
+        assert model.weight.shape == (4, 6)
+        expected = torch.arange(24).reshape(4, 6).float()[rank * 2 : rank * 2 + 2]
+        torch.testing.assert_close(model.weight.to_local(), expected, rtol=0, atol=0)
+        torch.testing.assert_close(model.rotary, torch.arange(3).float(), rtol=0, atol=0)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_streaming_load_materializes_dtensor_with_its_original_layout(tmp_path):
+    save_file({"weight": torch.arange(24).reshape(4, 6).float()}, tmp_path / "model.safetensors")
+    mp.spawn(_check_sharded_meta_load, args=(str(tmp_path),), nprocs=2, join=True)

--- a/tests/workers/engine/test_kimi_full_r3_gate_on_cpu.py
+++ b/tests/workers/engine/test_kimi_full_r3_gate_on_cpu.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from fsdp_turbo.models.kimi.kimi_r3_utils import (
+    align_kimi_full_model_routes,
+)
+
+from verl.trainer.ppo.padding_utils import build_padding_full_r3_pair
+
+
+def test_full_model_alignment_moves_ids_weights_and_mask_together():
+    routes = torch.arange(3 * 2 * 2).reshape(1, 3, 2, 2)
+    weights = (routes.float() + 1).to(torch.bfloat16) / 16
+    source_mask = torch.tensor([[True, True, True]])
+    target_attention_mask = torch.tensor([[False, True, True, True, True]])
+
+    aligned_ids, aligned_weights, aligned_mask = align_kimi_full_model_routes(
+        routes,
+        weights,
+        source_mask,
+        target_attention_mask,
+    )
+
+    torch.testing.assert_close(aligned_ids[:, 1:4], routes)
+    torch.testing.assert_close(aligned_weights[:, 1:4], weights)
+    assert aligned_mask.tolist() == [[False, True, True, True, False]]
+    assert not bool(aligned_ids[:, (0, 4)].any())
+    assert not bool(aligned_weights[:, (0, 4)].any())
+
+
+def test_full_r3_padding_reuses_one_valid_causal_route_row():
+    source_ids = torch.tensor(
+        [
+            [[0, 0], [0, 0]],
+            [[0, 1], [2, 3]],
+            [[1, 2], [0, 3]],
+        ],
+        dtype=torch.uint8,
+    )
+    source_weights = torch.tensor(
+        [
+            [[0.0, 0.0], [0.0, 0.0]],
+            [[0.25, 0.75], [0.5, 0.5]],
+            [[0.5, 0.5], [0.25, 0.75]],
+        ],
+        dtype=torch.bfloat16,
+    )
+
+    padding_ids, padding_weights = build_padding_full_r3_pair(
+        source_ids,
+        source_weights,
+        causal_rows=1,
+    )
+
+    assert padding_ids.shape == (1, 2, 2)
+    torch.testing.assert_close(padding_ids[0], source_ids[1])
+    torch.testing.assert_close(padding_weights[0], source_weights[1])
+    aligned_ids, aligned_weights, aligned_mask = align_kimi_full_model_routes(
+        padding_ids.unsqueeze(0),
+        padding_weights.unsqueeze(0),
+        torch.tensor([[True]]),
+        torch.tensor([[True, True]]),
+    )
+    assert aligned_mask.tolist() == [[True, False]]
+    torch.testing.assert_close(aligned_ids[:, :1], padding_ids.unsqueeze(0))
+    torch.testing.assert_close(
+        aligned_weights[:, :1],
+        padding_weights.unsqueeze(0),
+    )

--- a/tests/workers/engine/test_kimi_packed_weight_sync_on_cpu.py
+++ b/tests/workers/engine/test_kimi_packed_weight_sync_on_cpu.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Shard, distribute_tensor
+
+from verl.workers.engine.fsdp.kimi_packed_weights import export_kimi_packed_local_param
+from verl.workers.engine.fsdp.utils import unfuse_moe_params
+
+
+def test_kimi_keeps_offset_aware_packed_expert_transport_abi():
+    tensor = torch.arange(2 * 3 * 8, dtype=torch.float32).reshape(2, 3, 8)
+    name = "model.layers.7.block_sparse_moe.experts.gate_up_proj.__verl_packed_local__.4"
+
+    updates = list(unfuse_moe_params([(name, tensor)], model_type="kimi_k3"))
+
+    assert len(updates) == 1
+    assert updates[0][0] == name
+    assert updates[0][1] is tensor
+
+
+def test_kimi_packed_transport_rejects_other_model_types():
+    tensor = torch.arange(2 * 3 * 8, dtype=torch.float32).reshape(2, 3, 8)
+    name = "model.layers.7.block_sparse_moe.experts.gate_up_proj.__verl_packed_local__.4"
+
+    with pytest.raises(ValueError, match="valid only for the Kimi K3"):
+        list(unfuse_moe_params([(name, tensor)], model_type="legacy"))
+
+
+def test_kimi_packed_transport_rejects_invalid_offset_before_passthrough():
+    tensor = torch.zeros(1, 3, 8)
+    name = "model.layers.7.block_sparse_moe.experts.gate_up_proj.__verl_packed_local__.bad"
+
+    with pytest.raises(ValueError, match="Invalid Kimi packed-local expert offset"):
+        list(unfuse_moe_params([(name, tensor)], model_type="kimi_k3"))
+
+
+def _check_colocated_export(rank, rendezvous):
+    dist.init_process_group("gloo", init_method=f"file://{rendezvous}", rank=rank, world_size=4)
+    try:
+        mesh = DeviceMesh("cpu", torch.arange(4).reshape(2, 2))
+        original = torch.arange(4 * 6 * 8).reshape(4, 6, 8).float()
+        layout = dict(
+            expert_parallel_size=2, tensor_parallel_size=2, data_parallel_size=1, pipeline_model_parallel_size=1
+        )
+        # Two eFSDP matrix shards x two expert shards. Check initial weights
+        # and a changed version, including delivery to both rollout replicas.
+        for version in (0, 1):
+            weights = original + version
+            param = distribute_tensor(weights, mesh, [Shard(1), Shard(0)])
+            name, local = export_kimi_packed_local_param("experts.gate_up_proj", param, "cpu", layout)
+            start = (rank % 2) * 2
+            assert name == f"experts.gate_up_proj.__verl_packed_local__.{start}"
+            torch.testing.assert_close(local, weights[start : start + 2], rtol=0, atol=0)
+            with pytest.raises(ValueError, match="matching actor/rollout EP"):
+                export_kimi_packed_local_param(
+                    "experts.gate_up_proj",
+                    param,
+                    "cpu",
+                    {**layout, "expert_parallel_size": 4, "tensor_parallel_size": 4},
+                )
+        reordered = DeviceMesh("cpu", torch.tensor([[0, 2], [1, 3]]))
+        param = distribute_tensor(original, reordered, [Shard(1), Shard(0)])
+        with pytest.raises(ValueError, match="ownership does not match"):
+            export_kimi_packed_local_param("experts.gate_up_proj", param, "cpu", layout)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_colocated_export_gathers_matrix_shards_and_keeps_expert_ownership(tmp_path):
+    mp.spawn(_check_colocated_export, args=(str(tmp_path / "gloo_rendezvous"),), nprocs=4, join=True)

--- a/tests/workers/rollout/test_kimi_full_r3_payload_on_cpu.py
+++ b/tests/workers/rollout/test_kimi_full_r3_payload_on_cpu.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from verl.workers.rollout.r3_utils import (
+    decode_kimi_full_r3_payload,
+    get_kimi_full_r3_topk,
+    is_kimi_full_r3_config,
+)
+
+
+def _pack_exact_bf16(ids: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    """Exercise the same BF16 byte split used by the Ascend capturer."""
+    ids_tensor = torch.from_numpy(ids.astype(np.int32))
+    weights_tensor = torch.from_numpy(weights).to(torch.bfloat16)
+    weight_bytes = weights_tensor.contiguous().view(torch.uint8).reshape(*weights_tensor.shape, 2)
+    packed = torch.cat(
+        (
+            ids_tensor,
+            weight_bytes[..., 0].to(torch.int32),
+            weight_bytes[..., 1].to(torch.int32),
+        ),
+        dim=-1,
+    )
+    return packed.numpy()
+
+
+def test_full_r3_payload_round_trips_ids_and_executed_bf16_weights():
+    ids = np.array(
+        [
+            [[[1, 7], [2, 6]], [[3, 5], [0, 4]]],
+            [[[7, 1], [6, 2]], [[5, 3], [4, 0]]],
+        ],
+        dtype=np.uint16,
+    ).reshape(4, 2, 2)
+    # These values are exactly representable in BF16, so the expected result
+    # is unambiguous and bit-preserving through FP32 decode.
+    weights = np.array(
+        [0.25, 0.5, 1.0, 2.0] * 4,
+        dtype=np.float32,
+    ).reshape(ids.shape)
+
+    decoded_ids, decoded_weights = decode_kimi_full_r3_payload(
+        _pack_exact_bf16(ids, weights),
+        expected_topk=2,
+    )
+
+    np.testing.assert_array_equal(decoded_ids, ids)
+    np.testing.assert_array_equal(decoded_weights, weights)
+
+
+def test_id_only_payload_is_rejected_instead_of_silently_downgrading_r3():
+    ids = np.zeros((3, 4, 2), dtype=np.uint8)
+    with pytest.raises(ValueError, match="weight capture is not active"):
+        decode_kimi_full_r3_payload(ids, expected_topk=2)
+
+
+def test_corrupt_weight_byte_lane_is_rejected():
+    payload = np.zeros((1, 1, 6), dtype=np.int32)
+    payload[..., 2] = 256
+    with pytest.raises(ValueError, match="byte lanes are out of range"):
+        decode_kimi_full_r3_payload(payload, expected_topk=2)
+
+
+def test_topk_is_resolved_from_nested_kimi_text_config():
+    config = SimpleNamespace(
+        model_type="kimi_k3",
+        text_config=SimpleNamespace(
+            model_type="kimi_linear",
+            num_experts_per_token=8,
+        ),
+    )
+    assert get_kimi_full_r3_topk(config) == 8
+    assert is_kimi_full_r3_config(config)
+
+
+def test_non_kimi_config_keeps_legacy_id_only_schema():
+    config = SimpleNamespace(
+        model_type="qwen3_moe",
+        num_experts_per_tok=8,
+    )
+    assert not is_kimi_full_r3_config(config)
+    with pytest.raises(ValueError, match="only for Kimi K3"):
+        get_kimi_full_r3_topk(config)
+
+
+def test_megatron_boundary_preserves_jagged_rows_and_bf16_bits():
+    from verl.workers.rollout.r3_utils import pack_kimi_full_r3_for_megatron
+
+    ids = torch.nested.as_nested_tensor(
+        [torch.tensor([[[1, 7]], [[3, 5]], [[4, 2]]]), torch.tensor([[[6, 0]]])],
+        layout=torch.jagged,
+    )
+    weights = torch.nested.nested_tensor_from_jagged(
+        torch.tensor([[[0.25, 0.5]], [[1.0, 2.0]], [[0.125, 4.0]], [[0.5, 0.5]]]),
+        offsets=ids.offsets(),
+    )
+    packed = pack_kimi_full_r3_for_megatron(ids, weights)
+    assert torch.equal(packed.offsets(), ids.offsets())
+    decoded_ids, decoded_weights = decode_kimi_full_r3_payload(packed.values().numpy(), expected_topk=2)
+    np.testing.assert_array_equal(decoded_ids, ids.values().numpy())
+    np.testing.assert_array_equal(decoded_weights, weights.values().numpy())
+    with pytest.raises(ValueError, match="both expert IDs and weights"):
+        pack_kimi_full_r3_for_megatron(ids, None)
+    with pytest.raises(ValueError, match="exact BF16"):
+        pack_kimi_full_r3_for_megatron(ids, weights + 0.00001)
+
+
+@pytest.mark.parametrize("invalid", [None, "duplicate", "range", "nan", "negative", "zero"])
+def test_full_route_validation_before_agent_transport(invalid):
+    from verl.workers.rollout.r3_utils import validate_kimi_full_model_routes
+
+    config = SimpleNamespace(model_type="kimi_k3", num_hidden_layers=2, num_experts=4, num_experts_per_token=2)
+    ids = torch.tensor([[[0, 1], [2, 3]]])
+    weights = torch.full(ids.shape, 0.5)
+    if invalid == "duplicate":
+        ids[0, 1, 0] = 3
+    elif invalid == "range":
+        ids[0, 1, 0] = 4
+    elif invalid == "nan":
+        weights[0, 1, 0] = float("nan")
+    elif invalid == "negative":
+        weights[0, 1, 0] = -0.5
+    elif invalid == "zero":
+        weights[0, 1] = 0
+    if invalid is None:
+        validate_kimi_full_model_routes(ids, weights, config)
+    else:
+        with pytest.raises(ValueError):
+            validate_kimi_full_model_routes(ids, weights, config)

--- a/tests/workers/rollout/test_llm_server_routed_experts_on_cpu.py
+++ b/tests/workers/rollout/test_llm_server_routed_experts_on_cpu.py
@@ -26,6 +26,7 @@ differ and the merge has to survive all of them:
 from __future__ import annotations
 
 import asyncio
+from functools import wraps
 from types import SimpleNamespace
 from typing import Any
 
@@ -39,6 +40,16 @@ from verl.workers.rollout.replica import TokenOutput
 
 LAYERS, TOPK = 2, 4
 BACKENDS = ["vllm", "sglang_detokenized", "sglang_skip_tokenizer_init"]
+
+
+def _run_async_test(coro):
+    """Run coroutine tests without requiring the optional pytest-asyncio plugin."""
+
+    @wraps(coro)
+    def wrapper(*args, **kwargs):
+        return asyncio.run(coro(*args, **kwargs))
+
+    return wrapper
 
 
 def _routing(markers: list[int], backend: str) -> np.ndarray:
@@ -60,6 +71,11 @@ def _routing(markers: list[int], backend: str) -> np.ndarray:
 
 def _markers(routing: Any) -> list[int]:
     return [int(v) for v in routing[:, 0, 0]]
+
+
+def _weights(markers: list[int]) -> np.ndarray:
+    values = np.asarray(markers, dtype=np.float32) / 100.0
+    return np.repeat(values, LAYERS * TOPK).reshape(-1, LAYERS, TOPK)
 
 
 def _install_segments(monkeypatch: pytest.MonkeyPatch, segments: list[TokenOutput]) -> list[list[int]]:
@@ -95,7 +111,7 @@ def _client() -> FullyAsyncLLMServerClient:
     return FullyAsyncLLMServerClient(config=SimpleNamespace(), load_balancer_handle=None)
 
 
-@pytest.mark.asyncio
+@_run_async_test
 @pytest.mark.parametrize("backend", BACKENDS)
 async def test_resume_appends_only_newly_generated_routing(monkeypatch, backend):
     """Two resumes: each attempt re-sends the accumulated prompt and returns routing for
@@ -132,7 +148,7 @@ async def test_resume_appends_only_newly_generated_routing(monkeypatch, backend)
     assert output.routed_experts.shape == (8, LAYERS, TOPK)
 
 
-@pytest.mark.asyncio
+@_run_async_test
 @pytest.mark.parametrize("backend", BACKENDS)
 async def test_merge_yields_numpy_and_preserves_dtype(monkeypatch, backend):
     """Backends agree on numpy, which is what lets the merge be a plain concatenate. Dtype
@@ -150,7 +166,7 @@ async def test_merge_yields_numpy_and_preserves_dtype(monkeypatch, backend):
     assert merged.dtype == original.dtype
 
 
-@pytest.mark.asyncio
+@_run_async_test
 @pytest.mark.parametrize("backend", BACKENDS)
 async def test_single_attempt_passes_backend_object_through(monkeypatch, backend):
     """Without a resume there is nothing to concatenate, so the backend object reaches the
@@ -164,7 +180,7 @@ async def test_single_attempt_passes_backend_object_through(monkeypatch, backend
     assert output.routed_experts is original
 
 
-@pytest.mark.asyncio
+@_run_async_test
 @pytest.mark.parametrize("backend", BACKENDS)
 async def test_merged_routing_converts_for_downstream(monkeypatch, backend):
     """Both downstream sinks normalize to int64 tensors: ``AgentLoopOutput.as_dict`` via
@@ -185,3 +201,54 @@ async def test_merged_routing_converts_for_downstream(monkeypatch, backend):
     # a fresh writable buffer, so from_numpy is safe without one.
     assert merged.flags.writeable
     assert _markers(torch.from_numpy(merged)) == [10, 11, 22]
+
+
+@_run_async_test
+async def test_full_r3_resume_keeps_ids_and_weights_on_identical_rows(monkeypatch):
+    segments = [
+        TokenOutput(
+            token_ids=[101, 102],
+            routed_experts=_routing([10, 11, 12, 13, 14], "vllm"),
+            routed_expert_weights=_weights([10, 11, 12, 13, 14]),
+            stop_reason="aborted",
+        ),
+        TokenOutput(
+            token_ids=[103],
+            routed_experts=_routing([20, 21, 22, 23, 24, 25], "vllm"),
+            routed_expert_weights=_weights([20, 21, 22, 23, 24, 25]),
+            stop_reason="completed",
+        ),
+    ]
+    _install_segments(monkeypatch, segments)
+
+    output = await _client().generate(request_id="req-full-r3", prompt_ids=[1, 2, 3], sampling_params={})
+
+    assert _markers(output.routed_experts) == [10, 11, 12, 13, 14, 25]
+    np.testing.assert_allclose(
+        output.routed_expert_weights[:, 0, 0],
+        np.asarray([0.10, 0.11, 0.12, 0.13, 0.14, 0.25], dtype=np.float32),
+    )
+    assert output.routed_expert_weights.shape == output.routed_experts.shape
+
+
+@_run_async_test
+async def test_full_r3_resume_rejects_incomplete_pair(monkeypatch):
+    _install_segments(
+        monkeypatch,
+        [
+            TokenOutput(
+                token_ids=[101],
+                routed_experts=_routing([10, 11], "vllm"),
+                routed_expert_weights=_weights([10, 11]),
+                stop_reason="aborted",
+            ),
+            TokenOutput(
+                token_ids=[102],
+                routed_experts=_routing([20, 21, 22], "vllm"),
+                stop_reason="completed",
+            ),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="cannot switch"):
+        await _client().generate(request_id="req-incomplete-r3", prompt_ids=[], sampling_params={})

--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -17,6 +17,7 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
 import torch
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -246,3 +247,43 @@ def test_vllm_update_weights_syncs_buffers_to_mtp_drafter():
     expected = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
     torch.testing.assert_close(main_model.model.layers[0].e_score_correction_bias, expected)
     torch.testing.assert_close(drafter_model.model.layers[0].e_score_correction_bias, expected)
+
+
+def test_layerwise_reload_owns_weights_across_reused_buckets():
+    pytest.importorskip("vllm.model_executor.model_loader.reload")
+    from vllm.model_executor.model_loader.reload import (
+        finalize_layerwise_reload,
+        initialize_layerwise_reload,
+        record_metadata_for_reloading,
+    )
+
+    model = torch.nn.Linear(3, 2)
+
+    def load_weights(weights):
+        for name, value in weights:
+            parameter = getattr(model, name)
+            parameter.weight_loader(parameter, value)
+
+    model.load_weights = load_weights
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = _FakeModelRunner(model)
+    record_metadata_for_reloading(model)
+    addresses = [parameter.data_ptr() for parameter in model.parameters()]
+    bucket = torch.empty(6)
+
+    for step in range(1, 6):
+        initialize_layerwise_reload(model)
+        bucket.fill_(step)
+        worker._update_weights(
+            [("weight", bucket.view(2, 3))], peft_config=None, base_sync_done=True, layerwise_reload=True
+        )
+        bucket.fill_(-step)
+        worker._update_weights(
+            [("bias", bucket[:2])], peft_config=None, base_sync_done=True, layerwise_reload=True
+        )
+        bucket.zero_()
+        finalize_layerwise_reload(model, None)
+
+        torch.testing.assert_close(model.weight, torch.full((2, 3), float(step)))
+        torch.testing.assert_close(model.bias, torch.full((2,), float(-step)))
+        assert [parameter.data_ptr() for parameter in model.parameters()] == addresses

--- a/verl/__init__.py
+++ b/verl/__init__.py
@@ -15,6 +15,7 @@
 import importlib
 import logging
 import os
+import sys
 
 from packaging.version import parse as parse_version
 
@@ -28,6 +29,23 @@ from packaging.version import parse as parse_version
 # uv environment to Ray workers via `runtime_env.py_executable`, so the hook is
 # redundant; disable it. `setdefault` keeps it overridable (set "1" to re-enable).
 os.environ.setdefault("RAY_ENABLE_UV_RUN_RUNTIME_ENV", "0")
+
+# TransferQueue 0.1.8 eagerly imports the optional Mooncake native binding even
+# when the configured storage backend is SimpleStorage.  The Mooncake wheel in
+# the Ascend runtime corrupts the glibc heap during interpreter teardown, so a
+# successful training step otherwise exits with SIGABRT (134).  Make the
+# optional bindings unavailable before TransferQueue and checkpoint engines
+# import them. Users
+# that actually configure Mooncake can opt back in explicitly after installing
+# a compatible wheel.
+def configure_transfer_queue_worker() -> None:
+    """Apply the optional native-backend guard before standalone TQ actors import."""
+    if os.getenv("VERL_TRANSFER_QUEUE_ENABLE_MOONCAKE", "0").lower() not in {"1", "true", "yes"}:
+        sys.modules.setdefault("mooncake.store", None)
+        sys.modules.setdefault("mooncake.engine", None)
+
+
+configure_transfer_queue_worker()
 
 from .protocol import DataProto  # noqa: E402
 from .utils.device import is_npu_available  # noqa: E402

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -48,6 +48,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from verl.protocol import DataProto
 from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
+from verl.utils import tensordict_utils as tu
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
 from verl.utils.import_utils import resolve_config_path
@@ -69,11 +70,23 @@ from verl.workers.config import (
     RolloutConfig,
 )
 from verl.workers.rollout.llm_server import LLMServerClient
+from verl.workers.rollout.r3_utils import (
+    KIMI_FULL_MODEL_ROUTE_SEMANTICS,
+    validate_kimi_full_model_routes,
+)
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 DEFAULT_ROUTING_CACHE_SIZE = 10000
+
+
+def _as_route_tensor(value: np.ndarray | torch.Tensor, name: str) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        return value
+    if isinstance(value, np.ndarray):
+        return torch.from_numpy(value if value.flags.writeable else value.copy())
+    raise TypeError(f"Unsupported type for {name}: {type(value)}")
 
 
 class AgentLoopMetrics(BaseModel):
@@ -98,6 +111,10 @@ class AgentLoopOutput(BaseModel):
     """Log probabilities for the response tokens."""
     routed_experts: Optional[Any] = None
     """Routed experts for the total tokens."""
+    routed_expert_weights: Optional[Any] = None
+    """Executed router weights paired elementwise with routed_experts."""
+    routed_experts_source_semantics: Optional[str] = None
+    """Explicit row semantics for routed_experts; never infer this from shape."""
     multi_modal_data: Optional[dict[str, Any]] = None
     """Multi-modal data for multi-modal tools."""
     reward_score: Optional[float] = None
@@ -124,18 +141,84 @@ class AgentLoopOutput(BaseModel):
             output["rollout_log_probs"] = torch.tensor(response_logprobs, dtype=torch.float32)
 
         routed_experts = output.pop("routed_experts", None)
+        routed_expert_weights = output.pop("routed_expert_weights", None)
+        route_semantics = output.pop("routed_experts_source_semantics", None)
+        if routed_expert_weights is not None and route_semantics != KIMI_FULL_MODEL_ROUTE_SEMANTICS:
+            raise ValueError("router weights require Kimi full-model row semantics")
+        if routed_experts is None and routed_expert_weights is not None:
+            raise ValueError("router weights cannot be transported without expert IDs")
+        if (
+            route_semantics == KIMI_FULL_MODEL_ROUTE_SEMANTICS
+            and routed_experts is not None
+            and routed_expert_weights is None
+        ):
+            raise ValueError("Kimi full R3 requires routed_experts and routed_expert_weights together")
         if routed_experts is not None:
-            routed_experts = torch.tensor(routed_experts, dtype=torch.int16)
-            # Router replay indexes this field by absolute token position, so it must
-            # span the whole sequence. The rollout engine records fewer rows than that:
-            # it only sees tokens fed through the model, and multi-turn loops stop
-            # recording at the last generation. Trailing rows stay zero; replay masks
-            # them out instead of consuming them.
-            total_length = output["prompts"].size(0) + output["responses"].size(0)
-            aligned = routed_experts.new_zeros((total_length, *routed_experts.shape[1:]))
-            num_rows = min(routed_experts.size(0), total_length)
-            aligned[:num_rows] = routed_experts[:num_rows]
+            routed_experts = _as_route_tensor(routed_experts, "routed_experts").to(torch.int64)
+            if routed_expert_weights is not None:
+                # Keep the exact BF16 values decoded by the rollout in an
+                # FP32 carrier while they pass through TensorDict and
+                # TransferQueue.  Every BF16 value is exactly representable
+                # in FP32.  Converting to BF16 here made the transport depend
+                # on TransferQueue's nested-BF16 serialization; restore BF16
+                # only at the actor input boundary, where the value is
+                # immediately consumed by the gate.
+                routed_expert_weights = _as_route_tensor(routed_expert_weights, "routed_expert_weights").to(
+                    torch.float32
+                )
+            if routed_expert_weights is not None and routed_expert_weights.shape != routed_experts.shape:
+                raise ValueError(
+                    "Kimi full R3 IDs/weights are misaligned: "
+                    f"ids={tuple(routed_experts.shape)}, "
+                    f"weights={tuple(routed_expert_weights.shape)}"
+                )
+            if route_semantics == KIMI_FULL_MODEL_ROUTE_SEMANTICS:
+                if routed_experts.dim() != 3:
+                    raise ValueError(
+                        "Kimi full-model routed_experts must be "
+                        "[model_rows, layers, topk], "
+                        f"got {tuple(routed_experts.shape)}"
+                    )
+                if not bool(torch.all(output["response_mask"] == 1)):
+                    raise ValueError(
+                        "Kimi full-model routing replay currently supports single-turn all-generated responses only"
+                    )
+                logical_rows = output["prompts"].size(0) + output["responses"].size(0)
+                if routed_experts.size(0) < logical_rows - 1:
+                    raise ValueError(
+                        "Kimi full-model route capture is shorter than the causal "
+                        "logical input: "
+                        f"routes={routed_experts.size(0)}, logical={logical_rows}"
+                    )
+                minimum = int(routed_experts.min().item()) if routed_experts.numel() else 0
+                maximum = int(routed_experts.max().item()) if routed_experts.numel() else 0
+                if minimum < 0 or maximum > 255:
+                    raise ValueError(
+                        f"Kimi full-model route transport requires uint8 expert IDs, got min={minimum}, max={maximum}"
+                    )
+                # Preserve every vLLM model row. list_of_dict_to_tensordict
+                # converts unequal row counts into a jagged tensor, so no
+                # max-model-length padding is needed in TransferQueue.
+                aligned = routed_experts.to(torch.uint8)
+                aligned_weights = routed_expert_weights
+            elif route_semantics is None:
+                # Backward-compatible text-only routing uses absolute logical
+                # token positions and therefore spans the complete sequence.
+                total_length = output["prompts"].size(0) + output["responses"].size(0)
+                aligned = routed_experts.new_zeros((total_length, *routed_experts.shape[1:]))
+                aligned_weights = None
+                num_rows = min(routed_experts.size(0), total_length)
+                aligned[:num_rows] = routed_experts[:num_rows]
+            else:
+                raise ValueError(f"unsupported routed_experts_source_semantics={route_semantics!r}")
             output["routed_experts"] = aligned
+            if aligned_weights is not None:
+                output["routed_expert_weights"] = aligned_weights
+            # The V1/TransferQueue path serializes ``AgentLoopOutput.as_dict``
+            # directly and does not call ``AgentLoopManager._postprocess``.
+            # Keep the row contract beside the routed-experts field so it
+            # survives replay-buffer storage, reordering and microbatching.
+            output["routed_experts_transport_semantics"] = route_semantics
 
         # rm_scores: reward score for each token
         reward_score = output.pop("reward_score", None)
@@ -183,6 +266,8 @@ class _InternalAgentLoopOutput(AgentLoopOutput):
     """Padded token ids corresponding to the teacher log probabilities."""
     routed_experts: Optional[torch.Tensor] = None
     """Padded routed experts for the total tokens."""
+    routed_expert_weights: Optional[torch.Tensor] = None
+    """Padded router weights paired elementwise with routed_experts."""
     multi_modal_inputs: Optional[dict[str, torch.Tensor]] = None
     """Multi-modal inputs for processors (e.g. pixel_values, image_grid_thw, video_grid_thw)."""
     extra_fields: dict[str, Any] = {}
@@ -202,6 +287,14 @@ class ToolListWrap:
 
     def __init__(self, tools: list):
         self.tools = tools
+
+
+class ModelConfigWrap:
+    """Wrapper for ``HFModelConfig`` to keep Hydra from recursively
+    interpreting its nested ``_target_`` fields during agent construction."""
+
+    def __init__(self, config: HFModelConfig):
+        self.config = config
 
 
 class AgentLoopBase(ABC):
@@ -227,10 +320,15 @@ class AgentLoopBase(ABC):
         dataset_cls: type[RLHFDataset],
         data_config: DictConfigWrap,
         hf_model_type: str | None = None,
+        model_config: Optional[HFModelConfig] = None,
         **kwargs,
     ):
         self.config = trainer_config.config
         self.rollout_config = self.config.actor_rollout_ref.rollout
+        # AgentLoopWorker already materializes HFModelConfig once per worker.
+        # Pass that object into each short-lived loop instead of rebuilding the
+        # tokenizer/processor/config for every trajectory.
+        self.model_config = model_config.config if isinstance(model_config, ModelConfigWrap) else model_config
         self.server_manager = server_manager
         self.tokenizer = tokenizer
         self.processor = processor
@@ -659,6 +757,7 @@ class AgentLoopWorker:
                 hf_model_type=self.hf_model_type,
                 dataset_cls=self.dataset_cls,
                 data_config=DictConfigWrap(self.config.data),
+                model_config=ModelConfigWrap(self.model_config),
                 tools=ToolListWrap(self.tools),
             )
             output: AgentLoopOutput = await agent_loop.run(sampling_params, **kwargs)
@@ -751,32 +850,81 @@ class AgentLoopWorker:
         input_ids = torch.cat([prompt_output["input_ids"], response_output["input_ids"]], dim=1)
 
         routed_experts = None
+        routed_expert_weights = None
+        if (
+            output.routed_expert_weights is not None
+            and output.routed_experts_source_semantics != KIMI_FULL_MODEL_ROUTE_SEMANTICS
+        ):
+            raise ValueError("router weights require Kimi full-model row semantics")
+        if output.routed_experts is None and output.routed_expert_weights is not None:
+            raise ValueError("router weights cannot be postprocessed without expert IDs")
+        if (
+            output.routed_experts_source_semantics == KIMI_FULL_MODEL_ROUTE_SEMANTICS
+            and output.routed_experts is not None
+            and output.routed_expert_weights is None
+        ):
+            raise ValueError("Kimi full R3 postprocess requires expert IDs and weights together")
         if output.routed_experts is not None:
             total_length = input_ids.shape[1]
-            length, layer_num, topk_num = output.routed_experts.shape
-            if isinstance(output.routed_experts, np.ndarray):
-                routed_experts_array = output.routed_experts
-                if not routed_experts_array.flags.writeable:
-                    routed_experts_array = routed_experts_array.copy()
-                experts_tensor = torch.from_numpy(routed_experts_array)
-            elif isinstance(output.routed_experts, torch.Tensor):
-                experts_tensor = output.routed_experts
-            else:
-                raise TypeError(f"Unsupported type for routed_experts: {type(output.routed_experts)}")
-            experts_tensor = experts_tensor.to(torch.int16)
-            routed_experts = torch.zeros(1, total_length, layer_num, topk_num, dtype=experts_tensor.dtype)
-
-            # Calculate start position: left padding means original prompt starts at the end
-            start_pos = prompt_output["input_ids"].shape[1] - len(output.prompt_ids)
-            end_pos = min(start_pos + length, total_length)
-
-            # Add boundary checks for robustness
-            if start_pos < 0 or end_pos > total_length:
+            experts_tensor = _as_route_tensor(output.routed_experts, "routed_experts")
+            length, layer_num, topk_num = experts_tensor.shape
+            weights_tensor = (
+                _as_route_tensor(output.routed_expert_weights, "routed_expert_weights")
+                if output.routed_expert_weights is not None
+                else None
+            )
+            if weights_tensor is not None:
+                # See AgentLoopOutput.as_dict: FP32 is an exact carrier for
+                # the captured BF16 bits and avoids lossy/unsupported jagged
+                # BF16 transport.  The FSDP actor converts once, immediately
+                # before replay.
+                weights_tensor = weights_tensor.to(torch.float32)
+            if weights_tensor is not None and weights_tensor.shape != experts_tensor.shape:
                 raise ValueError(
-                    f"Invalid position range: start_pos={start_pos}, end_pos={end_pos}, total_length={total_length}"
+                    "Kimi full R3 postprocess IDs/weights are misaligned: "
+                    f"ids={tuple(experts_tensor.shape)}, "
+                    f"weights={tuple(weights_tensor.shape)}"
                 )
-
-            routed_experts[:, start_pos:end_pos] = experts_tensor.unsqueeze(0)
+            route_semantics = output.routed_experts_source_semantics
+            if route_semantics == KIMI_FULL_MODEL_ROUTE_SEMANTICS:
+                response_rows = len(output.response_ids)
+                if len(output.response_mask) != response_rows or any(int(value) != 1 for value in output.response_mask):
+                    raise ValueError(
+                        "Kimi full-model routing replay currently supports single-turn all-generated responses only"
+                    )
+                logical_rows = len(output.prompt_ids) + response_rows
+                if length < logical_rows - 1:
+                    raise ValueError(
+                        "Kimi full-model route capture is shorter than the causal "
+                        f"logical input: routes={length}, logical={logical_rows}"
+                    )
+                validate_kimi_full_model_routes(
+                    experts_tensor,
+                    weights_tensor,
+                    self.model_config.hf_config,
+                )
+                routed_experts = torch.nested.as_nested_tensor(
+                    [experts_tensor.to(torch.uint8)],
+                    layout=torch.jagged,
+                )
+                routed_expert_weights = torch.nested.as_nested_tensor(
+                    [weights_tensor],
+                    layout=torch.jagged,
+                )
+            elif route_semantics is None:
+                routed_experts = torch.zeros(1, total_length, layer_num, topk_num, dtype=experts_tensor.dtype)
+                # Text-only/backward-compatible route payloads use the logical
+                # token axis.  Kimi multimodal payloads must never reach this
+                # branch without explicit row semantics.
+                start_pos = prompt_output["input_ids"].shape[1] - len(output.prompt_ids)
+                end_pos = min(start_pos + length, total_length)
+                if start_pos < 0 or end_pos > total_length:
+                    raise ValueError(
+                        f"Invalid position range: start_pos={start_pos}, end_pos={end_pos}, total_length={total_length}"
+                    )
+                routed_experts[:, start_pos:end_pos] = experts_tensor.unsqueeze(0)
+            else:
+                raise ValueError(f"unsupported routed_experts_source_semantics={route_semantics!r}")
 
         multi_modal_inputs = self._compute_multi_modal_inputs(output, input_ids)
         position_ids = self._compute_position_ids(
@@ -824,6 +972,8 @@ class AgentLoopWorker:
             attention_mask=attention_mask,
             response_logprobs=response_logprobs,
             routed_experts=routed_experts,
+            routed_expert_weights=routed_expert_weights,
+            routed_experts_source_semantics=output.routed_experts_source_semantics,
             multi_modal_inputs=multi_modal_inputs,
             multi_modal_data=output.multi_modal_data,
             mm_processor_kwargs=output.mm_processor_kwargs,
@@ -1040,8 +1190,28 @@ class AgentLoopWorker:
         optional_outputs = {}
         if inputs[0].response_logprobs is not None:
             optional_outputs["rollout_log_probs"] = torch.cat([input.response_logprobs for input in inputs], dim=0)
-        if inputs[0].routed_experts is not None:
-            optional_outputs["routed_experts"] = torch.cat([input.routed_experts for input in inputs], dim=0)
+        route_presence = [input.routed_experts is not None for input in inputs]
+        if any(route_presence) and not all(route_presence):
+            raise ValueError("a routing batch cannot mix samples with and without expert IDs")
+        if all(route_presence):
+            route_tensors = [input.routed_experts for input in inputs]
+            optional_outputs["routed_experts"] = (
+                tu.concat_nested_tensors(route_tensors)
+                if route_tensors[0].is_nested
+                else torch.cat(route_tensors, dim=0)
+            )
+            weight_presence = [input.routed_expert_weights is not None for input in inputs]
+            if any(weight_presence) and not all(weight_presence):
+                raise ValueError("a routing batch cannot mix ID-only and ID+weight samples")
+            if all(weight_presence):
+                weight_tensors = [input.routed_expert_weights for input in inputs]
+                optional_outputs["routed_expert_weights"] = (
+                    tu.concat_nested_tensors(weight_tensors)
+                    if weight_tensors[0].is_nested
+                    else torch.cat(weight_tensors, dim=0)
+                )
+        elif any(input.routed_expert_weights is not None for input in inputs):
+            raise ValueError("Kimi full R3 batch contains router weights without expert IDs")
         if inputs[0].teacher_logprobs is not None and inputs[0].teacher_ids is not None:
             optional_outputs["teacher_logprobs"] = torch.cat([input.teacher_logprobs for input in inputs], dim=0)
             optional_outputs["teacher_ids"] = torch.cat([input.teacher_ids for input in inputs], dim=0)
@@ -1058,6 +1228,19 @@ class AgentLoopWorker:
             },
             batch_size=len(inputs),
         )
+        if all(route_presence):
+            route_semantics = {item.routed_experts_source_semantics for item in inputs}
+            if route_semantics == {KIMI_FULL_MODEL_ROUTE_SEMANTICS}:
+                tu.assign_non_tensor_data(
+                    batch,
+                    "routed_experts_transport_semantics",
+                    KIMI_FULL_MODEL_ROUTE_SEMANTICS,
+                )
+            elif route_semantics != {None}:
+                raise ValueError(
+                    "a routed-experts batch cannot mix row-semantics contracts, got "
+                    f"{sorted(repr(value) for value in route_semantics)}"
+                )
 
         scores = [input.reward_score for input in inputs]
         if all(score is not None for score in scores):

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -19,6 +19,10 @@ from uuid import uuid4
 from verl.experimental.agent_loop.agent_loop import AgentLoopBase, AgentLoopOutput, register
 from verl.utils.profiler import simple_timer
 from verl.utils.rollout_trace import rollout_trace_op
+from verl.workers.rollout.r3_utils import (
+    KIMI_FULL_MODEL_ROUTE_SEMANTICS,
+    is_kimi_full_r3_config,
+)
 from verl.workers.rollout.replica import TokenOutput
 
 logger = logging.getLogger(__file__)
@@ -33,6 +37,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         super().__init__(*args, **kwargs)
         self.prompt_length = self.rollout_config.prompt_length
         self.response_length = self.rollout_config.response_length
+        self._kimi_full_r3 = bool(self.model_config is not None and is_kimi_full_r3_config(self.model_config.hf_config))
 
     @rollout_trace_op
     async def run(self, sampling_params: dict[str, Any], priority: int = 0, **kwargs) -> AgentLoopOutput:
@@ -84,15 +89,31 @@ class SingleTurnAgentLoop(AgentLoopBase):
         response_ids = merge_result.token_ids[-len(response_mask) :] if response_mask else []
         prompt_ids = merge_result.token_ids[: len(merge_result.token_ids) - len(response_mask)]
 
+        if output.routed_experts is None and output.routed_expert_weights is not None:
+            raise RuntimeError("router weights cannot be transported without expert IDs")
+        if self._kimi_full_r3 and output.routed_experts is not None:
+            if output.routed_expert_weights is None:
+                raise RuntimeError("Kimi full R3 rollout returned expert IDs without executed router weights")
+            if len(response_ids) > self.response_length:
+                raise ValueError(
+                    "Kimi full-model routing replay cannot truncate generated "
+                    "tokens after route capture: "
+                    f"generated={len(response_ids)}, configured={self.response_length}"
+                )
+
         output: AgentLoopOutput = AgentLoopOutput(
             prompt_ids=prompt_ids,
             response_ids=response_ids[: self.response_length],
             response_mask=response_mask[: self.response_length],
             response_logprobs=response_logprobs[: self.response_length] if response_logprobs else None,
             routed_experts=(
-                output.routed_experts[: len(prompt_ids) + self.response_length]
-                if output.routed_experts is not None
-                else None
+                output.routed_experts
+                if self._kimi_full_r3 or output.routed_experts is None
+                else output.routed_experts[: len(prompt_ids) + self.response_length]
+            ),
+            routed_expert_weights=output.routed_expert_weights,
+            routed_experts_source_semantics=(
+                KIMI_FULL_MODEL_ROUTE_SEMANTICS if self._kimi_full_r3 and output.routed_experts is not None else None
             ),
             multi_modal_data=multi_modal_data,
             mm_processor_kwargs=mm_processor_kwargs,

--- a/verl/models/mcore/bridge.py
+++ b/verl/models/mcore/bridge.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 try:
-    from megatron.bridge import AutoBridge
+    from megatron.bridge.models.conversion.auto_bridge import AutoBridge
 except ImportError:
     print("Megatron-Bridge package not found. Please install Megatron-Bridge with `pip install megatron-bridge`")
     raise

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -13,12 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+import math
+from typing import Callable, Optional
 
 import torch
 from torch.nested._internal.nested_tensor import NestedTensor
 
 from verl.utils.megatron_utils import unwrap_model
+from verl.utils.model_adapters import kimi_k3_logits_to_input_indices
 from verl.workers.config import MtpConfig
 
 from .util import (
@@ -210,6 +212,116 @@ def _convert_to_nested_tensor(v, input_ids_lengths):
     return v
 
 
+def _pad_kimi_k3_jagged_inputs(
+    input_ids: torch.Tensor,
+    pad_token_id: int,
+    forced_max_seqlen: Optional[int],
+    length_alignment: int,
+) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    """Right-pad Kimi's raw-token view before visual-token expansion."""
+    if not isinstance(input_ids, NestedTensor):
+        raise TypeError(f"Kimi K3 Megatron expects jagged input_ids, got {type(input_ids).__name__}")
+
+    batch_size = input_ids.shape[0]
+    lengths = [int(length) for length in input_ids.offsets().diff().tolist()]
+    max_seqlen = max(lengths)
+    if forced_max_seqlen is not None:
+        if forced_max_seqlen < max_seqlen:
+            raise ValueError(f"forced_max_seqlen={forced_max_seqlen} is shorter than Kimi K3 input length {max_seqlen}")
+        max_seqlen = forced_max_seqlen
+    max_seqlen = (max_seqlen + length_alignment - 1) // length_alignment * length_alignment
+
+    dense = input_ids.to_padded_tensor(
+        pad_token_id,
+        output_size=(batch_size, max_seqlen),
+    )
+    positions = torch.arange(max_seqlen, device=dense.device).unsqueeze(0)
+    length_tensor = torch.tensor(lengths, device=dense.device).unsqueeze(1)
+    valid_mask = positions < length_tensor
+    return dense, valid_mask, lengths
+
+
+def _pad_kimi_k3_argument(
+    value: torch.Tensor,
+    lengths: list[int],
+    max_seqlen: int,
+    *,
+    fill_value: int | float,
+    need_roll: bool = False,
+) -> torch.Tensor:
+    """Pad a jagged raw-token argument to the model's dense input shape."""
+    if not isinstance(value, NestedTensor):
+        raise TypeError(f"Kimi K3 expects jagged logits arguments, got {type(value).__name__}")
+    value_lengths = [int(length) for length in value.offsets().diff().tolist()]
+    if value_lengths != lengths:
+        raise ValueError(f"Kimi K3 logits argument lengths {value_lengths} do not match input lengths {lengths}")
+    dense = value.to_padded_tensor(fill_value, output_size=(len(lengths), max_seqlen))
+    if need_roll:
+        dense = torch.roll(dense, shifts=-1, dims=1)
+    return dense
+
+
+def _kimi_k3_dense_to_jagged(value: torch.Tensor, lengths: list[int]) -> torch.Tensor:
+    pieces = [value[index, :length] for index, length in enumerate(lengths)]
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+def _kimi_k3_dynamic_multimodal_length(raw_to_expanded_indices: torch.Tensor, config) -> int:
+    """Return a bounded bucket for the valid image-expanded sequence.
+
+    Kimi's Bridge model historically padded every multimodal micro-batch to
+    ``config.seq_length``.  CountBench uses one 448x448 image (256 projected
+    tokens), so that made roughly 1K useful tokens run through a 4K decoder.
+    Keep a small number of stable shapes while removing that trailing work.
+    """
+    if raw_to_expanded_indices.numel() == 0:
+        raise ValueError("Kimi K3 cannot derive an expanded length from empty indices")
+
+    required_length = int(raw_to_expanded_indices.max().item()) + 1
+    tp_alignment = int(config.tensor_model_parallel_size) if config.sequence_parallel else 1
+    bucket_alignment = int(getattr(config, "kimi_multimodal_length_alignment", 1))
+    if bucket_alignment <= 0:
+        raise ValueError(f"kimi_multimodal_length_alignment must be positive, got {bucket_alignment}")
+    alignment = math.lcm(tp_alignment, bucket_alignment)
+    target_length = (required_length + alignment - 1) // alignment * alignment
+    configured_length = int(config.seq_length)
+    if target_length > configured_length:
+        raise ValueError(
+            "Kimi K3 aligned multimodal length exceeds the configured limit: "
+            f"required={required_length}, aligned={target_length}, configured={configured_length}"
+        )
+    return target_length
+
+
+def _select_kimi_k3_raw_logits(
+    logits: torch.Tensor,
+    raw_to_expanded_indices: torch.Tensor,
+    expected_sequence_length: int,
+) -> torch.Tensor:
+    """Restore verl's raw-token coordinates from full expanded logits."""
+    if logits.ndim != 3:
+        raise ValueError(f"Kimi K3 expected 3-D logits, got shape {tuple(logits.shape)}")
+    if logits.shape[1] != expected_sequence_length:
+        raise ValueError(
+            "Kimi K3 output sequence length does not match the expanded layout: "
+            f"logits={logits.shape[1]}, expected={expected_sequence_length}"
+        )
+    if raw_to_expanded_indices.shape[0] != logits.shape[0]:
+        raise ValueError(
+            "Kimi K3 logit index batch size does not match model output: "
+            f"indices={tuple(raw_to_expanded_indices.shape)}, logits={tuple(logits.shape)}"
+        )
+    if raw_to_expanded_indices.numel():
+        first = int(raw_to_expanded_indices.min())
+        last = int(raw_to_expanded_indices.max())
+        if first < 0 or last >= logits.shape[1]:
+            raise ValueError(
+                f"Kimi K3 raw-token logit indices [{first}, {last}] exceed output length {logits.shape[1]}"
+            )
+    batch_indices = torch.arange(logits.shape[0], device=logits.device)[:, None]
+    return logits[batch_indices, raw_to_expanded_indices]
+
+
 def _build_mtp_loss_mask_nested(response_mask, input_ids_lengths, response_attention_mask):
     """Build a nested loss_mask aligned to ``input_ids = [prompt; response]`` for MTP.
 
@@ -259,6 +371,134 @@ def _build_mtp_loss_mask_nested(response_mask, input_ids_lengths, response_atten
         pieces.append(full)
 
     return torch.nested.nested_tensor(pieces, layout=torch.jagged)
+
+
+def kimi_k3_forward_model_engine(
+    model,
+    input_ids,
+    multi_modal_inputs: dict,
+    logits_processor=None,
+    logits_processor_args: dict = None,
+    value_model=False,
+    vision_model=False,
+    pad_token_id=None,
+    data_format: str = "bshd",
+    mtp_enable_train: bool = False,
+    local_cp_size: Optional[int] = None,
+    forced_max_seqlen: Optional[int] = None,
+    cp_layout: str = "contiguous",
+    router_replay_prepare: Optional[Callable[[int], None]] = None,
+    router_padding_mask: torch.Tensor | None = None,
+    mtp_loss_normalization_factor: float | None = None,
+    pad_to_length_bucket: int | None = None,
+):
+    """Megatron forward contract for Kimi K3's image-expanded sequence.
+
+    verl keeps labels, masks, and temperatures in raw-token coordinates.  The
+    Kimi replaces each media placeholder with projected image features and
+    computes logits in expanded coordinates. This path contracts those logits
+    back to raw-token positions before verl computes log probabilities.
+    """
+    del vision_model, cp_layout
+    if data_format != "bshd":
+        raise ValueError("Kimi K3 Megatron requires BSHD; set actor/ref megatron.use_remove_padding=False")
+    if mtp_enable_train or mtp_loss_normalization_factor is not None:
+        raise NotImplementedError("Kimi K3 Megatron does not support MTP training")
+    if local_cp_size is not None or router_padding_mask is not None:
+        raise NotImplementedError("Kimi K3 Megatron does not support verl dynamic context parallelism")
+    if pad_to_length_bucket is not None:
+        raise NotImplementedError("Kimi K3 Megatron does not support THD length padding")
+    if value_model:
+        raise NotImplementedError("Kimi K3 Megatron value models are not supported")
+
+    unwrapped_model = unwrap_model(model)
+    post_process = unwrapped_model.post_process
+    config = unwrapped_model.config
+    if getattr(config, "context_parallel_size", 1) != 1:
+        raise NotImplementedError("Kimi K3 verl integration currently requires context_parallel_size=1")
+    if pad_token_id is None:
+        raise ValueError("Kimi K3 Megatron requires a tokenizer pad_token_id")
+
+    dense_input_ids, raw_valid_mask, input_lengths = _pad_kimi_k3_jagged_inputs(
+        input_ids,
+        int(pad_token_id),
+        forced_max_seqlen,
+        int(config.tensor_model_parallel_size) if config.sequence_parallel else 1,
+    )
+
+    model_kwargs = {"layout_padding_mask": raw_valid_mask}
+    pixel_values = multi_modal_inputs.get("pixel_values")
+    grid_thws = multi_modal_inputs.get("grid_thws")
+    if (pixel_values is None) != (grid_thws is None):
+        raise ValueError("Kimi K3 pixel_values and grid_thws must be provided together")
+    if pixel_values is not None:
+        model_kwargs.update(
+            pixel_values=pixel_values.to(dense_input_ids.device),
+            grid_thws=grid_thws.to(dense_input_ids.device),
+        )
+
+    raw_to_expanded_indices = kimi_k3_logits_to_input_indices(
+        dense_input_ids,
+        multi_modal_inputs,
+        config,
+        padding_mask=raw_valid_mask,
+    )
+    if raw_to_expanded_indices is None:
+        raw_to_expanded_indices = (
+            torch.arange(dense_input_ids.shape[1], device=dense_input_ids.device, dtype=torch.long)
+            .unsqueeze(0)
+            .expand_as(dense_input_ids)
+        )
+
+    expanded_sequence_length = int(config.seq_length) if pixel_values is not None else dense_input_ids.shape[1]
+    if pixel_values is not None and getattr(config, "kimi_dynamic_multimodal_length", False):
+        expanded_sequence_length = _kimi_k3_dynamic_multimodal_length(raw_to_expanded_indices, config)
+        model_kwargs["multimodal_sequence_length"] = expanded_sequence_length
+
+    if router_replay_prepare is not None:
+        # Full R3 is captured in image-expanded coordinates. Pad/crop it to
+        # this exact runtime axis before sequence-parallel scatter; using the
+        # configured 4K ceiling here would give every TP rank the wrong slice.
+        router_replay_prepare(max_model_rows=expanded_sequence_length)
+
+    output_orig = model(
+        input_ids=dense_input_ids,
+        attention_mask=None,
+        position_ids=None,
+        **model_kwargs,
+    )
+    if post_process:
+        # ColumnParallelLinear(sequence_parallel=True) gathers the sequence-
+        # sharded hidden states before the vocabulary projection, so its logits
+        # already cover the full expanded sequence. Gathering them again would
+        # concatenate different TP vocabulary shards along the sequence axis.
+        output_orig = _select_kimi_k3_raw_logits(
+            output_orig,
+            raw_to_expanded_indices,
+            expanded_sequence_length,
+        )
+    if post_process and logits_processor is not None:
+        processor_args = {
+            "label": _pad_kimi_k3_argument(
+                logits_processor_args["label"],
+                input_lengths,
+                dense_input_ids.shape[1],
+                fill_value=int(pad_token_id),
+                need_roll=True,
+            ),
+            "temperature": _pad_kimi_k3_argument(
+                logits_processor_args["temperature"],
+                input_lengths,
+                dense_input_ids.shape[1],
+                fill_value=1.0,
+            ),
+        }
+        output_dict = logits_processor(output_orig, **processor_args)
+        output = {name: _kimi_k3_dense_to_jagged(value, input_lengths) for name, value in output_dict.items()}
+    else:
+        output = output_orig
+
+    return output
 
 
 def gptmodel_forward_model_engine(

--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -22,7 +22,11 @@ from typing import Callable
 import torch
 import torch.nn as nn
 
-from .model_forward import gptmodel_forward_model_engine, model_forward_gen
+from .model_forward import (
+    gptmodel_forward_model_engine,
+    kimi_k3_forward_model_engine,
+    model_forward_gen,
+)
 from .model_forward_fused import fused_forward_model_gen, fused_forward_model_engine
 
 
@@ -32,6 +36,7 @@ class SupportedVLM(Enum):
     QWEN3_VL = "Qwen3VLForConditionalGeneration"
     QWEN3_5_MOE_VL = "Qwen3_5MoeForConditionalGeneration"
     QWEN3_5_VL = "Qwen3_5ForConditionalGeneration"
+    KIMI_K3 = "KimiK3ForConditionalGeneration"
 
 
 supported_vlm = [member.value for member in SupportedVLM]
@@ -54,6 +59,8 @@ def get_mcore_engine_forward_fn(hf_config) -> Callable:
     Get the forward function for given model architecture.
     """
     assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
+    if hf_config.architectures[0] == SupportedVLM.KIMI_K3.value:
+        return kimi_k3_forward_model_engine
     return gptmodel_forward_model_engine
 
 
@@ -74,6 +81,8 @@ def get_mcore_forward_fused_model_engine_fn(hf_config) -> Callable:
     Get the fused forward function for no-padding inputs.
     """
     assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
+    if hf_config.architectures[0] == SupportedVLM.KIMI_K3.value:
+        raise NotImplementedError("Kimi K3 Megatron does not support fused log-prob kernels")
     if hf_config.architectures[0] in supported_vlm:
         return fused_forward_model_engine(True)
     else:

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -7,6 +7,9 @@ param_offload: False
 # Whether to offload optimizer state to CPU
 optimizer_offload: False
 
+# Release disposable gradient buffers between phases, independently of parameters
+grad_offload: False
+
 # tensor model parallel size
 tensor_model_parallel_size: 1
 

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -116,6 +116,8 @@ def get_ppo_ray_runtime_env(config=None):
     )
 
     runtime_env = {
+        # Standalone TransferQueue actors can import their native dependencies before verl.
+        "worker_process_setup_hook": "verl.configure_transfer_queue_worker",
         "env_vars": PPO_RAY_RUNTIME_ENV["env_vars"].copy(),
         **({"working_dir": None} if working_dir is None else {}),
     }

--- a/verl/trainer/ppo/padding_utils.py
+++ b/verl/trainer/ppo/padding_utils.py
@@ -69,6 +69,63 @@ def build_padding_routed_experts(source_routed_experts: Any, seq_len: int) -> to
     )
 
 
+def build_padding_full_r3_pair(
+    source_routed_experts: Any,
+    source_routed_expert_weights: Any,
+    causal_rows: int,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Build a valid causal full-R3 pair for a synthetic padding sample.
+
+    Full-model R3 needs one route row for every model input row except the
+    final causal token.  A zero-filled route is not valid: top-k IDs must be
+    real and the executed weights must have a positive sum.  Reuse one already
+    validated source row; padding samples have a zero loss mask, so the choice
+    cannot contribute a policy gradient.
+    """
+    if source_routed_experts is None and source_routed_expert_weights is None:
+        return None, None
+    if not isinstance(source_routed_experts, torch.Tensor):
+        raise TypeError("full R3 padding requires tensor routed_experts when weights are present")
+    if not isinstance(source_routed_expert_weights, torch.Tensor):
+        raise TypeError("full R3 padding requires tensor routed_expert_weights with expert IDs")
+    if source_routed_experts.dim() != 3:
+        raise ValueError(
+            f"full R3 padding source IDs must be [rows, layers, topk], got {tuple(source_routed_experts.shape)}"
+        )
+    if source_routed_expert_weights.shape != source_routed_experts.shape:
+        raise ValueError(
+            "full R3 padding source IDs/weights are misaligned: "
+            f"ids={tuple(source_routed_experts.shape)}, "
+            f"weights={tuple(source_routed_expert_weights.shape)}"
+        )
+    if not source_routed_expert_weights.is_floating_point():
+        raise TypeError(
+            f"full R3 padding source weights must be floating point, got {source_routed_expert_weights.dtype}"
+        )
+    if causal_rows < 0:
+        raise ValueError(f"causal_rows must be nonnegative, got {causal_rows}")
+    if causal_rows == 0:
+        return (
+            source_routed_experts[:0].clone(),
+            source_routed_expert_weights[:0].clone(),
+        )
+    if source_routed_experts.shape[0] == 0:
+        raise ValueError("full R3 padding cannot reuse an empty source route")
+
+    flattened_weights = source_routed_expert_weights.float().reshape(source_routed_expert_weights.shape[0], -1)
+    valid_rows = torch.isfinite(flattened_weights).all(dim=1) & (flattened_weights.sum(dim=1) > 0)
+    valid_indices = torch.where(valid_rows)[0]
+    if valid_indices.numel() == 0:
+        raise ValueError("full R3 padding source has no finite route row with positive weights")
+    source_row = int(valid_indices[0].item())
+    route = source_routed_experts[source_row : source_row + 1]
+    weights = source_routed_expert_weights[source_row : source_row + 1]
+    return (
+        route.expand(causal_rows, *route.shape[1:]).clone(),
+        weights.expand(causal_rows, *weights.shape[1:]).clone(),
+    )
+
+
 def construct_minimal_padding_template(
     source_td: dict,
     source_tag: dict,
@@ -100,7 +157,22 @@ def construct_minimal_padding_template(
     attention_mask = torch.ones_like(input_ids, dtype=torch.int64)
     response_mask = torch.zeros_like(responses)
     position_ids = build_padding_position_ids(template_sample.get("position_ids"), attention_mask)
-    routed_experts = build_padding_routed_experts(template_sample.get("routed_experts"), input_ids.size(0))
+    source_routed_experts = template_sample.get("routed_experts")
+    source_routed_expert_weights = template_sample.get("routed_expert_weights")
+    if source_routed_expert_weights is not None:
+        routed_experts, routed_expert_weights = build_padding_full_r3_pair(
+            source_routed_experts,
+            source_routed_expert_weights,
+            causal_rows=max(input_ids.size(0) - 1, 0),
+        )
+    else:
+        # Legacy ID-only replay uses the logical token axis rather than Kimi's
+        # natural full-model causal-row contract.
+        routed_experts = build_padding_routed_experts(
+            source_routed_experts,
+            input_ids.size(0),
+        )
+        routed_expert_weights = None
 
     # Update the fields and remove redundant parts
     template_sample.update(
@@ -119,8 +191,13 @@ def construct_minimal_padding_template(
         template_sample["multi_modal_inputs"] = {}
     if routed_experts is not None:
         template_sample["routed_experts"] = routed_experts
+        if routed_expert_weights is not None:
+            template_sample["routed_expert_weights"] = routed_expert_weights
+        else:
+            template_sample.pop("routed_expert_weights", None)
     else:
         template_sample.pop("routed_experts", None)
+        template_sample.pop("routed_expert_weights", None)
 
     # Padding flag is deployed to protect metrics calculation (e.g. response length, score, reward).
     template_tag.update(

--- a/verl/trainer/ppo/v1/agent_loop_tq.py
+++ b/verl/trainer/ppo/v1/agent_loop_tq.py
@@ -119,7 +119,6 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             if not trajectory["validate"] and not do_sample:
                 apply_greedy_sampling_params(run_sampling_params)
 
-            tasks = []
             for i in range(n):
                 task = asyncio.create_task(
                     self._run_agent_loop(
@@ -190,9 +189,14 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                 input_ids.unsqueeze(0), attention_mask.unsqueeze(0), multi_modal_inputs
             ).squeeze(0)
 
-            keys.append(f"{uid}_{session_id}_{i}")
+            rollout_key = f"{uid}_{session_id}_{i}"
+            keys.append(rollout_key)
             field = output.as_dict()
             field.update(kwargs)
+            # ``uid`` intentionally remains the prompt/group id used by GRPO.
+            # Persist the unique TransferQueue row key separately so audit
+            # dumps can verify and sort rows without conflating the two ids.
+            field["rollout_key"] = rollout_key
             # do not store raw image/video
             field.pop("multi_modal_data", None)
             # TODO: uniform response_mask and loss_mask

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1251,12 +1251,13 @@ class PPOTrainer(ABC):
     def _log_rollout_data(self, batch: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout data from TransferQueue and dump sorted by uid."""
         with marked_timer("dump_rollout_generations", timing_raw, color="green"):
-            fields = ["uid", "prompts", "responses", "rm_scores", "reward_model"]
+            fields = ["uid", "rollout_key", "prompts", "responses", "rm_scores", "reward_model"]
             data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
             data["prompts"] = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
             data["responses"] = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
 
             uids = data.pop("uid").tolist()
+            rollout_keys = data.pop("rollout_key").tolist()
             inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["prompts"]]
             outputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["responses"]]
             scores = data["rm_scores"].sum(dim=1).tolist()
@@ -1269,7 +1270,7 @@ class PPOTrainer(ABC):
 
             # Sort by uid key ({sample}_{rollout}_{output})
             sort_keys = []
-            for key in batch.keys:
+            for key in rollout_keys:
                 parts = key.rsplit("_", 2)
                 if len(parts) == 3:
                     sort_keys.append((parts[0], int(parts[1]), int(parts[2])))
@@ -1282,7 +1283,10 @@ class PPOTrainer(ABC):
             gts = [gts[i] for i in sorted_indices]
             scores = [scores[i] for i in sorted_indices]
 
-            reward_extra_infos_dict = {"uid": [batch.keys[i] for i in sorted_indices]}
+            reward_extra_infos_dict = {
+                "uid": [rollout_keys[i] for i in sorted_indices],
+                "prompt_uid": [uids[i] for i in sorted_indices],
+            }
 
             self._dump_generations(
                 inputs=inputs,
@@ -1589,10 +1593,13 @@ class PPOTrainer(ABC):
             tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data)
             return batch
 
-        # 1. compute log probs
+        # 1. compute log probs. Entropy is an expensive full-vocabulary
+        # reduction; only request it when it is consumed by the actor config.
+        actor_config = self.config.actor_rollout_ref.actor
+        calculate_entropy = actor_config.calculate_entropy or actor_config.entropy_coeff != 0.0
         batch.extra_info.update(
             {
-                "calculate_entropy": True,
+                "calculate_entropy": calculate_entropy,
                 "compute_loss": False,
                 "temperature": self.config.actor_rollout_ref.rollout.temperature,
             }
@@ -1600,33 +1607,32 @@ class PPOTrainer(ABC):
         output: KVBatchMeta = self.actor_rollout_wg.compute_log_prob(batch)
         assert len(output) == len(batch)
 
-        fields = ["entropy", "log_probs", "response_mask"]
+        fields = ["log_probs", "response_mask"]
+        if calculate_entropy:
+            fields.append("entropy")
         if self.config.actor_rollout_ref.rollout.calculate_log_probs:
             fields.extend(["responses", "rollout_log_probs"])
         data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
 
         # 2. write old_log_probs and entropy back to TransferQueue
         data["old_log_probs"] = response_from_nested(data.pop("log_probs"), data["response_mask"])
-        data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
-        batch = tq.kv_batch_put(
-            keys=batch.keys, partition_id=batch.partition_id, fields=data.select("old_log_probs", "entropy")
-        )
+        output_fields = ["old_log_probs"]
+        if calculate_entropy:
+            data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
+            output_fields.append("entropy")
+        batch = tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data.select(*output_fields))
 
         data = DataProto(batch=data.to_padded_tensor())
 
-        # 3. calculate actor entroy metrics
-        actor_config = self.config.actor_rollout_ref.actor
-        entropy_agg = agg_loss(
-            loss_mat=data.batch["entropy"],
-            loss_mask=data.batch["response_mask"],
-            loss_agg_mode=actor_config.loss_agg_mode,
-            loss_scale_factor=actor_config.loss_scale_factor,
-        )
-        old_log_prob_metrics = {
-            "actor/entropy": entropy_agg.detach().item(),
-            # "perf/mfu/actor_infer": old_log_prob_mfu,
-        }
-        metrics.update(old_log_prob_metrics)
+        # 3. calculate actor entropy metrics only when entropy was requested
+        if calculate_entropy:
+            entropy_agg = agg_loss(
+                loss_mat=data.batch["entropy"],
+                loss_mask=data.batch["response_mask"],
+                loss_agg_mode=actor_config.loss_agg_mode,
+                loss_scale_factor=actor_config.loss_scale_factor,
+            )
+            metrics["actor/entropy"] = entropy_agg.detach().item()
 
         # 4. calculate rollout vs actor logprobs diff
         if self.config.actor_rollout_ref.rollout.calculate_log_probs:

--- a/verl/utils/debug/metrics.py
+++ b/verl/utils/debug/metrics.py
@@ -108,14 +108,18 @@ def calculate_debug_metrics(data: DataProto) -> dict:
             "training/rollout_probs_diff_mean": float("nan"),
             "training/rollout_probs_diff_std": float("nan"),
             "training/rollout_actor_probs_pearson_corr": float("nan"),
+            "training/rollout_log_probs_diff_mean": float("nan"),
         }
 
     pearson_corrcoef = pearson_correlation_coefficient(actor_probs, rollout_probs, response_mask_bool)
     rollout_probs_diff = calculate_log_prob_diff(actor_probs, rollout_probs, response_mask_bool)
+    log_prob_abs_diff = calculate_log_prob_diff(rollout_old_log_probs, actor_old_log_probs, response_mask_bool)
     return {
         "training/rollout_probs_diff_valid": 1,
         "training/rollout_probs_diff_max": torch.max(rollout_probs_diff).detach().item(),
         "training/rollout_probs_diff_mean": torch.mean(rollout_probs_diff).detach().item(),
         "training/rollout_probs_diff_std": torch.std(rollout_probs_diff).detach().item(),
         "training/rollout_actor_probs_pearson_corr": pearson_corrcoef,
+        # Historical key: this is the mean absolute log-probability difference.
+        "training/rollout_log_probs_diff_mean": log_prob_abs_diff.mean().detach().item(),
     }

--- a/verl/utils/megatron/dist_checkpointing.py
+++ b/verl/utils/megatron/dist_checkpointing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 import megatron.core
 import torch
 from megatron.core import dist_checkpointing, mpu
@@ -26,6 +28,47 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 from packaging import version
 
 
+def _preload_tensors_for_sync_save(write_buckets, non_blocking=True):
+    """Stage device tensors while reusing CPU tensors for a synchronous save.
+
+    MegatronAdaptor's async-safe preloader clones every CPU tensor so training
+    cannot mutate optimizer state while a background writer is running.  A
+    synchronous checkpoint blocks the training worker until all writer threads
+    have joined, so that clone is unnecessary and can nearly double host memory
+    when the optimizer itself is CPU-offloaded.
+    """
+    result = []
+    for file_name, storage_key, (bytes_data, tensor_data) in write_buckets:
+        staged_tensors = []
+        for item, tensor in tensor_data:
+            staged = tensor if tensor.is_cpu else tensor.to("cpu", non_blocking=non_blocking)
+            staged_tensors.append((item, staged))
+        result.append((file_name, storage_key, (bytes_data, staged_tensors)))
+    if non_blocking:
+        torch.cuda.synchronize()
+    return result
+
+
+class _MemoryEfficientSyncSaveStrategy(TorchDistSaveShardedStrategy):
+    """Reuse CPU tensors only while executing a synchronous save request."""
+
+    def save(self, sharded_state_dict, checkpoint_dir):
+        request = self.async_save(sharded_state_dict, checkpoint_dir, async_strategy="mcore")
+        preload = request.preload_fn
+        if preload is not None:
+            if not isinstance(preload, functools.partial) or not preload.args:
+                raise RuntimeError("Unexpected Megatron checkpoint preload callback")
+            non_blocking = preload.args[1] if len(preload.args) > 1 else True
+            request = request._replace(
+                preload_fn=functools.partial(
+                    _preload_tensors_for_sync_save,
+                    preload.args[0],
+                    non_blocking,
+                )
+            )
+        request.execute_sync()
+
+
 def save_dist_checkpointing(
     sharded_state_dict,
     ckpt_path,
@@ -34,7 +77,7 @@ def save_dist_checkpointing(
 ):
     validate_sharding_integrity = True
     # Get checkpointing strategies
-    save_strategy = TorchDistSaveShardedStrategy(backend="torch_dist", version=1)
+    save_strategy = _MemoryEfficientSyncSaveStrategy()
     save_strategy = FullyParallelSaveStrategyWrapper(
         save_strategy, mpu.get_data_parallel_group(with_context_parallel=True)
     )

--- a/verl/utils/megatron/router_replay_patch.py
+++ b/verl/utils/megatron/router_replay_patch.py
@@ -84,18 +84,34 @@ class RouterReplay:
     def __init__(self):
         """Initializes a RouterReplay instance for a specific layer."""
         self.target_topk_idx = None  # For replay
+        self.target_topk_weight = None
         self.target_replay_mask = None
         self.recorded_topk_idx = None  # For recording
         self.router_replay_action = None  # Router replay action for this layer
         self.replay_backward_list = []  # List of tensors for backward pass replay
+        self.replay_backward_weight_list = []
         self.replay_backward_mask_list = []
+        self.active_topk_weight = None
+        self.active_replay_mask = None
         RouterReplay.router_instances.append(self)
 
-    def set_target_indices(self, topk_indices: torch.Tensor, replay_mask: torch.Tensor | None = None):
-        """Sets the target topk indices for replay."""
+    def set_target_indices(
+        self,
+        topk_indices: torch.Tensor,
+        replay_mask: torch.Tensor | None = None,
+        topk_weights: torch.Tensor | None = None,
+    ):
+        """Set externally captured expert IDs and optional executed weights."""
+        if topk_weights is not None and topk_weights.shape != topk_indices.shape:
+            raise ValueError(
+                "replayed expert IDs and weights must have identical shapes: "
+                f"ids={tuple(topk_indices.shape)}, weights={tuple(topk_weights.shape)}"
+            )
         self.target_topk_idx = topk_indices
+        self.target_topk_weight = topk_weights
         self.target_replay_mask = replay_mask
         self.replay_backward_list.append(topk_indices)
+        self.replay_backward_weight_list.append(topk_weights)
         self.replay_backward_mask_list.append(replay_mask)
 
     def get_recorded_indices(self):
@@ -108,6 +124,8 @@ class RouterReplay:
 
     def get_replay_topk(self, scores, topk, num_groups=None, group_topk=None, default_compute_topk=None):
         """Select native or replayed experts using the current replay action."""
+        self.active_topk_weight = None
+        self.active_replay_mask = None
         action = self.router_replay_action
         if action == RouterReplayAction.RECORD:
             probs, indices = default_compute_topk(scores, topk, num_groups=num_groups, group_topk=group_topk)
@@ -116,15 +134,30 @@ class RouterReplay:
 
         if action == RouterReplayAction.REPLAY_FORWARD and self.target_topk_idx is not None:
             indices = self.target_topk_idx
+            weights = self.target_topk_weight
             replay_mask = self.target_replay_mask
         elif action == RouterReplayAction.REPLAY_BACKWARD and self.replay_backward_list:
             indices = self.replay_backward_list.pop(0)
+            weights = self.replay_backward_weight_list.pop(0)
             replay_mask = self.replay_backward_mask_list.pop(0)
         else:
             return default_compute_topk(scores, topk, num_groups=num_groups, group_topk=group_topk)
 
-        indices = indices.to(scores.device)
+        indices = indices.to(device=scores.device, dtype=torch.long)
+        if indices.shape != (scores.shape[0], topk):
+            raise ValueError(
+                "replayed route shape does not match the local router: "
+                f"replay={tuple(indices.shape)}, native={(scores.shape[0], topk)}"
+            )
+        if indices.numel() and (indices.min() < 0 or indices.max() >= scores.shape[1]):
+            raise ValueError("replayed route contains an out-of-range expert ID")
         if replay_mask is not None:
+            replay_mask = replay_mask.to(device=scores.device, dtype=torch.bool).reshape(-1)
+            if replay_mask.numel() != scores.shape[0]:
+                raise ValueError(
+                    "replay mask row count does not match the local router: "
+                    f"mask={replay_mask.numel()}, native={scores.shape[0]}"
+                )
             _, native_indices = default_compute_topk(scores, topk, num_groups=num_groups, group_topk=group_topk)
             if indices.shape != native_indices.shape or replay_mask.numel() != scores.shape[0]:
                 raise RuntimeError(
@@ -133,15 +166,51 @@ class RouterReplay:
                     f"native={tuple(native_indices.shape)}, mask={tuple(replay_mask.shape)}"
                 )
             indices = torch.where(replay_mask.to(scores.device).bool().unsqueeze(-1), indices, native_indices)
+        if weights is not None:
+            if replay_mask is None:
+                raise ValueError("full R3 replay requires an explicit model-row mask")
+            self.active_topk_weight = weights.to(device=scores.device)
+            self.active_replay_mask = replay_mask
         return scores.gather(1, indices), indices
+
+    def apply_replay_weights(self, probs: torch.Tensor, scaling_factor: float) -> torch.Tensor:
+        """Replay executed weights in forward while retaining local gate gradients."""
+        weights = self.active_topk_weight
+        replay_mask = self.active_replay_mask
+        self.active_topk_weight = None
+        self.active_replay_mask = None
+        if weights is None:
+            return probs
+        if weights.shape != probs.shape:
+            raise ValueError(
+                "replayed weight shape does not match router probabilities: "
+                f"replay={tuple(weights.shape)}, native={tuple(probs.shape)}"
+            )
+        weights = weights.to(dtype=probs.dtype)
+        selected = weights[replay_mask]
+        if selected.numel():
+            if not bool(torch.isfinite(selected).all()) or bool((selected < 0).any()):
+                raise ValueError("replayed router weights must be finite and non-negative")
+            if bool((selected.sum(dim=-1) <= 0).any()):
+                raise ValueError("replayed router weights contain a zero-sum row")
+            if scaling_factor:
+                expected = torch.full_like(selected[:, 0], float(scaling_factor))
+                if not bool(torch.isclose(selected.float().sum(-1), expected.float(), atol=0.02, rtol=0).all()):
+                    raise ValueError("replayed router weights violate the normalized sum contract")
+        replayed = weights + (probs - probs.detach())
+        return torch.where(replay_mask.unsqueeze(-1), replayed, probs)
 
     def clear_indices(self):
         """Clears the recorded and target topk indices."""
-        self.recorded_topk_idx = None
-        self.target_topk_idx = None
+        self.recorded_topk_idx = None  # For recording
+        self.target_topk_idx = None  # For replay
+        self.target_topk_weight = None
         self.target_replay_mask = None
-        self.replay_backward_list = []
+        self.replay_backward_list = []  # List of tensors for backward pass replay
+        self.replay_backward_weight_list = []
         self.replay_backward_mask_list = []
+        self.active_topk_weight = None
+        self.active_replay_mask = None
 
     def set_router_replay_action(self, router_replay_action: RouterReplayAction):
         """Sets the router replay action for this layer."""
@@ -226,6 +295,9 @@ def _patched_topk_routing_with_score_function(
 
     if scaling_factor:
         probs = probs * scaling_factor
+
+    if router_replay is not None:
+        probs = router_replay.apply_replay_weights(probs, scaling_factor)
 
     if torch.are_deterministic_algorithms_enabled():
         # build [num_tokens, num_experts] from [num_tokens, topk]

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -47,12 +47,6 @@ from verl.utils.megatron.router_replay_patch import RouterReplay, RouterReplayAc
 device_name = get_device_name()
 
 
-def _context_parallel_layout(tf_config) -> str:
-    if getattr(tf_config, "experimental_attention_variant", None) == "dsv4_hybrid":
-        return "contiguous"
-    return "zigzag"
-
-
 # from megatron.core.transformer.transformer_block import get_num_layers_to_build
 def get_num_layers_to_build(config: TransformerConfig, vp_stage: int | None = None, pp_rank: int | None = None) -> int:
     """
@@ -280,8 +274,6 @@ def merge_router_topk_indices(
             else None
         )
 
-        cp_layout = _context_parallel_layout(tf_config)
-
         if input_ids.is_nested:
             batch_size = input_ids.shape[0]
             _, packed_seq_params, _ = preprocess_thd_engine(
@@ -372,6 +364,76 @@ def align_r3_router_replay_data(layers_topk_idx: torch.Tensor, input_ids: torch.
     return torch.nested.as_nested_tensor(aligned_parts, layout=torch.jagged)
 
 
+def _prepare_kimi_full_r3_model_rows(
+    payload: torch.Tensor,
+    *,
+    max_model_rows: int,
+    topk: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Right-pad executed image-expanded vLLM rows to Megatron's model axis."""
+    if not payload.is_nested:
+        raise TypeError("Kimi full R3 routes must remain a jagged model-row tensor")
+    if max_model_rows <= 0:
+        raise ValueError("Kimi full R3 requires a positive Megatron model sequence length")
+
+    lengths = payload.offsets().diff()
+    if bool((lengths > max_model_rows).any()):
+        raise ValueError(
+            "Kimi full R3 captured more model rows than Megatron can consume: "
+            f"max_capture={int(lengths.max())}, max_model_rows={max_model_rows}"
+        )
+    batch_size = payload.shape[0]
+    dense = payload.to_padded_tensor(
+        0,
+        output_size=(batch_size, max_model_rows, payload.shape[2], payload.shape[3]),
+    )
+    positions = torch.arange(max_model_rows, device=dense.device).unsqueeze(0)
+    mask = positions < lengths.unsqueeze(1)
+
+    # A natural autoregressive rollout samples its final response token but
+    # never feeds that token back through the model. vLLM may also return
+    # unused request-capacity slots after it; all such packed weight lanes are
+    # zero. Exclude only this verified trailing suffix. An internal hole is an
+    # incomplete capture and must fail closed rather than silently fall back
+    # to native routing.
+    expected_width = topk * 3
+    if dense.shape[-1] != expected_width:
+        raise ValueError(f"Kimi full R3 payload width is {dense.shape[-1]}, expected {expected_width}")
+    row_has_weights = dense[..., topk:].ne(0).any(dim=(-1, -2))
+    captured_with_weights = mask & row_has_weights
+    empty_captured_rows = mask & ~row_has_weights
+    valid_after = captured_with_weights.flip(1).cumsum(dim=1).flip(1) > 0
+    if bool((empty_captured_rows & valid_after).any()):
+        raise ValueError("Kimi full R3 capture contains an empty internal model row")
+    if bool((captured_with_weights.sum(dim=1) == 0).any()):
+        raise ValueError("Kimi full R3 capture contains no executed model rows")
+    mask = captured_with_weights
+
+    # Megatron's router flattens [sequence, batch], not [batch, sequence].
+    dense = dense.permute(1, 0, 2, 3).reshape(1, max_model_rows * batch_size, *dense.shape[2:])
+    mask = mask.transpose(0, 1).reshape(1, max_model_rows * batch_size)
+    return dense.contiguous(), mask.contiguous()
+
+
+def _decode_kimi_full_r3_payload(
+    payload: torch.Tensor,
+    *,
+    topk: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Decode IDs and exact BF16 values from ``[ids, low-byte, high-byte]``."""
+    expected_width = topk * 3
+    if payload.shape[-1] != expected_width:
+        raise ValueError(f"Kimi full R3 payload width is {payload.shape[-1]}, expected {expected_width}")
+    ids = payload[..., :topk].to(torch.int64)
+    low = payload[..., topk : 2 * topk].to(torch.int32)
+    high = payload[..., 2 * topk :].to(torch.int32)
+    if low.numel() and bool(((low < 0) | (low > 255) | (high < 0) | (high > 255)).any()):
+        raise ValueError("Kimi full R3 BF16 byte lane is outside [0, 255]")
+    fp32_bits = ((low | (high << 8)) << 16).contiguous()
+    weights = fp32_bits.view(torch.float32)
+    return ids, weights
+
+
 def set_router_replay_data(
     layers_topk_idx,
     attention_mask,
@@ -380,6 +442,7 @@ def set_router_replay_data(
     replay_mask=None,
     local_cp_size=None,
     model=None,
+    max_model_rows: int | None = None,
 ):
     """
     Scatter the packed router top-k indices back to sequence-parallel ranks and update each local
@@ -399,6 +462,9 @@ def set_router_replay_data(
             unmasked tokens keep native Megatron routes.
         model: The forwarded model (or list of VPP chunks). When given, targets are written to its own
             routers instead of a positional slice of the global RouterReplay.router_instances list.
+        max_model_rows (Optional[int]): Runtime Kimi image-expanded sequence length. When omitted,
+            the configured maximum sequence length is used. The runtime value must be applied before
+            sequence-parallel scatter so every TP rank receives the same rows as the model forward.
 
     Returns:
         None: The function updates internal RouterReplay instances in-place.
@@ -413,10 +479,30 @@ def set_router_replay_data(
             else None
         )
 
-        cp_layout = _context_parallel_layout(tf_config)
-
         replay_mask_rmpad = None
-        if layers_topk_idx.is_nested:
+        layers_topk_weight_rmpad = None
+        logical_topk = int(getattr(tf_config, "moe_router_topk", 0) or 0)
+        payload_width = int(layers_topk_idx.shape[-1])
+        packed_full_r3 = logical_topk > 0 and payload_width == logical_topk * 3
+
+        if packed_full_r3:
+            configured_model_rows = int(getattr(tf_config, "seq_length", 0) or 0)
+            effective_model_rows = configured_model_rows if max_model_rows is None else int(max_model_rows)
+            if effective_model_rows <= 0 or effective_model_rows > configured_model_rows:
+                raise ValueError(
+                    "Kimi full R3 runtime model rows must be within the configured sequence limit: "
+                    f"runtime={effective_model_rows}, configured={configured_model_rows}"
+                )
+            layers_topk_idx_rmpad, replay_mask_rmpad = _prepare_kimi_full_r3_model_rows(
+                layers_topk_idx,
+                max_model_rows=effective_model_rows,
+                topk=logical_topk,
+            )
+            layers_topk_idx_rmpad, layers_topk_weight_rmpad = _decode_kimi_full_r3_payload(
+                layers_topk_idx_rmpad,
+                topk=logical_topk,
+            )
+        elif layers_topk_idx.is_nested:
             layers_topk_idx_rmpad, _, _ = preprocess_thd_engine(
                 layers_topk_idx,
                 pre_process=True,
@@ -444,6 +530,11 @@ def set_router_replay_data(
         layers_topk_idx_rmpad_split = scatter_to_sequence_parallel_region(
             layers_topk_idx_rmpad.to(device_name).squeeze(dim=0)
         ).unsqueeze(dim=0)
+        layers_topk_weight_rmpad_split = None
+        if layers_topk_weight_rmpad is not None:
+            layers_topk_weight_rmpad_split = scatter_to_sequence_parallel_region(
+                layers_topk_weight_rmpad.to(device_name).squeeze(dim=0)
+            ).unsqueeze(dim=0)
         replay_mask_rmpad_split = None
         if replay_mask_rmpad is not None:
             replay_mask_rmpad_split = scatter_to_sequence_parallel_region(
@@ -454,6 +545,10 @@ def set_router_replay_data(
         layers_topk_idx_reshape = layers_topk_idx_rmpad_split.permute(0, 2, 1, 3).squeeze(
             dim=0
         )  # layer_num, dynamic_bs_all, topk
+
+        layers_topk_weight_reshape = None
+        if layers_topk_weight_rmpad_split is not None:
+            layers_topk_weight_reshape = layers_topk_weight_rmpad_split.permute(0, 2, 1, 3).squeeze(dim=0)
         # When dim-0 covers all layers (e.g. R3, or R2 with all-MoE models),
         # index by absolute layer_idx; otherwise (R2 with mixed dense/MoE),
         # dim-0 only contains MoE layers, index by MoE-layer ordinal.
@@ -467,6 +562,9 @@ def set_router_replay_data(
                     router.set_target_indices(
                         layers_topk_idx_reshape[idx].to(torch.int64),
                         replay_mask=replay_mask_rmpad_split,
+                        topk_weights=(
+                            layers_topk_weight_reshape[idx] if layers_topk_weight_reshape is not None else None
+                        ),
                     )
             return
 
@@ -486,6 +584,7 @@ def set_router_replay_data(
             router.set_target_indices(
                 layers_topk_idx_reshape[idx].to(torch.int64),
                 replay_mask=replay_mask_rmpad_split,
+                topk_weights=(layers_topk_weight_reshape[idx] if layers_topk_weight_reshape is not None else None),
             )
             router_offset += 1
             moe_idx += 1

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -659,6 +659,32 @@ def _clear_te_fp8_weight_workspaces(model_chunk):
     return cleared
 
 
+def _iter_ddp_buffers(model_chunk):
+    for buffers in (model_chunk.buffers, model_chunk.expert_parallel_buffers):
+        yield from buffers
+
+
+def _release_ddp_grad_storage(buffer) -> None:
+    size = buffer.grad_data.storage().size()
+    if size > 0:
+        buffer.grad_data_size = size
+        buffer.grad_data.storage().resize_(0)
+
+
+def _restore_ddp_grad_storage(buffer) -> None:
+    if not hasattr(buffer, "grad_data_size"):
+        return
+    current_size = buffer.grad_data.storage().size()
+    if current_size == 0:
+        buffer.grad_data.storage().resize_(buffer.grad_data_size)
+    elif current_size != buffer.grad_data_size:
+        raise RuntimeError(
+            "Megatron gradient buffer changed size while offloaded: "
+            f"current={current_size}, expected={buffer.grad_data_size}"
+        )
+    buffer.grad_data.zero_()
+
+
 @torch.no_grad()
 def offload_megatron_model_to_cpu(models):
     """
@@ -670,57 +696,52 @@ def offload_megatron_model_to_cpu(models):
     """
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
-            for buffers in model_chunk_all_buffers:
-                for buffer in buffers:
-                    # offload parameters
-                    if buffer.param_data.storage().size() > 0:
-                        # Reuse a single pinned cpu_data buffer per DDP buffer.
-                        # The previous implementation reallocated cpu_data via
-                        # `.cpu().pin_memory()` on every offload. Python evaluates
-                        # the RHS before the assignment, so the new pinned block is
-                        # allocated while the old cpu_data is still referenced --
-                        # peak host memory at the moment of allocation is 2x
-                        # param_data size. On large Megatron models this transient
-                        # peak exceeds the cgroup limit and OOMKills the pod even
-                        # though steady-state usage would be 1x. Reallocating here
-                        # would re-trigger the same 2x peak, so we allocate at most
-                        # once per buffer and assert shape/dtype invariance on
-                        # subsequent calls -- a mismatch means a caller rebuilt
-                        # param_data under us, which is a bug we want surfaced
-                        # rather than silently worked around.
-                        existing = getattr(buffer.param_data, "cpu_data", None)
-                        if existing is None:
-                            buffer.param_data.cpu_data = torch.empty(
-                                buffer.param_data.size(),
-                                dtype=buffer.param_data.dtype,
-                                device="cpu",
-                                pin_memory=True,
-                            )
-                            buffer.param_data_size = buffer.param_data.storage().size()
-                        else:
-                            assert existing.shape == buffer.param_data.shape, (
-                                f"cpu_data shape {tuple(existing.shape)} != "
-                                f"param_data shape {tuple(buffer.param_data.shape)}; "
-                                "reallocating would reintroduce the 2x peak."
-                            )
-                            assert existing.dtype == buffer.param_data.dtype, (
-                                f"cpu_data dtype {existing.dtype} != "
-                                f"param_data dtype {buffer.param_data.dtype}; "
-                                "reallocating would reintroduce the 2x peak."
-                            )
-                        # Synchronous D2H copy into the preexisting pinned
-                        # buffer; must complete before resize_(0) frees the
-                        # GPU storage.
-                        buffer.param_data.cpu_data.copy_(buffer.param_data.data, non_blocking=False)
-                        buffer.param_data.storage().resize_(0)
+            for buffer in _iter_ddp_buffers(model_chunk):
+                # offload parameters
+                if buffer.param_data.storage().size() > 0:
+                    # Reuse a single pinned cpu_data buffer per DDP buffer.
+                    # The previous implementation reallocated cpu_data via
+                    # `.cpu().pin_memory()` on every offload. Python evaluates
+                    # the RHS before the assignment, so the new pinned block is
+                    # allocated while the old cpu_data is still referenced --
+                    # peak host memory at the moment of allocation is 2x
+                    # param_data size. On large Megatron models this transient
+                    # peak exceeds the cgroup limit and OOMKills the pod even
+                    # though steady-state usage would be 1x. Reallocating here
+                    # would re-trigger the same 2x peak, so we allocate at most
+                    # once per buffer and assert shape/dtype invariance on
+                    # subsequent calls -- a mismatch means a caller rebuilt
+                    # param_data under us, which is a bug we want surfaced
+                    # rather than silently worked around.
+                    existing = getattr(buffer.param_data, "cpu_data", None)
+                    if existing is None:
+                        buffer.param_data.cpu_data = torch.empty(
+                            buffer.param_data.size(),
+                            dtype=buffer.param_data.dtype,
+                            device="cpu",
+                            pin_memory=True,
+                        )
+                        buffer.param_data_size = buffer.param_data.storage().size()
+                    else:
+                        assert existing.shape == buffer.param_data.shape, (
+                            f"cpu_data shape {tuple(existing.shape)} != "
+                            f"param_data shape {tuple(buffer.param_data.shape)}; "
+                            "reallocating would reintroduce the 2x peak."
+                        )
+                        assert existing.dtype == buffer.param_data.dtype, (
+                            f"cpu_data dtype {existing.dtype} != "
+                            f"param_data dtype {buffer.param_data.dtype}; "
+                            "reallocating would reintroduce the 2x peak."
+                        )
+                    # Synchronous D2H copy into the preexisting pinned
+                    # buffer; must complete before resize_(0) frees the
+                    # GPU storage.
+                    buffer.param_data.cpu_data.copy_(buffer.param_data.data, non_blocking=False)
+                    buffer.param_data.storage().resize_(0)
 
-                    assert buffer.param_data_size == buffer.param_data.cpu_data.storage().size()
+                assert buffer.param_data_size == buffer.param_data.cpu_data.storage().size()
 
-                    if buffer.grad_data.storage().size() > 0:
-                        # if the grad_data size is already zero, we assume that it is already offloaded
-                        buffer.grad_data_size = buffer.grad_data.storage().size()
-                        buffer.grad_data.storage().resize_(0)
+                _release_ddp_grad_storage(buffer)
             # Offload frozen parameters not in DDP buffers (e.g. base model in LoRA/PEFT)
             # DDP buffers only contain requires_grad=True params, so frozen params must be offloaded separately.
             for param in model_chunk.module.parameters():
@@ -750,6 +771,58 @@ def offload_megatron_model_to_cpu(models):
 
 
 @torch.no_grad()
+def offload_megatron_grad_to_cpu(models):
+    """Release Megatron gradient storage while keeping model parameters resident.
+
+    Megatron DDP preallocates persistent FP32 gradient buffers.  After an
+    optimizer step those buffers no longer contain state that must survive
+    until the next training phase, but keeping their storage resident can
+    prevent a colocated rollout engine from materializing TP-gathered weights.
+    Record each buffer size before releasing it so
+    :func:`load_megatron_model_to_gpu` can recreate and zero the storage on the
+    next train-mode entry.
+    """
+    # Gradient reduction/zeroing may have been enqueued asynchronously.  The
+    # storage must not be resized while any device work still references it.
+    get_torch_device().synchronize()
+
+    for model_chunk in models:
+        if isinstance(model_chunk, DDP):
+            for buffer in _iter_ddp_buffers(model_chunk):
+                _release_ddp_grad_storage(buffer)
+        else:
+            # Non-DDP modules do not have a recreatable flat grad buffer. Keep
+            # their gradients on CPU so this helper remains safe for reference
+            # and small-model uses of the generic Megatron engine.
+            for _, param in model_chunk.named_parameters():
+                if param.grad is not None and param.grad.device.type != "cpu":
+                    old_grad = param.grad
+                    param.grad = param.grad.to("cpu")
+                    if _can_safely_resize_storage(old_grad):
+                        old_grad.storage().resize_(0)
+
+    gc.collect()
+    get_torch_device().empty_cache()
+
+
+@torch.no_grad()
+def load_megatron_grad_to_gpu(models):
+    """Restore gradient storage released by :func:`offload_megatron_grad_to_cpu`."""
+    device_id = get_device_id()
+    for model_chunk in models:
+        if isinstance(model_chunk, DDP):
+            for buffer in _iter_ddp_buffers(model_chunk):
+                _restore_ddp_grad_storage(buffer)
+        else:
+            for parameter in model_chunk.parameters():
+                if parameter.grad is not None and parameter.grad.device.type == "cpu":
+                    parameter.grad = parameter.grad.to(device_id, non_blocking=True)
+
+    gc.collect()
+    get_torch_device().empty_cache()
+
+
+@torch.no_grad()
 def load_megatron_model_to_gpu(models, load_grad=True, load_frozen_params=True):
     """
     Load megatron model to GPU.
@@ -760,25 +833,14 @@ def load_megatron_model_to_gpu(models, load_grad=True, load_frozen_params=True):
     """
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
-            model_chunk_all_buffers = [model_chunk.buffers, model_chunk.expert_parallel_buffers]
-            for buffers in model_chunk_all_buffers:
-                for buffer in buffers:
-                    # sometimes, we don't want to load grad for pure inference
-                    if load_grad and hasattr(buffer, "grad_data_size"):
-                        current_storage_size = buffer.grad_data.storage().size()
-                        if current_storage_size == 0 or current_storage_size == buffer.grad_data_size:
-                            buffer.grad_data.storage().resize_(buffer.grad_data_size)
-                            buffer.grad_data.zero_()
-                        else:
-                            # Non-standard layers (e.g. GatedDeltaNet) may have grad
-                            # buffers with mismatched storage size; skip resize and
-                            # zero in-place with current storage.
-                            buffer.grad_data.zero_()
+            for buffer in _iter_ddp_buffers(model_chunk):
+                if load_grad:
+                    _restore_ddp_grad_storage(buffer)
 
-                    if buffer.param_data.storage().size() == 0:
-                        buffer.param_data.storage().resize_(buffer.param_data_size)
-                        # copy data from cpu to cuda
-                        buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
+                if buffer.param_data.storage().size() == 0:
+                    buffer.param_data.storage().resize_(buffer.param_data_size)
+                    # copy data from cpu to cuda
+                    buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)
 
             # Load frozen parameters that were offloaded (e.g. base model in LoRA/PEFT)
             if load_frozen_params:

--- a/verl/utils/model_adapters.py
+++ b/verl/utils/model_adapters.py
@@ -1,0 +1,224 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import torch
+
+
+class ProcessorAdapter:
+    def __init__(self, processor):
+        self._processor = processor
+
+    def __getattr__(self, name):
+        try:
+            processor = object.__getattribute__(self, "_processor")
+        except AttributeError:
+            raise AttributeError(name) from None
+        return getattr(processor, name)
+
+
+class KimiK3Adapter(ProcessorAdapter):
+    # Kimi maps this token to ``media_placeholder_token_id`` (163605 in the
+    # released config). It has no meaning in a generated response because no
+    # image feature accompanies it. Exposing the token lets the generic
+    # rollout logits mask resolve and ban it via ``get_processor_token_id``.
+    image_token = "<|media_pad|>"
+
+    _MEDIA_PROMPT_PATTERN = re.compile(
+        r"<\|media_begin\|>image \d+x\d+<\|media_content\|><\|media_pad\|><\|media_end\|>"
+    )
+    _VLLM_MEDIA_PROMPT = "<|media_begin|>image<|media_content|><|media_pad|><|media_end|>"
+
+    @staticmethod
+    def _validate_media(video_data, audio_data):
+        if video_data is not None or audio_data is not None:
+            raise ValueError("KimiK3Processor only supports image inputs")
+
+    def __call__(self, *, text, images=None, videos=None, audio=None, **kwargs):
+        self._validate_media(videos, audio)
+        if isinstance(text, list | tuple):
+            if len(text) != 1:
+                raise ValueError("KimiK3Processor only supports one text input at a time")
+            text = text[0]
+
+        if images:
+            medias = [
+                image if isinstance(image, dict) and image.get("type") == "image" else {"type": "image", "image": image}
+                for image in images
+            ]
+            return self._processor(medias=medias, text=text, **kwargs)
+
+        return self._processor.tokenizer(text=text, **kwargs)
+
+    @classmethod
+    def prepare_vllm_prompt_ids(cls, prompt_ids: list[int], tokenizer, image_data) -> list[int]:
+        if not image_data:
+            return prompt_ids
+
+        prompt = tokenizer.decode(prompt_ids)
+        vllm_prompt = cls._MEDIA_PROMPT_PATTERN.sub(cls._VLLM_MEDIA_PROMPT, prompt)
+        if vllm_prompt == prompt:
+            return prompt_ids
+        from verl.utils.tokenizer import normalize_token_ids
+
+        return normalize_token_ids(tokenizer.encode(vllm_prompt))
+
+    @classmethod
+    def build_vllm_multimodal_data(cls, image_data=None, video_data=None, audio_data=None) -> dict:
+        cls._validate_media(video_data, audio_data)
+        if image_data is None:
+            return {}
+        return {
+            "vision_chunk": [
+                image if isinstance(image, dict) and image.get("type") == "image" else {"type": "image", "image": image}
+                for image in image_data
+            ]
+        }
+
+
+def kimi_k3_logits_to_input_indices(
+    input_ids: torch.Tensor,
+    multi_modal_inputs: dict,
+    config,
+    padding_mask: torch.Tensor | None = None,
+) -> torch.Tensor | None:
+    """Map raw Kimi K3 token positions to positions after image expansion.
+
+    Kimi K3 replaces each ``media_placeholder_token_id`` with all projected
+    image features before running the language model.  The returned LM logits
+    therefore have the expanded sequence length, whereas verl's labels and
+    response masks retain the original one-placeholder sequence.  Selecting
+    the first ``raw_sequence_length`` logits shifts every token after an image.
+
+    The index for the placeholder itself is the *last* feature position.  Its
+    causal logit is consequently the one that predicts the first text token
+    after the image, matching the original-token label shift used by verl.
+    """
+    if getattr(config, "model_type", None) != "kimi_k3":
+        return None
+    if input_ids.ndim != 2:
+        raise ValueError(f"Kimi K3 logit alignment expects 2-D input_ids, got {tuple(input_ids.shape)}")
+
+    image_token_id = getattr(config, "media_placeholder_token_id", None)
+    if image_token_id is None:
+        raise ValueError("Kimi K3 config is missing media_placeholder_token_id")
+    if padding_mask is not None:
+        if padding_mask.shape != input_ids.shape:
+            raise ValueError(
+                "Kimi K3 padding mask must match input_ids: "
+                f"mask={tuple(padding_mask.shape)}, input_ids={tuple(input_ids.shape)}"
+            )
+        padding_mask = padding_mask.to(device=input_ids.device, dtype=torch.bool)
+
+    image_mask = input_ids == image_token_id
+    if padding_mask is not None:
+        image_mask &= padding_mask
+    image_count = int(image_mask.sum().item())
+    if image_count == 0:
+        return None
+
+    grid_thws = multi_modal_inputs.get("grid_thws")
+    if not isinstance(grid_thws, torch.Tensor):
+        raise ValueError("Kimi K3 image inputs require a grid_thws tensor for logit alignment")
+    grid_thws = grid_thws.reshape(-1, 3).to(device=input_ids.device, dtype=torch.long)
+    if grid_thws.shape[0] != image_count:
+        raise ValueError(
+            f"Kimi K3 image placeholder/grid count mismatch: placeholders={image_count}, grids={grid_thws.shape[0]}"
+        )
+
+    vision_config = getattr(config, "vision_config", None)
+    merge_kernel_size = getattr(vision_config, "merge_kernel_size", None)
+    merge_type = getattr(vision_config, "merge_type", None)
+    if merge_type != "sd2_tpool" or not merge_kernel_size or len(merge_kernel_size) != 2:
+        raise ValueError(
+            "Unsupported Kimi K3 vision merge configuration for logit alignment: "
+            f"merge_type={merge_type!r}, merge_kernel_size={merge_kernel_size!r}"
+        )
+    kernel_height, kernel_width = (int(value) for value in merge_kernel_size)
+    heights, widths = grid_thws[:, 1], grid_thws[:, 2]
+    if bool(((heights % kernel_height) != 0).any()) or bool(((widths % kernel_width) != 0).any()):
+        raise ValueError("Kimi K3 grid dimensions must be divisible by merge_kernel_size")
+
+    # tpool_patch_merger averages the temporal dimension and spatially merges
+    # kernel_height x kernel_width patches, so t is deliberately absent here.
+    feature_lengths = (heights // kernel_height) * (widths // kernel_width)
+    occupations = torch.ones_like(input_ids, dtype=torch.long)
+    occupations[image_mask] = feature_lengths
+    if padding_mask is not None:
+        occupations[~padding_mask] = 0
+    indices = occupations.cumsum(dim=-1) - 1
+
+    # Megatron receives a right-padded dense view of verl's jagged input and
+    # passes the same explicit mask to KimiK3Model.build_multimodal_layout.
+    # That model always left-aligns the expanded valid tokens, so its mapping is
+    # complete here.  The legacy HF/FSDP path below retains the padding-side
+    # compatibility logic used by KimiK3ForConditionalGeneration.
+    if padding_mask is not None:
+        return indices
+
+    # Mirror KimiK3ForConditionalGeneration._merge_input_ids_with_image_features.
+    # It left-aligns right-padded batches and right-aligns left/no-padding batches.
+    pad_token_id = getattr(config, "pad_token_id", None)
+    if pad_token_id is None:
+        raise ValueError("Kimi K3 config is missing pad_token_id")
+    left_padding = not bool((input_ids[:, -1] == pad_token_id).sum().item())
+    if left_padding:
+        max_embed_dim = occupations.sum(dim=-1).max()
+        image_padding = max_embed_dim - 1 - indices[:, -1]
+        indices = indices + image_padding[:, None]
+    return indices
+
+
+_PROCESSOR_ADAPTERS = {
+    "KimiK3Processor": KimiK3Adapter,
+}
+_VLLM_ADAPTERS = {
+    "kimi_k3": KimiK3Adapter,
+}
+
+
+def adapt_processor(processor):
+    adapter_cls = _PROCESSOR_ADAPTERS.get(processor.__class__.__name__)
+    return processor if adapter_cls is None else adapter_cls(processor)
+
+
+def get_vllm_adapter(model_type):
+    return _VLLM_ADAPTERS.get(model_type)
+
+
+_KIMI_K3_RESPONSE_CLOSE = "<|close|> response <|sep|>"
+
+
+def add_kimi_k3_stop_conditions(
+    sampling_params: dict,
+    model_type: str | None,
+    end_of_msg_token_id: int | None,
+) -> None:
+    """Stop Kimi-K3 after its first complete assistant response."""
+    if model_type != "kimi_k3":
+        return
+    if end_of_msg_token_id is None:
+        raise ValueError("Kimi K3 config must define eos_token_id")
+
+    stop_token_ids = list(sampling_params.get("stop_token_ids") or [])
+    if end_of_msg_token_id not in stop_token_ids:
+        stop_token_ids.append(end_of_msg_token_id)
+    sampling_params["stop_token_ids"] = stop_token_ids
+
+    stop = sampling_params.get("stop")
+    stop_strings = [stop] if isinstance(stop, str) else list(stop or [])
+    if _KIMI_K3_RESPONSE_CLOSE not in stop_strings:
+        stop_strings.append(_KIMI_K3_RESPONSE_CLOSE)
+    sampling_params["stop"] = stop_strings

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -86,10 +86,14 @@ def default_compute_score(
 
             # Assuming prime_code doesn't need the URL
             res = prime_code.compute_score(solution_str, ground_truth, continuous=True)
-    elif data_source in ["hiyouga/geometry3k"]:
+    elif data_source == "hiyouga/geometry3k":
         from . import geo3k
 
         res = geo3k.compute_score(solution_str, ground_truth)
+    elif data_source == "countbenchqa_lite":
+        from . import countbenchqa
+
+        res = countbenchqa.compute_score(solution_str, ground_truth)
     elif data_source in [
         "searchR1_nq",
         "searchR1_triviaqa",

--- a/verl/utils/reward_score/countbenchqa.py
+++ b/verl/utils/reward_score/countbenchqa.py
@@ -1,0 +1,92 @@
+"""Reward for CountBenchQA outputs rendered with the Kimi K3 XTML template."""
+
+from __future__ import annotations
+
+import re
+
+_THINK_CLOSE_RE = re.compile(r"<\|close\|>\s*think\s*<\|sep\|>", re.IGNORECASE)
+_RESPONSE_OPEN_RE = re.compile(r"^\s*<\|open\|>\s*response\s*<\|sep\|>", re.IGNORECASE)
+_RESPONSE_END_RE = re.compile(
+    r"<\|close\|>\s*(?:response|message)\s*<\|sep\|>|<\|end_of_msg\|>",
+    re.IGNORECASE,
+)
+_BOXED_INTEGER_RE = re.compile(
+    r"\\boxed\s*(?:\{\s*([+-]?\d+)\s*\}|\(\s*([+-]?\d+)\s*\)|([+-]?\d+))",
+    re.IGNORECASE,
+)
+_INTEGER_RE = re.compile(r"^[+-]?\d+$")
+_STRICT_FINAL_RE = re.compile(r".*\\boxed\s*\{\s*[+-]?\d+\s*\}\s*$", re.DOTALL | re.IGNORECASE)
+
+
+def extract_response(solution_str: str) -> str | None:
+    """Return the first response channel, never an answer from the think channel."""
+    think_close = _THINK_CLOSE_RE.search(solution_str)
+    if think_close is None:
+        return None
+    response = solution_str[think_close.end() :]
+    response = _RESPONSE_OPEN_RE.sub("", response, count=1)
+    response_end = _RESPONSE_END_RE.search(response)
+    if response_end is not None:
+        response = response[: response_end.start()]
+    return response.strip()
+
+
+def _canonicalize_integer_text(value: object) -> str | None:
+    """Return a canonical decimal string without constructing an unbounded int.
+
+    TransferQueue's wire encoder only accepts integers in its 64-bit range.  A
+    model response is untrusted text and can contain an arbitrarily long boxed
+    integer, so converting it to ``int`` before transport can crash an otherwise
+    healthy rollout.  Canonical strings preserve exact equality and auditability
+    without depending on Python's integer-string digit limit or a wire integer
+    width.
+    """
+    text = str(value).strip()
+    if _INTEGER_RE.fullmatch(text) is None:
+        return None
+
+    negative = text.startswith("-")
+    digits = text.lstrip("+-").lstrip("0") or "0"
+    if digits == "0":
+        return "0"
+    return f"-{digits}" if negative else digits
+
+
+def extract_boxed_integer(response: str) -> str | None:
+    """Extract the last boxed integer as a canonical decimal string."""
+    matches = list(_BOXED_INTEGER_RE.finditer(response))
+    if not matches:
+        return None
+    groups = matches[-1].groups()
+    value = next(group for group in groups if group is not None)
+    return _canonicalize_integer_text(value)
+
+
+def compute_score(
+    solution_str: str, ground_truth: str, format_score: float = 0.1
+) -> dict[str, float | str | bool | None]:
+    """Score CountBench and expose auditable components without changing the total."""
+    expected = _canonicalize_integer_text(ground_truth)
+    if expected is None:
+        return {
+            "score": 0.0,
+            "acc": 0.0,
+            "format": 0.0,
+            "predicted": None,
+            "expected": None,
+            "has_response": False,
+        }
+
+    response = extract_response(str(solution_str))
+    predicted = extract_boxed_integer(response) if response is not None else None
+    accuracy = float(predicted == expected)
+    valid_format = float(response is not None and bool(_STRICT_FINAL_RE.fullmatch(response)))
+    score = (1.0 - format_score) * accuracy + format_score * valid_format
+    return {
+        "score": score,
+        "acc": accuracy,
+        "format": valid_format,
+        "predicted": predicted,
+        "expected": expected,
+        "has_response": response is not None,
+    }

--- a/verl/utils/tokenizer/tokenizer.py
+++ b/verl/utils/tokenizer/tokenizer.py
@@ -16,6 +16,8 @@
 import types
 import warnings
 
+from verl.utils.model_adapters import ProcessorAdapter, adapt_processor
+
 __all__ = [
     "hf_tokenizer",
     "hf_processor",
@@ -228,6 +230,8 @@ def hf_processor(name_or_path, **kwargs):
                 model_class = Glm46VModel
             case "MllamaProcessor":
                 pass  # MllamaProcessor and MllamaModel doesn't have get_rope_index property
+            case "KimiK3Processor":
+                pass  # MllamaProcessor and MllamaModel doesn't have get_rope_index property
             case "Gemma4Processor":
                 # Gemma4 uses standard 1D RoPE -> no get_rope_index to bind. Disable its strict
                 # per-image-token check (which Qwen's processor lacks).
@@ -239,6 +243,8 @@ def hf_processor(name_or_path, **kwargs):
             processor.get_rope_index = types.MethodType(model_class.get_rope_index, processor)
             if hasattr(model_class, "get_vision_position_ids"):
                 processor.get_vision_position_ids = types.MethodType(model_class.get_vision_position_ids, processor)
+
+        processor = adapt_processor(processor)
     except Exception as e:
         processor = None
         # TODO(haibin.lin): try-catch should be removed after adding transformer version req to setup.py to avoid
@@ -246,7 +252,11 @@ def hf_processor(name_or_path, **kwargs):
         warnings.warn(f"Failed to create processor: {e}. This may affect multimodal processing", stacklevel=1)
     # Avoid load tokenizer, see:
     # https://github.com/huggingface/transformers/blob/v4.49.0/src/transformers/models/auto/processing_auto.py#L344
-    if processor is not None and "Processor" not in processor.__class__.__name__:
+    if (
+        processor is not None
+        and "Processor" not in processor.__class__.__name__
+        and not isinstance(processor, ProcessorAdapter)
+    ):
         processor = None
 
     return processor

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -70,7 +70,7 @@ def gather_from_labels(data: torch.Tensor, label: torch.Tensor) -> torch.Tensor:
     return output
 
 
-def logprobs_from_logits(logits, labels, inplace_backward=True):
+def logprobs_from_logits(logits, labels, inplace_backward=True, force_fp32=False):
     """
     Compute per-token log-probabilities for the given labels.
 
@@ -83,10 +83,19 @@ def logprobs_from_logits(logits, labels, inplace_backward=True):
         logits (Tensor): Model outputs of shape (..., vocab_size).
         labels (LongTensor): True class indices of shape matching logits[..., :-1].
         inplace_backward (bool): If True and Flash-Attn is available, perform backward in-place.
+        force_fp32 (bool): Compute the returned log-probabilities in FP32. On NPU
+            this uses chunked FP32 cross-entropy so the full vocabulary logits are
+            not duplicated at once.
 
     Returns:
         Tensor: Log-probabilities of the target labels, shape logits.shape[:-1].
     """
+    if force_fp32:
+        if NPU_CROSS_ENTROPY_LOSS_AVAILABLE and logits.device.type == "npu":
+            return logprobs_from_logits_torch_npu(logits, labels, force_fp32=True)
+        # Keep the fallback numerically consistent when running outside NPU.
+        logits = logits.float()
+
     # The flash-attn Triton cross-entropy kernel's reduction may be non-deterministic
     # and is NOT controlled by FLASH_ATTENTION_DETERMINISTIC (that only governs the
     # attention kernels) nor by torch.use_deterministic_algorithms (Triton custom ops
@@ -100,7 +109,7 @@ def logprobs_from_logits(logits, labels, inplace_backward=True):
         labels = labels.reshape(-1)
         output = logprobs_from_logits_flash_attn(logits, labels, inplace_backward=inplace_backward)
         output = output.view(*batch_dim)
-    elif NPU_CROSS_ENTROPY_LOSS_AVAILABLE:
+    elif NPU_CROSS_ENTROPY_LOSS_AVAILABLE and logits.device.type == "npu":
         output = logprobs_from_logits_torch_npu(logits, labels)
     else:
         output = logprobs_from_logits_v2(logits, labels)
@@ -133,7 +142,9 @@ def logprobs_from_logits_flash_attn(
     return -output[0]
 
 
-def logprobs_from_logits_torch_npu(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+def logprobs_from_logits_torch_npu(
+    logits: torch.Tensor, labels: torch.Tensor, force_fp32: bool = False, chunk_size: int = 1024
+) -> torch.Tensor:
     """Compute log-probabilities using Ascend NPU's optimized cross-entropy.
 
     Uses torch_npu's native cross-entropy implementation for efficient
@@ -148,7 +159,22 @@ def logprobs_from_logits_torch_npu(logits: torch.Tensor, labels: torch.Tensor) -
     """
     batch_dim = logits.shape[:-1]
     logits = logits.reshape(-1, logits.shape[-1])
-    loss, _, _, _ = torch_npu.npu_cross_entropy_loss(logits, labels.reshape(-1), reduction="none")
+    labels = labels.reshape(-1)
+
+    if force_fp32:
+        if logits.shape[0] == 0:
+            return logits.new_empty(batch_dim, dtype=torch.float32)
+        output_chunks = []
+        for start in range(0, logits.shape[0], chunk_size):
+            end = min(start + chunk_size, logits.shape[0])
+            # Only the active chunk is promoted, keeping the extra HBM bounded
+            # by chunk_size * vocab_size instead of the complete micro-batch.
+            chunk_logits = logits[start:end].float()
+            loss, _, _, _ = torch_npu.npu_cross_entropy_loss(chunk_logits, labels[start:end], reduction="none")
+            output_chunks.append(-loss)
+        return torch.cat(output_chunks, dim=0).view(*batch_dim)
+
+    loss, _, _, _ = torch_npu.npu_cross_entropy_loss(logits, labels, reduction="none")
     return -loss.view(*batch_dim)
 
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -181,6 +181,8 @@ class McoreEngineConfig(EngineConfig):
 
     # sequence_parallel is not listed as a frozen field for auto-correction purpose
     _mutable_fields = EngineConfig._mutable_fields | {"sequence_parallel"}
+    # Release disposable gradient buffers while actor parameters stay resident.
+    grad_offload: bool = False
     # mcore parallelism
     tensor_model_parallel_size: int = 1
     expert_model_parallel_size: int = 1

--- a/verl/workers/engine/__init__.py
+++ b/verl/workers/engine/__init__.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 import warnings
 
+from .bootstrap import bootstrap_megatron_runtime
+
+# Install the adaptor before importing FSDP/Megatron engine modules.
+bootstrap_megatron_runtime()
+
 from .base import BaseEngine, EngineRegistry
 from .fsdp import FSDPEngine, FSDPEngineWithLMHead, FSDPTurboEngineWithLMHead
 

--- a/verl/workers/engine/bootstrap.py
+++ b/verl/workers/engine/bootstrap.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0.
+"""Explicit early runtime bootstrap for Megatron-based engines."""
+
+from __future__ import annotations
+
+import os
+
+_ENABLED_VALUES = {"1", "true", "enabled"}
+
+
+def bootstrap_megatron_runtime() -> None:
+    """Register MegatronAdaptor before any Megatron engine imports."""
+    enabled = os.getenv("VERL_USE_MEGATRON_ADAPTOR", "").lower() in _ENABLED_VALUES
+    if not enabled:
+        return
+
+    try:
+        from mindspeed_bridge.runtime import state
+        from mindspeed_bridge.runtime.auto_register import register_mindspeed_adaptor
+    except ImportError as exc:
+        raise RuntimeError("VERL_USE_MEGATRON_ADAPTOR=enabled requires MS-Bridge and MegatronAdaptor") from exc
+    if not state.MEGATRON_ADAPTOR_REGISTERED_BY_RUNTIME:
+        register_mindspeed_adaptor(strict=True)

--- a/verl/workers/engine/fsdp/fsdp_turbo_impl.py
+++ b/verl/workers/engine/fsdp/fsdp_turbo_impl.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+import logging
+import math
+from contextlib import contextmanager
+
 import torch
 
+from verl.utils.device import get_device_id, get_device_name
 from verl.utils.fsdp_utils import fsdp2_load_full_state_dict
 
 from ..base import EngineRegistry
 from .transformer_impl import FSDPEngineWithLMHead
+
+logger = logging.getLogger(__file__)
 
 
 @EngineRegistry.register(model_type="language_model", backend="fsdp_turbo", device=["cuda", "npu"])
@@ -30,25 +38,69 @@ class FSDPTurboEngineWithLMHead(FSDPEngineWithLMHead):
         from fsdp_turbo.distributed.parallel_state import get_parallel_state, init_parallel_state
         from fsdp_turbo.fsdp_turbo_config import FSDPTurboConfig, _dict_to_dataclass
 
-        self.fsdp_turbo_config = _dict_to_dataclass(FSDPTurboConfig, self.engine_config.turbo_config)
-        self.fsdp_turbo_config.distributed.fsdp_plan.cpu_offload = self.engine_config.offload_policy
+        turbo_config = copy.deepcopy(self.engine_config.turbo_config)
+        fsdp_plan = turbo_config.setdefault("distributed", {}).setdefault("fsdp_plan", {})
+        cpu_offload = bool(self.engine_config.offload_policy or self.engine_config.forward_only)
+        fsdp_plan["cpu_offload"] = cpu_offload
+        if cpu_offload and get_device_name() == "npu":
+            fsdp_plan["pin_memory"] = False
+        reshard_after_forward = self.engine_config.reshard_after_forward
+        fsdp_plan["reshard_after_forward"] = True if reshard_after_forward is None else reshard_after_forward
+        self.fsdp_turbo_config = _dict_to_dataclass(FSDPTurboConfig, turbo_config)
+        attn_implementation = getattr(self.fsdp_turbo_config.model, "attn_implementation", "eager")
+        for config in (
+            self.model_config.hf_config,
+            getattr(self.model_config.hf_config, "text_config", None),
+        ):
+            if config is not None:
+                config._attn_implementation = attn_implementation
+        vision_config = getattr(self.model_config.hf_config, "vision_config", None)
+        if vision_config is not None:
+            vision_config._attn_implementation = (
+                "flash_attention_2" if self.model_config.hf_config.model_type == "kimi_k3" else attn_implementation
+            )
         init_parallel_state(self.fsdp_turbo_config)
         self._parallel_state = get_parallel_state()
         if self._is_ulysses_enabled():
             self._process_ulysses_config()
 
-    def _build_module(self):
+    def _build_module(self, load_pretrained=None, force_meta=False):
         # Do not let verl's Qwen VLM monkey patch slice the text model before
         # FSDP-Turbo's post-fusion model patch does the CP split.
         cp_size = self.ulysses_sequence_parallel_size
         self.ulysses_sequence_parallel_size = 1
         try:
-            return super()._build_module()
+            if self.model_config.hf_config.model_type == "kimi_k3":
+                load_pretrained = False
+                force_meta = True
+            return super()._build_module(load_pretrained=load_pretrained, force_meta=force_meta)
         finally:
             self.ulysses_sequence_parallel_size = cp_size
 
     def _build_fsdp_module(self, module):
         from fsdp_turbo.fsdp_turbo import FSDPTurbo
+
+        if self.model_config.hf_config.model_type == "kimi_k3":
+            # Wrap the meta model first, then materialize only final local shards.
+            module = FSDPTurbo(self.fsdp_turbo_config, module).model
+            if self.engine_config.offload_policy or self.engine_config.forward_only:
+                self._is_offload_param = False
+                self._is_offload_optimizer = False
+                self._uses_fsdp2_cpu_offload_policy = True
+
+            from .streaming_loader import load_kimi_k3_checkpoint_to_local_shards
+
+            materialize_device = (
+                "cpu" if self.engine_config.offload_policy or self.engine_config.forward_only else get_device_id()
+            )
+            load_kimi_k3_checkpoint_to_local_shards(
+                module,
+                self.model_config.local_path,
+                materialize_device=materialize_device,
+            )
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                torch.distributed.barrier()
+            return module
 
         full_state = module.state_dict()
         module = FSDPTurbo(self.fsdp_turbo_config, module).model
@@ -102,6 +154,11 @@ class FSDPTurboEngineWithLMHead(FSDPEngineWithLMHead):
             is_collect = True
         return is_collect
 
+    @contextmanager
+    def _gradient_sync_context(self, *, is_last_micro_batch: bool):
+        # FSDP-Turbo owns gradient synchronization at its collective boundary.
+        yield
+
     def optimizer_step(self):
         """
         Clip gradients, skip update if non-finite, and step optimizer.
@@ -121,24 +178,23 @@ class FSDPTurboEngineWithLMHead(FSDPEngineWithLMHead):
 
         from fsdp_turbo.training.clip_grads import clip_grad_norm
 
-        grad_norm_value = clip_grad_norm(model=self.module, max_norm=self.optimizer_config.clip_grad)
-        grad_norm = torch.tensor(grad_norm_value, device=next(self.module.parameters()).device, dtype=torch.float32)
-
-        if scaler is not None:
+        grad_norm = clip_grad_norm(model=self.module, max_norm=self.optimizer_config.clip_grad)
+        if not math.isfinite(grad_norm):
+            rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+            marker = f"FSDP-Turbo NONFINITE GRADIENT: rank={rank} grad_norm={grad_norm} optimizer_step=False"
+            logger.error(marker)
+            self.optimizer.zero_grad()
+            raise FloatingPointError(marker)
+        elif scaler is not None:
             # scaler handles inf/nan skipping internally via _check_inf_per_device.
             scaler.step(self.optimizer)
             scaler.update()
         else:
-            # if grad_norm is not finite, skip the update
-            if not torch.isfinite(grad_norm):
-                print(f"WARN: grad_norm is not finite: {grad_norm}")
-                self.optimizer.zero_grad()
-            else:
-                self.optimizer.step()
+            self.optimizer.step()
 
         if self._qat_enabled:
             from verl.utils.qat.core import invalidate_all_scales
 
             invalidate_all_scales(self.module)
 
-        return grad_norm.item()
+        return grad_norm

--- a/verl/workers/engine/fsdp/kimi_packed_weights.py
+++ b/verl/workers/engine/fsdp/kimi_packed_weights.py
@@ -1,0 +1,59 @@
+"""Export packed Kimi experts for the colocated FSDP-Turbo rollout layout."""
+
+import torch
+import torch.distributed as dist
+from torch.distributed.tensor import DTensor, Replicate, Shard
+from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+
+KIMI_PACKED_LOCAL_MARKER = ".__verl_packed_local__."
+
+
+def export_kimi_packed_local_param(name: str, param: DTensor, device, rollout_layout: dict):
+    """Gather eFSDP matrix shards while retaining each rank's expert interval.
+
+    The Kimi example uses matching actor EP and rollout TP/EP, with DP=PP=1
+    inside each rollout replica. Validate that contract on the complete mesh
+    before any redistribution so every rank takes the same collective path.
+    """
+    if not isinstance(param, DTensor) or param.ndim != 3:
+        raise TypeError(f"Kimi packed export requires a 3-D DTensor: {name}")
+    if rollout_layout is None:
+        raise ValueError("Kimi packed export requires the rollout layout")
+    ep = int(rollout_layout["expert_parallel_size"])
+    tp = int(rollout_layout["tensor_parallel_size"])
+    dp = int(rollout_layout["data_parallel_size"])
+    pp = int(rollout_layout["pipeline_model_parallel_size"])
+    if ep <= 0 or tp != ep or dp != 1 or pp != 1:
+        raise ValueError("Kimi packed export requires rollout TP=EP>0 and DP=PP=1")
+
+    placements = param.placements
+    expert_dims = [
+        index for index, placement in enumerate(placements) if isinstance(placement, Shard) and placement.dim == 0
+    ]
+    if len(expert_dims) != 1:
+        raise ValueError(f"Kimi packed export requires one expert Shard(0): {placements}")
+    expert_dim = expert_dims[0]
+    mesh = param.device_mesh.mesh.cpu()
+    world_size = dist.get_world_size()
+    if mesh.numel() != world_size or mesh.shape[expert_dim] != ep or world_size % ep:
+        raise ValueError("Kimi packed export requires matching actor/rollout EP on the full actor mesh")
+    coordinate_shape = [1] * mesh.ndim
+    coordinate_shape[expert_dim] = ep
+    expected_ranks = torch.arange(ep).reshape(coordinate_shape).expand(mesh.shape)
+    if not torch.equal(mesh.remainder(ep), expected_ranks):
+        raise ValueError("Kimi actor expert ownership does not match colocated rollout ranks")
+    if param.shape[0] % ep:
+        raise ValueError(f"Kimi experts must be divisible by EP: experts={param.shape[0]}, EP={ep}")
+
+    export_placements = tuple(
+        placement if index == expert_dim else Replicate() for index, placement in enumerate(placements)
+    )
+    exported = param.to(device, non_blocking=True)
+    if export_placements != placements:
+        exported = exported.redistribute(param.device_mesh, export_placements)
+    _, offset = compute_local_shape_and_global_offset(param.shape, param.device_mesh, export_placements)
+    local = exported.to_local().detach().contiguous()
+    expected_start = (dist.get_rank() % ep) * (param.shape[0] // ep)
+    if offset[0] != expected_start or local.shape[0] != param.shape[0] // ep:
+        raise RuntimeError(f"Unexpected Kimi local expert interval: {name}, offset={offset}, shape={local.shape}")
+    return f"{name}{KIMI_PACKED_LOCAL_MARKER}{expected_start}", local

--- a/verl/workers/engine/fsdp/streaming_loader.py
+++ b/verl/workers/engine/fsdp/streaming_loader.py
@@ -1,0 +1,262 @@
+"""Streaming safetensors loading for Kimi-K3 FSDP-Turbo models.
+
+The legacy Kimi loader first assembles every expert into a CPU full state dict
+and lets FSDP-Turbo broadcast/shard that state.  This module builds the final
+DTensor layout first and reads only the slice owned by the current rank.
+
+The loader intentionally does not call ``state_dict`` or ``full_tensor``.
+Those operations are both correctness hazards for a large EP model and the
+source of the multi-hundred-GB initialization peak seen with the old path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+
+import torch
+from safetensors import safe_open
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+
+
+@dataclass
+class _TensorSpec:
+    name: str
+    global_shape: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    global_offset: tuple[int, ...]
+    local_tensor: torch.Tensor
+
+
+@dataclass
+class _LoadTask:
+    target_name: str
+    source_key: str
+    destination: torch.Tensor
+    source_slices: tuple[slice, ...]
+    expected_source_shape: tuple[int, ...]
+    transpose: bool = False
+
+
+def _as_shape(value) -> tuple[int, ...]:
+    return tuple(int(item) for item in value)
+
+
+def _local_spec(name: str, tensor: torch.Tensor) -> _TensorSpec:
+    if isinstance(tensor, DTensor):
+        local_tensor = tensor.to_local()
+        local_shape, global_offset = compute_local_shape_and_global_offset(
+            tensor.shape,
+            tensor.device_mesh,
+            tensor.placements,
+        )
+        local_shape = _as_shape(local_shape)
+        global_offset = _as_shape(global_offset)
+    else:
+        local_tensor = tensor
+        local_shape = _as_shape(tensor.shape)
+        global_offset = (0,) * len(local_shape)
+
+    global_shape = _as_shape(tensor.shape)
+    if _as_shape(local_tensor.shape) != local_shape:
+        raise RuntimeError(
+            f"Local DTensor shape mismatch for {name}: "
+            f"computed={local_shape}, actual={tuple(local_tensor.shape)}, "
+            f"global={global_shape}"
+        )
+    if any(
+        offset < 0 or offset + size > global_size
+        for offset, size, global_size in zip(global_offset, local_shape, global_shape, strict=True)
+    ):
+        raise RuntimeError(
+            f"Invalid local DTensor range for {name}: "
+            f"offset={global_offset}, local={local_shape}, global={global_shape}"
+        )
+    return _TensorSpec(
+        name=name,
+        global_shape=global_shape,
+        local_shape=local_shape,
+        global_offset=global_offset,
+        local_tensor=local_tensor,
+    )
+
+
+def _slice_tuple(offset: tuple[int, ...], shape: tuple[int, ...]) -> tuple[slice, ...]:
+    return tuple(slice(start, start + size) for start, size in zip(offset, shape, strict=True))
+
+
+def _add_task(
+    tasks_by_file: dict[str, list[_LoadTask]],
+    weight_map: dict[str, str],
+    task: _LoadTask,
+) -> None:
+    tasks_by_file[weight_map[task.source_key]].append(task)
+
+
+def _add_direct_task(
+    spec: _TensorSpec,
+    source_key: str,
+    weight_map: dict[str, str],
+    tasks_by_file,
+) -> None:
+    source_slices = _slice_tuple(spec.global_offset, spec.local_shape)
+    _add_task(
+        tasks_by_file,
+        weight_map,
+        _LoadTask(
+            target_name=spec.name,
+            source_key=source_key,
+            destination=spec.local_tensor,
+            source_slices=source_slices,
+            expected_source_shape=spec.global_shape,
+        ),
+    )
+
+
+def _add_kimi_packed_tasks(spec: _TensorSpec, weight_map, tasks_by_file) -> None:
+    """Map local [expert, input, output] slices to transposed HF matrices."""
+    if len(spec.global_shape) != 3:
+        raise ValueError(f"Packed Kimi parameter must be 3-D: {spec.name}")
+    _, rows, columns = spec.global_shape
+    prefix, projection = spec.name.rsplit(".", 1)
+    if projection == "gate_up_proj":
+        if columns % 2:
+            raise ValueError(f"Packed gate/up width must be even: {spec.name}")
+        projections = (("w1", 0, columns // 2), ("w3", columns // 2, columns))
+    else:
+        projections = (("w2", 0, columns),)
+
+    expert_start, row_start, column_start = spec.global_offset
+    expert_count, row_count, column_count = spec.local_shape
+    for local_expert in range(expert_count):
+        for source_projection, begin, end in projections:
+            left = max(column_start, begin)
+            right = min(column_start + column_count, end)
+            if left >= right:
+                continue
+            _add_task(
+                tasks_by_file,
+                weight_map,
+                _LoadTask(
+                    target_name=spec.name,
+                    source_key=f"{prefix}.{expert_start + local_expert}.{source_projection}.weight",
+                    destination=spec.local_tensor[local_expert, :, left - column_start : right - column_start],
+                    source_slices=(slice(left - begin, right - begin), slice(row_start, row_start + row_count)),
+                    expected_source_shape=(end - begin, rows),
+                    transpose=True,
+                ),
+            )
+
+
+def _read_index(checkpoint_path: str) -> dict[str, str]:
+    index_path = os.path.join(checkpoint_path, "model.safetensors.index.json")
+    if not os.path.isfile(index_path):
+        single_path = os.path.join(checkpoint_path, "model.safetensors")
+        if os.path.isfile(single_path):
+            # Read only metadata; no tensor payload is materialized.
+            with safe_open(single_path, framework="pt", device="cpu") as handle:
+                return {key: "model.safetensors" for key in handle.keys()}
+        raise FileNotFoundError(f"No safetensors index or single checkpoint found in {checkpoint_path}")
+    with open(index_path, encoding="utf-8") as index_file:
+        index = json.load(index_file)
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise RuntimeError(f"Invalid safetensors weight_map in {index_path}")
+    return {str(key): str(value) for key, value in weight_map.items()}
+
+
+def _check_shape(task: _LoadTask, source_shape: tuple[int, ...]) -> None:
+    if source_shape != task.expected_source_shape:
+        raise RuntimeError(
+            f"Checkpoint shape mismatch for {task.source_key} -> {task.target_name}: "
+            f"checkpoint={source_shape}, expected={task.expected_source_shape}"
+        )
+    for axis, item in enumerate(task.source_slices):
+        start = 0 if item.start is None else item.start
+        stop = source_shape[axis] if item.stop is None else item.stop
+        if start < 0 or stop < start or stop > source_shape[axis]:
+            raise RuntimeError(
+                f"Source slice out of range for {task.source_key}: slices={task.source_slices}, shape={source_shape}"
+            )
+
+
+def _copy_task(task: _LoadTask, accessor) -> None:
+    source_shape = _as_shape(accessor.get_shape())
+    if (
+        task.source_key.endswith(".self_attn.A_log")
+        and len(source_shape) == len(task.expected_source_shape) == 1
+        and source_shape[0] > task.expected_source_shape[0]
+    ):
+        # The source pads 96 active KDA heads to 128; only zero padding may be discarded.
+        if torch.count_nonzero(accessor[task.expected_source_shape[0] :]).item():
+            raise ValueError(f"Nonzero inactive A_log entries in {task.source_key}")
+        source_shape = task.expected_source_shape
+    _check_shape(task, source_shape)
+    source = accessor[task.source_slices] if task.source_slices else accessor[()]
+    if task.transpose:
+        if source.ndim != 2:
+            raise RuntimeError(f"Transpose task is not 2-D: {task.source_key} shape={tuple(source.shape)}")
+        source = source.transpose(0, 1)
+    destination = task.destination
+    if tuple(source.shape) != tuple(destination.shape):
+        raise RuntimeError(
+            f"Local slice shape mismatch for {task.source_key} -> {task.target_name}: "
+            f"source={tuple(source.shape)}, destination={tuple(destination.shape)}"
+        )
+    destination.copy_(source)
+
+
+@torch.no_grad()
+def load_kimi_k3_checkpoint_to_local_shards(
+    model: torch.nn.Module,
+    checkpoint_path: str,
+    *,
+    materialize_device,
+) -> None:
+    """Load raw Kimi checkpoint weights directly into local DTensor shards.
+
+    ``model`` must already have the final FSDP-Turbo/TP/EP wrappers applied.
+    Missing parameters and mismatched checkpoint shapes are errors.
+    """
+
+    # Materialize meta tensors without discarding initialized rotary/cache buffers.
+    model._apply(
+        lambda tensor: torch.empty_like(tensor, device=materialize_device)
+        if tensor.is_meta
+        else tensor.to(device=materialize_device)
+    )
+
+    weight_map = _read_index(checkpoint_path)
+    tasks_by_file: dict[str, list[_LoadTask]] = defaultdict(list)
+    missing_parameters: list[str] = []
+
+    for target_name, parameter in model.named_parameters():
+        spec = _local_spec(target_name, parameter)
+        source_key = target_name
+        if source_key in weight_map:
+            _add_direct_task(spec, source_key, weight_map, tasks_by_file)
+            continue
+
+        if target_name.endswith((".experts.gate_up_proj", ".experts.down_proj")) and len(spec.global_shape) == 3:
+            _add_kimi_packed_tasks(spec, weight_map, tasks_by_file)
+            continue
+
+        missing_parameters.append(target_name)
+
+    for target_name, buffer in model.named_buffers():
+        if target_name in weight_map:
+            _add_direct_task(_local_spec(target_name, buffer), target_name, weight_map, tasks_by_file)
+
+    if missing_parameters:
+        raise RuntimeError(
+            "Streaming Kimi checkpoint is missing target parameters: " + ", ".join(missing_parameters[:32])
+        )
+
+    for shard_name in sorted(tasks_by_file):
+        shard_path = shard_name if os.path.isabs(shard_name) else os.path.join(checkpoint_path, shard_name)
+        with safe_open(shard_path, framework="pt", device="cpu") as handle:
+            for task in tasks_by_file[shard_name]:
+                _copy_task(task, handle.get_slice(task.source_key))

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -26,7 +26,7 @@ from typing import Callable, ContextManager, Optional
 import torch
 import torch.distributed
 from peft import LoraConfig, TaskType, get_peft_model
-from tensordict import TensorDict
+from tensordict import NonTensorStack, TensorDict
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.api import FullStateDictConfig, ShardedStateDictConfig, StateDictType
 from torch.distributed.tensor import DTensor
@@ -61,6 +61,7 @@ from verl.utils.fsdp_utils import (
     replace_lora_wrapper,
 )
 from verl.utils.model import convert_weight_keys, extract_multi_modal_inputs
+from verl.utils.model_adapters import kimi_k3_logits_to_input_indices
 from verl.utils.py_functional import convert_to_regular_types
 from verl.utils.seqlen_balancing import ceildiv
 from verl.utils.torch_functional import logprobs_from_logits
@@ -72,10 +73,14 @@ from verl.utils.ulysses import (
     ulysses_pad_and_slice_inputs,
 )
 from verl.workers.config import FSDPEngineConfig, FSDPOptimizerConfig, HFModelConfig
+from verl.workers.rollout.r3_utils import (
+    KIMI_FULL_MODEL_ROUTE_SEMANTICS,
+)
 from verl.workers.utils.padding import build_attention_mask_from_nested
 
 from ..base import BaseEngine, BaseEngineCtx, EngineRegistry
 from ..utils import enable_full_determinism, pad_packed_inputs, postprocess_batch_func, prepare_micro_batches
+from .kimi_packed_weights import export_kimi_packed_local_param
 from .utils import create_device_mesh, get_sharding_strategy, unfuse_moe_params
 
 logger = logging.getLogger(__file__)
@@ -96,6 +101,130 @@ def _scale_logits_by_temperature(logits, temperature, *, is_unit_temperature: bo
     if is_unit_temperature:
         return logits
     return logits / temperature.clamp(min=1e-8).to(logits.dtype)
+
+
+def _resolve_uniform_route_transport_semantics(value):
+    """Collapse TransferQueue's per-sample metadata to one batch contract."""
+    value = tu.unwrap_non_tensor_data(value)
+    if isinstance(value, NonTensorStack):
+        value = value.tolist()
+    if isinstance(value, (list, tuple)):
+        values = [tu.unwrap_non_tensor_data(item) for item in value]
+        if not values:
+            return None
+        first = values[0]
+        if any(item != first for item in values[1:]):
+            raise RuntimeError(
+                f"FSDP Kimi R3 cannot mix routed-experts transport semantics within one microbatch, got {values!r}"
+            )
+        return first
+    return value
+
+
+def _build_kimi_full_model_route_mask(
+    padded_routes: torch.Tensor,
+    route_lengths: torch.Tensor,
+    model_attention_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Build the jagged source mask for vLLM's complete causal model rows.
+
+    The exact image-expanded alignment is intentionally deferred to the Kimi
+    multimodal merge, where FSDP's final model-row attention mask is known.
+    Here we validate the batch/ragged contract. Exact row-count validation is
+    deferred to the multimodal merge, after image expansion is known.
+    """
+    if padded_routes.dim() != 4:
+        raise ValueError(f"padded_routes must be [batch, route_rows, layers, topk], got {tuple(padded_routes.shape)}")
+    if model_attention_mask.dim() != 2:
+        raise ValueError(f"Kimi full-model R3 requires a 2-D attention mask, got {tuple(model_attention_mask.shape)}")
+    batch_size = padded_routes.shape[0]
+    if model_attention_mask.shape[0] != batch_size or route_lengths.numel() != batch_size:
+        raise ValueError(
+            "Kimi full-model R3 batch mismatch: "
+            f"routes={batch_size}, attention={model_attention_mask.shape[0]}, "
+            f"route_lengths={route_lengths.numel()}"
+        )
+    route_lengths = route_lengths.to(device=padded_routes.device, dtype=torch.long)
+    return torch.arange(padded_routes.shape[1], device=padded_routes.device).unsqueeze(0) < route_lengths.unsqueeze(1)
+
+
+def _is_kimi_packed_expert_param(name: str, param: torch.Tensor) -> bool:
+    return (
+        isinstance(param, DTensor)
+        and param.ndim == 3
+        and name.endswith(
+            (
+                ".block_sparse_moe.experts.gate_up_proj",
+                ".block_sparse_moe.experts.down_proj",
+            )
+        )
+    )
+
+
+def _get_fsdp2_parameter_export(module):
+    """Return live FSDP2 handles, preserving tied aliases for weight sync."""
+    return dict(module.named_parameters(remove_duplicate=False))
+
+
+def _is_weight_source_rank(mesh) -> bool:
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return True
+    if mesh is None:
+        return torch.distributed.get_rank() == 0
+    coordinate = mesh.get_coordinate()
+    return coordinate is None or coordinate[-1] == 0
+
+
+def _load_hf_language_model(
+    auto_class,
+    model_config,
+    torch_dtype,
+    load_pretrained=True,
+):
+    if not load_pretrained:
+        return auto_class.from_config(
+            model_config.hf_config,
+            torch_dtype=torch_dtype,
+            trust_remote_code=model_config.trust_remote_code,
+        )
+    return auto_class.from_pretrained(
+        pretrained_model_name_or_path=model_config.local_path,
+        torch_dtype=torch_dtype,
+        config=model_config.hf_config,
+        trust_remote_code=model_config.trust_remote_code,
+    )
+
+
+def _select_raw_token_logits(logits: torch.Tensor, indices: torch.Tensor | None) -> torch.Tensor:
+    """Contract image-expanded logits back to the raw input-token sequence."""
+    if indices is None:
+        return logits
+    if logits.ndim != 3 or indices.ndim != 2 or logits.shape[0] != indices.shape[0]:
+        raise ValueError(
+            f"Invalid multimodal logit alignment shapes: logits={tuple(logits.shape)}, indices={tuple(indices.shape)}"
+        )
+    indices = indices.to(device=logits.device, dtype=torch.long)
+    expanded_length = int(indices.max().item()) + 1
+    if logits.shape[1] != expanded_length:
+        raise ValueError(
+            "Multimodal logit length does not match the reconstructed expanded sequence: "
+            f"logits={logits.shape[1]}, reconstructed={expanded_length}"
+        )
+    batch_indices = torch.arange(logits.shape[0], device=logits.device)[:, None]
+    return logits[batch_indices, indices]
+
+
+def _move_multimodal_inputs_to_device(value, device):
+    # Move tensor leaves from non-tensor multimodal replay data to the model device.
+    if isinstance(value, torch.Tensor):
+        return value.to(device=device, non_blocking=True)
+    if isinstance(value, list):
+        return [_move_multimodal_inputs_to_device(item, device) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_move_multimodal_inputs_to_device(item, device) for item in value)
+    if isinstance(value, dict):
+        return {key: _move_multimodal_inputs_to_device(item, device) for key, item in value.items()}
+    return value
 
 
 class FSDPEngine(BaseEngine):
@@ -246,7 +375,7 @@ class FSDPEngine(BaseEngine):
 
         self.use_ulysses_sp = self.ulysses_sequence_parallel_size > 1
 
-    def _build_module(self):
+    def _build_module(self, load_pretrained=None, force_meta=False):
         from verl.utils.model import get_hf_auto_model_class
         from verl.utils.torch_dtypes import PrecisionType
 
@@ -258,21 +387,29 @@ class FSDPEngine(BaseEngine):
 
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
-        init_context = get_init_weight_context_manager(
-            use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings, mesh=self.device_mesh
-        )
+        if force_meta:
+            # Streaming FSDP-Turbo loading materializes only the final local
+            # DTensor shard.  No rank may construct the full CPU model.
+            from accelerate import init_empty_weights
+
+            init_context = init_empty_weights
+        else:
+            init_context = get_init_weight_context_manager(
+                use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings, mesh=self.device_mesh
+            )
 
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")
 
             if self.model_config.model_type == "language_model":
                 auto_class = get_hf_auto_model_class(hf_config=self.model_config.hf_config)
-
-                module = auto_class.from_pretrained(
-                    pretrained_model_name_or_path=self.model_config.local_path,
+                if load_pretrained is None:
+                    load_pretrained = _is_weight_source_rank(self.device_mesh)
+                module = _load_hf_language_model(
+                    auto_class=auto_class,
+                    model_config=self.model_config,
                     torch_dtype=torch_dtype,
-                    config=self.model_config.hf_config,
-                    trust_remote_code=self.model_config.trust_remote_code,
+                    load_pretrained=load_pretrained,
                 )
 
                 # Strip sub-modules listed in _verl_strip_modules (e.g.
@@ -454,7 +591,12 @@ class FSDPEngine(BaseEngine):
             if self.engine_config.offload_policy or self.engine_config.forward_only:
                 self._is_offload_param = False
                 self._is_offload_optimizer = False
-                offload_policy = CPUOffloadPolicy(pin_memory=True)
+                # torch_npu cannot reliably complete the asynchronous pinned-CPU
+                # destination used by FSDP2 foreach_reduce().  It reports a null
+                # destination during the first actor backward even when HBM is
+                # available.  Keep CPU offload, but use synchronous pageable host
+                # copies on NPU; CUDA retains the pinned-copy fast path.
+                offload_policy = CPUOffloadPolicy(pin_memory=get_device_name() != "npu")
                 self._uses_fsdp2_cpu_offload_policy = True
 
             fsdp_kwargs = {
@@ -844,7 +986,13 @@ class FSDPEngine(BaseEngine):
         super().to(device=device, model=model, optimizer=optimizer, grad=grad)
 
         if self.engine_config.forward_only:
-            # force cpu_offload
+            # FSDP1's CPUOffload handles forward-only parameters itself, but
+            # FSDP2/FSDP-Turbo's CPUOffloadPolicy does not move the initial
+            # materialized shard when an explicit to("cpu") is requested.
+            # Keep the policy for normal execution while honoring this manual
+            # residency transition so colocated vLLM can reclaim the NPU.
+            if device == "cpu" and model:
+                offload_fsdp_model_to_cpu(self.module)
             return
 
         device_name = get_device_name()
@@ -923,7 +1071,8 @@ class FSDPEngine(BaseEngine):
         _needs_staging = fsdp_version(self.module) == 1
         if _needs_staging and not self._uses_fsdp2_cpu_offload_policy:
             load_fsdp_model_to_gpu(self.module)
-        params = self.module.state_dict()
+        use_live_fsdp2_params = fsdp_version(self.module) == 2 and self._uses_fsdp2_cpu_offload_policy
+        params = _get_fsdp2_parameter_export(self.module) if use_live_fsdp2_params else self.module.state_dict()
         params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
         if _needs_staging and self._is_offload_param:
             offload_fsdp_model_to_cpu(self.module)
@@ -939,7 +1088,11 @@ class FSDPEngine(BaseEngine):
                 if p.is_floating_point():
                     p = p.to(torch.bfloat16, non_blocking=True)
                 local = p.to_local() if hasattr(p, "to_local") else p
-                yield name, local.reshape(-1), spec
+                # ``named_parameters`` preserves autograd-connected live
+                # handles.  The old state_dict path detached them implicitly;
+                # detach only after device staging so CPUOffloadPolicy never
+                # sees the invalid CPU-wrapper/NPU-storage combination.
+                yield name, local.reshape(-1).detach(), spec
 
         return _gen(), None
 
@@ -971,6 +1124,8 @@ class FSDPEngine(BaseEngine):
         return hf_delta_export(gen, self._delta_shard_snap, self._hf_delta_entry), None
 
     def get_per_tensor_param(self, layered_summon=False, base_sync_done=False, **kwargs):
+        kimi_rollout_layout = kwargs.pop("rollout_layout", None)
+        kimi_model = self.model_config.hf_config.model_type == "kimi_k3"
         log_gpu_memory_usage("Before load_fsdp_model_to_gpu", logger=logger)
 
         # FSDP2 CPUOffloadPolicy owns CPU<->GPU placement; calling model.to(device) here
@@ -983,6 +1138,9 @@ class FSDPEngine(BaseEngine):
         # (adapter merge does real weight math on the module).
         _is_peft = hasattr(getattr(self.module, "_fsdp_wrapped_module", self.module), "peft_config")
         _skip_staging = fsdp_version(self.module) == 2 and not _is_peft
+        use_live_fsdp2_params = (
+            fsdp_version(self.module) == 2 and (self._uses_fsdp2_cpu_offload_policy or kimi_model) and not _is_peft
+        )
         if not self._uses_fsdp2_cpu_offload_policy and not _skip_staging:
             load_fsdp_model_to_gpu(self.module)
 
@@ -1009,7 +1167,18 @@ class FSDPEngine(BaseEngine):
                 # Materializing after exit silently sends base weights without adapters.
                 return self._merged_lora_per_tensor_param(), None
         else:
-            params = self.module.state_dict()
+            # Kimi routed experts are already packed and Shard(0)-distributed
+            # over the EP mesh.  Keep those physical DTensors in the online
+            # state dict; rewriting them to per-expert w1/w2/w3 here triggers
+            # a full EP all-gather for every layer before rollout can discard
+            # all non-local experts again.
+            if use_live_fsdp2_params:
+                params = _get_fsdp2_parameter_export(self.module)
+            else:
+                # Packed Kimi experts now use nn.Module's physical state-dict
+                # ABI unconditionally. External w1/w2/w3 conversion is an
+                # explicit rank-0 HF-checkpoint post-process only.
+                params = self.module.state_dict()
 
         params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
 
@@ -1021,14 +1190,31 @@ class FSDPEngine(BaseEngine):
         if peft_config is not None and base_sync_done:
             per_tensor_param = params.items()
         else:
-            device = get_device_id()  # used when fsdp2 set cpu_offload_policy
-            per_tensor_param = (
-                (
-                    name,
-                    param.to(device, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param,
-                )
-                for name, param in params.items()
-            )
+            device = get_device_id()
+
+            def iter_rollout_params():
+                for name, param in params.items():
+                    if _is_kimi_packed_expert_param(name, param):
+                        marked_name, local_param = export_kimi_packed_local_param(
+                            name, param, device, kimi_rollout_layout
+                        )
+                        # ``state_dict(keep_vars=False)`` used to provide a
+                        # detached tensor.  Preserve that transport contract
+                        # after the packed-local DTensor has been staged.
+                        yield marked_name, local_param.detach()
+                    else:
+                        if isinstance(param, DTensor):
+                            # Detach the materialized result, not the live
+                            # CPU-offloaded DTensor handle.
+                            export_param = param.to(device, non_blocking=True).full_tensor().detach()
+                        else:
+                            # Unwrapped parameters are not subject to FSDP2's
+                            # DTensor staging.  Match state_dict's default
+                            # keep_vars=False behavior for the transport.
+                            export_param = param.detach()
+                        yield name, export_param
+
+            per_tensor_param = iter_rollout_params()
             per_tensor_param = unfuse_moe_params(per_tensor_param, self.model_config.hf_config.model_type)
 
         if self._qat_enabled:
@@ -1107,12 +1293,17 @@ class EngineEvalModeCtx(BaseEngineCtx):
         set_ulysses_sequence_parallel_group(self.prev_sp_group)
 
         # https://pytorch.org/docs/stable/notes/fsdp.html#fsdp-notes
-        # unshard the root FSDP module
-        if self.engine.engine_config.fsdp_size > 1:
-            if fsdp_version(self.engine.module) == 1:
-                self.engine.module._handle.reshard(True)
-            elif fsdp_version(self.engine.module) == 2:
-                self.engine.module.reshard()
+        # Reshard every FSDP unit before leaving eval. FSDPModule.reshard() is
+        # explicitly non-recursive, so calling it only on the root leaves nested
+        # all-gather storage alive and carries the old-logprob forward peak into
+        # the following actor backward. Traverse children first, then the root.
+        version = fsdp_version(self.engine.module)
+        if version == 1 and self.engine.engine_config.fsdp_size > 1:
+            self.engine.module._handle.reshard(True)
+        elif version == 2:
+            for module in reversed(list(self.engine.module.modules())):
+                if isinstance(module, FSDPModule):
+                    module.reshard()
 
         super().__exit__(exc_type, exc_value, traceback)
 
@@ -1161,9 +1352,42 @@ class FSDPEngineWithLMHead(FSDPEngine):
             )
         assert pad_mode == DatasetPadMode.NO_PADDING, f"pad_mode {pad_mode} not supported"
 
-        multi_modal_inputs = extract_multi_modal_inputs(micro_batch.get("multi_modal_inputs", []))
         input_ids = micro_batch["input_ids"]
         position_ids = micro_batch["position_ids"]
+        enable_routing_replay = tu.get_non_tensor_data(data=micro_batch, key="enable_routing_replay", default=False)
+        routed_experts = micro_batch.get("routed_experts", None) if enable_routing_replay else None
+        routed_expert_weights = micro_batch.get("routed_expert_weights", None) if enable_routing_replay else None
+        if enable_routing_replay and (routed_experts is None or routed_expert_weights is None):
+            raise RuntimeError(
+                "FSDP full R3 replay is enabled for this actor forward, but "
+                "the batch does not contain both routed_experts and "
+                "routed_expert_weights"
+            )
+        if routed_experts is not None and use_remove_padding:
+            raise NotImplementedError(
+                "Kimi-K3 FSDP R3 replay currently requires model.use_remove_padding=False so "
+                "multimodal model-row routes stay independently aligned"
+            )
+        if routed_experts is not None:
+            if routed_experts.is_nested != routed_expert_weights.is_nested:
+                raise RuntimeError("FSDP full R3 IDs and weights use different dense/jagged layouts")
+            route_semantics = _resolve_uniform_route_transport_semantics(
+                tu.get_non_tensor_data(
+                    data=micro_batch,
+                    key="routed_experts_transport_semantics",
+                    default=None,
+                )
+            )
+            if route_semantics != KIMI_FULL_MODEL_ROUTE_SEMANTICS:
+                raise RuntimeError(
+                    "FSDP Kimi R3 requires explicit natural-rollout full-model "
+                    "transport semantics, got "
+                    f"{route_semantics!r}"
+                )
+        multi_modal_inputs = _move_multimodal_inputs_to_device(
+            extract_multi_modal_inputs(micro_batch.get("multi_modal_inputs", [])),
+            input_ids.device,
+        )
         pass_packed_cu_seqlens = getattr(self, "pass_packed_cu_seqlens", False)
 
         if not isinstance(temperature, torch.Tensor):
@@ -1304,6 +1528,85 @@ class FSDPEngineWithLMHead(FSDPEngine):
                     "position_ids": position_ids,
                 }
 
+                if routed_experts is not None:
+                    if routed_experts.is_nested:
+                        route_lengths = routed_experts.offsets().diff()
+                        route_values = routed_experts.values()
+                        weight_values = routed_expert_weights.values()
+                        if not torch.equal(
+                            routed_experts.offsets(),
+                            routed_expert_weights.offsets(),
+                        ):
+                            raise ValueError("nested full R3 IDs and weights have different offsets")
+                        if route_values.dim() != 3:
+                            raise ValueError(
+                                "nested routed_experts values must be [total_rows, layers, topk], "
+                                f"got {tuple(route_values.shape)}"
+                            )
+                        if weight_values.shape != route_values.shape:
+                            raise ValueError(
+                                "nested full R3 IDs/weights are misaligned: "
+                                f"ids={tuple(route_values.shape)}, "
+                                f"weights={tuple(weight_values.shape)}"
+                            )
+                        if not weight_values.is_floating_point():
+                            raise TypeError(f"nested full R3 weights must be floating point, got {weight_values.dtype}")
+                        max_route_len = int(route_lengths.max().item())
+                        routed_experts_padded = torch.nested.to_padded_tensor(
+                            routed_experts,
+                            padding=0,
+                            output_size=(
+                                batch_size,
+                                max_route_len,
+                                route_values.shape[-2],
+                                route_values.shape[-1],
+                            ),
+                        )
+                        routed_expert_weights_padded = torch.nested.to_padded_tensor(
+                            routed_expert_weights,
+                            padding=0.0,
+                            output_size=(
+                                batch_size,
+                                max_route_len,
+                                weight_values.shape[-2],
+                                weight_values.shape[-1],
+                            ),
+                        )
+                    else:
+                        if routed_experts.dim() != 4:
+                            raise ValueError(
+                                "routed_experts must be [batch, model_rows, layers, topk], "
+                                f"got {tuple(routed_experts.shape)}"
+                            )
+                        if routed_expert_weights.shape != routed_experts.shape:
+                            raise ValueError(
+                                "dense full R3 IDs/weights are misaligned: "
+                                f"ids={tuple(routed_experts.shape)}, "
+                                f"weights={tuple(routed_expert_weights.shape)}"
+                            )
+                        if not routed_expert_weights.is_floating_point():
+                            raise TypeError(
+                                f"dense full R3 weights must be floating point, got {routed_expert_weights.dtype}"
+                            )
+                        routed_experts_padded = routed_experts
+                        routed_expert_weights_padded = routed_expert_weights
+                        route_lengths = torch.full(
+                            (batch_size,),
+                            routed_experts.shape[1],
+                            dtype=torch.long,
+                            device=routed_experts.device,
+                        )
+
+                    replay_mask = _build_kimi_full_model_route_mask(
+                        routed_experts_padded,
+                        route_lengths,
+                        attention_mask,
+                    )
+                    model_inputs["routed_experts"] = routed_experts_padded.to(torch.long)
+                    model_inputs["routed_expert_weights"] = routed_expert_weights_padded.to(torch.bfloat16)
+                    model_inputs["router_replay_mask"] = replay_mask
+                    model_inputs["r3_full_model_rows"] = True
+
             else:
                 raise NotImplementedError(f"pad_mode {pad_mode} not implemented")
 
@@ -1322,6 +1625,16 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
         model_inputs.update(multi_modal_inputs)
         model_inputs.update(extra_args)
+
+        logits_to_input_indices = kimi_k3_logits_to_input_indices(
+            model_inputs["input_ids"], multi_modal_inputs, self.model_config.hf_config
+        )
+        if logits_to_input_indices is not None:
+            if use_fused_kernels:
+                raise NotImplementedError("Kimi K3 image-expanded logits are not supported by fused log-prob kernels")
+            if self.use_ulysses_sp:
+                raise NotImplementedError("Kimi K3 image-expanded logit alignment is not implemented with Ulysses SP")
+            output_args["logits_to_input_indices"] = logits_to_input_indices
 
         return model_inputs, output_args
 
@@ -1375,10 +1688,12 @@ class FSDPEngineWithLMHead(FSDPEngine):
                             v = self._gather_and_unpad_packed(v, output_args["pad_size"])
                             model_output[field_name] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
             else:
-                logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
+                logits = output.logits  # (bsz, response_length, vocab_size)
                 # With TP, logits are DTensors sharded on vocab dim; gather for log_softmax.
-                if isinstance(logits_rmpad, DTensor):
-                    logits_rmpad = logits_rmpad.full_tensor()
+                if isinstance(logits, DTensor):
+                    logits = logits.full_tensor()
+                logits = _select_raw_token_logits(logits, output_args.get("logits_to_input_indices"))
+                logits_rmpad = logits.squeeze(0)  # (total_nnz, vocab_size)
                 logits_rmpad = _scale_logits_by_temperature(
                     logits_rmpad,
                     temperature_rmpad.unsqueeze(-1),
@@ -1425,6 +1740,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                         logits=logits_rmpad,
                         labels=input_ids_rmpad_rolled,
                         inplace_backward=inplace_backward,
+                        force_fp32=logits_processor_func is None,
                     )
 
             # gather across the ulysses sp group and drop the packed-sequence padding
@@ -1476,6 +1792,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 # With TP, logits are DTensors sharded on vocab dim; gather for log_softmax.
                 if isinstance(logits, DTensor):
                     logits = logits.full_tensor()
+                logits = _select_raw_token_logits(logits, output_args.get("logits_to_input_indices"))
                 logits = _scale_logits_by_temperature(
                     logits,
                     temperature,
@@ -1515,8 +1832,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
                     log_probs = None
                     if not distillation_only:
-                        log_probs = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)
-
+                        log_probs = logprobs_from_logits(
+                            logits=logits_rmpad,
+                            labels=input_ids_rmpad_rolled,
+                            force_fp32=logits_processor_func is None,
+                        )
                     # (bsz, j1), for each sample, length of each sample: [real_prompt_length + real_response_length]
                     if not distillation_only:
                         log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)

--- a/verl/workers/engine/fsdp/utils.py
+++ b/verl/workers/engine/fsdp/utils.py
@@ -17,6 +17,7 @@ import os
 from torch.distributed.device_mesh import init_device_mesh
 
 from verl.utils.device import get_device_name, is_npu_available
+from verl.workers.engine.fsdp.kimi_packed_weights import KIMI_PACKED_LOCAL_MARKER
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -99,6 +100,24 @@ def unfuse_moe_params(weights, model_type: str | None = None):
     weight sync, so stream those keys without materializing a full dict.
     """
     for name, tensor in weights:
+        if KIMI_PACKED_LOCAL_MARKER in name:
+            _, _, offset_text = name.rpartition(KIMI_PACKED_LOCAL_MARKER)
+            try:
+                int(offset_text)
+            except ValueError as exc:
+                raise ValueError(f"Invalid Kimi packed-local expert offset in parameter name: {name}") from exc
+
+            if tensor.dim() != 3:
+                raise ValueError(f"Kimi packed-local parameter must be 3-D: {name}, shape={tuple(tensor.shape)}")
+
+            if model_type != "kimi_k3":
+                raise ValueError(
+                    "Kimi packed-local transport is valid only for the Kimi K3 "
+                    f"rollout loader, got model_type={model_type!r}"
+                )
+            yield name, tensor
+            continue
+
         # GPT-OSS checkpoint weights use packed 3D expert tensors directly.
         # Splitting them into per-expert 2D tensors makes vLLM's GPT-OSS loader
         # index a 2D tensor as 3D during TP slicing.

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -67,8 +67,10 @@ from verl.utils.megatron_utils import (
     check_mtp_config,
     get_megatron_module_device,
     get_megatron_mtp_loss,
+    load_megatron_grad_to_gpu,
     load_megatron_model_to_gpu,
     load_megatron_optimizer,
+    offload_megatron_grad_to_cpu,
     offload_megatron_model_to_cpu,
     offload_megatron_optimizer,
     patch_engine_mtp,
@@ -161,6 +163,20 @@ def _attach_dcp_recorded_routes(losses_reduced: list[dict], layers_topk_idx: tor
         )
 
 
+def _is_kimi_k3_config(hf_config) -> bool:
+    architectures = getattr(hf_config, "architectures", None) or ()
+    return getattr(hf_config, "model_type", None) == "kimi_k3" or "KimiK3ForConditionalGeneration" in architectures
+
+
+def _register_kimi_k3_runtime() -> None:
+    """Bootstrap the Kimi bridge through MS-Bridge's public runtime API."""
+    try:
+        from mindspeed_bridge.runtime.kimi_k3 import ensure_kimi_k3_runtime
+    except ImportError as exc:
+        raise RuntimeError("Kimi K3 Megatron requires MS-Bridge-KIMI-K3 to be installed and importable") from exc
+    ensure_kimi_k3_runtime()
+
+
 class MegatronEngine(BaseEngine):
     # mcore keeps model-parallel-local params resident and moves large host
     # buffers every step; pinning the whole delta snapshot set on top of that
@@ -182,6 +198,7 @@ class MegatronEngine(BaseEngine):
         optimizer_config: McoreOptimizerConfig,
         checkpoint_config: CheckpointConfig,
     ):
+        is_kimi_k3 = _is_kimi_k3_config(model_config.hf_config)
         super().__init__()
 
         self.model_config = model_config
@@ -191,10 +208,16 @@ class MegatronEngine(BaseEngine):
         assert self.engine_config.use_mbridge, "use_mbridge must be True"
         _check_dcp_unsupported_features(self.engine_config, self.model_config)
         self._init_device_mesh()
+        if is_kimi_k3:
+            # The task-selected MegatronAdaptor is installed before this module
+            # is imported. Keep the model plugin lazy until the engine topology
+            # is initialized, but before provider/bridge construction.
+            _register_kimi_k3_runtime()
 
         set_random_seed(seed=self.engine_config.seed)
 
         self._is_offload_param = self.engine_config.param_offload
+        self._is_offload_grad = self.engine_config.grad_offload
         self._is_offload_optimizer = self.engine_config.optimizer_offload
 
         self.mode = None
@@ -285,7 +308,26 @@ class MegatronEngine(BaseEngine):
         from verl.utils.torch_dtypes import PrecisionType
 
         self.is_value_model = self.model_config.model_type == "value_model"
+        is_kimi_k3 = _is_kimi_k3_config(self.model_config.hf_config)
         self.share_embeddings_and_output_weights = self.model_config.share_embeddings_and_output_weights
+
+        if is_kimi_k3:
+            if self.engine_config.vanilla_mbridge:
+                raise ValueError("Kimi K3 requires Megatron-Bridge; set vanilla_mbridge=False")
+            if self.engine_config.use_remove_padding:
+                raise ValueError("Kimi K3 Megatron requires use_remove_padding=False (BSHD)")
+            if self.engine_config.dynamic_context_parallel:
+                raise ValueError("Kimi K3 Megatron does not support dynamic_context_parallel")
+            if self.engine_config.context_parallel_size != 1:
+                raise ValueError("Kimi K3 verl integration currently requires context_parallel_size=1")
+            if self.engine_config.use_fused_kernels:
+                raise ValueError("Kimi K3 Megatron does not support fused log-prob kernels")
+            if "seq_length" not in self.engine_config.override_transformer_config:
+                raise ValueError(
+                    "Kimi K3 Megatron requires an explicit static expanded sequence length: "
+                    "set override_transformer_config.seq_length to a value large enough for "
+                    "the raw prompt/response plus projected image tokens"
+                )
 
         check_mtp_config(self.model_config, self.engine_config)
 
@@ -374,6 +416,9 @@ class MegatronEngine(BaseEngine):
             # the provider here rather than via override_transformer_config.
             if self.is_value_model and hasattr(provider, "share_embeddings_and_output_weights"):
                 provider_overrides["share_embeddings_and_output_weights"] = False
+
+            if is_kimi_k3:
+                provider_overrides["attention_backend"] = AttnBackend.auto
             if (
                 self.model_config.hf_config.model_type == "deepseek_v4"
                 and not self.model_config.mtp.enable
@@ -496,7 +541,12 @@ class MegatronEngine(BaseEngine):
         self.tf_config = updated_tf_config
         print(f"module: {len(module)}")
 
-        if self.engine_config.use_dist_checkpointing:
+        # ``use_dist_checkpointing`` also selects the format used by the
+        # checkpoint manager for subsequent training saves.  A fresh run can
+        # therefore request sharded saves while still bootstrapping from the
+        # HuggingFace path in ``model.local_path``.  Only take the direct
+        # MCore-load branch when an initial dist-checkpoint path was supplied.
+        if self.engine_config.use_dist_checkpointing and self.engine_config.dist_checkpointing_path is not None:
             load_mcore_dist_weights(
                 module, self.engine_config.dist_checkpointing_path, is_value_model=self.is_value_model
             )
@@ -653,6 +703,8 @@ class MegatronEngine(BaseEngine):
             optimizer=self._is_offload_optimizer,
             grad=self._is_offload_param,
         )
+        if self._is_offload_grad and not self._is_offload_param:
+            self._set_grad_storage("cpu")
 
         log_gpu_memory_usage("After offload model/optimizer/grad during init", logger=logger)
 
@@ -693,9 +745,10 @@ class MegatronEngine(BaseEngine):
         Returns:
             grad_norm (float): The norm of the gradients before clipping or update.
         """
-        # forward_kl_topk leaves large fp32 vocab tensors until backward ends;
-        # free cached blocks before grad-norm all_reduce to reduce OOM on tight VRAM.
-        if getattr(self, "_distillation_use_topk_active", False):
+        # Distillation and grad offload are memory-reclamation modes. Release
+        # inactive allocator blocks before HCCL creates its grad-norm workspace.
+        if getattr(self, "_distillation_use_topk_active", False) or self._is_offload_grad:
+            get_torch_device().synchronize()
             get_torch_device().empty_cache()
         update_successful, grad_norm, num_zeros_in_grad = self.optimizer.step()
 
@@ -728,6 +781,7 @@ class MegatronEngine(BaseEngine):
             device: Target device identifier.
             model: If True, move the model.
             optimizer: If True, move the optimizer states.
+            grad: If True, move or recreate gradient storage.
         """
         super().to(device=device, model=model, optimizer=optimizer, grad=grad)
 
@@ -744,6 +798,16 @@ class MegatronEngine(BaseEngine):
                 offload_megatron_model_to_cpu(self.module)
             if optimizer and self.optimizer is not None:
                 offload_megatron_optimizer(self.optimizer)
+        else:
+            raise ValueError(f"Invalid device type: {device}")
+
+    def _set_grad_storage(self, device: str) -> None:
+        """Stage Megatron DDP gradient storage independently of parameters."""
+        device_name = get_device_name()
+        if device == device_name:
+            load_megatron_grad_to_gpu(self.module)
+        elif device == "cpu":
+            offload_megatron_grad_to_cpu(self.module)
         else:
             raise ValueError(f"Invalid device type: {device}")
 
@@ -955,15 +1019,21 @@ class MegatronEngine(BaseEngine):
 
         # TODO: we may use the new schedule instead
         # for flash-attn: (seq_len, batch_size, hidden_size) = (mbs*seq_len, 1, hidden_size)
-        losses_reduced = forward_backward_func(
-            forward_step_func=forward_step,
-            data_iterator=batch_generator,
-            model=self.module,
-            num_microbatches=n_micro_batch,
-            seq_length=1,  # the communication shape is obtained via p2p comm
-            micro_batch_size=1,  # the communication shape is obtained via p2p comm
-            forward_only=forward_only,
-        )
+        # Megatron's pipeline schedule skips backward for forward-only calls,
+        # but it does not disable autograd itself.  Old/ref log-prob therefore
+        # retained a useless graph and could not take inference-only operator
+        # paths.  Keep training unchanged while matching the no-grad contract
+        # already used by the FSDP and AutoModel engines.
+        with torch.set_grad_enabled(not forward_only):
+            losses_reduced = forward_backward_func(
+                forward_step_func=forward_step,
+                data_iterator=batch_generator,
+                model=self.module,
+                num_microbatches=n_micro_batch,
+                seq_length=1,  # the communication shape is obtained via p2p comm
+                micro_batch_size=1,  # the communication shape is obtained via p2p comm
+                forward_only=forward_only,
+            )
 
         if self.model_config.mtp.enable and mpu.is_pipeline_last_stage(ignore_virtual=True):
             # All CP ranks must participate in the all_reduce inside get_megatron_mtp_loss,
@@ -1148,6 +1218,12 @@ class EngineTrainModeCtx(BaseEngineCtx):
     def __enter__(self):
         assert isinstance(self.engine, MegatronEngine)
         super().__enter__()
+        # train_mini_batch opens an outer context and train_batch opens a nested
+        # context with disable_auto_offload=True.  Stage the flat DDP gradient
+        # storage only at the outer boundary; doing it in both contexts leaves
+        # the outer zero_grad() pointing at storage released by the inner one.
+        if self.engine._is_offload_grad and not self.engine._is_offload_param and not self.disable_auto_offload:
+            self.engine._set_grad_storage(get_device_name())
         # mcore module is a list of model chunk in each vpp stage
         for module in self.engine.module:
             module.train()
@@ -1156,6 +1232,8 @@ class EngineTrainModeCtx(BaseEngineCtx):
         assert isinstance(self.engine, MegatronEngine)
         if self.zero_grad_on_exit or exc_type is not None:
             self.engine.optimizer_zero_grad()
+        if self.engine._is_offload_grad and not self.engine._is_offload_param and not self.disable_auto_offload:
+            self.engine._set_grad_storage("cpu")
         super().__exit__(exc_type, exc_value, traceback)
 
 
@@ -1295,21 +1373,43 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 router.set_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
             set_model_router_replay_action(unwrapped_model, RouterReplayAction.REPLAY_FORWARD)
 
+        router_replay_prepare = None
         if RouterReplayHelper.is_replay_forward_action(self.tf_config, vp_rank):
             layers_topk_idx = model_inputs["routed_experts"]
             replay_mask = None
-            if self.engine_config.router_replay.mode == "R3":
+            if self.engine_config.router_replay.mode == "R3" and _is_kimi_k3_config(self.model_config.hf_config):
+                from verl.workers.rollout.r3_utils import pack_kimi_full_r3_for_megatron
+
+                layers_topk_idx = pack_kimi_full_r3_for_megatron(layers_topk_idx, batch.get("routed_expert_weights"))
+            elif self.engine_config.router_replay.mode == "R3":
                 layers_topk_idx = align_r3_router_replay_data(layers_topk_idx, input_ids)
                 replay_mask = build_r3_replay_mask(input_ids, batch["response_mask"])
-            set_router_replay_data(
-                layers_topk_idx,
-                None,
-                self.tf_config,
-                vp_rank,
-                replay_mask=replay_mask,
-                local_cp_size=local_cp_size,
-                model=unwrapped_model,
-            )
+            if _is_kimi_k3_config(self.model_config.hf_config) and getattr(
+                self.tf_config, "kimi_dynamic_multimodal_length", False
+            ):
+                # The exact image-expanded bucket is only known inside Kimi's
+                # forward adapter. Defer replay preparation until that adapter
+                # has computed the same runtime sequence length as the model.
+                router_replay_prepare = partial(
+                    set_router_replay_data,
+                    layers_topk_idx,
+                    None,
+                    self.tf_config,
+                    vp_rank,
+                    replay_mask=replay_mask,
+                    local_cp_size=local_cp_size,
+                    model=unwrapped_model,
+                )
+            else:
+                set_router_replay_data(
+                    layers_topk_idx,
+                    None,
+                    self.tf_config,
+                    vp_rank,
+                    replay_mask=replay_mask,
+                    local_cp_size=local_cp_size,
+                    model=unwrapped_model,
+                )
 
         if pad_mode == DatasetPadMode.NO_PADDING:
             label = input_ids.clone()
@@ -1379,6 +1479,9 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 routed_num_tokens = tu.get_non_tensor_data(batch, key="routed_num_tokens", default=0)
                 if batch_num_tokens > 0:
                     mtp_loss_normalization_factor = routed_num_tokens / batch_num_tokens
+            kimi_forward_kwargs = {}
+            if router_replay_prepare is not None:
+                kimi_forward_kwargs["router_replay_prepare"] = router_replay_prepare
 
             output = forward_fn(
                 model,
@@ -1396,6 +1499,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
                 pad_to_length_bucket=pad_to_length_bucket,
                 cp_layout=cp_layout,
+                **kimi_forward_kwargs,
             )
 
         # Router replay: record routing decisions for R2 mode

--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -15,10 +15,20 @@
 import logging
 import os
 
-try:
-    from mindspeed.megatron_adaptor import repatch
-except ImportError:
+_use_megatron_adaptor = os.getenv("VERL_USE_MEGATRON_ADAPTOR", "").lower() in {
+    "1",
+    "true",
+    "enabled",
+}
+
+if _use_megatron_adaptor:
     repatch = None
+
+else:
+    try:
+        from mindspeed.megatron_adaptor import repatch
+    except ImportError:
+        repatch = None
 
 from verl.trainer.config import CheckpointConfig
 from verl.workers.config import (

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -52,10 +52,28 @@ from verl.workers.config import (
     TrainingWorkerConfig,
 )
 from verl.workers.rollout.base import BaseRollout, get_rollout_class
+from verl.workers.rollout.r3_utils import is_kimi_full_r3_config
 from verl.workers.utils.losses import ppo_loss
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def _restore_module_buffers_to_device(module) -> None:
+    """Restore non-parameter buffers after an explicit FSDP2 CPU offload.
+
+    ``FSDPEngine.to("cpu")`` uses ``module.cpu()`` for FSDP2 forward-only
+    engines.  That also moves ordinary buffers (for example Kimi's vision
+    RoPE ``time_weight``) to CPU, while the next FSDP pre-forward only
+    re-materializes parameters.  Keeping those buffers on CPU makes the
+    following forward mix CPU RoPE tensors with NPU activations.  Move only
+    buffers back; parameter shards remain offloaded.
+    """
+    device = f"{get_device_name()}:{get_torch_device().current_device()}"
+    for buffer in module.buffers():
+        if buffer is None or str(buffer.device) == device:
+            continue
+        buffer.data = buffer.data.to(device=device, non_blocking=True)
 
 
 def _with_routing_replay_flag(enabled: bool):
@@ -66,6 +84,17 @@ def _with_routing_replay_flag(enabled: bool):
         def wrapper(self, data: TensorDict, *args, **kwargs):
             if self.enable_routing_replay:
                 tu.assign_non_tensor_data(data, "enable_routing_replay", enabled)
+                if enabled:
+                    routed_experts = data.get("routed_experts", None)
+                    routed_expert_weights = data.get("routed_expert_weights", None)
+                    if routed_experts is None:
+                        raise RuntimeError(
+                            "routing replay is active but the actor batch does not contain routed_experts"
+                        )
+                    if getattr(self, "_kimi_full_r3_requested", False) and routed_expert_weights is None:
+                        raise RuntimeError(
+                            "Kimi full R3 actor dispatch requires both routed_experts and routed_expert_weights"
+                        )
             return func(self, data, *args, **kwargs)
 
         return wrapper
@@ -495,14 +524,30 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         # engine. Both expose `router_replay` on their per-strategy engine
         # config (the field lives on the shared `EngineConfig` base).
         actor_strategy = self.config.actor.strategy
-        if actor_strategy == "megatron":
+        actor_strategy_name = str(getattr(actor_strategy, "value", actor_strategy)).lower()
+        self._rollout_r3_requested = bool(
+            self._is_actor and self.config.rollout.get("enable_rollout_routing_replay", False)
+        )
+        if actor_strategy_name == "megatron":
             rr_mode = self.config.actor.megatron.router_replay.mode
-        elif actor_strategy == "veomni":
+        elif actor_strategy_name == "veomni":
             rr_mode = self.config.actor.veomni.router_replay.mode
+        elif actor_strategy_name in ("fsdp", "fsdp2", "fsdp_turbo"):
+            # R3 records expert ids in the rollout engine and replays them in
+            # actor forwards.  FSDP has no strategy-local router_replay block,
+            # so the rollout switch is its source of truth.  The existing
+            # decorators below still set the flag to False for reference
+            # forwards and True only for actor infer/update calls.
+            rr_mode = "R3" if self._rollout_r3_requested else "disabled"
         else:
             rr_mode = "disabled"
         self.enable_routing_replay = rr_mode != "disabled"
-
+        if self._rollout_r3_requested and not self.enable_routing_replay:
+            raise RuntimeError(
+                "rollout routing replay was requested but actor replay "
+                f"resolved disabled: role={self.role!r}, "
+                f"strategy={actor_strategy_name!r}, rr_mode={rr_mode!r}"
+            )
         # Keep the raw (un-dataclassed) role profiler config so the inner actor
         # TrainingWorker can build a matching DistProfiler in init_model. Its stages then
         # annotate themselves in the (process-global) torch profiler even though start/stop
@@ -537,7 +582,17 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
         model_config: HFModelConfig = omega_conf_to_dataclass(self.config.model)
-
+        self._kimi_full_r3_requested = bool(
+            self._rollout_r3_requested and is_kimi_full_r3_config(model_config.hf_config)
+        )
+        if self._kimi_full_r3_requested:
+            rollout_name = str(self.config.rollout.get("name", "")).lower()
+            if rollout_name != "vllm":
+                raise RuntimeError(
+                    "Kimi full R3 requires the vLLM rollout backend because "
+                    "the SGLang/generic backend does not capture executed "
+                    f"router weights; got rollout.name={rollout_name!r}"
+                )
         # 1. build reference model
         if "ref" in self.role:
             # TODO: align ref config with actor config
@@ -645,6 +700,14 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             self.actor.set_loss_fn(self.loss_fn)
             self.set_dispatch_collect(mesh_name="actor", **self.actor.get_dispatch_collect())
 
+        # Free policy-managed FSDP shards before colocated rollout starts.
+        if "rollout" in self.role:
+            for role in ("ref", "actor"):
+                worker = getattr(self, role, None)
+                if worker is not None and getattr(worker.engine, "_uses_fsdp2_cpu_offload_policy", False):
+                    worker.to(device="cpu", model=True, optimizer=(role == "actor"), grad=True)
+            aggressive_empty_cache(force_sync=True)
+
         # 3. build rollout engine
         if "rollout" in self.role:
             rollout_config: RolloutConfig = omega_conf_to_dataclass(self.config.rollout)
@@ -694,7 +757,20 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     @_with_routing_replay_flag(enabled=False)
     def compute_ref_log_prob(self, data: TensorDict) -> TensorDict:
         output = self.ref.infer_batch(data=data)
-        return output.cpu() if output is not None else None
+        # The ref engine is forward-only and uses FSDP2 CPUOffloadPolicy.  That
+        # policy releases full parameters after a forward, but keeps the root
+        # local shards materialized on NPU.  Those shards are not needed during
+        # the subsequent actor update and otherwise share the small HBM margin
+        # with the actor's backward all-gathers.  Park the ref shard explicitly
+        # after the CPU result has been materialized.  ``to("cpu")`` also moves
+        # ordinary buffers; restore only those buffers so the next FSDP forward
+        # does not mix CPU RoPE state with NPU activations.
+        output = output.cpu() if output is not None else None
+        if getattr(self.ref.engine, "_uses_fsdp2_cpu_offload_policy", False):
+            self.ref.engine.to(device="cpu", model=True, optimizer=False, grad=False)
+            _restore_module_buffers_to_device(self.ref.engine.module)
+            aggressive_empty_cache(force_sync=True)
+        return output
 
     @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))
     @DistProfiler.annotate(color="blue", role="actor_compute_log_prob")
@@ -752,6 +828,14 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         # Resolve mode: "auto" falls back to config, explicit values take precedence
         effective_mode = mode if mode != "auto" else self.config.rollout.checkpoint_engine.backend
+        rollout_layout = {
+            # RolloutConfig normalizes EP=1 to None, while the resharder uses
+            # an explicit 1 so the single-EP case is handled identically.
+            "expert_parallel_size": getattr(self.config.rollout, "expert_parallel_size", None) or 1,
+            "tensor_parallel_size": getattr(self.config.rollout, "tensor_model_parallel_size", None) or 1,
+            "data_parallel_size": getattr(self.config.rollout, "data_parallel_size", None) or 1,
+            "pipeline_model_parallel_size": getattr(self.config.rollout, "pipeline_model_parallel_size", None) or 1,
+        }
 
         # 0. send_weights only for async training with disaggregated trainer and rollout
         if effective_mode != "naive":
@@ -760,7 +844,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 # snapshot prime), so it drives the training engine itself.
                 metrics = await self.checkpoint_engine.send_weights(self.actor.engine, global_steps=global_steps)
                 return metrics or {}
-            per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
+            per_tensor_param, _ = self.actor.engine.get_per_tensor_param(rollout_layout=rollout_layout)
             metrics = await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
             return metrics or {}
 
@@ -783,7 +867,9 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         # 2. determine if we need a base weight sync (adapter path only)
         per_tensor_param, peft_config = self.actor.engine.get_per_tensor_param(
-            layered_summon=self.layered_summon, base_sync_done=True
+            layered_summon=self.layered_summon,
+            base_sync_done=True,
+            rollout_layout=rollout_layout,
         )
 
         do_lora_base_sync = False
@@ -794,7 +880,9 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         # 3. sync weights: For SGLang, we need base first (when needed), then adapter/merged
         if do_lora_base_sync:
             per_tensor_param_base, _base_peft_config = self.actor.engine.get_per_tensor_param(
-                layered_summon=self.layered_summon, base_sync_done=False
+                layered_summon=self.layered_summon,
+                base_sync_done=False,
+                rollout_layout=rollout_layout,
             )
             await self.rollout.update_weights(
                 per_tensor_param_base, peft_config=_base_peft_config, base_sync_done=False, global_steps=global_steps

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -296,14 +296,41 @@ class FullyAsyncLLMServerClient(LLMServerClient):
             if output.log_probs is not None:
                 final_output.log_probs.extend(output.log_probs)
             # On partial rollout resume the model version may differ, so keep
-            # existing routing and only append routing for newly generated tokens.
-            if output.routed_experts is not None and len(output.token_ids) > 0:
+            # existing routing and only append routing for newly generated
+            # tokens. IDs and weights are one atomic full-R3 record; accepting
+            # only one side would silently recreate ID-only replay.
+            has_route_ids = output.routed_experts is not None
+            has_route_weights = output.routed_expert_weights is not None
+            if has_route_weights and not has_route_ids:
+                raise RuntimeError(
+                    "rollout returned router weights without expert IDs: "
+                    f"ids={has_route_ids}, weights={has_route_weights}"
+                )
+            if has_route_ids and len(output.token_ids) > 0:
+                if has_route_weights and (output.routed_experts.shape != output.routed_expert_weights.shape):
+                    raise RuntimeError(
+                        "full R3 rollout IDs/weights are misaligned: "
+                        f"ids={output.routed_experts.shape}, "
+                        f"weights={output.routed_expert_weights.shape}"
+                    )
                 if final_output.routed_experts is None:
                     final_output.routed_experts = output.routed_experts
+                    final_output.routed_expert_weights = output.routed_expert_weights
                 else:
+                    if (final_output.routed_expert_weights is None) != (output.routed_expert_weights is None):
+                        raise RuntimeError(
+                            "a resumed rollout cannot switch between legacy ID-only routing and complete ID+weight R3"
+                        )
                     final_output.routed_experts = np.concatenate(
                         [final_output.routed_experts, output.routed_experts[-len(output.token_ids) :]]
                     )
+                    if has_route_weights:
+                        final_output.routed_expert_weights = np.concatenate(
+                            [
+                                final_output.routed_expert_weights,
+                                output.routed_expert_weights[-len(output.token_ids) :],
+                            ]
+                        )
             if output.num_preempted is not None:
                 final_output.num_preempted += output.num_preempted
             final_output.stop_reason = output.stop_reason

--- a/verl/workers/rollout/r3_utils.py
+++ b/verl/workers/rollout/r3_utils.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Strict Kimi full-R3 rollout payload helpers.
+
+vLLM's routed-experts API has one integer tensor slot.  The Ascend worker
+uses that slot to carry, for every top-k entry, the expert id followed by the
+low and high bytes of the *executed BF16 router weight*.  Keeping the wire
+payload integer-valued lets the existing vLLM slot manager retain its compact
+uint8/uint16 storage without changing the EngineCore protocol.
+
+The payload layout is ``[..., ids[K], weight_low_bytes[K],
+weight_high_bytes[K]]``.  It is decoded at the verl boundary and never exposed
+to the trainer as an overloaded tensor: downstream code receives explicit
+``routed_experts`` and ``routed_expert_weights`` fields.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+KIMI_FULL_R3_PACK_FACTOR = 3
+KIMI_FULL_MODEL_ROUTE_SEMANTICS = "kimi_natural_rollout_full_model_rows_v1"
+
+
+def is_kimi_full_r3_config(hf_config: Any) -> bool:
+    """Whether the model uses Kimi K3's IDs+executed-weights R3 schema."""
+    return getattr(hf_config, "model_type", None) == "kimi_k3"
+
+
+def get_kimi_full_r3_topk(hf_config: Any) -> int:
+    """Return Kimi K3's real (unpacked) experts-per-token width."""
+    if not is_kimi_full_r3_config(hf_config):
+        raise ValueError("full routing replay with gate weights is implemented only for Kimi K3")
+    text_config = getattr(hf_config, "text_config", hf_config)
+    topk = int(text_config.num_experts_per_token)
+    if topk <= 0:
+        raise ValueError("Kimi full R3 requires a positive num_experts_per_token in the HF config")
+    return topk
+
+
+def validate_kimi_full_model_routes(
+    routes: torch.Tensor,
+    route_weights: torch.Tensor,
+    hf_config: Any,
+) -> None:
+    """Validate complete Kimi route rows once before agent-loop transport."""
+    if routes.dim() != 3 or route_weights.shape != routes.shape:
+        raise ValueError(
+            f"Kimi full-model R3 shape mismatch: ids={tuple(routes.shape)}, weights={tuple(route_weights.shape)}"
+        )
+    if not route_weights.is_floating_point():
+        raise TypeError(f"Kimi full-model route weights must be floating point, got {route_weights.dtype}")
+    text_config = getattr(hf_config, "text_config", hf_config)
+    expected_layers = int(getattr(text_config, "num_hidden_layers", 0) or 0)
+    num_experts = int(getattr(text_config, "num_experts", 0) or 0)
+    expected_topk = get_kimi_full_r3_topk(hf_config)
+    first_dense = int(getattr(text_config, "first_k_dense_replace", 0) or 0)
+    moe_frequency = int(getattr(text_config, "moe_layer_freq", 1) or 1)
+    if expected_layers <= 0 or num_experts <= 0:
+        raise ValueError("Kimi R3 requires positive num_hidden_layers and num_experts")
+    if routes.shape[1:] != (expected_layers, expected_topk):
+        raise ValueError(
+            "Kimi route capture shape does not match the model config: "
+            f"routes={tuple(routes.shape)}, layers={expected_layers}, "
+            f"topk={expected_topk}"
+        )
+    if routes.shape[0] == 0:
+        return
+
+    moe_layers = [
+        layer_idx for layer_idx in range(expected_layers) if layer_idx >= first_dense and layer_idx % moe_frequency == 0
+    ]
+    if not moe_layers:
+        return
+    moe_routes = routes[:, moe_layers, :].to(dtype=torch.long)
+    moe_weights = route_weights[:, moe_layers, :].to(dtype=torch.float32)
+
+    bad_range = (moe_routes < 0) | (moe_routes >= num_experts)
+    if bool(bad_range.any()):
+        bad = torch.nonzero(bad_range, as_tuple=False)[0]
+        raise ValueError(
+            "Kimi route capture contains an out-of-range expert ID: "
+            f"row={int(bad[0])}, layer={moe_layers[int(bad[1])]}, "
+            f"topk_slot={int(bad[2])}, "
+            f"value={int(moe_routes[tuple(bad.tolist())])}, "
+            f"num_experts={num_experts}"
+        )
+
+    ordered = torch.sort(moe_routes, dim=-1).values
+    duplicate = ordered[..., 1:] == ordered[..., :-1]
+    if bool(duplicate.any()):
+        bad = torch.nonzero(duplicate, as_tuple=False)[0]
+        row, layer = int(bad[0]), int(bad[1])
+        raise ValueError(
+            "Kimi route capture contains duplicate top-k expert IDs: "
+            f"row={row}, layer={moe_layers[layer]}, "
+            f"routes={moe_routes[row, layer].tolist()}"
+        )
+
+    finite = torch.isfinite(moe_weights)
+    if not bool(finite.all()):
+        bad = torch.nonzero(~finite, as_tuple=False)[0]
+        raise ValueError(
+            "Kimi full R3 route weight is NaN/Inf: "
+            f"row={int(bad[0])}, layer={moe_layers[int(bad[1])]}, "
+            f"topk_slot={int(bad[2])}"
+        )
+    if bool((moe_weights < 0).any()):
+        bad = torch.nonzero(moe_weights < 0, as_tuple=False)[0]
+        raise ValueError(
+            "Kimi full R3 route weight is negative: "
+            f"row={int(bad[0])}, layer={moe_layers[int(bad[1])]}, "
+            f"topk_slot={int(bad[2])}, "
+            f"value={float(moe_weights[tuple(bad.tolist())])}"
+        )
+
+    weight_sums = moe_weights.sum(dim=-1)
+    if bool((weight_sums <= 0).any()):
+        bad = torch.nonzero(weight_sums <= 0, as_tuple=False)[0]
+        raise ValueError(
+            f"Kimi full R3 route weights sum to zero: row={int(bad[0])}, layer={moe_layers[int(bad[1])]}"
+        )
+    if not bool(getattr(text_config, "moe_renormalize", False)):
+        return
+
+    expected_sum = float(getattr(text_config, "routed_scaling_factor", 1.0))
+    tolerance = max(abs(expected_sum) * 0.02, 0.02)
+    close = torch.isclose(
+        weight_sums,
+        torch.full_like(weight_sums, expected_sum),
+        rtol=0.0,
+        atol=tolerance,
+    )
+    if not bool(close.all()):
+        bad = torch.nonzero(~close, as_tuple=False)[0]
+        raise ValueError(
+            "Kimi full R3 route weights violate the normalized sum contract: "
+            f"row={int(bad[0])}, layer={moe_layers[int(bad[1])]}, "
+            f"actual={float(weight_sums[tuple(bad.tolist())])}, "
+            f"expected={expected_sum}, tolerance={tolerance}"
+        )
+
+
+def decode_kimi_full_r3_payload(
+    packed: Any,
+    *,
+    expected_topk: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Decode vLLM's integer Kimi full-R3 payload without losing BF16 bits.
+
+    Returns expert IDs and FP32 values.  Every BF16 value is exactly
+    representable in FP32, so converting back to BF16 in the trainer is
+    bit-exact.
+    """
+    payload = np.asarray(packed)
+    if payload.ndim != 3:
+        raise ValueError(f"Kimi full R3 packed payload must be [model_rows, layers, 3*topk], got {payload.shape!r}")
+    if expected_topk <= 0:
+        raise ValueError(f"expected_topk must be positive, got {expected_topk}")
+    expected_width = expected_topk * KIMI_FULL_R3_PACK_FACTOR
+    if payload.shape[-1] != expected_width:
+        raise ValueError(
+            "Kimi full R3 payload width proves that rollout weight capture is "
+            "not active or is incompatible: "
+            f"got={payload.shape[-1]}, expected={expected_width} "
+            f"(topk={expected_topk})"
+        )
+    if not np.issubdtype(payload.dtype, np.integer):
+        raise TypeError(f"Kimi full R3 packed payload must use an integer transport dtype, got {payload.dtype}")
+
+    expert_ids = np.array(payload[..., :expected_topk], copy=True)
+    low = payload[..., expected_topk : 2 * expected_topk]
+    high = payload[..., 2 * expected_topk :]
+    if low.size:
+        low_min, low_max = int(low.min()), int(low.max())
+        high_min, high_max = int(high.min()), int(high.max())
+        if low_min < 0 or low_max > 255 or high_min < 0 or high_max > 255:
+            raise ValueError(
+                "Kimi full R3 BF16 byte lanes are out of range: "
+                f"low=[{low_min}, {low_max}], high=[{high_min}, {high_max}]"
+            )
+
+    bf16_bits = low.astype(np.uint16) | (high.astype(np.uint16) << 8)
+    fp32_bits = bf16_bits.astype(np.uint32) << 16
+    weights = np.array(fp32_bits.view(np.float32), copy=True)
+    if not np.isfinite(weights).all():
+        raise ValueError("Kimi full R3 decoded router weights contain NaN or Inf")
+    if (weights < 0).any():
+        raise ValueError("Kimi full R3 decoded router weights contain negative values")
+    return expert_ids, weights
+
+
+def pack_kimi_full_r3_for_megatron(ids, weights):
+    """Convert shared split routes into Megatron's exact BF16 byte payload.
+
+    Keep expanded model rows and sequence boundaries; raw token lengths do not
+    describe multimodal routes. Only the Megatron engine uses this wire layout.
+    """
+    if weights is None:
+        raise ValueError("Kimi full R3 requires both expert IDs and weights")
+    if not ids.is_nested or not weights.is_nested:
+        raise TypeError("Kimi full R3 requires jagged IDs and weights")
+    if not torch.equal(ids.offsets(), weights.offsets()):
+        raise ValueError("Kimi full R3 IDs and weights have different sequence boundaries")
+    id_values, weight_values = ids.values(), weights.values()
+    if id_values.shape != weight_values.shape:
+        raise ValueError("Kimi full R3 IDs and weights have different shapes")
+    if id_values.numel() and bool(((id_values < 0) | (id_values > 255)).any()):
+        raise ValueError("Kimi full R3 expert IDs must fit in uint8")
+    bf16_weights = weight_values.to(torch.bfloat16)
+    if not torch.equal(bf16_weights.float(), weight_values.float()):
+        raise ValueError("Kimi full R3 weights must be finite exact BF16 values")
+    bits = bf16_weights.contiguous().view(torch.uint8).reshape(*weight_values.shape, 2)
+    packed = torch.cat((id_values.to(torch.uint8), bits[..., 0], bits[..., 1]), dim=-1)
+    return torch.nested.nested_tensor_from_jagged(packed, offsets=ids.offsets())

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -43,6 +43,8 @@ class TokenOutput(BaseModel):
     """logprobs of response token ids"""
     routed_experts: Optional[Any] = None
     """routed experts of response token ids"""
+    routed_expert_weights: Optional[Any] = None
+    """router weights paired elementwise with routed_experts"""
     stop_reason: Optional[str] = None
     """stop reason: 'completed', 'aborted', or None for unknown"""
     num_preempted: Optional[int] = None

--- a/verl/workers/rollout/schemas.py
+++ b/verl/workers/rollout/schemas.py
@@ -24,6 +24,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, Processor
 
 from verl.tools.schemas import OpenAIFunctionToolCall, OpenAIFunctionToolSchema, ToolResponse
 from verl.utils.model import compute_position_id_with_mask
+from verl.utils.model_adapters import ProcessorAdapter
 from verl.utils.tokenizer import build_multimodal_processor_inputs
 
 logger = logging.getLogger(__file__)
@@ -255,7 +256,7 @@ class AsyncRolloutRequest(BaseModel):
                     "There is multi_modal_data but you are not using a processor. Multi-modal data will be ignored."
                 )
             model_inputs = processing_class(text=[raw_prompt], return_tensors="pt")
-        elif isinstance(processing_class, ProcessorMixin):
+        elif isinstance(processing_class, ProcessorMixin | ProcessorAdapter):
             images = images if len(images := multi_modal_data.get("image", [])) > 0 else None
             videos = videos if len(videos := multi_modal_data.get("video", [])) > 0 else None
             audio = audio if len(audio := multi_modal_data.get("audio", [])) > 0 else None

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -41,15 +41,46 @@ class TensorMetadata(TypedDict):
     handle: tuple
 
 
+_ACCELERATOR_REBUILD_FUNCTIONS = frozenset(
+    {
+        "rebuild_cuda_tensor",
+        "rebuild_npu_tensor",
+        # Compatibility with older torch/torch_npu spellings.
+        "rebuild_tensor_cuda",
+        "rebuild_tensor_npu",
+    }
+)
+
+
 # copy from https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/rlhf_utils.py
 def rebuild_ipc(handle: tuple[Callable, tuple], device_id: int | None = None) -> torch.Tensor:
     func, args = handle
     list_args = list(args)
-    if device_id is not None:
-        # the key is to change device id to the current device id
-        # in case two processes have different CUDA_VISIBLE_DEVICES
+    func_name = getattr(func, "__name__", type(func).__name__)
+    if device_id is not None and func_name in _ACCELERATOR_REBUILD_FUNCTIONS:
+        if len(list_args) <= 6:
+            raise RuntimeError(
+                f"{func_name} IPC handle has {len(list_args)} arguments; "
+                "expected an accelerator device id at argument 6"
+            )
+        # Accelerator rebuilders carry the producer device at argument 6.
+        # Rewrite it when sender and receiver have different local visibility.
         list_args[6] = device_id
+    elif device_id is not None and func_name == "rebuild_tensor":
+        # CPU reduce_tensor() handles intentionally have no device-id slot.
+        logger.debug("Rebuilding CPU IPC tensor on receiver before accelerator copy")
     buffer = func(*list_args)
+    # vLLM weight loaders consume device tensors.  A CPU IPC handle is rebuilt
+    # on the receiver first, then copied to the local accelerator; this keeps
+    # CPU-offloaded large parameters compatible with the existing IPC protocol
+    # without forcing the actor to stage the whole tensor on NPU beforehand.
+    if (
+        device_id is not None
+        and isinstance(buffer, torch.Tensor)
+        and buffer.device.type == "cpu"
+        and get_device_name() != "cpu"
+    ):
+        buffer = buffer.to(device=f"{get_device_name()}:{device_id}", non_blocking=True)
     return buffer
 
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -249,6 +249,7 @@ class vLLMColocateWorkerExtension:
 
         # =========================== step 1: prepare for weight loading ===========================
         quant_reload_states = None
+        layerwise_finalize = None
 
         # The engine came up on dummy weights, whose init zeroes integer buffers on
         # ROCm -- including the expert-parallel routing maps, which no weight stream
@@ -281,6 +282,18 @@ class vLLMColocateWorkerExtension:
             quant_reload_states = [
                 (model, prepare_quanted_weights_for_loading(model)) for model in self._iter_all_models()
             ]
+        elif peft_config is None:
+            from vllm.model_executor.model_loader.reload import (
+                finalize_layerwise_reload,
+                initialize_layerwise_reload,
+            )
+
+            # vLLM 0.26 keeps kernel-formatted weights after initialization.
+            # Restore checkpoint-format metadata before the bucket stream, then
+            # repack once after the final bucket.
+            for model in self._iter_all_models():
+                initialize_layerwise_reload(model)
+            layerwise_finalize = finalize_layerwise_reload
         else:
             # TODO(wuxibin): not need anymore for newer vllm version.
             for model in self._iter_all_models():
@@ -307,6 +320,7 @@ class vLLMColocateWorkerExtension:
                     list(lora_weights.items()),
                     peft_config=peft_config,
                     base_sync_done=base_sync_done,
+                    layerwise_reload=layerwise_finalize is not None,
                 )
                 lora_weights.clear()
                 return
@@ -314,12 +328,16 @@ class vLLMColocateWorkerExtension:
                 weights,
                 peft_config=peft_config,
                 base_sync_done=base_sync_done,
+                layerwise_reload=layerwise_finalize is not None,
             )
 
         receiver.receive_weights(on_bucket_received=on_bucket_received)
 
         # =========================== step 3: process weights after loading ===========================
-        if self._is_qat_model:
+        if layerwise_finalize is not None:
+            for model, model_config in self._iter_all_models_with_config():
+                layerwise_finalize(model, model_config)
+        elif self._is_qat_model:
             # QAT (compressed-tensors): call process_weights_after_loading AFTER all buckets are received
             from verl.utils.qat import manual_process_weights_after_loading
 
@@ -362,6 +380,7 @@ class vLLMColocateWorkerExtension:
         weights: list[tuple[str, torch.Tensor]],
         peft_config: dict,
         base_sync_done: bool,
+        layerwise_reload: bool = False,
     ):
         if peft_config and base_sync_done:
             # Clone out of the receiver's reused IPC bucket buffer: add_lora keeps these tensors
@@ -376,6 +395,11 @@ class vLLMColocateWorkerExtension:
             )
             self.add_lora(lora_request)
             logger.info(f"vLLM load weights, loaded_params: {len(weights)}")
+        elif layerwise_reload:
+            # Layerwise loaders may retain inputs until a later bucket completes
+            # the layer. Own each tensor before the IPC receiver reuses its storage.
+            for model in self._iter_all_models():
+                model.load_weights((name, tensor.clone()) for name, tensor in weights)
         else:
             param_updates, buffer_updates, named_buffers = split_buffer_updates(self.model_runner.model, weights)
             # Add the FP8 related logic here as sharding manager has been deprecated.

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -42,6 +42,8 @@ from vllm.v1.engine.async_llm import AsyncLLM
 from verl.plugin.platform import get_platform
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_resource_name, get_visible_devices_keyword, is_torch_npu_available
+from verl.utils.model_adapters import add_kimi_k3_stop_conditions as _add_kimi_k3_stop_conditions
+from verl.utils.model_adapters import get_vllm_adapter
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import (
     build_rollout_dist_profiler,
@@ -53,6 +55,11 @@ from verl.utils.tokenizer import normalize_token_ids
 from verl.utils.tracking import RLInsightLogger
 from verl.utils.vllm.vllm_quant_utils import apply_vllm_quant_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
+from verl.workers.rollout.r3_utils import (
+    decode_kimi_full_r3_payload,
+    get_kimi_full_r3_topk,
+    is_kimi_full_r3_config,
+)
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.utils import (
     get_max_position_embeddings,
@@ -82,6 +89,28 @@ if os.getenv("VERL_USE_GPT_OSS", "0") == "1":
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
+
+
+def _disable_expandable_segments_for_vllm() -> None:
+    """Keep vLLM's CaMem memory pool compatible with torch-npu.
+
+    The colocated FSDP actor benefits from expandable segments, but vLLM's
+    CaMemAllocator explicitly rejects that allocator option.  vLLM servers run
+    in separate Ray actors, so remove only that option in the server process
+    before EngineCore and its TP workers inherit the environment.
+    """
+    env_name = "PYTORCH_NPU_ALLOC_CONF"
+    conf = os.environ.get(env_name, "")
+    options = [option.strip() for option in conf.split(",") if option.strip()]
+    retained = [option for option in options if option.replace(" ", "").lower() != "expandable_segments:true"]
+    if len(retained) == len(options):
+        return
+
+    if retained:
+        os.environ[env_name] = ",".join(retained)
+    else:
+        os.environ.pop(env_name, None)
+    logger.info("Disabled expandable_segments in %s for the vLLM CaMem memory pool", env_name)
 
 
 class vLLMHttpServer:
@@ -144,6 +173,7 @@ class vLLMHttpServer:
 
         self.config = self._init_config(config)
         self.model_config = self._init_model_config(model_config)
+        self._vllm_adapter = get_vllm_adapter(getattr(self.model_config.hf_config, "model_type", None))
         self._validate_configs()
 
         if self.config.full_determinism:
@@ -446,6 +476,12 @@ class vLLMHttpServer:
                     f"(installed: {vllm.__version__}). Upgrade vLLM (e.g. `pip install -U "
                     "'vllm>=0.22.0'`) or disable enable_rollout_routing_replay."
                 )
+            # Kimi extends the legacy ID-only vLLM schema with the BF16
+            # weights that actually entered FusedMoE.  Other model families
+            # retain vLLM's original ID-only replay contract.
+            self._kimi_full_r3_topk = None
+            if is_kimi_full_r3_config(self.model_config.hf_config):
+                self._kimi_full_r3_topk = get_kimi_full_r3_topk(self.model_config.hf_config)
             args.update({"enable_return_routed_experts": True})
 
         if self._disaggregation_role != "null":
@@ -470,7 +506,9 @@ class vLLMHttpServer:
         if server_args.subparser in cmds:
             cmds[server_args.subparser].validate(server_args)
 
-        # 3. launch server
+        # 3. launch server. The actor/ref workers are separate processes and
+        # keep their expandable-segments allocator setting.
+        _disable_expandable_segments_for_vllm()
         if self.node_rank == 0:
             await self.run_server(server_args)
         else:
@@ -583,6 +621,8 @@ class vLLMHttpServer:
             )
 
         prompt_ids = normalize_token_ids(prompt_ids)
+        if self._vllm_adapter is not None:
+            prompt_ids = self._vllm_adapter.prepare_vllm_prompt_ids(prompt_ids, self.model_config.tokenizer, image_data)
 
         # Calculate the maximum possible new tokens based on available context space
         # This serves as a safety upper bound. vLLM v0.20+ rejects `max_tokens < 1`
@@ -620,6 +660,11 @@ class vLLMHttpServer:
         sampling_params["logprobs"] = 0 if sampling_params.pop("logprobs", False) else None
         sampling_params.setdefault("repetition_penalty", self.config.get("repetition_penalty", 1.0))
         sampling_params.setdefault("ignore_eos", self.config.get("ignore_eos", False))
+        _add_kimi_k3_stop_conditions(
+            sampling_params,
+            getattr(self.model_config.hf_config, "model_type", None),
+            getattr(self.model_config.hf_config, "eos_token_id", None),
+        )
         # Inject per-request seed for deterministic sampling when full_determinism is enabled.
         if self.config.full_determinism:
             sampling_params.setdefault("seed", self.replica_rank + self.config.seed)
@@ -631,13 +676,16 @@ class vLLMHttpServer:
 
         sampling_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
         prompt_ids = qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
-        multi_modal_data = {}
-        if image_data is not None:
-            multi_modal_data["image"] = image_data
-        if video_data is not None:
-            multi_modal_data["video"] = video_data
-        if audio_data is not None:
-            multi_modal_data["audio"] = audio_data
+        if self._vllm_adapter is not None:
+            multi_modal_data = self._vllm_adapter.build_vllm_multimodal_data(image_data, video_data, audio_data)
+        else:
+            multi_modal_data = {}
+            if image_data is not None:
+                multi_modal_data["image"] = image_data
+            if video_data is not None:
+                multi_modal_data["video"] = video_data
+            if audio_data is not None:
+                multi_modal_data["audio"] = audio_data
 
         prompt_kwargs = {"prompt_token_ids": prompt_ids, "multi_modal_data": multi_modal_data}
         if mm_processor_kwargs:
@@ -696,6 +744,7 @@ class vLLMHttpServer:
                 token_ids=[],
                 log_probs=None,
                 routed_experts=None,
+                routed_expert_weights=None,
                 stop_reason="aborted",
                 extra_fields=extra_fields,
             )
@@ -714,8 +763,22 @@ class vLLMHttpServer:
             log_probs = [logprobs[token_ids[i]].logprob for i, logprobs in enumerate(final_res.outputs[0].logprobs)]
 
         routed_experts = None
+        routed_expert_weights = None
         if self.config.enable_rollout_routing_replay:
-            routed_experts = final_res.outputs[0].routed_experts
+            routing_payload = final_res.outputs[0].routed_experts
+            expected_topk = getattr(self, "_kimi_full_r3_topk", None)
+            if routing_payload is None and token_ids:
+                raise RuntimeError(
+                    "routing replay was requested but vLLM returned no routing "
+                    f"payload for {len(token_ids)} generated tokens"
+                )
+            if routing_payload is not None and expected_topk is not None:
+                routed_experts, routed_expert_weights = decode_kimi_full_r3_payload(
+                    routing_payload,
+                    expected_topk=expected_topk,
+                )
+            elif routing_payload is not None:
+                routed_experts = routing_payload
 
         # Determine stop reason from finish_reason
         finish_reason = final_res.outputs[0].finish_reason
@@ -753,6 +816,7 @@ class vLLMHttpServer:
             token_ids=token_ids,
             log_probs=log_probs,
             routed_experts=routed_experts,
+            routed_expert_weights=routed_expert_weights,
             stop_reason=stop_reason,
             num_preempted=num_preempted,
             extra_fields=extra_fields,
@@ -831,8 +895,6 @@ class vLLMHttpServer:
         )
 
     async def wake_up(self, tags: list[str] | None = None):
-        if self.node_rank != 0:
-            return
 
         if self.rollout_mode == RolloutMode.HYBRID:
             # engine.wake_up() broadcasts via the DP coordinator to ALL EngineCore
@@ -852,7 +914,7 @@ class vLLMHttpServer:
             logger.info("skip wake_up in standalone mode")
 
     async def sleep(self):
-        if self.node_rank != 0 or not self.config.free_cache_engine:
+        if not self.config.free_cache_engine:
             return
 
         if self.rollout_mode == RolloutMode.HYBRID:
@@ -863,15 +925,14 @@ class vLLMHttpServer:
             logger.info("skip sleep in standalone mode")
 
     async def clear_kv_cache(self):
-        if self.node_rank == 0:
-            # reset_connector=True drops any attached external KV store
-            # (e.g. MooncakeStoreConnector) whose entries were computed
-            # against the previous model weights. With no connector it
-            # is a no-op success, so we can pass it unconditionally.
-            await self.engine.reset_prefix_cache(reset_connector=True)
+        # reset_connector=True drops any attached external KV store
+        # (e.g. MooncakeStoreConnector) whose entries were computed
+        # against the previous model weights. With no connector it
+        # is a no-op success, so we can pass it unconditionally.
+        await self.engine.reset_prefix_cache(reset_connector=True)
 
-            await self.engine.reset_mm_cache()
-            await self.engine.reset_encoder_cache()
+        await self.engine.reset_mm_cache()
+        await self.engine.reset_encoder_cache()
 
     async def release_kv_cache(self):
         """Free the kv_cache pool for the duration of a weight sync."""

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -18,6 +18,7 @@ from tensordict import TensorDict
 
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
+from verl.workers.rollout.r3_utils import KIMI_FULL_MODEL_ROUTE_SEMANTICS
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
@@ -71,12 +72,82 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
     data["loss_mask"] = data["response_mask"]
 
     routed_experts = data.get("routed_experts", None)
+    routed_expert_weights = data.get("routed_expert_weights", None)
+    route_semantics = tu.get_non_tensor_data(
+        data,
+        "routed_experts_transport_semantics",
+        None,
+    )
+    if routed_expert_weights is not None and route_semantics != KIMI_FULL_MODEL_ROUTE_SEMANTICS:
+        raise ValueError("router weights require Kimi full-model row semantics")
+    if routed_experts is None and routed_expert_weights is not None:
+        raise ValueError("router weights cannot be padded without expert IDs")
+    if (
+        route_semantics == KIMI_FULL_MODEL_ROUTE_SEMANTICS
+        and routed_experts is not None
+        and routed_expert_weights is None
+    ):
+        raise ValueError("Kimi full R3 padding requires routed_experts and routed_expert_weights together")
+    if routed_expert_weights is not None and (routed_experts.is_nested != routed_expert_weights.is_nested):
+        raise ValueError("full R3 expert IDs and weights must use the same dense/jagged layout")
+    if routed_expert_weights is not None and routed_experts.is_nested:
+        if not torch.equal(routed_experts.offsets(), routed_expert_weights.offsets()):
+            raise ValueError("full R3 expert IDs and weights have different jagged offsets")
+        if routed_experts.values().shape != routed_expert_weights.values().shape:
+            raise ValueError(
+                "full R3 jagged IDs/weights are misaligned: "
+                f"ids={tuple(routed_experts.values().shape)}, "
+                f"weights={tuple(routed_expert_weights.values().shape)}"
+            )
     if routed_experts is not None and not routed_experts.is_nested:
-        routed_experts_rmpad = index_first_axis(routed_experts.unsqueeze(-1).flatten(0, 1), indices)
-        routed_experts_nested = torch.nested.nested_tensor_from_jagged(
-            routed_experts_rmpad.squeeze(-1), offsets=cu_seqlens
-        )
+        if routed_expert_weights is not None and routed_experts.shape != routed_expert_weights.shape:
+            raise ValueError(
+                "full R3 dense IDs/weights are misaligned: "
+                f"ids={tuple(routed_experts.shape)}, "
+                f"weights={tuple(routed_expert_weights.shape)}"
+            )
+        if route_semantics not in {
+            None,
+            KIMI_FULL_MODEL_ROUTE_SEMANTICS,
+        }:
+            raise ValueError(f"unsupported routed-experts transport semantics: {route_semantics!r}")
+        full_model_transport = route_semantics == KIMI_FULL_MODEL_ROUTE_SEMANTICS
+        if routed_experts.max() <= 255:
+            routed_experts = routed_experts.to(torch.uint8)
+        if full_model_transport:
+            # Kimi full R3 uses vLLM's image-expanded model-row axis, which is
+            # independent of tokenizer padding. Equal-length dense captures
+            # are still converted to jagged rows under the explicit contract.
+            route_seq_len = routed_experts.shape[1]
+            route_offsets = torch.arange(
+                0,
+                (routed_experts.shape[0] + 1) * route_seq_len,
+                route_seq_len,
+                dtype=torch.int64,
+                device=routed_experts.device,
+            )
+            routed_experts_nested = torch.nested.nested_tensor_from_jagged(
+                routed_experts.flatten(0, 1), offsets=route_offsets
+            )
+            if routed_expert_weights is not None:
+                routed_expert_weights_nested = torch.nested.nested_tensor_from_jagged(
+                    routed_expert_weights.flatten(0, 1),
+                    offsets=route_offsets,
+                )
+        else:
+            if routed_experts.shape[1] != attention_mask.shape[1]:
+                raise ValueError(
+                    "logical-token routed experts must match attention-mask "
+                    f"length: routes={routed_experts.shape[1]}, "
+                    f"tokens={attention_mask.shape[1]}"
+                )
+            routed_experts_rmpad = index_first_axis(routed_experts.unsqueeze(-1).flatten(0, 1), indices)
+            routed_experts_nested = torch.nested.nested_tensor_from_jagged(
+                routed_experts_rmpad.squeeze(-1), offsets=cu_seqlens
+            )
         data["routed_experts"] = routed_experts_nested
+        if routed_expert_weights is not None:
+            data["routed_expert_weights"] = routed_expert_weights_nested
 
     # (bsz, seqlen, topk)
     teacher_logprobs = data.get("teacher_logprobs", None)


### PR DESCRIPTION
# Title

[BREAKING][fsdp, megatron, rollout, model] feat: support Kimi K3 training on Ascend NPUs

### What does this PR do?

Integrates Kimi K3 multimodal GRPO training on Ascend NPUs with FSDP-Turbo and Megatron/MindSpeed-Bridge backends and vLLM-Ascend rollout. Adds shared multimodal processing, full-model R3 routing replay, backend-specific checkpoint loading and weight synchronization, and CountBenchQA data preparation and reward scoring.

Duplicate-work check: searches for open PRs matching `"Kimi K3"`, `fsdpturbo`, and `head:merge-backend-kimi-k3` in `verl-project/verl` returned no matches on 2026-09-15. No related issue was supplied. This integrates both Kimi K3 training backends and their shared rollout path; no matching open implementation was found in those searches.

AI assistance was used to inspect the changes and prepare this PR description. Human review of every changed line and execution of the relevant tests remain required before submission.

### Checklist Before Starting

- [x] Search for similar PRs: [Kimi K3](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22Kimi+K3%22), [FSDP-Turbo](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fsdpturbo).
- [x] Format the PR title as `[{modules}] {type}: {description}`, with `[BREAKING]` for the Mooncake default behavior change described below.

### Test

Completed locally against the five Kimi K3 commits (`64876ef5` through `e1d94ba5`):

```bash
git diff --check 64876ef5^..e1d94ba5
bash -n examples/ascend_extras/grpo_trainer/run_kimi_k3_fsdpturbo.sh
bash -n examples/ascend_extras/grpo_trainer/run_kimi_k3_megatron.sh
```

All checks passed. These checks establish whitespace and shell syntax correctness only.

Added or extended regression tests cover multimodal adaptation, Megatron forward processing, checkpoint loading, packed expert weight export, full R3 payload validation, IPC weight reconstruction, optimizer offload, and CountBenchQA scoring. Pytest and full pre-commit results have not been verified for this branch during PR preparation.

Ascend end-to-end validation is pending. Attach results for both backends, including dependency revisions, model configuration, NPU topology, training steps, reward/loss curves, actor–rollout log-probability differences, repeated weight updates, and checkpoint save/resume. These experiments require Ascend hardware, Kimi K3 weights, and matching FSDP-Turbo/MS-Bridge/vLLM-Ascend implementations; the added unit tests do not establish end-to-end correctness.

### API and Usage Example

Adds `actor_rollout_ref.actor.megatron.grad_offload` (default `False`) to release disposable gradient buffers independently of parameter offload. MegatronAdaptor bootstrap can be enabled with `VERL_USE_MEGATRON_ADAPTOR=1`.

**Breaking behavior:** importing verl now disables the optional `mooncake.store` and `mooncake.engine` bindings by default. Existing Mooncake users must set `VERL_TRANSFER_QUEUE_ENABLE_MOONCAKE=1` before Python starts and use a compatible Mooncake installation.

Prepare CountBenchQA data:

```bash
python examples/data_preprocess/prepare_countbenchqa_lite_parquet.py \
  --input /path/to/raw.parquet \
  --output /path/to/train.parquet \
  --split train
```

Backend launch configurations are provided in:

- `examples/ascend_extras/grpo_trainer/run_kimi_k3_fsdpturbo.sh`
- `examples/ascend_extras/grpo_trainer/run_kimi_k3_megatron.sh`

The launchers are not yet self-contained: both require the absent `kimi_k3_runtime.sh`; the FSDP-Turbo launcher also requires `prepare_kimi_k3_model.py`. Their multinode mode expects an external `ray_start_multi_nodes.sh` entry point. Supply these helpers and document the backend directory layout and dependency revisions before treating the scripts as runnable examples.

### Design & Code Changes

- **Shared model and data path:** add Kimi processor/tokenizer adaptation, image-expanded sequence alignment, CountBenchQA parquet conversion without caption-label leakage, and answer scoring.
- **Rollout and trainer:** carry full-model routing IDs and weights through rollout responses, agent loops, TransferQueue, batching, and training; validate R3 payload shapes and align routes with expanded multimodal rows.
- **FSDP-Turbo:** integrate Kimi training and log-probability alignment, stream checkpoint tensors into local shards, and export packed local expert weights for supported colocated actor/rollout layouts.
- **Megatron:** register the Kimi multimodal forward path, initialize the MindSpeed adaptor before engine imports, integrate routing replay, and update optimizer/gradient offload and distributed checkpoint handling.
- **Weight synchronization and runtime:** support CPU/NPU IPC reconstruction and Kimi weight loading, and guard optional Mooncake native imports.
- **Examples and tests:** add both backend launch configurations and focused regression coverage. Matching external backend changes are required and are not included in this verl PR.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md). Read during AI preparation; submitting author confirmation is pending.
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Document dependency revisions, runtime layout, launch helpers, and the Mooncake migration setting.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Regression tests are included; CI execution and Ascend end-to-end coverage remain to be verified.
- [ ] Once ready for CI, send a message in the [ci-request channel](https://verl-project.slack.com/archives/C091TCESWB1) in the [verl Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ), or the [Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).
- [ ] If related to the `recipe` submodule, update its commit reference. Not applicable to the five Kimi K3 commits.
